### PR TITLE
feat(ui): standardize page skeletons vs Loader2 for ENG-77

### DIFF
--- a/components/dashboard/EarningsDashboardSkeleton.tsx
+++ b/components/dashboard/EarningsDashboardSkeleton.tsx
@@ -4,7 +4,10 @@ function StatCardsSkeleton() {
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
       {[1, 2, 3].map((i) => (
-        <div key={i} className="bg-white rounded-lg shadow p-6 dark:bg-card dark:border dark:border-border">
+        <div
+          key={i}
+          className="bg-white rounded-lg shadow p-6 dark:bg-card dark:border dark:border-border"
+        >
           <Skeleton className="h-4 w-24 mb-4" />
           <Skeleton className="h-8 w-20 mb-2" />
           <Skeleton className="h-3 w-16" />

--- a/components/dashboard/EarningsDashboardSkeleton.tsx
+++ b/components/dashboard/EarningsDashboardSkeleton.tsx
@@ -1,17 +1,91 @@
 import { Skeleton } from '@/components/ui/skeleton'
 
-export function EarningsDashboardSkeleton() {
+function StatCardsSkeleton() {
   return (
-    <div className="space-y-6">
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        {[1, 2, 3].map((i) => (
-          <div key={i} className="bg-white rounded-lg shadow p-6">
-            <Skeleton className="h-4 w-24 mb-4" />
-            <Skeleton className="h-8 w-20 mb-2" />
-            <Skeleton className="h-3 w-16" />
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="bg-white rounded-lg shadow p-6 dark:bg-card dark:border dark:border-border">
+          <Skeleton className="h-4 w-24 mb-4" />
+          <Skeleton className="h-8 w-20 mb-2" />
+          <Skeleton className="h-3 w-16" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function MonthlyChartSkeleton() {
+  return (
+    <div className="bg-white rounded-lg shadow p-6 dark:bg-card dark:border dark:border-border">
+      <Skeleton className="h-6 w-40 mb-4" />
+      <div className="grid grid-cols-6 gap-2">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="text-center">
+            <Skeleton className="h-3 w-full mb-1 mx-auto" />
+            <Skeleton className="h-16 w-full rounded-lg" />
           </div>
         ))}
       </div>
+    </div>
+  )
+}
+
+function TopArticlesListSkeleton() {
+  return (
+    <div className="bg-white rounded-lg shadow dark:bg-card dark:border dark:border-border">
+      <div className="p-6 border-b border-border">
+        <Skeleton className="h-6 w-56" />
+      </div>
+      <div className="divide-y divide-border">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="p-4">
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-3/4 max-w-md" />
+                <Skeleton className="h-3 w-24" />
+              </div>
+              <Skeleton className="h-5 w-16 shrink-0" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function RecentTipsSkeleton() {
+  return (
+    <div className="bg-white rounded-lg shadow dark:bg-card dark:border dark:border-border">
+      <div className="p-6 border-b border-border">
+        <Skeleton className="h-6 w-32" />
+      </div>
+      <div className="divide-y divide-border">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="p-4">
+            <div className="flex items-center justify-between gap-4">
+              <div className="space-y-2 flex-1">
+                <Skeleton className="h-4 w-36" />
+                <Skeleton className="h-3 w-64 max-w-full" />
+              </div>
+              <div className="text-right space-y-2 shrink-0">
+                <Skeleton className="h-5 w-14 ml-auto" />
+                <Skeleton className="h-3 w-20 ml-auto" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function EarningsDashboardSkeleton() {
+  return (
+    <div className="space-y-6">
+      <StatCardsSkeleton />
+      <MonthlyChartSkeleton />
+      <TopArticlesListSkeleton />
+      <RecentTipsSkeleton />
     </div>
   )
 }

--- a/components/profile/ProfileNftsTabContent.tsx
+++ b/components/profile/ProfileNftsTabContent.tsx
@@ -2,27 +2,8 @@
 
 import { useNFTsByOwner, useUserMintedNFTs } from '@/hooks/convex'
 import type { Id } from '@/types/convex'
-import { Skeleton } from '@/components/ui/skeleton'
+import { ProfileNftsTabSkeleton } from '@/components/profile/ProfileNftsTabSkeleton'
 import { Image, Trophy } from 'lucide-react'
-
-function ProfileNftsSkeleton() {
-  return (
-    <div className="space-y-8">
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <div
-            key={i}
-            className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-4"
-          >
-            <Skeleton className="aspect-video w-full rounded-lg mb-4" />
-            <Skeleton className="h-5 w-3/4 mb-2" />
-            <Skeleton className="h-4 w-1/2" />
-          </div>
-        ))}
-      </div>
-    </div>
-  )
-}
 
 export function ProfileNftsTabContent({
   userId,
@@ -37,7 +18,7 @@ export function ProfileNftsTabContent({
   const mintedNFTs = useUserMintedNFTs(userId)
 
   if (userNFTs === undefined || mintedNFTs === undefined) {
-    return <ProfileNftsSkeleton />
+    return <ProfileNftsTabSkeleton />
   }
 
   return (

--- a/components/profile/ProfileNftsTabSkeleton.tsx
+++ b/components/profile/ProfileNftsTabSkeleton.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+export function ProfileNftsTabSkeleton() {
+  return (
+    <div className="space-y-8">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-4"
+          >
+            <Skeleton className="aspect-video w-full rounded-lg mb-4" />
+            <Skeleton className="h-5 w-3/4 mb-2" />
+            <Skeleton className="h-4 w-1/2" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/profile/ProfilePageLoadingSkeleton.tsx
+++ b/components/profile/ProfilePageLoadingSkeleton.tsx
@@ -1,21 +1,51 @@
 import { Skeleton } from '@/components/ui/skeleton'
+import { ArticleGridSkeleton } from '@/components/articles/ArticleCardSkeleton'
 
 export function ProfilePageLoadingSkeleton() {
   return (
     <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12">
-      <div className="mb-8 space-y-4">
-        <Skeleton className="h-32 w-full rounded-lg" />
-        <div className="flex gap-4">
-          <Skeleton className="h-10 w-24" />
-          <Skeleton className="h-10 w-24" />
-          <Skeleton className="h-10 w-24" />
+      <div className="mb-8">
+        <div className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-8">
+          <div className="flex flex-col sm:flex-row gap-6">
+            <div className="flex-shrink-0">
+              <Skeleton className="h-[120px] w-[120px] rounded-full" />
+            </div>
+            <div className="flex-grow space-y-4">
+              <div>
+                <Skeleton className="h-9 w-48 max-w-full mb-2" />
+                <Skeleton className="h-6 w-32 max-w-full" />
+              </div>
+              <div className="space-y-2 max-w-2xl">
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-5/6" />
+              </div>
+              <div className="flex flex-wrap gap-6 pt-2">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-9 w-9 rounded-lg" />
+                  <div className="space-y-1">
+                    <Skeleton className="h-4 w-8" />
+                    <Skeleton className="h-3 w-16" />
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-9 w-9 rounded-lg" />
+                  <Skeleton className="h-4 w-28" />
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        {Array.from({ length: 3 }).map((_, i) => (
-          <Skeleton key={i} className="h-64 rounded-lg" />
-        ))}
+
+      <div className="border-b border-border mb-8">
+        <nav className="-mb-px flex flex-wrap gap-6 sm:space-x-8 sm:gap-0">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-24 mb-px rounded-none" />
+          ))}
+        </nav>
       </div>
+
+      <ArticleGridSkeleton count={9} />
     </main>
   )
 }

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,3 +1,11 @@
+/**
+ * Loading UI convention (Quilltip):
+ * - Page and section async data: composed placeholders built from `Skeleton` and
+ *   named `*Skeleton` components (e.g. ArticleGridSkeleton). Use `animate-pulse`
+ *   via this primitive only.
+ * - Buttons and inline async actions: `Loader2` from lucide-react with
+ *   `animate-spin`, not full-page spinners for main content.
+ */
 import { cn } from '@/lib/utils'
 
 function Skeleton({


### PR DESCRIPTION
## Summary

Implements ENG-77: page-level loading uses composed skeleton UIs; async
actions on controls keep the Loader2 + animate-spin pattern.

## Changes

- Document loading UI rules in a file-level comment on `components/ui/skeleton.tsx`.
- Expand `EarningsDashboardSkeleton` to mirror the loaded earnings view: stat
  cards, monthly chart placeholder, top articles list, and recent tips list
  (all `Skeleton`, no spinners).
- Redesign `ProfilePageLoadingSkeleton` to match profile layout: header
  (avatar, text, stats row), tab strip, and `ArticleGridSkeleton` (9 cards).
- Extract `ProfileNftsTabSkeleton` and use it from `ProfileNftsTabContent`.

Search (`/articles`) and authenticated home recent articles already used
`ArticleGridSkeleton`; no functional change there.