### PR TITLE
feat(ui): ENG-81 withdraw minimum copy and empty-state CTAs

### DIFF
--- a/components/articles/ArticleGrid.tsx
+++ b/components/articles/ArticleGrid.tsx
@@ -27,15 +27,15 @@ export default function ArticleGrid({
             <div className="flex flex-col sm:flex-row gap-3 justify-center">
               <Link
                 href="/articles"
-                className="inline-flex items-center justify-center rounded-md text-sm font-medium bg-muted text-foreground hover:bg-muted/80 h-9 px-4 border border-border"
+                className="inline-flex items-center justify-center rounded-md text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 h-9 px-4"
               >
                 Browse articles
               </Link>
               <Link
                 href="/write"
-                className="inline-flex items-center justify-center rounded-md text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 h-9 px-4"
+                className="inline-flex items-center justify-center rounded-md text-sm font-medium bg-muted text-foreground hover:bg-muted/80 h-9 px-4 border border-border"
               >
-                Write article
+                Write your first article
               </Link>
             </div>
           </div>

--- a/components/dashboard/EarningsStats.test.tsx
+++ b/components/dashboard/EarningsStats.test.tsx
@@ -87,4 +87,24 @@ describe('EarningsStats', () => {
       screen.getByRole('heading', { name: /Stellar Wallet Not Configured/i })
     ).toBeInTheDocument()
   })
+
+  it('shows minimum withdrawal helper and disables withdraw when balance is below minimum', () => {
+    const earnings = makeEarnings({
+      availableBalanceUsd: 4.5,
+      availableBalanceCents: 450,
+    })
+    render(
+      <EarningsStats
+        earnings={earnings}
+        userProfile={{ stellarAddress: 'G' + 'A'.repeat(55) }}
+        minWithdrawalUsd={10}
+        onOpenWithdrawModal={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.getByText(/minimum available balance of \$10\.00/i)
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /withdraw/i })).toBeDisabled()
+  })
 })

--- a/components/dashboard/EarningsStats.tsx
+++ b/components/dashboard/EarningsStats.tsx
@@ -23,8 +23,7 @@ export function EarningsStats({
   onOpenWithdrawModal,
 }: EarningsStatsProps) {
   const lastWithdrawal = earnings.lastWithdrawalAt
-  const belowWithdrawalMinimum =
-    earnings.availableBalanceUsd < minWithdrawalUsd
+  const belowWithdrawalMinimum = earnings.availableBalanceUsd < minWithdrawalUsd
   const showMinimumWithdrawalHelper =
     belowWithdrawalMinimum && Boolean(userProfile?.stellarAddress)
 

--- a/components/dashboard/EarningsStats.tsx
+++ b/components/dashboard/EarningsStats.tsx
@@ -23,6 +23,10 @@ export function EarningsStats({
   onOpenWithdrawModal,
 }: EarningsStatsProps) {
   const lastWithdrawal = earnings.lastWithdrawalAt
+  const belowWithdrawalMinimum =
+    earnings.availableBalanceUsd < minWithdrawalUsd
+  const showMinimumWithdrawalHelper =
+    belowWithdrawalMinimum && Boolean(userProfile?.stellarAddress)
 
   return (
     <>
@@ -65,6 +69,13 @@ export function EarningsStats({
             <Wallet className="w-4 h-4" />
             {!userProfile?.stellarAddress ? 'Set Up Wallet' : 'Withdraw'}
           </button>
+          {showMinimumWithdrawalHelper && (
+            <p className="mt-2 text-sm text-gray-500">
+              Withdrawals require a minimum available balance of $
+              {minWithdrawalUsd.toFixed(2)}. Add earnings until your balance
+              reaches this amount.
+            </p>
+          )}
         </div>
 
         <div className="bg-white rounded-lg shadow p-6">

--- a/components/profile/ProfileArticlesTabContent.tsx
+++ b/components/profile/ProfileArticlesTabContent.tsx
@@ -6,6 +6,7 @@ import ArticleGrid from '@/components/articles/ArticleGrid'
 import Pagination from '@/components/articles/Pagination'
 import { ArticleGridSkeleton } from '@/components/articles/ArticleCardSkeleton'
 import { BookOpen } from 'lucide-react'
+import Link from 'next/link'
 
 export function ProfileArticlesTabContent({
   username,
@@ -36,10 +37,18 @@ export function ProfileArticlesTabContent({
     return (
       <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-12 text-center">
         <BookOpen className="w-12 h-12 text-muted-foreground/50 mx-auto mb-4" />
-        <p className="text-muted-foreground text-lg">
+        <p className="text-muted-foreground text-lg mb-6">
           {isOwnProfile ? "You haven't" : `${displayName} hasn't`} published any
           articles yet.
         </p>
+        {isOwnProfile && (
+          <Link
+            href="/write"
+            className="inline-flex items-center justify-center rounded-md text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 h-9 px-4"
+          >
+            Write your first article
+          </Link>
+        )}
       </div>
     )
   }


### PR DESCRIPTION
## Summary

Implements [ENG-81](https://linear.app): explain the minimum withdrawal amount when Withdraw is disabled, and add clear CTAs for empty profile articles and the home feed empty state.

## Changes

- **Earnings:** When a Stellar wallet is configured and available balance is below the configured minimum (e.g. $10), show always-visible helper text under the Withdraw button (not hover-only). Withdraw stays disabled until the minimum is met.
- **Profile / Articles tab:** If the signed-in user has no published articles, show a primary **Write your first article** link to `/write`.
- **Home / Recent Articles (empty):** **Browse articles** is the primary action (`/articles`); **Write your first article** is secondary (`/write`).
- **Withdraw / earnings UI:** Primary actions use the emerald/green gradient (aligned with updated dashboard styling).
