### PR TITLE
fix(search): replace useCallback debounce with stable ref-based implementation

### DIFF
--- a/components/articles/SearchInput.test.tsx
+++ b/components/articles/SearchInput.test.tsx
@@ -1,6 +1,5 @@
 /** @vitest-environment jsdom */
 import { render, screen, fireEvent, act } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import SearchInput from '@/components/articles/SearchInput'
 

--- a/components/articles/SearchInput.test.tsx
+++ b/components/articles/SearchInput.test.tsx
@@ -1,0 +1,116 @@
+/** @vitest-environment jsdom */
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import SearchInput from '@/components/articles/SearchInput'
+
+describe('SearchInput debounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not call onChange before the debounce delay', () => {
+    const onChange = vi.fn()
+    render(<SearchInput value="" onChange={onChange} debounceMs={300} />)
+    const input = screen.getByRole('textbox')
+
+    fireEvent.change(input, { target: { value: 't' } })
+    fireEvent.change(input, { target: { value: 'te' } })
+    fireEvent.change(input, { target: { value: 'tes' } })
+    fireEvent.change(input, { target: { value: 'test' } })
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('calls onChange exactly once with the final value after rapid typing', () => {
+    const onChange = vi.fn()
+    render(<SearchInput value="" onChange={onChange} debounceMs={300} />)
+    const input = screen.getByRole('textbox')
+
+    fireEvent.change(input, { target: { value: 't' } })
+    fireEvent.change(input, { target: { value: 'te' } })
+    fireEvent.change(input, { target: { value: 'tes' } })
+    fireEvent.change(input, { target: { value: 'test' } })
+
+    act(() => vi.advanceTimersByTime(300))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith('test')
+  })
+
+  it('calls onChange for each character when typing slowly (>=300ms apart)', () => {
+    const onChange = vi.fn()
+    render(<SearchInput value="" onChange={onChange} debounceMs={300} />)
+    const input = screen.getByRole('textbox')
+
+    fireEvent.change(input, { target: { value: 't' } })
+    act(() => vi.advanceTimersByTime(300))
+
+    fireEvent.change(input, { target: { value: 'te' } })
+    act(() => vi.advanceTimersByTime(300))
+
+    expect(onChange).toHaveBeenCalledTimes(2)
+    expect(onChange).toHaveBeenNthCalledWith(1, 't')
+    expect(onChange).toHaveBeenNthCalledWith(2, 'te')
+  })
+
+  it('calls onChange immediately when the clear button is clicked, cancelling any pending timer', () => {
+    const onChange = vi.fn()
+    render(<SearchInput value="test" onChange={onChange} debounceMs={300} />)
+    const input = screen.getByRole('textbox')
+
+    fireEvent.change(input, { target: { value: 'tests' } })
+
+    const clearButton = screen.getByRole('button', { name: /clear search/i })
+    fireEvent.click(clearButton)
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith('')
+
+    act(() => vi.advanceTimersByTime(300))
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire stale intermediate values when backspacing quickly', () => {
+    const onChange = vi.fn()
+    render(<SearchInput value="" onChange={onChange} debounceMs={300} />)
+    const input = screen.getByRole('textbox')
+
+    fireEvent.change(input, { target: { value: 'test' } })
+    fireEvent.change(input, { target: { value: 'tes' } })
+    fireEvent.change(input, { target: { value: 'te' } })
+
+    act(() => vi.advanceTimersByTime(300))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith('te')
+  })
+
+  it('cancels pending timer on unmount', () => {
+    const onChange = vi.fn()
+    const { unmount } = render(
+      <SearchInput value="" onChange={onChange} debounceMs={300} />
+    )
+    const input = screen.getByRole('textbox')
+
+    fireEvent.change(input, { target: { value: 'test' } })
+    unmount()
+
+    act(() => vi.advanceTimersByTime(300))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})
+
+describe('SearchInput controlled value sync', () => {
+  it('updates displayed value when the value prop changes externally', () => {
+    const { rerender } = render(<SearchInput value="foo" onChange={vi.fn()} />)
+    expect(screen.getByRole('textbox')).toHaveValue('foo')
+
+    rerender(<SearchInput value="bar" onChange={vi.fn()} />)
+    expect(screen.getByRole('textbox')).toHaveValue('bar')
+  })
+})

--- a/components/articles/SearchInput.tsx
+++ b/components/articles/SearchInput.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { Search, X } from 'lucide-react'
 
 interface SearchInputProps {
@@ -19,36 +19,42 @@ export default function SearchInput({
   debounceMs = 300,
 }: SearchInputProps) {
   const [localValue, setLocalValue] = useState(value)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const onChangeRef = useRef(onChange)
 
-  // Debounced onChange callback
-  const debouncedOnChange = useCallback(
-    (searchValue: string) => {
-      const timer = setTimeout(() => {
-        onChange(searchValue)
-      }, debounceMs)
-
-      return () => clearTimeout(timer)
-    },
-    [onChange, debounceMs]
-  )
+  useEffect(() => {
+    onChangeRef.current = onChange
+  }, [onChange])
 
   // Update local value when prop value changes (for external updates)
   useEffect(() => {
     setLocalValue(value)
   }, [value])
 
-  // Handle input change
+  // Cancel pending timer on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current)
+    }
+  }, [])
+
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value
     setLocalValue(newValue)
 
-    // Clear previous timeout and set new one
-    const cleanup = debouncedOnChange(newValue)
-    return cleanup
+    if (timerRef.current !== null) clearTimeout(timerRef.current)
+
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null
+      onChangeRef.current(newValue)
+    }, debounceMs)
   }
 
-  // Clear search
   const clearSearch = () => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
     setLocalValue('')
     onChange('')
   }


### PR DESCRIPTION
## What

Rewrites the debounce logic in `SearchInput` to use a `useRef`-based timer instead of `useCallback` + closure.

## Why

The previous implementation recreated the debounced callback on every `onChange`/`debounceMs` change, which could cause stale closure issues and made the cleanup logic fragile (returning a cleanup function from an event handler has no effect — React does not call it). The ref-based approach avoids these problems:

- `timerRef` holds the active timer ID, cleared correctly on each keystroke and on unmount
- `onChangeRef` keeps the latest `onChange` stable without adding it to the debounce dependency chain, preventing timer resets on parent re-renders


https://github.com/user-attachments/assets/0fc9e7d5-9d34-4fdd-bc45-bc65a2b3d489

