### PR TITLE
fix: migrate animation imports to motion/react and guard auth redirects (ENG-87)

### DIFF
--- a/app/drafts/page.tsx
+++ b/app/drafts/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@/components/providers/AuthContext'
 import Link from 'next/link'
@@ -35,6 +35,11 @@ export default function DraftsPage() {
   const deleteArticleMutation = useMutation(api.articles.deleteArticle)
   const [deleteTarget, setDeleteTarget] = useState<Id<'articles'> | null>(null)
 
+  useEffect(() => {
+    if (isLoading || isAuthenticated) return
+    router.replace('/login')
+  }, [isLoading, isAuthenticated, router])
+
   if (isLoading) {
     return (
       <div className="min-h-screen bg-muted/30">
@@ -50,8 +55,7 @@ export default function DraftsPage() {
     )
   }
 
-  if (!isAuthenticated && !isLoading) {
-    router.push('/login')
+  if (!isAuthenticated) {
     return null
   }
 

--- a/app/write/page.tsx
+++ b/app/write/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@/components/providers/AuthContext'
 import AppNavigation from '@/components/layout/AppNavigation'
@@ -12,6 +13,11 @@ export default function WritePage() {
   const router = useRouter()
   const { isAuthenticated, isLoading } = useAuth()
 
+  useEffect(() => {
+    if (isLoading || isAuthenticated) return
+    router.replace('/login')
+  }, [isLoading, isAuthenticated, router])
+
   if (isLoading) {
     return (
       <div className="min-h-screen bg-background">
@@ -22,7 +28,6 @@ export default function WritePage() {
   }
 
   if (!isAuthenticated) {
-    router.push('/login')
     return null
   }
 

--- a/components/guide/WalletStepCard.tsx
+++ b/components/guide/WalletStepCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { motion } from 'framer-motion'
+import { motion } from 'motion/react'
 import { LucideIcon } from 'lucide-react'
 
 interface WalletStepCardProps {

--- a/components/landing/FAQSection.tsx
+++ b/components/landing/FAQSection.tsx
@@ -2,8 +2,7 @@
 
 import { useState } from 'react'
 import { ChevronDown } from 'lucide-react'
-import { motion, AnimatePresence } from 'framer-motion'
-import { useInView } from 'framer-motion'
+import { motion, AnimatePresence, useInView } from 'motion/react'
 import { useRef } from 'react'
 
 export default function FAQSection() {

--- a/components/landing/FeaturesSection.tsx
+++ b/components/landing/FeaturesSection.tsx
@@ -10,8 +10,7 @@ import {
   Globe,
   Sparkles,
 } from 'lucide-react'
-import { motion } from 'framer-motion'
-import { useInView } from 'framer-motion'
+import { motion, useInView } from 'motion/react'
 import { useRef } from 'react'
 import { LucideIcon } from 'lucide-react'
 

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Heart, PenTool } from 'lucide-react'
-import { motion } from 'framer-motion'
+import { motion } from 'motion/react'
 
 export default function Footer() {
   const currentYear = new Date().getFullYear()

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { ArrowRight, Zap } from 'lucide-react'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion, AnimatePresence } from 'motion/react'
 import { useEffect, useState, useCallback, useRef } from 'react'
 
 const ARTICLE_TEXT = `Writers pour their hearts into stories that shape how we think — yet most see nothing in return. The quiet revolution of open knowledge deserves better. What if readers could reward the exact words that moved them?`

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -14,8 +14,7 @@ import {
   Wallet,
   Heart,
 } from 'lucide-react'
-import { motion, AnimatePresence } from 'framer-motion'
-import { useInView } from 'framer-motion'
+import { motion, AnimatePresence, useInView } from 'motion/react'
 import { useRef } from 'react'
 import { LucideIcon } from 'lucide-react'
 

--- a/components/landing/Navigation.tsx
+++ b/components/landing/Navigation.tsx
@@ -17,7 +17,7 @@ import {
   Globe,
   Sparkles,
 } from 'lucide-react'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion, AnimatePresence } from 'motion/react'
 import { LucideIcon } from 'lucide-react'
 import { ThemeToggle } from '@/components/theme/ThemeToggle'
 

--- a/components/layout/AppNavigation.tsx
+++ b/components/layout/AppNavigation.tsx
@@ -16,7 +16,7 @@ import {
 } from 'lucide-react'
 import { usePathname } from 'next/navigation'
 import { ThemeToggle } from '@/components/theme/ThemeToggle'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion, AnimatePresence } from 'motion/react'
 
 export default function AppNavigation() {
   const { user, isAuthenticated, signOut } = useAuth()

--- a/components/onboarding/OnboardingDialog.tsx
+++ b/components/onboarding/OnboardingDialog.tsx
@@ -13,7 +13,7 @@ import {
   DialogDescription,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion, AnimatePresence } from 'motion/react'
 import {
   Sparkles,
   Wallet,


### PR DESCRIPTION
## Summary

- Replace all app imports from `framer-motion` with `motion/react` (same React API; aligns with the direct `motion` dependency).
- Fix React 19 warning on `/write` and `/drafts` when unauthenticated: move login redirect out of render into `useEffect` and use `router.replace('/login')`.

## Changes

- **Motion:** `Footer`, landing sections (`Hero`, `Features`, `HowItWorks`, `FAQ`), landing `Navigation`, `AppNavigation`, `OnboardingDialog`, `WalletStepCard`.
- **Auth redirect:** `app/write/page.tsx`, `app/drafts/page.tsx`.


https://github.com/user-attachments/assets/5ba078cd-c1a6-4b81-92b9-1f7e9cb13e33


https://github.com/user-attachments/assets/3749a21b-ce38-457b-bc86-a13eb38fb4ad

<img width="1438" height="859" alt="onboard" src="https://github.com/user-attachments/assets/52b0938f-34f1-42e8-b891-1a7a901d1bcb" />
