### PR TITLE
feat: make article tags clickable filters (ENG-89)

### DIFF
--- a/components/articles/ArticleCard.tsx
+++ b/components/articles/ArticleCard.tsx
@@ -58,10 +58,7 @@ export default function ArticleCard({ article, priority }: ArticleCardProps) {
         {article.tags.length > 0 && (
           <div className="flex flex-wrap gap-2 mb-4">
             {article.tags.slice(0, 3).map((tag) => (
-              <TagFilterLink
-                key={tag.id}
-                tag={tag.name}
-              >
+              <TagFilterLink key={tag.id} tag={tag.name}>
                 {tag.name}
               </TagFilterLink>
             ))}

--- a/components/articles/ArticleCard.tsx
+++ b/components/articles/ArticleCard.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image'
 import { UserAvatar } from '@/components/ui/user-avatar'
 import { formatDistanceToNow } from 'date-fns'
 import { ArticleForDisplay } from '@/types/index'
+import { TagFilterLink } from '@/components/articles/TagFilterLink'
 
 interface ArticleCardProps {
   article: ArticleForDisplay
@@ -57,12 +58,12 @@ export default function ArticleCard({ article, priority }: ArticleCardProps) {
         {article.tags.length > 0 && (
           <div className="flex flex-wrap gap-2 mb-4">
             {article.tags.slice(0, 3).map((tag) => (
-              <span
+              <TagFilterLink
                 key={tag.id}
-                className="text-xs px-2 py-1 bg-muted text-foreground rounded-full"
+                tag={tag.name}
               >
                 {tag.name}
-              </span>
+              </TagFilterLink>
             ))}
             {article.tags.length > 3 && (
               <span className="text-xs px-2 py-1 text-muted-foreground">

--- a/components/articles/ArticleDisplay.tsx
+++ b/components/articles/ArticleDisplay.tsx
@@ -17,6 +17,7 @@ import { useAuth } from '@/components/providers/AuthContext'
 import type { Id } from '@/types/convex'
 import type { ArticleForDisplay } from '@/types/index'
 import { EDITOR_PROSE_CLASS } from '@/lib/constants'
+import { TagFilterLink } from '@/components/articles/TagFilterLink'
 
 const EMPTY_DOC: JSONContent = { type: 'doc', content: [] }
 
@@ -119,12 +120,13 @@ export default function ArticleDisplay({
         {article.tags.length > 0 && (
           <div className="flex flex-wrap gap-2 mb-6">
             {article.tags.map((tag) => (
-              <span
+              <TagFilterLink
                 key={tag.id}
-                className="px-3 py-1 bg-muted text-foreground text-sm rounded-full"
+                tag={tag.name}
+                className="px-3 py-1 text-sm"
               >
                 {tag.name}
-              </span>
+              </TagFilterLink>
             ))}
           </div>
         )}

--- a/components/articles/TagFilterLink.tsx
+++ b/components/articles/TagFilterLink.tsx
@@ -36,4 +36,3 @@ export function TagFilterLink({
     </Link>
   )
 }
-

--- a/components/articles/TagFilterLink.tsx
+++ b/components/articles/TagFilterLink.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+
+export function TagFilterLink({
+  tag,
+  className = '',
+  children,
+}: {
+  tag: string
+  className?: string
+  children?: React.ReactNode
+}) {
+  const searchParams = useSearchParams()
+
+  const params = new URLSearchParams(searchParams?.toString() || '')
+  params.set('tag', tag)
+  params.set('page', '1')
+
+  const href = `/articles?${params.toString()}`
+
+  return (
+    <Link
+      href={href}
+      aria-label={`Filter by tag ${tag}`}
+      className={[
+        'focus-ring inline-flex items-center rounded-full',
+        'text-xs px-2 py-1 bg-muted text-foreground',
+        'hover:bg-muted/80 hover:text-foreground',
+        'transition-colors',
+        className,
+      ].join(' ')}
+    >
+      {children ?? tag}
+    </Link>
+  )
+}
+


### PR DESCRIPTION
## Summary
- Makes tag badges on article cards clickable and navigates to /articles?tag=<tag>&page=1
- Preserves existing /articles query params (e.g. search, author) so clicking a tag combines filters
- Makes tag badges on the single article view clickable with the same behavior (shareable URL)
## Changes
- Added components/articles/TagFilterLink.tsx to build the filtered /articles URL while keeping existing params and resetting pagination
- Updated tag rendering in:
  - components/articles/ArticleCard.tsx
  - components/articles/ArticleDisplay.tsx
<img width="1438" height="856" alt="art_tag" src="https://github.com/user-attachments/assets/b81b59ba-9fbf-4a2d-b8e2-e6f188c62962" />
<img width="1436" height="857" alt="tag_appr" src="https://github.com/user-attachments/assets/98c60370-1e38-4ee0-bb32-545c77fe6198" />
