### PR TITLE
fix(editor): semantic color tokens and drag-drop for write UI (ENG-92)

### DIFF
--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -79,7 +79,7 @@ export function Editor({
         lowlight,
         HTMLAttributes: {
           class:
-            'rounded-lg bg-gray-900 text-gray-100 p-4 my-4 overflow-x-auto',
+            'rounded-lg bg-muted text-foreground border border-border p-4 my-4 overflow-x-auto',
         },
       }),
     ],
@@ -171,19 +171,19 @@ export function Editor({
   return (
     <div
       className={`editor-wrapper bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border relative ${className} ${
-        isDragging ? 'border-blue-400 bg-blue-50' : ''
+        isDragging ? 'border-primary bg-primary/10' : ''
       } ${isUploading ? 'pointer-events-none' : ''}`}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
       {isDragging && (
-        <div className="absolute inset-0 bg-blue-50 bg-opacity-90 flex items-center justify-center z-10 rounded-lg border-2 border-dashed border-blue-400">
+        <div className="absolute inset-0 bg-primary/15 flex items-center justify-center z-10 rounded-lg border-2 border-dashed border-primary">
           <div className="text-center">
-            <div className="text-blue-600 text-lg font-medium mb-2">
+            <div className="text-primary text-lg font-medium mb-2">
               Drop image here
             </div>
-            <div className="text-blue-500 text-sm">Release to upload</div>
+            <div className="text-primary/80 text-sm">Release to upload</div>
           </div>
         </div>
       )}
@@ -191,13 +191,13 @@ export function Editor({
       {isUploading && (
         <div className="absolute inset-0 bg-card bg-opacity-90 flex items-center justify-center z-10 rounded-lg">
           <div className="text-center">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-2"></div>
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-2"></div>
             <div className="text-muted-foreground text-sm">
               Optimizing and uploading image...
             </div>
             <div className="mt-2 w-48 bg-muted rounded-full h-2 mx-auto">
               <div
-                className="bg-blue-600 h-2 rounded-full transition-all duration-300"
+                className="bg-primary h-2 rounded-full transition-all duration-300"
                 style={{ width: `${uploadProgress}%` }}
               ></div>
             </div>

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -83,7 +83,7 @@ function MoreMenu({
               <DropdownMenu.Separator className="h-px bg-border my-1" />
               <DropdownMenu.Item
                 onSelect={onDelete}
-                className="px-4 py-2.5 text-sm text-red-600 hover:bg-red-50 cursor-pointer outline-none flex items-center gap-2"
+                className="px-4 py-2.5 text-sm text-destructive hover:bg-destructive/10 focus:bg-destructive/10 cursor-pointer outline-none flex items-center gap-2"
               >
                 <Trash2 className="w-4 h-4 shrink-0" />
                 Delete draft
@@ -145,7 +145,7 @@ export function EditorActionBar({
     statusClassName = 'text-destructive'
   } else if (hasUnsavedChanges) {
     statusText = 'Unsaved changes'
-    statusClassName = 'text-red-500'
+    statusClassName = 'text-destructive'
   } else if (lastSavedAt) {
     statusText = `Saved ${formatDistanceToNow(lastSavedAt, { addSuffix: true })}`
   } else {
@@ -167,7 +167,7 @@ export function EditorActionBar({
   )
 
   const publishControl = isPublished ? (
-    <span className="px-4 py-2 text-sm font-medium text-green-700 bg-green-50 rounded-full shrink-0">
+    <span className="px-4 py-2 text-sm font-medium bg-success text-success-foreground rounded-full shrink-0">
       Published
     </span>
   ) : (
@@ -175,7 +175,7 @@ export function EditorActionBar({
       type="button"
       onClick={onPublish}
       disabled={isPublishing || !canPublish}
-      className="px-5 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed rounded-full transition-colors shrink-0"
+      className="px-5 py-2 text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed rounded-full transition-colors shrink-0"
       title="Publish article"
     >
       {isPublishing ? 'Publishing...' : 'Publish'}
@@ -185,10 +185,10 @@ export function EditorActionBar({
   const draftStatus = (
     <span className="flex min-w-0 items-center gap-2 text-sm shrink-0">
       <span
-        className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full font-medium ${hasUnsavedChanges ? 'bg-red-50 text-red-700' : 'bg-yellow-100 text-amber-800'}`}
+        className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full font-medium border ${hasUnsavedChanges ? 'bg-destructive/15 text-destructive border-destructive/25' : 'bg-warning text-warning-foreground border-transparent'}`}
       >
         <span
-          className={`w-1.5 h-1.5 rounded-full shrink-0 ${hasUnsavedChanges ? 'bg-red-500' : 'bg-amber-500'}`}
+          className={`w-1.5 h-1.5 rounded-full shrink-0 ${hasUnsavedChanges ? 'bg-destructive' : 'bg-warning-foreground/80'}`}
           aria-hidden
         />
         Draft
@@ -327,7 +327,7 @@ export function EditorActionBar({
 
       {error && (
         <div
-          className="border-t border-border px-4 py-2 text-xs text-red-500"
+          className="border-t border-border bg-destructive/10 px-4 py-2 text-xs text-destructive"
           title={error}
         >
           Save failed

--- a/components/editor/EditorWithToolbar.tsx
+++ b/components/editor/EditorWithToolbar.tsx
@@ -73,7 +73,7 @@ export function EditorWithToolbar({
         lowlight,
         HTMLAttributes: {
           class:
-            'rounded-lg bg-gray-900 text-gray-100 p-4 my-4 overflow-x-auto',
+            'rounded-lg bg-muted text-foreground border border-border p-4 my-4 overflow-x-auto',
         },
       }),
     ],

--- a/components/editor/ImageUploadDialog.tsx
+++ b/components/editor/ImageUploadDialog.tsx
@@ -236,7 +236,7 @@ export function ImageUploadDialog({
               <div
                 className={`border-2 border-dashed rounded-lg p-6 text-center transition-colors ${
                   dragActive
-                    ? 'border-primary bg-primary/10'
+                    ? 'border-primary bg-primary/15'
                     : 'border-border hover:border-muted-foreground/40'
                 }`}
                 onDragOver={handleDragOver}
@@ -356,8 +356,8 @@ export function ImageUploadDialog({
           )}
 
           {error && (
-            <div className="mt-3 p-3 bg-red-50 border border-red-200 rounded-lg">
-              <p className="text-sm text-red-600">{error}</p>
+            <div className="mt-3 rounded-lg border border-destructive/25 bg-destructive/10 p-3">
+              <p className="text-sm text-destructive">{error}</p>
             </div>
           )}
         </div>

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -396,24 +396,18 @@ export function WriteEditorWorkspace() {
     }
   }, [hasUnsavedChanges, router])
 
-  const handleCoverPlaceholderDragOver = useCallback(
-    (e: React.DragEvent) => {
-      e.preventDefault()
-      e.stopPropagation()
-      setCoverDropActive(true)
-    },
-    []
-  )
+  const handleCoverPlaceholderDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setCoverDropActive(true)
+  }, [])
 
-  const handleCoverPlaceholderDragLeave = useCallback(
-    (e: React.DragEvent) => {
-      e.preventDefault()
-      if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-        setCoverDropActive(false)
-      }
-    },
-    []
-  )
+  const handleCoverPlaceholderDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      setCoverDropActive(false)
+    }
+  }, [])
 
   const handleCoverPlaceholderDrop = useCallback(
     async (e: React.DragEvent) => {

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -17,7 +17,7 @@ import { ImageUploadDialog } from '@/components/editor/ImageUploadDialog'
 import { useAuth } from '@/components/providers/AuthContext'
 import { EditorChromeSkeleton } from '@/components/editor/EditorChromeSkeleton'
 import { useAutoSave } from '@/hooks/useAutoSave'
-import { useMutation } from 'convex/react'
+import { useConvex, useMutation } from 'convex/react'
 import { api } from '@/convex/_generated/api'
 import { useArticleById } from '@/hooks/convex'
 import type { Id } from '@/types/convex'
@@ -41,6 +41,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import { cn } from '@/lib/utils'
+import { compressImage, uploadFile } from '@/lib/upload'
 
 const PUBLISH_EXCERPT_PREVIEW_MAX = 280
 const EXCERPT_MAX_CHARS = 500
@@ -77,11 +79,17 @@ function getInternalNavHref(
 }
 
 export function WriteEditorWorkspace() {
+  const convex = useConvex()
   const [title, setTitle] = useState('')
   const [excerpt, setExcerpt] = useState('')
   const [tags, setTags] = useState('')
   const [coverImage, setCoverImage] = useState('')
   const [showCoverImageDialog, setShowCoverImageDialog] = useState(false)
+  const [coverDropActive, setCoverDropActive] = useState(false)
+  const [coverDropUploading, setCoverDropUploading] = useState(false)
+  const [bodyImageDragging, setBodyImageDragging] = useState(false)
+  const [bodyImageUploading, setBodyImageUploading] = useState(false)
+  const [bodyImageUploadProgress, setBodyImageUploadProgress] = useState(0)
   const [isPublishing, setIsPublishing] = useState(false)
   const [articleId, setArticleId] = useState<string | undefined>()
   const [editorContent, setEditorContent] = useState<JSONContent | null>(null)
@@ -140,7 +148,7 @@ export function WriteEditorWorkspace() {
         lowlight,
         HTMLAttributes: {
           class:
-            'rounded-lg bg-gray-900 text-gray-100 p-4 my-4 overflow-x-auto',
+            'rounded-lg bg-muted text-foreground border border-border p-4 my-4 overflow-x-auto',
         },
       }),
       TextAlign.configure({ types: ['heading', 'paragraph'] }),
@@ -388,6 +396,123 @@ export function WriteEditorWorkspace() {
     }
   }, [hasUnsavedChanges, router])
 
+  const handleCoverPlaceholderDragOver = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      setCoverDropActive(true)
+    },
+    []
+  )
+
+  const handleCoverPlaceholderDragLeave = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault()
+      if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+        setCoverDropActive(false)
+      }
+    },
+    []
+  )
+
+  const handleCoverPlaceholderDrop = useCallback(
+    async (e: React.DragEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      setCoverDropActive(false)
+
+      const file = e.dataTransfer.files?.[0]
+      if (!file) return
+      if (!file.type.startsWith('image/')) {
+        toast.error('Please drop an image file')
+        return
+      }
+
+      setCoverDropUploading(true)
+      try {
+        const compressedFile = await compressImage(file, 1200, 0.8)
+        const result = await uploadFile(
+          compressedFile,
+          convex,
+          'article_image',
+          undefined,
+          undefined
+        )
+        if (result.success && result.url) {
+          setCoverImage(result.url)
+          setHasUnsavedChanges(true)
+        } else {
+          toast.error(result.error || 'Upload failed')
+        }
+      } catch (err) {
+        console.error('Cover drop upload error:', err)
+        toast.error('Upload failed. Please try again.')
+      } finally {
+        setCoverDropUploading(false)
+      }
+    },
+    [convex]
+  )
+
+  const handleBodyEditorDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setBodyImageDragging(true)
+  }, [])
+
+  const handleBodyEditorDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      setBodyImageDragging(false)
+    }
+  }, [])
+
+  const handleBodyEditorDrop = useCallback(
+    async (e: React.DragEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      setBodyImageDragging(false)
+
+      if (!editor) return
+
+      const files = Array.from(e.dataTransfer.files)
+      const imageFiles = files.filter((file) => file.type.startsWith('image/'))
+      if (imageFiles.length === 0) return
+
+      const file = imageFiles[0]
+      if (!file) return
+
+      setBodyImageUploading(true)
+      setBodyImageUploadProgress(0)
+
+      try {
+        const compressedFile = await compressImage(file, 1200, 0.8)
+        const result = await uploadFile(
+          compressedFile,
+          convex,
+          'article_image',
+          undefined,
+          (progress) => {
+            setBodyImageUploadProgress(progress.percentage)
+          }
+        )
+
+        if (result.success && result.url) {
+          editor.chain().focus().setResizableImage({ src: result.url }).run()
+        } else {
+          toast.error(result.error || 'Upload failed')
+        }
+      } catch (err) {
+        console.error('Error uploading dropped image:', err)
+        toast.error('Upload failed. Please try again.')
+      } finally {
+        setBodyImageUploading(false)
+      }
+    },
+    [convex, editor]
+  )
+
   const confirmLeaveNavigation = useCallback(() => {
     setNavConfirm((current) => {
       if (!current) return null
@@ -481,7 +606,7 @@ export function WriteEditorWorkspace() {
             />
           </div>
           <div
-            className="pointer-events-none absolute bottom-0 left-0 right-0 h-[2px] bg-sky-400"
+            className="pointer-events-none absolute bottom-0 left-0 right-0 h-[2px] bg-primary"
             aria-hidden
           />
         </div>
@@ -510,23 +635,39 @@ export function WriteEditorWorkspace() {
                       setCoverImage('')
                       setHasUnsavedChanges(true)
                     }}
-                    className="rounded-lg border border-border bg-card px-4 py-2 text-sm font-medium text-red-600 shadow hover:bg-red-500/10"
+                    className="rounded-lg border border-border bg-card px-4 py-2 text-sm font-medium text-destructive shadow hover:bg-destructive/10"
                   >
                     Remove
                   </button>
                 </div>
               </div>
             ) : (
-              <button
-                type="button"
+              <div
+                role="button"
+                tabIndex={0}
                 onClick={() => setShowCoverImageDialog(true)}
-                className="group flex h-28 w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-border text-muted-foreground transition-colors hover:border-sky-400 hover:text-sky-500"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    setShowCoverImageDialog(true)
+                  }
+                }}
+                onDragOver={handleCoverPlaceholderDragOver}
+                onDragLeave={handleCoverPlaceholderDragLeave}
+                onDrop={handleCoverPlaceholderDrop}
+                className={cn(
+                  'group flex h-28 w-full cursor-pointer items-center justify-center gap-2 rounded-xl border-2 border-dashed border-border text-muted-foreground transition-colors hover:border-primary hover:text-primary',
+                  coverDropActive &&
+                    'border-primary bg-primary/15 text-primary',
+                  coverDropUploading && 'pointer-events-none opacity-70'
+                )}
               >
                 <svg
-                  className="h-5 w-5"
+                  className="h-5 w-5 shrink-0"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
+                  aria-hidden
                 >
                   <path
                     strokeLinecap="round"
@@ -535,8 +676,14 @@ export function WriteEditorWorkspace() {
                     d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
                   />
                 </svg>
-                <span className="text-sm font-medium">Add cover image</span>
-              </button>
+                <span className="text-sm font-medium">
+                  {coverDropUploading
+                    ? 'Uploading…'
+                    : coverDropActive
+                      ? 'Drop image to set cover'
+                      : 'Add cover image'}
+                </span>
+              </div>
             )}
           </div>
 
@@ -632,10 +779,54 @@ export function WriteEditorWorkspace() {
           </div>
 
           {editor && (
-            <EditorContent
-              editor={editor}
-              className="editor-content min-h-[400px]"
-            />
+            <div
+              className={cn(
+                'relative min-h-[400px] rounded-[var(--card-radius)] border border-transparent transition-colors',
+                bodyImageDragging && 'border-primary bg-primary/10',
+                bodyImageUploading && 'pointer-events-none'
+              )}
+              onDragOver={handleBodyEditorDragOver}
+              onDragLeave={handleBodyEditorDragLeave}
+              onDrop={handleBodyEditorDrop}
+            >
+              <EditorContent
+                editor={editor}
+                className="editor-content min-h-[400px]"
+              />
+
+              {bodyImageDragging && (
+                <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center rounded-[var(--card-radius)] border-2 border-dashed border-primary bg-primary/15">
+                  <div className="text-center">
+                    <div className="mb-2 text-lg font-medium text-primary">
+                      Drop image here
+                    </div>
+                    <div className="text-sm text-primary/80">
+                      Release to add to article
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {bodyImageUploading && (
+                <div className="absolute inset-0 z-20 flex items-center justify-center rounded-[var(--card-radius)] bg-card/90">
+                  <div className="text-center">
+                    <div className="mx-auto mb-2 h-8 w-8 animate-spin rounded-full border-b-2 border-primary" />
+                    <div className="text-sm text-muted-foreground">
+                      Optimizing and uploading image...
+                    </div>
+                    <div className="mx-auto mt-2 h-2 w-48 rounded-full bg-muted">
+                      <div
+                        className="h-2 rounded-full bg-primary transition-all duration-300"
+                        style={{ width: `${bodyImageUploadProgress}%` }}
+                      />
+                    </div>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {bodyImageUploadProgress}%
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
           )}
 
           <div id="field-tags" className="mt-8 border-t border-border pt-4">

--- a/components/editor/YouTubeEmbedDialog.tsx
+++ b/components/editor/YouTubeEmbedDialog.tsx
@@ -111,7 +111,7 @@ export function YouTubeEmbedDialog({
       >
         <DialogHeader className="p-4 border-b border-border space-y-0 text-left pr-12">
           <div className="flex items-center gap-2">
-            <Youtube className="w-5 h-5 text-red-600 shrink-0" />
+            <Youtube className="w-5 h-5 text-muted-foreground shrink-0" />
             <DialogTitle>Embed YouTube Video</DialogTitle>
           </div>
           <DialogDescription className="sr-only">
@@ -166,8 +166,8 @@ export function YouTubeEmbedDialog({
                   unoptimized
                 />
                 <div className="absolute inset-0 flex items-center justify-center">
-                  <div className="w-12 h-12 bg-red-600 rounded-full flex items-center justify-center">
-                    <Play className="w-6 h-6 text-white ml-1" />
+                  <div className="w-12 h-12 bg-primary rounded-full flex items-center justify-center">
+                    <Play className="w-6 h-6 text-primary-foreground ml-1" />
                   </div>
                 </div>
               </div>
@@ -181,8 +181,8 @@ export function YouTubeEmbedDialog({
               </span>
               <div className="relative bg-muted rounded-lg overflow-hidden h-32 flex items-center justify-center">
                 <div className="text-center">
-                  <div className="w-12 h-12 bg-red-600 rounded-full flex items-center justify-center mx-auto mb-2">
-                    <Youtube className="w-6 h-6 text-white" />
+                  <div className="w-12 h-12 bg-primary rounded-full flex items-center justify-center mx-auto mb-2">
+                    <Youtube className="w-6 h-6 text-primary-foreground" />
                   </div>
                   <p className="text-sm text-muted-foreground">YouTube Video</p>
                 </div>
@@ -254,8 +254,8 @@ export function YouTubeEmbedDialog({
           </div>
 
           {error && (
-            <div className="p-3 bg-red-50 border border-red-200 rounded-lg">
-              <p className="text-sm text-red-600">{error}</p>
+            <div className="rounded-lg border border-destructive/25 bg-destructive/10 p-3">
+              <p className="text-sm text-destructive">{error}</p>
             </div>
           )}
 

--- a/components/editor/extensions/ResizableImageComponent.tsx
+++ b/components/editor/extensions/ResizableImageComponent.tsx
@@ -148,7 +148,7 @@ export default function ResizableImageComponent({
             {/* Resize Handle - mouse-only interaction for drag resizing */}
             {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
             <div
-              className="absolute bottom-0 right-0 w-4 h-4 bg-blue-500 border-2 border-background rounded cursor-nw-resize opacity-0 group-hover:opacity-100 transition-opacity"
+              className="absolute bottom-0 right-0 w-4 h-4 bg-primary border-2 border-background rounded cursor-nw-resize opacity-0 group-hover:opacity-100 transition-opacity"
               onMouseDown={handleMouseDown}
               style={{ transform: 'translate(50%, 50%)' }}
             />


### PR DESCRIPTION
## Summary

Replaces hardcoded palette utilities in editor-related UI with theme tokens (`primary`, `destructive`, `success`, `warning`, `muted`, `foreground`, etc.) so light and dark modes stay consistent. Adds missing drag-and-drop on the write flow: cover placeholder and main article body (upload + insert resizable image).



## Changes

- **EditorActionBar:** Draft / published / unsaved / save-error / delete menu use semantic status and primary CTA styling.
- **Editor.tsx:** Body drag overlay, upload progress, and code block classes use tokens (kept for any consumer of this component).
- **WriteEditorWorkspace:** Code blocks use `bg-muted` + `border-border`; destructive control uses destructive tokens; sticky toolbar accent line uses `primary` instead of `sky`; **cover** “Add cover image” accepts drop + upload; **body** `EditorContent` wrapped with drag overlay + upload + `setResizableImage` (write page did not use `Editor.tsx` before).
- **ImageUploadDialog / YouTubeEmbedDialog:** Error callouts and drag/active states use destructive / primary tokens; YouTube preview controls use primary instead of raw red.
- **EditorWithToolbar:** Code block HTML classes aligned with workspace.
- **ResizableImageComponent:** Resize handle uses `primary`.

<img width="1439" height="811" alt="publish_d" src="https://github.com/user-attachments/assets/7837a25d-1708-4bc8-8e87-4d51b52b75dd" />
<img width="1439" height="811" alt="publish_l" src="https://github.com/user-attachments/assets/0b34feb3-aa7d-411e-a2ed-97560c1a8003" />

<img width="1197" height="677" alt="drk_rd" src="https://github.com/user-attachments/assets/5c26f242-cff3-419b-9ddc-9af062ab1867" />
