### PR TITLE
fix(dashboard): replace hardcoded colors with semantic/status tokens (ENG-91)

### DIFF
--- a/components/dashboard/EarningsDashboard.tsx
+++ b/components/dashboard/EarningsDashboard.tsx
@@ -57,12 +57,12 @@ export function EarningsDashboard() {
   if (!earnings) {
     return (
       <div className="space-y-6">
-        <div className="bg-white rounded-lg shadow p-12 text-center">
-          <Coins className="w-16 h-16 text-gray-300 mx-auto mb-4" />
-          <h3 className="text-lg font-semibold text-gray-900 mb-2">
+        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-12 text-center">
+          <Coins className="w-16 h-16 text-muted-foreground mx-auto mb-4" />
+          <h3 className="text-lg font-semibold text-foreground mb-2">
             No earnings yet
           </h3>
-          <p className="text-gray-600">
+          <p className="text-muted-foreground">
             Start earning by sharing great content that readers love!
           </p>
         </div>

--- a/components/dashboard/EarningsDashboardSkeleton.tsx
+++ b/components/dashboard/EarningsDashboardSkeleton.tsx
@@ -6,7 +6,7 @@ function StatCardsSkeleton() {
       {[1, 2, 3].map((i) => (
         <div
           key={i}
-          className="bg-white rounded-lg shadow p-6 dark:bg-card dark:border dark:border-border"
+          className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6"
         >
           <Skeleton className="h-4 w-24 mb-4" />
           <Skeleton className="h-8 w-20 mb-2" />
@@ -19,7 +19,7 @@ function StatCardsSkeleton() {
 
 function MonthlyChartSkeleton() {
   return (
-    <div className="bg-white rounded-lg shadow p-6 dark:bg-card dark:border dark:border-border">
+    <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
       <Skeleton className="h-6 w-40 mb-4" />
       <div className="grid grid-cols-6 gap-2">
         {Array.from({ length: 6 }).map((_, i) => (
@@ -35,7 +35,7 @@ function MonthlyChartSkeleton() {
 
 function TopArticlesListSkeleton() {
   return (
-    <div className="bg-white rounded-lg shadow dark:bg-card dark:border dark:border-border">
+    <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border">
       <div className="p-6 border-b border-border">
         <Skeleton className="h-6 w-56" />
       </div>
@@ -58,7 +58,7 @@ function TopArticlesListSkeleton() {
 
 function RecentTipsSkeleton() {
   return (
-    <div className="bg-white rounded-lg shadow dark:bg-card dark:border dark:border-border">
+    <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border">
       <div className="p-6 border-b border-border">
         <Skeleton className="h-6 w-32" />
       </div>

--- a/components/dashboard/EarningsStats.test.tsx
+++ b/components/dashboard/EarningsStats.test.tsx
@@ -58,7 +58,7 @@ describe('EarningsStats', () => {
         '2024-03': 30,
       },
     })
-    const { container } = render(
+    render(
       <EarningsStats
         earnings={earnings}
         userProfile={{ stellarAddress: 'x' }}
@@ -67,9 +67,9 @@ describe('EarningsStats', () => {
       />
     )
 
-    const months = container.querySelectorAll('.text-xs.text-gray-500.mb-1')
-    const labels = [...months].map((el) => el.textContent)
-    expect(labels).toEqual(['2024-01', '2024-02', '2024-03'])
+    expect(screen.getByText('2024-01')).toBeInTheDocument()
+    expect(screen.getByText('2024-02')).toBeInTheDocument()
+    expect(screen.getByText('2024-03')).toBeInTheDocument()
   })
 
   it('shows wallet setup notice when profile has no Stellar address', () => {

--- a/components/dashboard/EarningsStats.tsx
+++ b/components/dashboard/EarningsStats.tsx
@@ -35,25 +35,25 @@ export function EarningsStats({
       {userProfile && !userProfile.stellarAddress && <WalletSetupNotice />}
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="bg-white rounded-lg shadow p-6">
+        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
           <div className="flex items-center justify-between mb-2">
-            <span className="text-gray-600">Total Earned</span>
-            <DollarSign className="w-5 h-5 text-green-500" />
+            <span className="text-muted-foreground">Total Earned</span>
+            <DollarSign className="w-5 h-5 text-success-foreground" />
           </div>
-          <p className="text-2xl font-bold text-gray-900">
+          <p className="text-2xl font-bold text-foreground">
             ${earnings.totalEarnedUsd.toFixed(2)}
           </p>
-          <p className="text-sm text-gray-500 mt-1">
+          <p className="text-sm text-muted-foreground mt-1">
             {earnings.tipCount} tips received
           </p>
         </div>
 
-        <div className="bg-white rounded-lg shadow p-6">
+        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
           <div className="flex items-center justify-between mb-2">
-            <span className="text-gray-600">Available Balance</span>
-            <Coins className="w-5 h-5 text-yellow-500" />
+            <span className="text-muted-foreground">Available Balance</span>
+            <Coins className="w-5 h-5 text-warning-foreground" />
           </div>
-          <p className="text-2xl font-bold text-gray-900">
+          <p className="text-2xl font-bold text-foreground">
             ${earnings.availableBalanceUsd.toFixed(2)}
           </p>
           <button
@@ -67,13 +67,13 @@ export function EarningsStats({
               }
             }}
             disabled={earnings.availableBalanceUsd < minWithdrawalUsd}
-            className="mt-3 w-full px-3 py-1.5 bg-gradient-to-r from-yellow-400 to-orange-500 text-white text-sm rounded-lg hover:from-yellow-500 hover:to-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            className="mt-3 w-full px-3 py-1.5 bg-brand text-brand-foreground text-sm rounded-lg hover:bg-brand-hover disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
           >
             <Wallet className="w-4 h-4" />
             {!userProfile?.stellarAddress ? 'Set Up Wallet' : 'Withdraw'}
           </button>
           {showMinimumWithdrawalHelper && (
-            <p className="mt-2 text-sm text-gray-500">
+            <p className="mt-2 text-sm text-muted-foreground">
               Withdrawals require a minimum available balance of $
               {minWithdrawalUsd.toFixed(2)}. Add earnings until your balance
               reaches this amount.
@@ -81,16 +81,16 @@ export function EarningsStats({
           )}
         </div>
 
-        <div className="bg-white rounded-lg shadow p-6">
+        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
           <div className="flex items-center justify-between mb-2">
-            <span className="text-gray-600">Total Withdrawn</span>
-            <Clock className="w-5 h-5 text-blue-500" />
+            <span className="text-muted-foreground">Total Withdrawn</span>
+            <Clock className="w-5 h-5 text-info-foreground" />
           </div>
-          <p className="text-2xl font-bold text-gray-900">
+          <p className="text-2xl font-bold text-foreground">
             ${earnings.withdrawnUsd.toFixed(2)}
           </p>
           {lastWithdrawal && (
-            <p className="text-sm text-gray-500 mt-1">
+            <p className="text-sm text-muted-foreground mt-1">
               Last: {new Date(lastWithdrawal).toLocaleDateString()}
             </p>
           )}

--- a/components/dashboard/TipHistory.tsx
+++ b/components/dashboard/TipHistory.tsx
@@ -17,27 +17,27 @@ export function TipHistory({ tips }: TipHistoryProps) {
   }
 
   return (
-    <div className="bg-white rounded-lg shadow">
-      <div className="p-6 border-b">
+    <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border">
+      <div className="p-6 border-b border-border">
         <h3 className="text-lg font-semibold">Recent Tips</h3>
       </div>
-      <div className="divide-y">
+      <div className="divide-y divide-border">
         {tips.slice(0, 10).map((tip) => (
-          <div key={tip._id} className="p-4 hover:bg-gray-50">
+          <div key={tip._id} className="p-4 hover:bg-muted/50">
             <div className="flex items-center justify-between">
               <div>
-                <p className="font-medium text-gray-900">
+                <p className="font-medium text-foreground">
                   {tip.tipper?.name || tip.tipper?.username || 'Anonymous'}
                 </p>
-                <p className="text-sm text-gray-500">
+                <p className="text-sm text-muted-foreground">
                   tipped on &ldquo;{tip.articleTitle}&rdquo;
                 </p>
               </div>
               <div className="text-right">
-                <p className="font-semibold text-green-800 dark:text-green-300">
+                <p className="font-semibold text-success-foreground">
                   +${tip.amountUsd.toFixed(2)}
                 </p>
-                <p className="text-xs text-gray-500">
+                <p className="text-xs text-muted-foreground">
                   {new Date(tip.createdAt).toLocaleDateString()}
                 </p>
               </div>

--- a/components/dashboard/WithdrawEarningsDialog.tsx
+++ b/components/dashboard/WithdrawEarningsDialog.tsx
@@ -119,12 +119,12 @@ export function WithdrawEarningsDialog({
           <div>
             <label
               htmlFor="withdraw-amount"
-              className="block text-sm font-medium text-gray-700 mb-2"
+              className="block text-sm font-medium text-foreground mb-2"
             >
               Amount (USD)
             </label>
             <div className="relative">
-              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
                 $
               </span>
               <input
@@ -136,11 +136,11 @@ export function WithdrawEarningsDialog({
                 value={withdrawAmount}
                 onChange={(e) => setWithdrawAmount(e.target.value)}
                 disabled={isWithdrawing}
-                className="w-full pl-8 pr-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-yellow-500"
+                className="w-full pl-8 pr-3 py-2 border border-input bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-ring"
                 placeholder={`${MIN_WITHDRAWAL_USD.toFixed(2)}`}
               />
             </div>
-            <p className="text-xs text-gray-500 mt-1">
+            <p className="text-xs text-muted-foreground mt-1">
               Available: ${availableBalanceUsd.toFixed(2)} | Min: $
               {MIN_WITHDRAWAL_USD.toFixed(2)}
             </p>
@@ -149,7 +149,7 @@ export function WithdrawEarningsDialog({
           <div>
             <label
               htmlFor="stellar-address"
-              className="block text-sm font-medium text-gray-700 mb-2"
+              className="block text-sm font-medium text-foreground mb-2"
             >
               Stellar Address
             </label>
@@ -160,18 +160,18 @@ export function WithdrawEarningsDialog({
               onChange={(e) => setStellarAddress(e.target.value)}
               readOnly={addressReadOnly}
               disabled={isWithdrawing}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-yellow-500 read-only:bg-gray-50"
+              className="w-full px-3 py-2 border border-input bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-ring read-only:bg-muted/50"
               placeholder="G..."
             />
-            <p className="text-xs text-gray-500 mt-1">
+            <p className="text-xs text-muted-foreground mt-1">
               {savedStellarAddress
                 ? 'Using your saved wallet address from Wallet settings'
                 : 'Enter your Stellar wallet address'}
             </p>
           </div>
 
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
-            <p className="text-sm text-blue-800">
+          <div className="bg-info border border-info/50 rounded-lg p-3">
+            <p className="text-sm text-info-foreground">
               Withdrawals are processed instantly on the Stellar network.
               Transaction fees are covered by Quilltip.
             </p>
@@ -183,7 +183,7 @@ export function WithdrawEarningsDialog({
             type="button"
             onClick={() => handleOpenChange(false)}
             disabled={isWithdrawing}
-            className="flex-1 px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed sm:flex-none"
+            className="flex-1 px-4 py-2 border border-input bg-background text-foreground rounded-lg hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed sm:flex-none"
           >
             Cancel
           </button>
@@ -195,7 +195,7 @@ export function WithdrawEarningsDialog({
               !withdrawAmount ||
               !effectiveAddress.startsWith('G')
             }
-            className="flex-1 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 sm:flex-none"
+            className="flex-1 px-4 py-2 bg-brand text-brand-foreground rounded-lg hover:bg-brand-hover disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 sm:flex-none"
           >
             {isWithdrawing ? (
               <>

--- a/components/dashboard/WithdrawalDialog.tsx
+++ b/components/dashboard/WithdrawalDialog.tsx
@@ -165,8 +165,8 @@ export function WithdrawalDialog({
             </p>
           </div>
 
-          <div className="bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-lg p-3">
-            <p className="text-sm text-blue-800 dark:text-blue-200">
+          <div className="bg-info border border-info/50 rounded-lg p-3">
+            <p className="text-sm text-info-foreground">
               Withdrawals are processed instantly on the Stellar network.
               Transaction fees are covered by Quilltip.
             </p>
@@ -191,7 +191,7 @@ export function WithdrawalDialog({
               !addressForSubmit ||
               !addressForSubmit.startsWith('G')
             }
-            className="flex-1 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 sm:flex-none"
+            className="flex-1 px-4 py-2 bg-brand text-brand-foreground rounded-lg hover:bg-brand-hover disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 sm:flex-none"
           >
             {isSubmitting ? (
               <>

--- a/components/dashboard/monthly-earnings-chart.tsx
+++ b/components/dashboard/monthly-earnings-chart.tsx
@@ -23,9 +23,7 @@ export function MonthlyEarningsChart({
             <div key={month} className="text-center">
               <div className="text-xs text-muted-foreground mb-1">{month}</div>
               <div className="bg-success text-success-foreground rounded-lg p-2">
-                <p className="text-sm font-semibold">
-                  ${amount.toFixed(0)}
-                </p>
+                <p className="text-sm font-semibold">${amount.toFixed(0)}</p>
               </div>
             </div>
           ))}

--- a/components/dashboard/monthly-earnings-chart.tsx
+++ b/components/dashboard/monthly-earnings-chart.tsx
@@ -12,7 +12,7 @@ export function MonthlyEarningsChart({
   }
 
   return (
-    <div className="bg-white rounded-lg shadow p-6">
+    <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
       <h3 className="text-lg font-semibold mb-4">Monthly Earnings</h3>
       <div className="grid grid-cols-6 gap-2">
         {Object.entries(monthlyEarnings)
@@ -21,9 +21,9 @@ export function MonthlyEarningsChart({
           .reverse()
           .map(([month, amount]) => (
             <div key={month} className="text-center">
-              <div className="text-xs text-gray-500 mb-1">{month}</div>
-              <div className="bg-gradient-to-t from-yellow-400 to-orange-500 rounded-lg p-2">
-                <p className="text-sm font-semibold text-white">
+              <div className="text-xs text-muted-foreground mb-1">{month}</div>
+              <div className="bg-success text-success-foreground rounded-lg p-2">
+                <p className="text-sm font-semibold">
                   ${amount.toFixed(0)}
                 </p>
               </div>

--- a/components/dashboard/top-earning-articles.tsx
+++ b/components/dashboard/top-earning-articles.tsx
@@ -35,7 +35,9 @@ export function TopEarningArticles({ articles }: TopEarningArticlesProps) {
                   <span className="text-sm font-medium text-muted-foreground">
                     #{index + 1}
                   </span>
-                  <h4 className="font-medium text-foreground">{article.title}</h4>
+                  <h4 className="font-medium text-foreground">
+                    {article.title}
+                  </h4>
                 </div>
                 <p className="text-sm text-muted-foreground mt-1">
                   {article.tipCount} tips

--- a/components/dashboard/top-earning-articles.tsx
+++ b/components/dashboard/top-earning-articles.tsx
@@ -19,30 +19,30 @@ export function TopEarningArticles({ articles }: TopEarningArticlesProps) {
   }
 
   return (
-    <div className="bg-white rounded-lg shadow">
-      <div className="p-6 border-b">
+    <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border">
+      <div className="p-6 border-b border-border">
         <h3 className="text-lg font-semibold flex items-center gap-2">
-          <TrendingUp className="w-5 h-5 text-green-500" />
+          <TrendingUp className="w-5 h-5 text-success-foreground" />
           Top Earning Articles
         </h3>
       </div>
-      <div className="divide-y">
+      <div className="divide-y divide-border">
         {articles.slice(0, 5).map((article, index) => (
-          <div key={article.articleId} className="p-4 hover:bg-gray-50">
+          <div key={article.articleId} className="p-4 hover:bg-muted/50">
             <div className="flex items-center justify-between">
               <div className="flex-1">
                 <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium text-gray-500">
+                  <span className="text-sm font-medium text-muted-foreground">
                     #{index + 1}
                   </span>
-                  <h4 className="font-medium text-gray-900">{article.title}</h4>
+                  <h4 className="font-medium text-foreground">{article.title}</h4>
                 </div>
-                <p className="text-sm text-gray-500 mt-1">
+                <p className="text-sm text-muted-foreground mt-1">
                   {article.tipCount} tips
                 </p>
               </div>
               <div className="text-right">
-                <p className="font-semibold text-gray-900">
+                <p className="font-semibold text-foreground">
                   ${article.earnings.toFixed(2)}
                 </p>
               </div>

--- a/components/dashboard/wallet-setup-notice.tsx
+++ b/components/dashboard/wallet-setup-notice.tsx
@@ -11,21 +11,21 @@ export function navigateToWalletTab() {
 
 export function WalletSetupNotice() {
   return (
-    <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-6">
+    <div className="bg-warning border border-warning/50 rounded-lg p-6">
       <div className="flex items-start gap-3">
-        <AlertCircle className="w-5 h-5 text-yellow-900 mt-0.5" />
+        <AlertCircle className="w-5 h-5 text-warning-foreground mt-0.5" />
         <div className="flex-1">
-          <h3 className="text-sm font-semibold text-yellow-900 mb-1">
+          <h3 className="text-sm font-semibold text-warning-foreground mb-1">
             Stellar Wallet Not Configured
           </h3>
-          <p className="text-sm text-yellow-800 mb-3">
+          <p className="text-sm text-warning-foreground mb-3">
             Please set up your Stellar wallet in the Wallet tab to enable
             withdrawals.
           </p>
           <button
             type="button"
             onClick={navigateToWalletTab}
-            className="text-sm font-medium text-yellow-900 hover:text-yellow-700 underline"
+            className="text-sm font-medium text-warning-foreground hover:text-warning-foreground/80 underline"
           >
             Go to Wallet Settings →
           </button>


### PR DESCRIPTION
## Summary
- Updated dashboard components to use semantic theme tokens (bg-card, text-foreground, text-muted-foreground, border-border) so dark mode renders correctly.
- Replaced color-coded indicators/callouts with status tokens (success/warning/info) and removed hardcoded gray/white backgrounds.
- Updated dashboard tests to avoid styling-dependent selectors.

<img width="1440" height="813" alt="drk" src="https://github.com/user-attachments/assets/38290394-c43a-42f5-8413-17d9c314c969" />
<img width="1440" height="811" alt="drk_" src="https://github.com/user-attachments/assets/fdf39c7d-7525-4dd8-9e98-16be145df81f" />
<img width="1440" height="810" alt="li" src="https://github.com/user-attachments/assets/50e8c00b-4006-4700-a182-4a6bba9b05a1" />
<img width="1439" height="813" alt="li_" src="https://github.com/user-attachments/assets/669403ac-17a4-4b31-bf97-9c14fe5bafc3" />
