### PR TITLE
fix(ui): replace navigation text arrows with Lucide ArrowRight icons (ENG-102)

### DIFF
--- a/components/landing/Navigation.tsx
+++ b/components/landing/Navigation.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useState, useEffect, useRef, useCallback } from 'react'
 import {
+  ArrowRight,
   Menu,
   X,
   PenTool,
@@ -339,9 +340,7 @@ export default function Navigation() {
                             </div>
                             <span className="text-[12px] font-medium text-muted-foreground group-hover/featured:text-foreground transition-colors mt-4 inline-flex items-center gap-1">
                               Learn more
-                              <span className="transition-transform group-hover/featured:translate-x-0.5">
-                                →
-                              </span>
+                              <ArrowRight className="w-3 h-3 shrink-0 transition-transform group-hover/featured:translate-x-0.5" />
                             </span>
                           </Link>
 
@@ -409,7 +408,7 @@ export default function Navigation() {
               className="focus-ring inline-flex items-center gap-1.5 bg-brand text-brand-foreground px-4 py-1.5 rounded-lg text-[13px] font-medium hover:bg-brand-hover transition-all duration-200 ml-1"
             >
               Try on Testnet
-              <span className="text-brand-foreground/80">→</span>
+              <ArrowRight className="w-3.5 h-3.5 shrink-0 text-brand-foreground/80" />
             </Link>
           </div>
 
@@ -500,10 +499,11 @@ export default function Navigation() {
                   </Link>
                   <Link
                     href="/register"
-                    className="focus-ring block bg-brand text-brand-foreground px-5 py-2.5 rounded-lg hover:bg-brand-hover transition-colors text-center text-sm font-medium"
+                    className="focus-ring inline-flex w-full items-center justify-center gap-1.5 bg-brand text-brand-foreground px-5 py-2.5 rounded-lg hover:bg-brand-hover transition-colors text-sm font-medium"
                     onClick={() => setIsOpen(false)}
                   >
-                    Try on Testnet →
+                    Try on Testnet
+                    <ArrowRight className="w-3.5 h-3.5 shrink-0 text-brand-foreground/80" />
                   </Link>
                 </motion.div>
               </div>


### PR DESCRIPTION
## Summary

Removes Unicode arrow characters (`→`) from the landing navigation UI. Where an arrow cue is still needed, it is rendered with the Lucide `ArrowRight` icon next to the label, not embedded in the string.

## Changes

- **Megamenu featured card:** "Learn more" uses `ArrowRight` with the same hover translate as before.
- **Desktop:** "Try on Testnet" CTA uses `ArrowRight` (aligned with hero CTA sizing).
- **Mobile:** "Try on Testnet" uses label text plus `ArrowRight`; link layout uses flex so label and icon stay centered on a full-width button.

The homepage hero (`HeroSection`) already used `ArrowRight` for "Start Reading" / "Start Writing"; no changes there.

<img width="1197" height="723" alt="read" src="https://github.com/user-attachments/assets/6cac30db-7b7c-4e9f-b6c6-f474b267331f" />
<img width="1195" height="711" alt="write" src="https://github.com/user-attachments/assets/ee98e422-e013-40a6-ad78-9104a73288cd" />
<img width="1197" height="716" alt="resource" src="https://github.com/user-attachments/assets/4a64c0c1-4954-4838-a66f-dfd9cc54f86b" />

<img width="1437" height="858" alt="mob_vw" src="https://github.com/user-attachments/assets/db59a3b3-223f-4fdb-9282-04e6bbac38b2" />
<img width="1195" height="714" alt="product" src="https://github.com/user-attachments/assets/7d010828-b337-4288-8be5-7a6373a0719f" />

