### PR TITLE
feat(auth): show CheckCircle on register success with success token

### DIFF
--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { registerSchema, type RegisterFormData } from '@/lib/validations/auth'
-import { Eye, EyeOff, Loader2 } from 'lucide-react'
+import { CheckCircle, Eye, EyeOff, Loader2 } from 'lucide-react'
 import { useAuth } from '@/components/providers/AuthContext'
 
 /**
@@ -63,8 +63,14 @@ export default function RegisterForm() {
     return (
       <div className="text-center space-y-4">
         <div className="p-4 bg-muted border border-border rounded-lg">
-          <p className="text-sm text-foreground">
-            Account created successfully! Redirecting to dashboard...
+          <p className="inline-flex items-center justify-center gap-2 text-sm text-foreground">
+            <CheckCircle
+              aria-hidden="true"
+              className="h-4 w-4 shrink-0 text-success-foreground"
+            />
+            <span>
+              Account created successfully! Redirecting to dashboard...
+            </span>
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Adds a lucide-react `CheckCircle` next to the post-registration success copy so the state reads clearly as confirmation. The icon uses `text-success-foreground` so it follows the existing success semantic tokens in light and dark mode.

## Changes

- `components/auth/RegisterForm.tsx`: import `CheckCircle`; success state uses `inline-flex`, `gap-2`, and `shrink-0` on the icon so layout stays stable when the message wraps.

<img width="1196" height="721" alt="mob_vw" src="https://github.com/user-attachments/assets/f5da0aa8-eb6a-4c42-8d0d-f79b51aff801" />
<img width="1196" height="721" alt="svg_drk" src="https://github.com/user-attachments/assets/1d278892-ccd3-4e05-bc2d-3cb85c093289" />
<img width="1193" height="722" alt="svg_li" src="https://github.com/user-attachments/assets/00d2dec2-2960-4526-bd28-5a36e6462f14" />
<img width="1191" height="719" alt="success_page" src="https://github.com/user-attachments/assets/2f1ac4df-b7aa-4959-8e60-992b7b77e526" />
<img width="1196" height="716" alt="drk_mod_succ_pg" src="https://github.com/user-attachments/assets/7ebe1d90-22c5-49f9-bca1-540ee6f83b72" />
