### PR TITLE
fix(auth): use shared UI primitives on login/register and humanize sign-up errors

### DIFF
--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -7,6 +7,11 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { loginSchema, type LoginFormData } from '@/lib/validations/auth'
 import { Eye, EyeOff, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+const authInputClassName =
+  'rounded-lg bg-background text-foreground focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:border-transparent'
 
 /**
  * Login Form Component
@@ -69,12 +74,12 @@ export default function LoginForm() {
         >
           Email address
         </label>
-        <input
+        <Input
           {...register('email')}
           type="email"
           id="email"
           autoComplete="email"
-          className="w-full px-3 py-2 border border-input bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue focus:border-transparent"
+          className={authInputClassName}
           placeholder="you@example.com"
         />
         {errors.email && (
@@ -91,25 +96,27 @@ export default function LoginForm() {
           Password
         </label>
         <div className="relative">
-          <input
+          <Input
             {...register('password')}
             type={showPassword ? 'text' : 'password'}
             id="password"
             autoComplete="current-password"
-            className="w-full px-3 py-2 pr-10 border border-input bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue focus:border-transparent"
+            className={`pr-10 ${authInputClassName}`}
             placeholder="Enter your password"
           />
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="icon"
             onClick={() => setShowPassword(!showPassword)}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
           >
             {showPassword ? (
               <EyeOff className="h-4 w-4" />
             ) : (
               <Eye className="h-4 w-4" />
             )}
-          </button>
+          </Button>
         </div>
         {errors.password && (
           <p className="mt-1 text-sm text-red-600">{errors.password.message}</p>
@@ -117,20 +124,20 @@ export default function LoginForm() {
       </div>
 
       {/* Submit Button */}
-      <button
+      <Button
         type="submit"
         disabled={isLoading}
-        className="w-full flex justify-center py-2 px-4 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-brand-blue hover:bg-brand-accent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-blue disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        className="w-full rounded-lg shadow-sm hover:bg-brand-accent focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-blue"
       >
         {isLoading ? (
           <>
-            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            <Loader2 className="h-4 w-4 animate-spin" />
             Signing in...
           </>
         ) : (
           'Sign in'
         )}
-      </button>
+      </Button>
     </form>
   )
 }

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -4,9 +4,15 @@ import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { mapRegisterSignInError } from '@/lib/auth/map-register-error'
 import { registerSchema, type RegisterFormData } from '@/lib/validations/auth'
 import { CheckCircle, Eye, EyeOff, Loader2 } from 'lucide-react'
 import { useAuth } from '@/components/providers/AuthContext'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+const authInputClassName =
+  'rounded-lg bg-background text-foreground focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:border-transparent'
 
 /**
  * Register Form Component
@@ -50,11 +56,7 @@ export default function RegisterForm() {
       // Use replace to prevent back button returning to register
       router.replace('/')
     } catch (error) {
-      setError(
-        error instanceof Error
-          ? error.message
-          : 'Registration failed. Please try again.'
-      )
+      setError(mapRegisterSignInError(error))
       setIsLoading(false)
     }
   }
@@ -94,12 +96,12 @@ export default function RegisterForm() {
         >
           Email address
         </label>
-        <input
+        <Input
           {...register('email')}
           type="email"
           id="email"
           autoComplete="email"
-          className="w-full px-3 py-2 border border-input bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue focus:border-transparent"
+          className={authInputClassName}
           placeholder="you@example.com"
         />
         {errors.email && (
@@ -115,12 +117,12 @@ export default function RegisterForm() {
         >
           Username
         </label>
-        <input
+        <Input
           {...register('username')}
           type="text"
           id="username"
           autoComplete="username"
-          className="w-full px-3 py-2 border border-input bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue focus:border-transparent"
+          className={authInputClassName}
           placeholder="Choose a unique username"
         />
         {errors.username && (
@@ -136,12 +138,12 @@ export default function RegisterForm() {
         >
           Full Name <span className="text-muted-foreground">(optional)</span>
         </label>
-        <input
+        <Input
           {...register('name')}
           type="text"
           id="name"
           autoComplete="name"
-          className="w-full px-3 py-2 border border-input bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue focus:border-transparent"
+          className={authInputClassName}
           placeholder="Your full name"
         />
         {errors.name && (
@@ -158,25 +160,27 @@ export default function RegisterForm() {
           Password
         </label>
         <div className="relative">
-          <input
+          <Input
             {...register('password')}
             type={showPassword ? 'text' : 'password'}
             id="password"
             autoComplete="new-password"
-            className="w-full px-3 py-2 pr-10 border border-input bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue focus:border-transparent"
+            className={`pr-10 ${authInputClassName}`}
             placeholder="Create a secure password"
           />
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="icon"
             onClick={() => setShowPassword(!showPassword)}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
           >
             {showPassword ? (
               <EyeOff className="h-4 w-4" />
             ) : (
               <Eye className="h-4 w-4" />
             )}
-          </button>
+          </Button>
         </div>
         {errors.password && (
           <p className="mt-1 text-sm text-red-600">{errors.password.message}</p>
@@ -192,25 +196,27 @@ export default function RegisterForm() {
           Confirm Password
         </label>
         <div className="relative">
-          <input
+          <Input
             {...register('confirmPassword')}
             type={showConfirmPassword ? 'text' : 'password'}
             id="confirmPassword"
             autoComplete="new-password"
-            className="w-full px-3 py-2 pr-10 border border-input bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue focus:border-transparent"
+            className={`pr-10 ${authInputClassName}`}
             placeholder="Confirm your password"
           />
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="icon"
             onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
           >
             {showConfirmPassword ? (
               <EyeOff className="h-4 w-4" />
             ) : (
               <Eye className="h-4 w-4" />
             )}
-          </button>
+          </Button>
         </div>
         {errors.confirmPassword && (
           <p className="mt-1 text-sm text-red-600">
@@ -220,20 +226,20 @@ export default function RegisterForm() {
       </div>
 
       {/* Submit Button */}
-      <button
+      <Button
         type="submit"
         disabled={isLoading}
-        className="w-full flex justify-center py-2 px-4 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-brand-blue hover:bg-brand-accent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-blue disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        className="w-full rounded-lg shadow-sm hover:bg-brand-accent focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-blue"
       >
         {isLoading ? (
           <>
-            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            <Loader2 className="h-4 w-4 animate-spin" />
             Creating account...
           </>
         ) : (
           'Create account'
         )}
-      </button>
+      </Button>
     </form>
   )
 }

--- a/lib/auth/map-register-error.test.ts
+++ b/lib/auth/map-register-error.test.ts
@@ -29,9 +29,9 @@ describe('mapRegisterSignInError', () => {
   })
 
   it('passes through a short single-line client message', () => {
-    expect(mapRegisterSignInError(new Error('Sign up is temporarily disabled.'))).toBe(
-      'Sign up is temporarily disabled.'
-    )
+    expect(
+      mapRegisterSignInError(new Error('Sign up is temporarily disabled.'))
+    ).toBe('Sign up is temporarily disabled.')
   })
 
   it('maps username conflict phrasing when present', () => {

--- a/lib/auth/map-register-error.test.ts
+++ b/lib/auth/map-register-error.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { mapRegisterSignInError } from './map-register-error'
+
+describe('mapRegisterSignInError', () => {
+  it('maps duplicate account messages from Convex-style errors', () => {
+    const msg = `[CONVEX A(auth:signIn)] Server Error Uncaught Error: Account user@example.com already exists at createAccountFromCredentialsImpl`
+    expect(mapRegisterSignInError(new Error(msg))).toBe(
+      'An account with this email already exists. Try signing in, or use a different email.'
+    )
+  })
+
+  it('maps plain duplicate wording', () => {
+    expect(mapRegisterSignInError(new Error('Account already exists'))).toBe(
+      'An account with this email already exists. Try signing in, or use a different email.'
+    )
+  })
+
+  it('maps Convex wrapper without duplicate to generic', () => {
+    const msg = `[CONVEX A(auth:signIn)] [Request ID: abc] Server Error Something went wrong`
+    expect(mapRegisterSignInError(new Error(msg))).toBe(
+      'Registration failed. Please try again.'
+    )
+  })
+
+  it('maps multiline errors to generic', () => {
+    expect(mapRegisterSignInError(new Error('line1\nline2'))).toBe(
+      'Registration failed. Please try again.'
+    )
+  })
+
+  it('passes through a short single-line client message', () => {
+    expect(mapRegisterSignInError(new Error('Sign up is temporarily disabled.'))).toBe(
+      'Sign up is temporarily disabled.'
+    )
+  })
+
+  it('maps username conflict phrasing when present', () => {
+    expect(
+      mapRegisterSignInError(new Error('Username "foo" is already taken'))
+    ).toBe('This username is not available. Try another one.')
+  })
+})

--- a/lib/auth/map-register-error.ts
+++ b/lib/auth/map-register-error.ts
@@ -1,8 +1,7 @@
 const DUPLICATE_ACCOUNT =
   'An account with this email already exists. Try signing in, or use a different email.'
 
-const USERNAME_UNAVAILABLE =
-  'This username is not available. Try another one.'
+const USERNAME_UNAVAILABLE = 'This username is not available. Try another one.'
 
 const GENERIC = 'Registration failed. Please try again.'
 

--- a/lib/auth/map-register-error.ts
+++ b/lib/auth/map-register-error.ts
@@ -1,0 +1,58 @@
+const DUPLICATE_ACCOUNT =
+  'An account with this email already exists. Try signing in, or use a different email.'
+
+const USERNAME_UNAVAILABLE =
+  'This username is not available. Try another one.'
+
+const GENERIC = 'Registration failed. Please try again.'
+
+/**
+ * Maps Convex Auth / network failures from sign-up into short user-facing copy.
+ * Avoids showing raw stack traces or `[CONVEX ...]` payloads in the UI.
+ */
+export function mapRegisterSignInError(error: unknown): string {
+  const raw = extractMessage(error)
+  const lower = raw.toLowerCase()
+
+  if (
+    lower.includes('already exists') ||
+    lower.includes('already registered') ||
+    /email.+?\b(in use|taken)\b/i.test(raw)
+  ) {
+    return DUPLICATE_ACCOUNT
+  }
+
+  if (
+    /\busername\b.+?\b(already|taken|in use|unavailable)\b/i.test(raw) ||
+    lower.includes('username is not available') ||
+    lower.includes('username not available')
+  ) {
+    return USERNAME_UNAVAILABLE
+  }
+
+  if (
+    lower.includes('[convex') ||
+    lower.includes('uncaught error') ||
+    lower.includes('server error') ||
+    lower.includes('request id:') ||
+    raw.includes('\n')
+  ) {
+    return GENERIC
+  }
+
+  if (raw.length > 0 && raw.length <= 200 && !looksLikeStackSnippet(raw)) {
+    return raw
+  }
+
+  return GENERIC
+}
+
+function extractMessage(error: unknown): string {
+  if (error instanceof Error) return error.message.trim()
+  if (typeof error === 'string') return error.trim()
+  return ''
+}
+
+function looksLikeStackSnippet(message: string): boolean {
+  return /\bat\s+[\w./$-]+:\d+/i.test(message)
+}


### PR DESCRIPTION
### Summary

- Switches login and register flows to `Button` and `Input` from `components/ui/` (no raw `<button>` / `<input>` for those controls). Shared `Input` exists at `components/ui/input.tsx`; no separate “add Input” follow-up.
- Maps Convex / duplicate-account style failures on register to short banner copy instead of exposing `[CONVEX …]` stack text (`lib/auth/map-register-error.ts` + Vitest).


<img width="1190" height="718" alt="email_1" src="https://github.com/user-attachments/assets/cd882ca3-ebcd-4d5c-952c-99858e301518" />

<img width="1192" height="717" alt="register_1" src="https://github.com/user-attachments/assets/2512c03f-36ce-4ade-9351-4937b2fe4d50" />



