### PR TITLE
feat(profile): paginate NFTs tab with URL params and loading transition

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -30,7 +30,18 @@ export default function ProfilePage({ params }: ProfilePageProps) {
   const [localWalletAddress, setLocalWalletAddress] = useState<
     string | null | undefined
   >()
-  const page = parseInt(searchParams?.get('page') || '1', 10)
+  const page = Math.max(
+    parseInt(searchParams?.get('page') || '1', 10) || 1,
+    1
+  )
+  const parsePositivePage = (raw: string | null) => {
+    const n = parseInt(raw || '1', 10)
+    return Number.isFinite(n) && n >= 1 ? n : 1
+  }
+  const nftOwnedPage = parsePositivePage(searchParams?.get('nftOwnedPage') ?? null)
+  const nftMintedPage = parsePositivePage(
+    searchParams?.get('nftMintedPage') ?? null
+  )
 
   // Fetch user profile
   const user = useUserByUsername(username)
@@ -169,6 +180,9 @@ export default function ProfilePage({ params }: ProfilePageProps) {
           {activeTab === 'nfts' && (
             <ProfileNftsTabContent
               userId={user._id}
+              username={username}
+              nftOwnedPage={nftOwnedPage}
+              nftMintedPage={nftMintedPage}
               isOwnProfile={isOwnProfile}
               displayName={user.name || user.username}
             />

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -30,15 +30,14 @@ export default function ProfilePage({ params }: ProfilePageProps) {
   const [localWalletAddress, setLocalWalletAddress] = useState<
     string | null | undefined
   >()
-  const page = Math.max(
-    parseInt(searchParams?.get('page') || '1', 10) || 1,
-    1
-  )
+  const page = Math.max(parseInt(searchParams?.get('page') || '1', 10) || 1, 1)
   const parsePositivePage = (raw: string | null) => {
     const n = parseInt(raw || '1', 10)
     return Number.isFinite(n) && n >= 1 ? n : 1
   }
-  const nftOwnedPage = parsePositivePage(searchParams?.get('nftOwnedPage') ?? null)
+  const nftOwnedPage = parsePositivePage(
+    searchParams?.get('nftOwnedPage') ?? null
+  )
   const nftMintedPage = parsePositivePage(
     searchParams?.get('nftMintedPage') ?? null
   )

--- a/components/articles/Pagination.test.tsx
+++ b/components/articles/Pagination.test.tsx
@@ -1,0 +1,29 @@
+/** @vitest-environment jsdom */
+import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import Pagination from '@/components/articles/Pagination'
+
+vi.mock('next/link', () => {
+  return {
+    default: (props: { href: string; children: ReactNode }) => (
+      <a href={props.href}>{props.children}</a>
+    ),
+  }
+})
+
+describe('Pagination getPageHref', () => {
+  it('uses getPageHref for links when basePath is omitted', () => {
+    const getPageHref = (page: number) => `/u?nftOwnedPage=${page}`
+    render(
+      <Pagination
+        currentPage={2}
+        totalPages={5}
+        getPageHref={getPageHref}
+      />
+    )
+
+    const next = screen.getByRole('link', { name: 'Next' })
+    expect(next).toHaveAttribute('href', '/u?nftOwnedPage=3')
+  })
+})

--- a/components/articles/Pagination.test.tsx
+++ b/components/articles/Pagination.test.tsx
@@ -16,11 +16,7 @@ describe('Pagination getPageHref', () => {
   it('uses getPageHref for links when basePath is omitted', () => {
     const getPageHref = (page: number) => `/u?nftOwnedPage=${page}`
     render(
-      <Pagination
-        currentPage={2}
-        totalPages={5}
-        getPageHref={getPageHref}
-      />
+      <Pagination currentPage={2} totalPages={5} getPageHref={getPageHref} />
     )
 
     const next = screen.getByRole('link', { name: 'Next' })

--- a/components/articles/Pagination.tsx
+++ b/components/articles/Pagination.tsx
@@ -8,6 +8,8 @@ interface PaginationProps {
   totalPages: number
   onPageChange?: (page: number) => void
   basePath?: string
+  /** When set, used for Link hrefs instead of `basePath` + `?page=`. */
+  getPageHref?: (page: number) => string
 }
 
 export default function Pagination({
@@ -15,6 +17,7 @@ export default function Pagination({
   totalPages,
   onPageChange,
   basePath,
+  getPageHref,
 }: PaginationProps) {
   const getPageNumbers = () => {
     const pages = []
@@ -68,6 +71,12 @@ export default function Pagination({
     return '#'
   }
 
+  const resolveLinkHref = (page: number) => {
+    if (getPageHref) return getPageHref(page)
+    if (basePath) return getPageUrl(page)
+    return null
+  }
+
   // Render button or link based on whether we have onPageChange or basePath
   const PaginationButton = ({
     page,
@@ -82,10 +91,11 @@ export default function Pagination({
     className: string
     ariaLabel: string
   }) => {
-    if (basePath && !disabled) {
+    const linkHref = !disabled ? resolveLinkHref(page) : null
+    if (linkHref !== null) {
       return (
         <Link
-          href={getPageUrl(page)}
+          href={linkHref}
           className={className}
           aria-label={ariaLabel}
         >

--- a/components/articles/Pagination.tsx
+++ b/components/articles/Pagination.tsx
@@ -94,11 +94,7 @@ export default function Pagination({
     const linkHref = !disabled ? resolveLinkHref(page) : null
     if (linkHref !== null) {
       return (
-        <Link
-          href={linkHref}
-          className={className}
-          aria-label={ariaLabel}
-        >
+        <Link href={linkHref} className={className} aria-label={ariaLabel}>
           {children}
         </Link>
       )

--- a/components/profile/PaginationTransition.tsx
+++ b/components/profile/PaginationTransition.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+
+export function PaginationTransition({
+  isPaginating,
+  children,
+}: {
+  isPaginating: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      aria-busy={isPaginating}
+      className={cn(
+        'transition-opacity duration-200',
+        isPaginating && 'animate-pulse opacity-70'
+      )}
+    >
+      {children}
+    </div>
+  )
+}

--- a/components/profile/ProfileArticlesTabContent.tsx
+++ b/components/profile/ProfileArticlesTabContent.tsx
@@ -57,8 +57,7 @@ export function ProfileArticlesTabContent({
     )
   }
 
-  const totalPages =
-    data.totalPages || Math.ceil(data.total / data.limit) || 0
+  const totalPages = data.totalPages || Math.ceil(data.total / data.limit) || 0
 
   return (
     <>

--- a/components/profile/ProfileArticlesTabContent.tsx
+++ b/components/profile/ProfileArticlesTabContent.tsx
@@ -1,10 +1,12 @@
 'use client'
 
 import { useListArticles } from '@/hooks/convex'
+import { usePaginationTransition } from '@/hooks/usePaginationTransition'
 import { mapListArticlesToDisplay } from '@/lib/articles/mapListArticleToDisplay'
 import ArticleGrid from '@/components/articles/ArticleGrid'
 import Pagination from '@/components/articles/Pagination'
 import { ArticleGridSkeleton } from '@/components/articles/ArticleCardSkeleton'
+import { PaginationTransition } from '@/components/profile/PaginationTransition'
 import { BookOpen } from 'lucide-react'
 import Link from 'next/link'
 
@@ -27,11 +29,13 @@ export function ProfileArticlesTabContent({
     limit: 9,
   })
 
-  if (articlesData === undefined) {
+  const { data, isPaginating } = usePaginationTransition(articlesData)
+
+  if (data === undefined) {
     return <ArticleGridSkeleton count={9} />
   }
 
-  const articles = mapListArticlesToDisplay(articlesData.articles)
+  const articles = mapListArticlesToDisplay(data.articles)
 
   if (articles.length === 0) {
     return (
@@ -54,13 +58,13 @@ export function ProfileArticlesTabContent({
   }
 
   const totalPages =
-    articlesData.totalPages ||
-    Math.ceil(articlesData.total / articlesData.limit) ||
-    0
+    data.totalPages || Math.ceil(data.total / data.limit) || 0
 
   return (
     <>
-      <ArticleGrid articles={articles} />
+      <PaginationTransition isPaginating={isPaginating}>
+        <ArticleGrid articles={articles} />
+      </PaginationTransition>
 
       {totalPages > 1 && (
         <div className="mt-12">
@@ -73,8 +77,8 @@ export function ProfileArticlesTabContent({
       )}
 
       <div className="mt-4 text-center text-sm text-muted-foreground">
-        Showing {(page - 1) * 9 + 1} - {Math.min(page * 9, articlesData.total)}{' '}
-        of {articlesData.total} articles
+        Showing {(page - 1) * 9 + 1} - {Math.min(page * 9, data.total)} of{' '}
+        {data.total} articles
       </div>
     </>
   )

--- a/components/profile/ProfileNftsTabContent.tsx
+++ b/components/profile/ProfileNftsTabContent.tsx
@@ -1,86 +1,196 @@
 'use client'
 
-import { useNFTsByOwner, useUserMintedNFTs } from '@/hooks/convex'
+import { useEffect, useState } from 'react'
+import { usePathname, useSearchParams } from 'next/navigation'
+import {
+  useNFTsByOwnerPaginated,
+  useUserMintedNFTsPaginated,
+} from '@/hooks/convex'
+import { usePaginationTransition } from '@/hooks/usePaginationTransition'
 import type { Id } from '@/types/convex'
 import { ProfileNftsTabSkeleton } from '@/components/profile/ProfileNftsTabSkeleton'
+import { PaginationTransition } from '@/components/profile/PaginationTransition'
+import Pagination from '@/components/articles/Pagination'
+import { buildProfileNftPaginationHref } from '@/lib/profile/buildProfileNftPaginationHref'
 import { Image, Trophy } from 'lucide-react'
+
+const NFT_PAGE_LIMIT = 9
 
 export function ProfileNftsTabContent({
   userId,
+  username,
+  nftOwnedPage,
+  nftMintedPage,
   isOwnProfile,
   displayName,
 }: {
   userId: Id<'users'>
+  username: string
+  nftOwnedPage: number
+  nftMintedPage: number
   isOwnProfile: boolean
   displayName: string
 }) {
-  const userNFTs = useNFTsByOwner(userId)
-  const mintedNFTs = useUserMintedNFTs(userId)
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const [hasInitiallyLoaded, setHasInitiallyLoaded] = useState(false)
 
-  if (userNFTs === undefined || mintedNFTs === undefined) {
+  const ownedRaw = useNFTsByOwnerPaginated({
+    ownerId: userId,
+    page: nftOwnedPage,
+    limit: NFT_PAGE_LIMIT,
+  })
+  const mintedRaw = useUserMintedNFTsPaginated({
+    userId,
+    page: nftMintedPage,
+    limit: NFT_PAGE_LIMIT,
+  })
+
+  const owned = usePaginationTransition(ownedRaw)
+  const minted = usePaginationTransition(mintedRaw)
+
+  useEffect(() => {
+    if (ownedRaw !== undefined && mintedRaw !== undefined) {
+      setHasInitiallyLoaded(true)
+    }
+  }, [ownedRaw, mintedRaw])
+
+  if (
+    !hasInitiallyLoaded &&
+    (ownedRaw === undefined || mintedRaw === undefined)
+  ) {
     return <ProfileNftsTabSkeleton />
   }
 
+  const ownedData = owned.data
+  const mintedData = minted.data
+
+  if (ownedData === undefined || mintedData === undefined) {
+    return <ProfileNftsTabSkeleton />
+  }
+
+  const ownedHref = (p: number) =>
+    buildProfileNftPaginationHref(
+      pathname || `/${username}`,
+      new URLSearchParams(searchParams?.toString() ?? ''),
+      'nftOwnedPage',
+      p
+    )
+  const mintedHref = (p: number) =>
+    buildProfileNftPaginationHref(
+      pathname || `/${username}`,
+      new URLSearchParams(searchParams?.toString() ?? ''),
+      'nftMintedPage',
+      p
+    )
+
+  const ownedNfts = ownedData.nfts
+  const mintedNfts = mintedData.nfts
+  const ownedTotalPages = ownedData.totalPages
+  const mintedTotalPages = mintedData.totalPages
+
+  const bothEmpty = ownedData.total === 0 && mintedData.total === 0
+
   return (
     <div className="space-y-8">
-      {userNFTs.length > 0 && (
+      {ownedData.total > 0 && (
         <div>
           <h3 className="text-xl font-semibold mb-4 flex items-center gap-2">
             <Trophy className="w-5 h-5 text-yellow-500" />
             Owned NFTs
           </h3>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {userNFTs.map((nft) => (
-              <div
-                key={nft._id}
-                className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-4"
-              >
-                <div className="aspect-video bg-gradient-to-br from-purple-400 to-pink-400 rounded-lg mb-4 flex items-center justify-center">
-                  <Image className="w-12 h-12 text-white" aria-label="NFT" />
+          <PaginationTransition isPaginating={owned.isPaginating}>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {ownedNfts.map((nft) => (
+                <div
+                  key={nft._id}
+                  className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-4"
+                >
+                  <div className="aspect-video bg-gradient-to-br from-purple-400 to-pink-400 rounded-lg mb-4 flex items-center justify-center">
+                    <Image className="w-12 h-12 text-white" aria-label="NFT" />
+                  </div>
+                  <h4 className="font-semibold text-foreground truncate">
+                    {nft.article?.title || 'Untitled'}
+                  </h4>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    Token ID: {nft.tokenId.slice(0, 8)}...
+                  </p>
+                  <p className="text-xs text-muted-foreground/80 mt-2">
+                    Minted by @{nft.minter?.username || 'unknown'}
+                  </p>
                 </div>
-                <h4 className="font-semibold text-foreground truncate">
-                  {nft.article?.title || 'Untitled'}
-                </h4>
-                <p className="text-sm text-muted-foreground mt-1">
-                  Token ID: {nft.tokenId.slice(0, 8)}...
-                </p>
-                <p className="text-xs text-muted-foreground/80 mt-2">
-                  Minted by @{nft.minter?.username || 'unknown'}
-                </p>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          </PaginationTransition>
+
+          {ownedTotalPages > 1 && (
+            <div className="mt-12">
+              <Pagination
+                currentPage={nftOwnedPage}
+                totalPages={ownedTotalPages}
+                getPageHref={ownedHref}
+              />
+            </div>
+          )}
+
+          {ownedTotalPages > 1 && (
+            <div className="mt-4 text-center text-sm text-muted-foreground">
+              Showing {(nftOwnedPage - 1) * NFT_PAGE_LIMIT + 1} -{' '}
+              {Math.min(nftOwnedPage * NFT_PAGE_LIMIT, ownedData.total)} of{' '}
+              {ownedData.total} NFTs
+            </div>
+          )}
         </div>
       )}
 
-      {mintedNFTs.length > 0 && (
+      {mintedData.total > 0 && (
         <div>
           <h3 className="text-xl font-semibold mb-4">Minted NFTs</h3>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {mintedNFTs.map((nft) => (
-              <div
-                key={nft._id}
-                className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-4"
-              >
-                <div className="aspect-video bg-gradient-to-br from-blue-400 to-green-400 rounded-lg mb-4 flex items-center justify-center">
-                  <Image className="w-12 h-12 text-white" aria-label="NFT" />
+          <PaginationTransition isPaginating={minted.isPaginating}>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {mintedNfts.map((nft) => (
+                <div
+                  key={nft._id}
+                  className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-4"
+                >
+                  <div className="aspect-video bg-gradient-to-br from-blue-400 to-green-400 rounded-lg mb-4 flex items-center justify-center">
+                    <Image className="w-12 h-12 text-white" aria-label="NFT" />
+                  </div>
+                  <h4 className="font-semibold text-foreground truncate">
+                    {nft.article?.title || 'Untitled'}
+                  </h4>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    Token ID: {nft.tokenId.slice(0, 8)}...
+                  </p>
+                  <p className="text-xs text-muted-foreground/80 mt-2">
+                    Owner: @{nft.currentOwnerInfo?.username || 'unknown'}
+                  </p>
                 </div>
-                <h4 className="font-semibold text-foreground truncate">
-                  {nft.article?.title || 'Untitled'}
-                </h4>
-                <p className="text-sm text-muted-foreground mt-1">
-                  Token ID: {nft.tokenId.slice(0, 8)}...
-                </p>
-                <p className="text-xs text-muted-foreground/80 mt-2">
-                  Owner: @{nft.currentOwnerInfo?.username || 'unknown'}
-                </p>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          </PaginationTransition>
+
+          {mintedTotalPages > 1 && (
+            <div className="mt-12">
+              <Pagination
+                currentPage={nftMintedPage}
+                totalPages={mintedTotalPages}
+                getPageHref={mintedHref}
+              />
+            </div>
+          )}
+
+          {mintedTotalPages > 1 && (
+            <div className="mt-4 text-center text-sm text-muted-foreground">
+              Showing {(nftMintedPage - 1) * NFT_PAGE_LIMIT + 1} -{' '}
+              {Math.min(nftMintedPage * NFT_PAGE_LIMIT, mintedData.total)} of{' '}
+              {mintedData.total} NFTs
+            </div>
+          )}
         </div>
       )}
 
-      {userNFTs.length === 0 && mintedNFTs.length === 0 && (
+      {bothEmpty && (
         <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-12 text-center">
           <Image
             className="w-12 h-12 text-muted-foreground/50 mx-auto mb-4"

--- a/convex/nfts.ts
+++ b/convex/nfts.ts
@@ -46,6 +46,62 @@ export const getNFTsByOwner = query({
   },
 })
 
+export const getNFTsByOwnerPaginated = query({
+  args: {
+    ownerId: v.id('users'),
+    page: v.optional(v.number()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const page = Math.max(args.page ?? 1, 1)
+    const limit = Math.min(Math.max(args.limit ?? 9, 1), 50)
+    const offset = (page - 1) * limit
+
+    const rows = await ctx.db
+      .query('articleNFTs')
+      .withIndex('by_current_owner', (q) =>
+        q.eq('currentOwner', args.ownerId)
+      )
+      .collect()
+
+    rows.sort((a, b) => b.mintedAt - a.mintedAt)
+    const total = rows.length
+    const slice = rows.slice(offset, offset + limit)
+
+    const nfts = await Promise.all(
+      slice.map(async (nft) => {
+        const [article, minter] = await Promise.all([
+          ctx.db.get(nft.articleId),
+          enrichWithUser(ctx, nft.mintedBy),
+        ])
+
+        return {
+          ...nft,
+          article: article
+            ? {
+                id: article._id,
+                title: article.title,
+                slug: article.slug,
+                excerpt: article.excerpt,
+                coverImage: article.coverImage,
+                authorUsername: article.authorUsername,
+              }
+            : null,
+          minter,
+        }
+      })
+    )
+
+    return {
+      nfts,
+      total,
+      page,
+      limit,
+      totalPages: total === 0 ? 0 : Math.ceil(total / limit),
+    }
+  },
+})
+
 // Get NFT by article
 export const getNFTByArticle = query({
   args: {
@@ -386,6 +442,60 @@ export const getUserMintedNFTs = query({
     )
 
     return enrichedNfts
+  },
+})
+
+export const getUserMintedNFTsPaginated = query({
+  args: {
+    userId: v.id('users'),
+    page: v.optional(v.number()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const page = Math.max(args.page ?? 1, 1)
+    const limit = Math.min(Math.max(args.limit ?? 9, 1), 50)
+    const offset = (page - 1) * limit
+
+    const rows = await ctx.db
+      .query('articleNFTs')
+      .withIndex('by_minted_by', (q) =>
+        q.eq('mintedBy', args.userId)
+      )
+      .collect()
+
+    rows.sort((a, b) => b.mintedAt - a.mintedAt)
+    const total = rows.length
+    const slice = rows.slice(offset, offset + limit)
+
+    const nfts = await Promise.all(
+      slice.map(async (nft) => {
+        const [article, currentOwnerInfo] = await Promise.all([
+          ctx.db.get(nft.articleId),
+          enrichWithUser(ctx, nft.currentOwner),
+        ])
+
+        return {
+          ...nft,
+          article: article
+            ? {
+                id: article._id,
+                title: article.title,
+                slug: article.slug,
+                authorUsername: article.authorUsername,
+              }
+            : null,
+          currentOwnerInfo,
+        }
+      })
+    )
+
+    return {
+      nfts,
+      total,
+      page,
+      limit,
+      totalPages: total === 0 ? 0 : Math.ceil(total / limit),
+    }
   },
 })
 

--- a/convex/nfts.ts
+++ b/convex/nfts.ts
@@ -59,9 +59,7 @@ export const getNFTsByOwnerPaginated = query({
 
     const rows = await ctx.db
       .query('articleNFTs')
-      .withIndex('by_current_owner', (q) =>
-        q.eq('currentOwner', args.ownerId)
-      )
+      .withIndex('by_current_owner', (q) => q.eq('currentOwner', args.ownerId))
       .collect()
 
     rows.sort((a, b) => b.mintedAt - a.mintedAt)
@@ -458,9 +456,7 @@ export const getUserMintedNFTsPaginated = query({
 
     const rows = await ctx.db
       .query('articleNFTs')
-      .withIndex('by_minted_by', (q) =>
-        q.eq('mintedBy', args.userId)
-      )
+      .withIndex('by_minted_by', (q) => q.eq('mintedBy', args.userId))
       .collect()
 
     rows.sort((a, b) => b.mintedAt - a.mintedAt)

--- a/hooks/convex/index.ts
+++ b/hooks/convex/index.ts
@@ -14,7 +14,11 @@ export {
 export {
   useNFTByArticle,
   useNFTsByOwner,
+  useNFTsByOwnerPaginated,
   useUserMintedNFTs,
+  useUserMintedNFTsPaginated,
+  type NFTsByOwnerPaginatedArgs,
+  type UserMintedNFTsPaginatedArgs,
 } from './useNftsQueries'
 export {
   useArticleHighlightsQuery,

--- a/hooks/convex/useNftsQueries.ts
+++ b/hooks/convex/useNftsQueries.ts
@@ -13,3 +13,33 @@ export function useNFTsByOwner(ownerId: Id<'users'> | undefined) {
 export function useUserMintedNFTs(userId: Id<'users'> | undefined) {
   return useQuery(api.nfts.getUserMintedNFTs, userId ? { userId } : 'skip')
 }
+
+export type NFTsByOwnerPaginatedArgs = {
+  ownerId: Id<'users'>
+  page?: number
+  limit?: number
+}
+
+export function useNFTsByOwnerPaginated(
+  args: NFTsByOwnerPaginatedArgs | 'skip'
+) {
+  return useQuery(
+    api.nfts.getNFTsByOwnerPaginated,
+    args === 'skip' ? 'skip' : args
+  )
+}
+
+export type UserMintedNFTsPaginatedArgs = {
+  userId: Id<'users'>
+  page?: number
+  limit?: number
+}
+
+export function useUserMintedNFTsPaginated(
+  args: UserMintedNFTsPaginatedArgs | 'skip'
+) {
+  return useQuery(
+    api.nfts.getUserMintedNFTsPaginated,
+    args === 'skip' ? 'skip' : args
+  )
+}

--- a/hooks/usePaginationTransition.test.ts
+++ b/hooks/usePaginationTransition.test.ts
@@ -1,0 +1,58 @@
+/** @vitest-environment jsdom */
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { usePaginationTransition } from './usePaginationTransition'
+
+describe('usePaginationTransition', () => {
+  it('reports no data and not paginating on first render with undefined', () => {
+    const { result } = renderHook(() =>
+      usePaginationTransition<string>(undefined)
+    )
+
+    expect(result.current.data).toBeUndefined()
+    expect(result.current.isPaginating).toBe(false)
+  })
+
+  it('returns the resolved value with isPaginating=false', () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string | undefined }) =>
+        usePaginationTransition(value),
+      { initialProps: { value: undefined as string | undefined } }
+    )
+
+    rerender({ value: 'page-1' })
+
+    expect(result.current.data).toBe('page-1')
+    expect(result.current.isPaginating).toBe(false)
+  })
+
+  it('keeps the previous value and flips isPaginating when current goes back to undefined', () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string | undefined }) =>
+        usePaginationTransition(value),
+      { initialProps: { value: 'page-1' as string | undefined } }
+    )
+
+    rerender({ value: undefined })
+
+    expect(result.current.data).toBe('page-1')
+    expect(result.current.isPaginating).toBe(true)
+  })
+
+  it('updates to the new value and clears isPaginating once the new query resolves', () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string | undefined }) =>
+        usePaginationTransition(value),
+      { initialProps: { value: 'page-1' as string | undefined } }
+    )
+
+    rerender({ value: undefined })
+    expect(result.current.data).toBe('page-1')
+    expect(result.current.isPaginating).toBe(true)
+
+    rerender({ value: 'page-2' })
+
+    expect(result.current.data).toBe('page-2')
+    expect(result.current.isPaginating).toBe(false)
+  })
+})

--- a/hooks/usePaginationTransition.ts
+++ b/hooks/usePaginationTransition.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Keeps the previously resolved value visible while a new query is in flight.
+ *
+ * When `current` is `undefined` (e.g. a Convex `useQuery` re-fetching after
+ * args change) but a prior value exists, this returns the prior value and
+ * sets `isPaginating` so callers can dim/pulse the stale content. Once
+ * `current` resolves to a defined value, `isPaginating` flips back to false.
+ */
+export function usePaginationTransition<T>(current: T | undefined): {
+  data: T | undefined
+  isPaginating: boolean
+} {
+  const [previous, setPrevious] = useState<T | undefined>(current)
+
+  useEffect(() => {
+    if (current !== undefined) setPrevious(current)
+  }, [current])
+
+  return {
+    data: current ?? previous,
+    isPaginating: current === undefined && previous !== undefined,
+  }
+}

--- a/lib/profile/buildProfileNftPaginationHref.test.ts
+++ b/lib/profile/buildProfileNftPaginationHref.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { buildProfileNftPaginationHref } from './buildProfileNftPaginationHref'
+
+describe('buildProfileNftPaginationHref', () => {
+  it('sets nftOwnedPage and preserves other params', () => {
+    const sp = new URLSearchParams('page=2&nftMintedPage=3')
+    expect(buildProfileNftPaginationHref('/alice', sp, 'nftOwnedPage', 2)).toBe(
+      '/alice?page=2&nftMintedPage=3&nftOwnedPage=2'
+    )
+  })
+
+  it('removes nftOwnedPage when page is 1', () => {
+    const sp = new URLSearchParams('nftOwnedPage=2&nftMintedPage=3')
+    expect(buildProfileNftPaginationHref('/alice', sp, 'nftOwnedPage', 1)).toBe(
+      '/alice?nftMintedPage=3'
+    )
+  })
+
+  it('returns pathname only when no query remains', () => {
+    const sp = new URLSearchParams('nftOwnedPage=2')
+    expect(buildProfileNftPaginationHref('/bob', sp, 'nftOwnedPage', 1)).toBe(
+      '/bob'
+    )
+  })
+
+  it('updates nftMintedPage without dropping nftOwnedPage', () => {
+    const sp = new URLSearchParams('nftOwnedPage=2&nftMintedPage=1')
+    expect(buildProfileNftPaginationHref('/bob', sp, 'nftMintedPage', 4)).toBe(
+      '/bob?nftOwnedPage=2&nftMintedPage=4'
+    )
+  })
+})

--- a/lib/profile/buildProfileNftPaginationHref.ts
+++ b/lib/profile/buildProfileNftPaginationHref.ts
@@ -1,0 +1,15 @@
+/**
+ * Builds profile URL with one NFT page param updated, preserving other query keys.
+ */
+export function buildProfileNftPaginationHref(
+  pathname: string,
+  searchParams: URLSearchParams,
+  key: 'nftOwnedPage' | 'nftMintedPage',
+  page: number
+): string {
+  const next = new URLSearchParams(searchParams.toString())
+  if (page <= 1) next.delete(key)
+  else next.set(key, String(page))
+  const qs = next.toString()
+  return qs ? `${pathname}?${qs}` : pathname
+}


### PR DESCRIPTION
## Summary

Closes ENG-106 for the profile **NFTs** tab: URL-backed pagination for owned and minted lists, with the same dim/pulse behavior as the articles tab while the next Convex result loads. Pagination controls stay outside the transitioning grid so they remain usable.

## Changes

- **Convex**: `getNFTsByOwnerPaginated` and `getUserMintedNFTsPaginated` — sort by `mintedAt` desc, slice by `page`/`limit`, enrich only the current page; return `{ nfts, total, page, limit, totalPages }`. Existing non-paginated queries unchanged.
- **Hooks**: `useNFTsByOwnerPaginated`, `useUserMintedNFTsPaginated`.
- **Pagination**: optional `getPageHref(page)` for links when query strings must be merged (e.g. keep `page` for articles and sibling NFT page).
- **Profile**: read `nftOwnedPage` and `nftMintedPage` (default 1, `>= 1`); pass into `ProfileNftsTabContent` with `username`.
- **UI**: `ProfileNftsTabContent` uses `usePaginationTransition` + `PaginationTransition` per section; skeleton until both lists have loaded once; `buildProfileNftPaginationHref` preserves other search params.
- **Tests**: `buildProfileNftPaginationHref` unit tests; `Pagination` test for `getPageHref`.

<img width="1196" height="720" alt="aria" src="https://github.com/user-attachments/assets/13d8b1e0-40ff-445f-b26e-50c6e80b3f06" />
<img width="1194" height="723" alt="pag" src="https://github.com/user-attachments/assets/6011274c-46e9-46b2-89df-16cc730f2259" />
<img width="1198" height="719" alt="prof_pag" src="https://github.com/user-attachments/assets/b9324b5d-d70
3-4c44-9d37-1e4adff9af7e" />

