### PR TITLE
fix(landing): viewport-safe mega-menu and theme-aligned nav (ENG-107)

### DIFF
--- a/components/landing/Navigation.tsx
+++ b/components/landing/Navigation.tsx
@@ -310,15 +310,9 @@ export default function Navigation() {
                         animate={{ opacity: 1, y: 0 }}
                         exit={{ opacity: 0, y: 8 }}
                         transition={{ duration: 0.18, ease: 'easeOut' }}
-                        className="absolute top-[calc(100%+8px)] right-0 w-[560px] bg-popover text-popover-foreground rounded-2xl shadow-xl border border-border"
-                        style={{
-                          transform:
-                            dropdown.label === 'Product'
-                              ? 'translateX(10%)'
-                              : 'translateX(30%)',
-                        }}
+                        className="absolute top-[calc(100%+8px)] right-0 w-[min(560px,calc(100vw-2rem))] bg-popover text-popover-foreground rounded-2xl shadow-xl border border-border"
                       >
-                        <div className="flex">
+                        <div className="flex min-w-0">
                           {/* Featured card */}
                           <Link
                             href={dropdown.featured.href}


### PR DESCRIPTION
## Summary

Updates the logged-out landing `Navigation` so the Product/Resources mega-menu stays within the viewport on narrow laptops (ENG-107), aligns styling with design tokens and dark mode, and improves desktop/mobile behavior without Radix.

## ENG-107

- Cap mega-menu width with `w-[min(560px,calc(100vw-2rem))]` so it respects the viewport with ~1rem margin each side.
- Remove fixed `translateX` offsets on the panel that could fight real layouts.
- Keep the existing two-column + featured layout at wider widths where `min()` resolves to `560px`.

## Other changes

- Migrate dropdown motion imports from `framer-motion` to `motion/react`.
- Restyle nav, mega-menu, and mobile drawer using semantic tokens (`background`, `foreground`, `muted`, `border`, `popover`, `brand`, `success`) instead of hard-coded neutrals.
- Add `ThemeToggle` to the desktop nav cluster.
- Mega triggers: `type="button"`, `aria-expanded` / `aria-haspopup`, keyboard support (Enter/Space), click toggle alongside hover, Escape closes an open desktop dropdown.
- Featured “Learn more” and CTA use `ArrowRight` icon; `min-w-0` on the mega inner flex to avoid overflow issues.
- Mobile: `aria-expanded` on the menu button, `focus-ring` and token-based link styles, full-width primary CTA with icon.

