### PR TITLE
fix(dashboard): show relative tip times with absolute date on hover (ENG-108)

### DIFF
--- a/components/dashboard/TipHistory.test.tsx
+++ b/components/dashboard/TipHistory.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   TipHistory,
   type ReceivedTipRow,
@@ -27,6 +27,10 @@ function makeTip(overrides: Partial<ReceivedTipRow>): ReceivedTipRow {
 }
 
 describe('TipHistory', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('renders nothing when tips are empty or undefined', () => {
     const { container: a } = render(<TipHistory tips={undefined} />)
     expect(a.firstChild).toBeNull()
@@ -34,7 +38,7 @@ describe('TipHistory', () => {
     expect(b.firstChild).toBeNull()
   })
 
-  it('shows tipper, article title, amount, and formatted date', () => {
+  it('shows tipper, article title, amount, and relative tip time', () => {
     const tips = [
       makeTip({
         _id: 'a1' as Id<'tips'>,
@@ -57,5 +61,24 @@ describe('TipHistory', () => {
     const tips = [makeTip({ tipper: null })]
     render(<TipHistory tips={tips} />)
     expect(screen.getByText('Anonymous')).toBeInTheDocument()
+  })
+
+  it('shows relative time with absolute date on title and aria-label', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-05T12:00:00Z'))
+    const createdAt = new Date('2026-05-03T12:00:00Z').getTime()
+    const tipDate = new Date(createdAt)
+    const absolute = tipDate.toLocaleDateString('en-US', { dateStyle: 'long' })
+
+    render(<TipHistory tips={[makeTip({ createdAt })]} />)
+
+    const timeEl = screen.getByText('2 days ago')
+    expect(timeEl.tagName).toBe('TIME')
+    expect(timeEl).toHaveAttribute('dateTime', tipDate.toISOString())
+    expect(timeEl).toHaveAttribute('title', absolute)
+    expect(timeEl).toHaveAttribute(
+      'aria-label',
+      `2 days ago. ${absolute}.`
+    )
   })
 })

--- a/components/dashboard/TipHistory.test.tsx
+++ b/components/dashboard/TipHistory.test.tsx
@@ -76,9 +76,6 @@ describe('TipHistory', () => {
     expect(timeEl.tagName).toBe('TIME')
     expect(timeEl).toHaveAttribute('dateTime', tipDate.toISOString())
     expect(timeEl).toHaveAttribute('title', absolute)
-    expect(timeEl).toHaveAttribute(
-      'aria-label',
-      `2 days ago. ${absolute}.`
-    )
+    expect(timeEl).toHaveAttribute('aria-label', `2 days ago. ${absolute}.`)
   })
 })

--- a/components/dashboard/TipHistory.tsx
+++ b/components/dashboard/TipHistory.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { formatDistanceToNow } from 'date-fns'
 import type { Doc } from '@/types/convex'
 
 export type ReceivedTipRow = Doc<'tips'> & {
@@ -22,28 +23,42 @@ export function TipHistory({ tips }: TipHistoryProps) {
         <h3 className="text-lg font-semibold">Recent Tips</h3>
       </div>
       <div className="divide-y divide-border">
-        {tips.slice(0, 10).map((tip) => (
-          <div key={tip._id} className="p-4 hover:bg-muted/50">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="font-medium text-foreground">
-                  {tip.tipper?.name || tip.tipper?.username || 'Anonymous'}
-                </p>
-                <p className="text-sm text-muted-foreground">
-                  tipped on &ldquo;{tip.articleTitle}&rdquo;
-                </p>
-              </div>
-              <div className="text-right">
-                <p className="font-semibold text-success-foreground">
-                  +${tip.amountUsd.toFixed(2)}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {new Date(tip.createdAt).toLocaleDateString()}
-                </p>
+        {tips.slice(0, 10).map((tip) => {
+          const tipDate = new Date(tip.createdAt)
+          const relative = formatDistanceToNow(tipDate, { addSuffix: true })
+          const absolute = tipDate.toLocaleDateString('en-US', {
+            dateStyle: 'long',
+          })
+          const a11yLabel = `${relative}. ${absolute}.`
+
+          return (
+            <div key={tip._id} className="p-4 hover:bg-muted/50">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="font-medium text-foreground">
+                    {tip.tipper?.name || tip.tipper?.username || 'Anonymous'}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    tipped on &ldquo;{tip.articleTitle}&rdquo;
+                  </p>
+                </div>
+                <div className="text-right">
+                  <p className="font-semibold text-success-foreground">
+                    +${tip.amountUsd.toFixed(2)}
+                  </p>
+                  <time
+                    dateTime={tipDate.toISOString()}
+                    title={absolute}
+                    aria-label={a11yLabel}
+                    className="text-xs text-muted-foreground"
+                  >
+                    {relative}
+                  </time>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Recent tip rows on the Earnings dashboard showed locale-dependent absolute dates (e.g. `4/23/2026`). They now show relative text via `date-fns` `formatDistanceToNow` for quicker scanning, while keeping the full calendar date available for hover and assistive technology.

## Changes

- `TipHistory`: render tip time with `formatDistanceToNow(..., { addSuffix: true })`.
- Wrap the timestamp in `<time dateTime={ISO}>`; set `title` to a long `en-US` absolute date; set `aria-label` to relative plus absolute so screen readers get both.
- Extend `TipHistory` tests with fake timers and assertions for relative text, `dateTime`, `title`, and `aria-label`.

<img width="1192" height="717" alt="1" src="https://github.com/user-attachments/assets/8b15507f-8ce4-4bbe-aa1a-0056799c3fe1" />
<img width="1194" height="721" alt="2" src="https://github.com/user-attachments/assets/2760895f-4cd2-4a60-a472-640956974c0a" />
<img width="1194" height="719" alt="3" src="https://github.com/user-attachments/assets/b7a6d850-ef97-4d5b-96c1-063b94539707" />
<img width="1440" height="900" alt="hov" src="https://github.com/user-attachments/assets/d86d5e9e-c23f-4584-90e6-561b12a8bdaa" />
