### PR TITLE
fix(dashboard): show tip history empty state

### DIFF
--- a/components/dashboard/TipHistory.test.tsx
+++ b/components/dashboard/TipHistory.test.tsx
@@ -33,13 +33,17 @@ describe('TipHistory', () => {
 
   it('shows empty state when tips are empty or undefined', () => {
     const { unmount, container } = render(<TipHistory tips={undefined} />)
-    expect(screen.getByRole('heading', { name: 'Recent Tips' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Recent Tips' })
+    ).toBeInTheDocument()
     expect(screen.getByText('No tips yet')).toBeInTheDocument()
     expect(container.firstChild).not.toBeNull()
     unmount()
 
     render(<TipHistory tips={[]} />)
-    expect(screen.getByRole('heading', { name: 'Recent Tips' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Recent Tips' })
+    ).toBeInTheDocument()
     expect(screen.getByText('No tips yet')).toBeInTheDocument()
   })
 

--- a/components/dashboard/TipHistory.test.tsx
+++ b/components/dashboard/TipHistory.test.tsx
@@ -31,11 +31,16 @@ describe('TipHistory', () => {
     vi.useRealTimers()
   })
 
-  it('renders nothing when tips are empty or undefined', () => {
-    const { container: a } = render(<TipHistory tips={undefined} />)
-    expect(a.firstChild).toBeNull()
-    const { container: b } = render(<TipHistory tips={[]} />)
-    expect(b.firstChild).toBeNull()
+  it('shows empty state when tips are empty or undefined', () => {
+    const { unmount, container } = render(<TipHistory tips={undefined} />)
+    expect(screen.getByRole('heading', { name: 'Recent Tips' })).toBeInTheDocument()
+    expect(screen.getByText('No tips yet')).toBeInTheDocument()
+    expect(container.firstChild).not.toBeNull()
+    unmount()
+
+    render(<TipHistory tips={[]} />)
+    expect(screen.getByRole('heading', { name: 'Recent Tips' })).toBeInTheDocument()
+    expect(screen.getByText('No tips yet')).toBeInTheDocument()
   })
 
   it('shows tipper, article title, amount, and relative tip time', () => {

--- a/components/dashboard/TipHistory.tsx
+++ b/components/dashboard/TipHistory.tsx
@@ -13,53 +13,60 @@ type TipHistoryProps = {
 }
 
 export function TipHistory({ tips }: TipHistoryProps) {
-  if (!tips || tips.length === 0) {
-    return null
-  }
+  const list = tips?.length ? tips : null
 
   return (
     <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border">
       <div className="p-6 border-b border-border">
         <h3 className="text-lg font-semibold">Recent Tips</h3>
       </div>
-      <div className="divide-y divide-border">
-        {tips.slice(0, 10).map((tip) => {
-          const tipDate = new Date(tip.createdAt)
-          const relative = formatDistanceToNow(tipDate, { addSuffix: true })
-          const absolute = tipDate.toLocaleDateString('en-US', {
-            dateStyle: 'long',
-          })
-          const a11yLabel = `${relative}. ${absolute}.`
+      {list ? (
+        <div className="divide-y divide-border">
+          {list.slice(0, 10).map((tip) => {
+            const tipDate = new Date(tip.createdAt)
+            const relative = formatDistanceToNow(tipDate, { addSuffix: true })
+            const absolute = tipDate.toLocaleDateString('en-US', {
+              dateStyle: 'long',
+            })
+            const a11yLabel = `${relative}. ${absolute}.`
 
-          return (
-            <div key={tip._id} className="p-4 hover:bg-muted/50">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="font-medium text-foreground">
-                    {tip.tipper?.name || tip.tipper?.username || 'Anonymous'}
-                  </p>
-                  <p className="text-sm text-muted-foreground">
-                    tipped on &ldquo;{tip.articleTitle}&rdquo;
-                  </p>
-                </div>
-                <div className="text-right">
-                  <p className="font-semibold text-success-foreground">
-                    +${tip.amountUsd.toFixed(2)}
-                  </p>
-                  <time
-                    dateTime={tipDate.toISOString()}
-                    title={absolute}
-                    aria-label={a11yLabel}
-                    className="text-xs text-muted-foreground"
-                  >
-                    {relative}
-                  </time>
+            return (
+              <div key={tip._id} className="p-4 hover:bg-muted/50">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium text-foreground">
+                      {tip.tipper?.name || tip.tipper?.username || 'Anonymous'}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      tipped on &ldquo;{tip.articleTitle}&rdquo;
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    <p className="font-semibold text-success-foreground">
+                      +${tip.amountUsd.toFixed(2)}
+                    </p>
+                    <time
+                      dateTime={tipDate.toISOString()}
+                      title={absolute}
+                      aria-label={a11yLabel}
+                      className="text-xs text-muted-foreground"
+                    >
+                      {relative}
+                    </time>
+                  </div>
                 </div>
               </div>
-            </div>
-          )
-        })}
-      </div>
+            )
+          })}
+        </div>
+      ) : (
+        <div className="flex min-h-[12rem] flex-col items-center justify-center gap-2 px-6 py-10 text-center">
+          <p className="font-medium text-foreground">No tips yet</p>
+          <p className="max-w-sm text-sm text-muted-foreground">
+            When readers tip your work, they will show up here.
+          </p>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Always render the Tip History card on the earnings dashboard (prevents a layout gap when there are no tips).
- When there are zero tips, show an empty state message: "No tips yet" (plus a short helper line).
- Add a minimum height to the empty state so the card height stays close to the populated state.
<img width="1192" height="721" alt="rows" src="https://github.com/user-attachments/assets/7c353513-4d19-447f-949d-f508d4c410a8" />
<img width="1192" height="721" alt="no_tip" src="https://github.com/user-attachments/assets/3655661c-2c37-4a2a-b64e-3aea5e17a929" />

<img width="1190" height="718" alt="1_row" src="https://github.com/user-attachments/assets/c4d7266e-1733-4bc2-a426-2e737feb0801" />
