### PR TITLE
fix: show TipStats skeleton while loading

### DIFF
--- a/components/tipping/TipStats.tsx
+++ b/components/tipping/TipStats.tsx
@@ -2,6 +2,7 @@
 
 import { useArticleTipStats } from '@/hooks/convex'
 import type { Id } from '@/types/convex'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Coins, Users } from 'lucide-react'
 
 interface TipStatsProps {
@@ -12,9 +13,24 @@ interface TipStatsProps {
 export function TipStats({ articleId, className = '' }: TipStatsProps) {
   const stats = useArticleTipStats(articleId)
 
-  // Don't show anything while loading
   if (stats === undefined) {
-    return null
+    return (
+      <div
+        className={`flex items-center gap-4 text-sm text-muted-foreground ${className}`}
+        aria-hidden
+      >
+        <div className="flex items-center gap-1">
+          <Skeleton className="h-4 w-4 rounded" />
+          <Skeleton className="h-4 w-14" />
+          <Skeleton className="h-4 w-12" />
+        </div>
+        <div className="flex items-center gap-1">
+          <Skeleton className="h-4 w-4 rounded" />
+          <Skeleton className="h-4 w-6" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+      </div>
+    )
   }
 
   return (


### PR DESCRIPTION
## Summary
The tip stats block briefly rendered empty on first paint because `TipStats` returned `null` while the Convex query was unresolved (`stats === undefined`). This PR replaces that empty flash with the existing `Skeleton` (`animate-pulse`) placeholder, sized to match the loaded layout to avoid layout shift. Loaded state visuals are unchanged.
<img width="1440" height="900" alt="skel" src="https://github.com/user-attachments/assets/76ec4d01-5d00-4241-a58d-a71ad970a508" />
