### PR TITLE
feat: add 7d/30d filters to highlight heatmap

### DIFF
--- a/components/articles/HighlightableArticle.tsx
+++ b/components/articles/HighlightableArticle.tsx
@@ -188,12 +188,15 @@ export function HighlightableArticle({
         if (domSelection && domSelection.rangeCount > 0) {
           const range = domSelection.getRangeAt(0)
           const rect = range.getBoundingClientRect()
+          const containerRect = editorRef.current?.getBoundingClientRect()
 
           setSelectedText({ text, from, to })
-          setPopoverPosition({
-            top: rect.top + window.scrollY - 60,
-            left: rect.left + rect.width / 2,
-          })
+          if (containerRect) {
+            setPopoverPosition({
+              top: rect.top - containerRect.top - 60,
+              left: rect.left - containerRect.left + rect.width / 2,
+            })
+          }
         }
       } else {
         setSelectedText(null)
@@ -244,10 +247,12 @@ export function HighlightableArticle({
         if (!domSelection || domSelection.rangeCount === 0) return
         const range = domSelection.getRangeAt(0)
         const rect = range.getBoundingClientRect()
+        const containerRect = editorRef.current?.getBoundingClientRect()
+        if (!containerRect) return
         setSelectedText({ text, from, to })
         setPopoverPosition({
-          top: rect.top + window.scrollY - 60,
-          left: rect.left + rect.width / 2,
+          top: rect.top - containerRect.top - 60,
+          left: rect.left - containerRect.left + rect.width / 2,
         })
       }, 0)
     }

--- a/components/highlights/HighlightHeatmap.tsx
+++ b/components/highlights/HighlightHeatmap.tsx
@@ -5,6 +5,7 @@ import type { Id } from '@/types/convex'
 import { getHeatmapColor, formatTipAmount } from '@/lib/stellar/highlight-utils'
 import { Flame, TrendingUp, Sparkles } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useMemo, useState } from 'react'
 
 interface HighlightHeatmapProps {
   articleId: Id<'articles'>
@@ -12,13 +13,24 @@ interface HighlightHeatmapProps {
   className?: string
 }
 
+type HeatmapWindow = 'all' | '7d' | '30d'
+
 export function HighlightHeatmap({
   articleId,
   isAuthor = false,
   className,
 }: HighlightHeatmapProps) {
+  const [window, setWindow] = useState<HeatmapWindow>('all')
+
+  const sinceMs = useMemo(() => {
+    const dayMs = 24 * 60 * 60 * 1000
+    if (window === '7d') return Date.now() - 7 * dayMs
+    if (window === '30d') return Date.now() - 30 * dayMs
+    return undefined
+  }, [window])
+
   // Fetch highlight tip stats for this article
-  const stats = useArticleHighlightTipStats(articleId)
+  const stats = useArticleHighlightTipStats(articleId, { sinceMs })
 
   // Loading state
   if (stats === undefined) {
@@ -30,12 +42,15 @@ export function HighlightHeatmap({
         )}
       >
         <div className="animate-pulse space-y-4">
-          <div className="h-6 bg-muted rounded w-1/2"></div>
+          <div className="h-6 bg-muted rounded w-1/2" />
           <div className="h-20 bg-muted rounded"></div>
         </div>
       </div>
     )
   }
+
+  const windowLabel =
+    window === '7d' ? '7 days' : window === '30d' ? '30 days' : 'all time'
 
   // Empty state - No tips yet
   if (!stats || stats.totalTips === 0) {
@@ -46,17 +61,62 @@ export function HighlightHeatmap({
           className
         )}
       >
-        <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-          <Flame className="w-5 h-5 text-orange-500" />
-          Highlight Heatmap
-        </h3>
+        <div className="flex items-center justify-between gap-3 mb-4">
+          <h3 className="text-lg font-semibold flex items-center gap-2">
+            <Flame className="w-5 h-5 text-orange-500" />
+            Highlight Heatmap
+          </h3>
+
+          <div className="flex items-center rounded-md border border-border overflow-hidden bg-muted/40">
+            <button
+              type="button"
+              onClick={() => setWindow('all')}
+              className={cn(
+                'px-2.5 py-1 text-xs font-medium transition-colors',
+                window === 'all'
+                  ? 'bg-background text-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              All
+            </button>
+            <div className="w-px self-stretch bg-border" />
+            <button
+              type="button"
+              onClick={() => setWindow('7d')}
+              className={cn(
+                'px-2.5 py-1 text-xs font-medium transition-colors',
+                window === '7d'
+                  ? 'bg-background text-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              7d
+            </button>
+            <div className="w-px self-stretch bg-border" />
+            <button
+              type="button"
+              onClick={() => setWindow('30d')}
+              className={cn(
+                'px-2.5 py-1 text-xs font-medium transition-colors',
+                window === '30d'
+                  ? 'bg-background text-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              30d
+            </button>
+          </div>
+        </div>
 
         <div className="text-center py-8">
           <Sparkles className="w-12 h-12 mx-auto text-muted-foreground mb-3" />
           <p className="text-muted-foreground text-sm mb-2">
-            {isAuthor
-              ? 'No highlight tips yet'
-              : 'Be the first to tip a highlight!'}
+            {window === 'all'
+              ? isAuthor
+                ? 'No highlight tips yet'
+                : 'Be the first to tip a highlight!'
+              : `No highlight tips in the last ${windowLabel}`}
           </p>
           <p className="text-foreground/85 text-xs">
             {isAuthor
@@ -90,10 +150,53 @@ export function HighlightHeatmap({
         className
       )}
     >
-      <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-        <Flame className="w-5 h-5 text-orange-500" />
-        Highlight Heatmap
-      </h3>
+      <div className="flex items-center justify-between gap-3 mb-4">
+        <h3 className="text-lg font-semibold flex items-center gap-2">
+          <Flame className="w-5 h-5 text-orange-500" />
+          Highlight Heatmap
+        </h3>
+
+        <div className="flex items-center rounded-md border border-border overflow-hidden bg-muted/40">
+          <button
+            type="button"
+            onClick={() => setWindow('all')}
+            className={cn(
+              'px-2.5 py-1 text-xs font-medium transition-colors',
+              window === 'all'
+                ? 'bg-background text-foreground'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            All
+          </button>
+          <div className="w-px self-stretch bg-border" />
+          <button
+            type="button"
+            onClick={() => setWindow('7d')}
+            className={cn(
+              'px-2.5 py-1 text-xs font-medium transition-colors',
+              window === '7d'
+                ? 'bg-background text-foreground'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            7d
+          </button>
+          <div className="w-px self-stretch bg-border" />
+          <button
+            type="button"
+            onClick={() => setWindow('30d')}
+            className={cn(
+              'px-2.5 py-1 text-xs font-medium transition-colors',
+              window === '30d'
+                ? 'bg-background text-foreground'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            30d
+          </button>
+        </div>
+      </div>
 
       {/* Summary Stats */}
       <div className="grid grid-cols-3 gap-4 mb-6">

--- a/convex/highlightTips.test.ts
+++ b/convex/highlightTips.test.ts
@@ -428,6 +428,47 @@ describe('highlightTips.create', () => {
     expect(stats.totalTips).toBe(0)
     expect(stats.totalAmountCents).toBe(0)
   })
+
+  it('filters heatmap stats by sinceMs', async () => {
+    const t = convexTest(schema, modules)
+    const { tipperId, articleId } = await seed(t)
+
+    const asTipper = t.withIdentity({ subject: tipperId })
+    const oldTipId = await asTipper.mutation(
+      api.highlightTips.create,
+      tipArgs(articleId, 'stellar-tx-old')
+    )
+    // Backdate so it falls outside the time window.
+    await t.run(async (ctx) => {
+      const tip = await ctx.db.get(oldTipId)
+      if (tip) {
+        await ctx.db.patch(oldTipId, { createdAt: tip.createdAt - 40 * 864e5 })
+      }
+    })
+    await confirmPending(t, oldTipId)
+
+    // Avoid cooldown: make the first tip older so the second insert is allowed.
+    await t.run(async (ctx) => {
+      const tip = await ctx.db.get(oldTipId)
+      if (tip) {
+        await ctx.db.patch(oldTipId, { createdAt: tip.createdAt - 60_000 })
+      }
+    })
+
+    const newTipId = await asTipper.mutation(
+      api.highlightTips.create,
+      tipArgs(articleId, 'stellar-tx-new')
+    )
+    await confirmPending(t, newTipId)
+
+    const sinceMs = Date.now() - 30 * 864e5
+    const stats = await t.query(api.highlightTips.getArticleStats, {
+      articleId,
+      sinceMs,
+    })
+    expect(stats.totalTips).toBe(1)
+    expect(stats.totalAmountCents).toBe(100)
+  })
 })
 
 describe('markHighlightTipConfirmed', () => {

--- a/convex/highlightTips.ts
+++ b/convex/highlightTips.ts
@@ -240,13 +240,21 @@ export const getByAuthor = query({
 export const getArticleStats = query({
   args: {
     articleId: v.id('articles'),
+    sinceMs: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const tips = await ctx.db
+    let tipsQuery = ctx.db
       .query('highlightTips')
       .withIndex('by_article', (q) => q.eq('articleId', args.articleId))
       .filter((q) => q.eq(q.field('status'), 'CONFIRMED'))
-      .collect()
+
+    if (args.sinceMs !== undefined) {
+      tipsQuery = tipsQuery.filter((q) =>
+        q.gte(q.field('createdAt'), args.sinceMs!)
+      )
+    }
+
+    const tips = await tipsQuery.collect()
 
     const totalTips = tips.length
     const totalAmountCents = tips.reduce((sum, tip) => sum + tip.amountCents, 0)

--- a/hooks/convex/useHighlightQueries.ts
+++ b/hooks/convex/useHighlightQueries.ts
@@ -23,15 +23,27 @@ export function useHighlightTipsByHighlight(highlightId: string) {
   return useQuery(api.highlightTips.getByHighlight, { highlightId })
 }
 
-export function useArticleHighlightTipStats(articleId: Id<'articles'>) {
-  return useQuery(api.highlightTips.getArticleStats, { articleId })
+export function useArticleHighlightTipStats(
+  articleId: Id<'articles'>,
+  opts?: { sinceMs?: number }
+) {
+  return useQuery(api.highlightTips.getArticleStats, {
+    articleId,
+    sinceMs: opts?.sinceMs,
+  })
 }
 
 export function useArticleHighlightTipStatsOptional(
-  articleId: Id<'articles'> | undefined
+  articleId: Id<'articles'> | undefined,
+  opts?: { sinceMs?: number }
 ) {
   return useQuery(
     api.highlightTips.getArticleStats,
-    articleId ? { articleId } : 'skip'
+    articleId
+      ? {
+          articleId,
+          sinceMs: opts?.sinceMs,
+        }
+      : 'skip'
   )
 }


### PR DESCRIPTION
## Summary
- Added All / 7d / 30d filter controls to the highlight heatmap UI (default remains All).
- Extended `highlightTips.getArticleStats` to accept an optional `sinceMs` and filter by `createdAt` when provided.
- Wired the frontend hook to pass `sinceMs`, and added a regression test for the time window behavior.
<img width="1193" height="718" alt="all" src="https://github.com/user-attachments/assets/9d2c039d-b1d8-4c8e-bd12-51644c11e586" />
<img width="1193" height="713" alt="7d" src="https://github.com/user-attachments/assets/3888e864-574c-471c-bb49-454d9103e9e2" />
<img width="1191" height="710" alt="30d" src="https://github.com/user-attachments/assets/967e3918-8ae6-4eb2-8e6d-fbd747d70742" />

