### PR TITLE
feat: add sorting and CSV export to tip history

### DIFF
--- a/components/dashboard/TipHistory.test.tsx
+++ b/components/dashboard/TipHistory.test.tsx
@@ -119,11 +119,11 @@ describe('TipHistory', () => {
     const createObjectURL = vi
       .spyOn(URL, 'createObjectURL')
       .mockImplementation(() => 'blob:mock' as unknown as string)
-    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(
-      () => {
+    const revokeObjectURL = vi
+      .spyOn(URL, 'revokeObjectURL')
+      .mockImplementation(() => {
         // noop
-      }
-    )
+      })
 
     const click = vi.fn()
     const remove = vi.fn()

--- a/components/dashboard/TipHistory.test.tsx
+++ b/components/dashboard/TipHistory.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   TipHistory,
@@ -60,9 +60,7 @@ describe('TipHistory', () => {
     render(<TipHistory tips={tips} />)
 
     expect(screen.getByText('bob')).toBeInTheDocument()
-    expect(
-      screen.getByText((_, el) => el?.textContent === 'tipped on “My Article”')
-    ).toBeInTheDocument()
+    expect(screen.getByText('My Article')).toBeInTheDocument()
     expect(screen.getByText('+$12.50')).toBeInTheDocument()
   })
 
@@ -86,5 +84,98 @@ describe('TipHistory', () => {
     expect(timeEl).toHaveAttribute('dateTime', tipDate.toISOString())
     expect(timeEl).toHaveAttribute('title', absolute)
     expect(timeEl).toHaveAttribute('aria-label', `2 days ago. ${absolute}.`)
+  })
+
+  it('toggles sort direction and shows indicator on active column', () => {
+    const tips = [
+      makeTip({
+        _id: 'a1' as Id<'tips'>,
+        amountUsd: 3,
+        createdAt: new Date('2024-03-01T00:00:00Z').getTime(),
+        tipper: { username: 'bob' },
+      }),
+      makeTip({
+        _id: 'a2' as Id<'tips'>,
+        amountUsd: 10,
+        createdAt: new Date('2024-03-02T00:00:00Z').getTime(),
+        tipper: { username: 'alice' },
+      }),
+    ]
+
+    render(<TipHistory tips={tips} />)
+
+    const amountBtn = screen.getByRole('button', { name: /amount/i })
+
+    fireEvent.click(amountBtn)
+    expect(amountBtn.textContent).toMatch(/▲|▼/)
+    expect(screen.getAllByText(/\+\$/)[0]).toHaveTextContent('+$3.00')
+
+    fireEvent.click(amountBtn)
+    expect(amountBtn.textContent).toMatch(/▲|▼/)
+    expect(screen.getAllByText(/\+\$/)[0]).toHaveTextContent('+$10.00')
+  })
+
+  it('downloads CSV in current sort order and escapes commas/quotes/newlines', () => {
+    const createObjectURL = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockImplementation(() => 'blob:mock' as unknown as string)
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(
+      () => {
+        // noop
+      }
+    )
+
+    const click = vi.fn()
+    const remove = vi.fn()
+
+    const originalCreateElement = document.createElement.bind(document)
+    vi.spyOn(document, 'createElement').mockImplementation(((tag: string) => {
+      if (tag !== 'a') return originalCreateElement(tag)
+      const a = originalCreateElement('a') as HTMLAnchorElement
+      vi.spyOn(a, 'click').mockImplementation(click)
+      vi.spyOn(a, 'remove').mockImplementation(remove)
+      return a
+    }) as typeof document.createElement)
+
+    const blobSpy = vi.spyOn(globalThis, 'Blob')
+
+    const tips = [
+      makeTip({
+        _id: 'a1' as Id<'tips'>,
+        articleTitle: 'Zeta',
+        amountUsd: 5,
+        createdAt: new Date('2024-03-01T00:00:00Z').getTime(),
+        tipper: { username: 'bob, "the"\nnew' },
+      }),
+      makeTip({
+        _id: 'a2' as Id<'tips'>,
+        articleTitle: 'Alpha',
+        amountUsd: 1,
+        createdAt: new Date('2024-03-02T00:00:00Z').getTime(),
+        tipper: { username: 'alice' },
+      }),
+    ]
+
+    render(<TipHistory tips={tips} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /article/i }))
+    fireEvent.click(screen.getByRole('button', { name: /download csv/i }))
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    const anchor = document.body.querySelector('a')
+    if (!(anchor instanceof HTMLAnchorElement)) {
+      throw new Error('Expected an anchor element to be created')
+    }
+    expect(anchor.getAttribute('href')).toBe('blob:mock')
+    expect(anchor.download).toMatch(/^tip-history-\d{4}-\d{2}-\d{2}\.csv$/)
+    expect(click).toHaveBeenCalledTimes(1)
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock')
+    expect(remove).toHaveBeenCalled()
+
+    const blobArg = blobSpy.mock.calls[0]?.[0]
+    const csvText = Array.isArray(blobArg) ? String(blobArg[0]) : ''
+    expect(csvText).toContain('Tipper,Article,AmountUsd,CreatedAt')
+    expect(csvText).toMatch(/\n.*Alpha,1\.00,/)
+    expect(csvText).toMatch(/"bob, ""the""\nnew"/)
   })
 })

--- a/components/dashboard/TipHistory.tsx
+++ b/components/dashboard/TipHistory.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useMemo, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import type { Doc } from '@/types/convex'
 
@@ -12,52 +13,252 @@ type TipHistoryProps = {
   tips: ReceivedTipRow[] | undefined
 }
 
+type PageSize = 10 | 25 | 50 | 'all'
+type SortKey = 'tipper' | 'articleTitle' | 'amountUsd' | 'createdAt'
+type SortDir = 'asc' | 'desc'
+
+function csvEscape(value: string) {
+  const mustQuote = /[",\n\r]/.test(value)
+  if (!mustQuote) return value
+  return `"${value.replaceAll('"', '""')}"`
+}
+
+function downloadCsv(args: { filename: string; csv: string }) {
+  const blob = new Blob([args.csv], { type: 'text/csv;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = args.filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
+}
+
 export function TipHistory({ tips }: TipHistoryProps) {
   const list = tips?.length ? tips : null
+  const [pageSize, setPageSize] = useState<PageSize>(10)
+  const [sortKey, setSortKey] = useState<SortKey>('createdAt')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+
+  const sortedTips = useMemo(() => {
+    if (!list) return null
+
+    const getTipperName = (tip: ReceivedTipRow) =>
+      tip.tipper?.name || tip.tipper?.username || 'Anonymous'
+
+    const dir = sortDir === 'asc' ? 1 : -1
+
+    const compareStrings = (a: string, b: string) =>
+      a.localeCompare(b, 'en', { sensitivity: 'base' }) * dir
+    const compareNumbers = (a: number, b: number) => (a - b) * dir
+
+    return [...list].sort((a, b) => {
+      switch (sortKey) {
+        case 'tipper':
+          return compareStrings(getTipperName(a), getTipperName(b))
+        case 'articleTitle':
+          return compareStrings(a.articleTitle, b.articleTitle)
+        case 'amountUsd':
+          return compareNumbers(a.amountUsd, b.amountUsd)
+        case 'createdAt':
+          return compareNumbers(a.createdAt, b.createdAt)
+        default: {
+          const _exhaustive: never = sortKey
+          return _exhaustive
+        }
+      }
+    })
+  }, [list, sortDir, sortKey])
+
+  const visibleTips = useMemo(() => {
+    if (!sortedTips) return null
+    if (pageSize === 'all') return sortedTips
+    return sortedTips.slice(0, pageSize)
+  }, [pageSize, sortedTips])
+
+  const setSort = (nextKey: SortKey) => {
+    if (nextKey === sortKey) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+      return
+    }
+    setSortKey(nextKey)
+    setSortDir(nextKey === 'createdAt' ? 'desc' : 'asc')
+  }
+
+  const ariaSort = (key: SortKey): 'none' | 'ascending' | 'descending' => {
+    if (key !== sortKey) return 'none'
+    return sortDir === 'asc' ? 'ascending' : 'descending'
+  }
+
+  const sortIndicator = (key: SortKey) => {
+    if (key !== sortKey) return null
+    return (
+      <span aria-hidden className="ml-1 text-xs text-muted-foreground">
+        {sortDir === 'asc' ? '▲' : '▼'}
+      </span>
+    )
+  }
+
+  const onDownloadCsv = () => {
+    if (!visibleTips?.length) return
+
+    const header = ['Tipper', 'Article', 'AmountUsd', 'CreatedAt']
+    const rows = visibleTips.map((tip) => {
+      const tipperName = tip.tipper?.name || tip.tipper?.username || 'Anonymous'
+      const createdAtIso = new Date(tip.createdAt).toISOString()
+      return [
+        tipperName,
+        tip.articleTitle,
+        tip.amountUsd.toFixed(2),
+        createdAtIso,
+      ]
+    })
+
+    const csv = [header, ...rows]
+      .map((fields) => fields.map((f) => csvEscape(f)).join(','))
+      .join('\r\n')
+      .concat('\r\n')
+
+    const date = new Date().toISOString().slice(0, 10)
+    downloadCsv({ filename: `tip-history-${date}.csv`, csv })
+  }
 
   return (
     <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border">
       <div className="p-6 border-b border-border">
-        <h3 className="text-lg font-semibold">Recent Tips</h3>
+        <div className="flex items-center justify-between gap-4">
+          <h3 className="text-lg font-semibold">Recent Tips</h3>
+          {list ? (
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={onDownloadCsv}
+                className="h-8 rounded-md border border-border bg-background px-3 text-sm text-foreground hover:bg-muted"
+              >
+                Download CSV
+              </button>
+              <label className="flex items-center gap-2 text-sm text-muted-foreground">
+                <span>Rows</span>
+                <select
+                  className="h-8 rounded-md border border-border bg-background px-2 text-foreground"
+                  value={pageSize}
+                  onChange={(e) => {
+                    const value = e.target.value
+                    setPageSize(
+                      value === 'all' ? 'all' : (Number(value) as 10 | 25 | 50)
+                    )
+                  }}
+                  aria-label="Rows per page"
+                >
+                  <option value="10">10</option>
+                  <option value="25">25</option>
+                  <option value="50">50</option>
+                  <option value="all">All</option>
+                </select>
+              </label>
+            </div>
+          ) : null}
+        </div>
       </div>
-      {list ? (
-        <div className="divide-y divide-border">
-          {list.slice(0, 10).map((tip) => {
-            const tipDate = new Date(tip.createdAt)
-            const relative = formatDistanceToNow(tipDate, { addSuffix: true })
-            const absolute = tipDate.toLocaleDateString('en-US', {
-              dateStyle: 'long',
-            })
-            const a11yLabel = `${relative}. ${absolute}.`
+      {visibleTips ? (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="border-b border-border bg-muted/30">
+              <tr>
+                <th
+                  scope="col"
+                  aria-sort={ariaSort('tipper')}
+                  className="px-4 py-3 text-left font-medium text-foreground"
+                >
+                  <button
+                    type="button"
+                    onClick={() => setSort('tipper')}
+                    className="inline-flex items-center hover:underline"
+                  >
+                    Tipper{sortIndicator('tipper')}
+                  </button>
+                </th>
+                <th
+                  scope="col"
+                  aria-sort={ariaSort('articleTitle')}
+                  className="px-4 py-3 text-left font-medium text-foreground"
+                >
+                  <button
+                    type="button"
+                    onClick={() => setSort('articleTitle')}
+                    className="inline-flex items-center hover:underline"
+                  >
+                    Article{sortIndicator('articleTitle')}
+                  </button>
+                </th>
+                <th
+                  scope="col"
+                  aria-sort={ariaSort('amountUsd')}
+                  className="px-4 py-3 text-right font-medium text-foreground"
+                >
+                  <button
+                    type="button"
+                    onClick={() => setSort('amountUsd')}
+                    className="inline-flex items-center hover:underline"
+                  >
+                    Amount{sortIndicator('amountUsd')}
+                  </button>
+                </th>
+                <th
+                  scope="col"
+                  aria-sort={ariaSort('createdAt')}
+                  className="px-4 py-3 text-right font-medium text-foreground"
+                >
+                  <button
+                    type="button"
+                    onClick={() => setSort('createdAt')}
+                    className="inline-flex items-center hover:underline"
+                  >
+                    Date{sortIndicator('createdAt')}
+                  </button>
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {visibleTips.map((tip) => {
+                const tipDate = new Date(tip.createdAt)
+                const relative = formatDistanceToNow(tipDate, {
+                  addSuffix: true,
+                })
+                const absolute = tipDate.toLocaleDateString('en-US', {
+                  dateStyle: 'long',
+                })
+                const a11yLabel = `${relative}. ${absolute}.`
+                const tipperName =
+                  tip.tipper?.name || tip.tipper?.username || 'Anonymous'
 
-            return (
-              <div key={tip._id} className="p-4 hover:bg-muted/50">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="font-medium text-foreground">
-                      {tip.tipper?.name || tip.tipper?.username || 'Anonymous'}
-                    </p>
-                    <p className="text-sm text-muted-foreground">
-                      tipped on &ldquo;{tip.articleTitle}&rdquo;
-                    </p>
-                  </div>
-                  <div className="text-right">
-                    <p className="font-semibold text-success-foreground">
+                return (
+                  <tr key={tip._id} className="hover:bg-muted/40">
+                    <td className="px-4 py-3 font-medium text-foreground">
+                      {tipperName}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {tip.articleTitle}
+                    </td>
+                    <td className="px-4 py-3 text-right font-semibold text-success-foreground">
                       +${tip.amountUsd.toFixed(2)}
-                    </p>
-                    <time
-                      dateTime={tipDate.toISOString()}
-                      title={absolute}
-                      aria-label={a11yLabel}
-                      className="text-xs text-muted-foreground"
-                    >
-                      {relative}
-                    </time>
-                  </div>
-                </div>
-              </div>
-            )
-          })}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <time
+                        dateTime={tipDate.toISOString()}
+                        title={absolute}
+                        aria-label={a11yLabel}
+                        className="text-xs text-muted-foreground"
+                      >
+                        {relative}
+                      </time>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
         </div>
       ) : (
         <div className="flex min-h-[12rem] flex-col items-center justify-center gap-2 px-6 py-10 text-center">

--- a/components/dashboard/WithdrawalDialog.test.tsx
+++ b/components/dashboard/WithdrawalDialog.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { createRef } from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { WithdrawalDialog } from '@/components/dashboard/WithdrawalDialog'
@@ -8,7 +8,9 @@ import { WithdrawalDialog } from '@/components/dashboard/WithdrawalDialog'
 const validGAddress = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
 
 describe('WithdrawalDialog', () => {
-  it('calls onWithdraw with entered amount and address', async () => {
+  it(
+    'calls onWithdraw with entered amount and address',
+    async () => {
     const user = userEvent.setup()
     const onWithdraw = vi.fn().mockResolvedValue(undefined)
     const onOpenChange = vi.fn()
@@ -30,12 +32,16 @@ describe('WithdrawalDialog', () => {
     await user.type(screen.getByLabelText(/Stellar Address/i), validGAddress)
     await user.click(screen.getByRole('button', { name: /Withdraw$/i }))
 
-    expect(onWithdraw).toHaveBeenCalledWith({
-      amountUsd: 10,
-      stellarAddress: validGAddress,
+    await waitFor(() => {
+      expect(onWithdraw).toHaveBeenCalledWith({
+        amountUsd: 10,
+        stellarAddress: validGAddress,
+      })
+      expect(onOpenChange).toHaveBeenCalledWith(false)
     })
-    expect(onOpenChange).toHaveBeenCalledWith(false)
-  })
+    },
+    10_000
+  )
 
   it('uses saved Stellar address without manual entry', async () => {
     const user = userEvent.setup()

--- a/components/dashboard/WithdrawalDialog.test.tsx
+++ b/components/dashboard/WithdrawalDialog.test.tsx
@@ -8,9 +8,7 @@ import { WithdrawalDialog } from '@/components/dashboard/WithdrawalDialog'
 const validGAddress = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
 
 describe('WithdrawalDialog', () => {
-  it(
-    'calls onWithdraw with entered amount and address',
-    async () => {
+  it('calls onWithdraw with entered amount and address', async () => {
     const user = userEvent.setup()
     const onWithdraw = vi.fn().mockResolvedValue(undefined)
     const onOpenChange = vi.fn()
@@ -39,9 +37,7 @@ describe('WithdrawalDialog', () => {
       })
       expect(onOpenChange).toHaveBeenCalledWith(false)
     })
-    },
-    10_000
-  )
+  }, 10_000)
 
   it('uses saved Stellar address without manual entry', async () => {
     const user = userEvent.setup()


### PR DESCRIPTION
## Summary
- Replaced hardcoded “top 10” tip history with a rows-per-page selector (10/25/50/All) using a plain HTML table.
- Added click-to-sort column headers (Tipper, Article, Amount, Date) with an active sort indicator and aria-sort.
- Added “Download CSV” that exports the currently displayed rows in the current sort order with correct escaping (commas, quotes, newlines).

<img width="1186" height="713" alt="row" src="https://github.com/user-attachments/assets/52867cc9-dace-4b8d-8a87-c34155a15416" />
<img width="1194" height="723" alt="tipper" src="https://github.com/user-attachments/assets/7601d5a1-0180-4732-a073-59d7c250cf2d" />
<img width="1195" height="716" alt="csv" src="https://github.com/user-attachments/assets/ed3c6255-7ebb-434a-8347-14488fd187ee" />
