### PR TITLE
feat(dashboard): improve Tip History UX (relative dates, empty state, sorting + CSV) and highlight heatmap time filters

### DIFF
--- a/components/articles/HighlightableArticle.tsx
+++ b/components/articles/HighlightableArticle.tsx
@@ -188,12 +188,15 @@ export function HighlightableArticle({
         if (domSelection && domSelection.rangeCount > 0) {
           const range = domSelection.getRangeAt(0)
           const rect = range.getBoundingClientRect()
+          const containerRect = editorRef.current?.getBoundingClientRect()
 
           setSelectedText({ text, from, to })
-          setPopoverPosition({
-            top: rect.top + window.scrollY - 60,
-            left: rect.left + rect.width / 2,
-          })
+          if (containerRect) {
+            setPopoverPosition({
+              top: rect.top - containerRect.top - 60,
+              left: rect.left - containerRect.left + rect.width / 2,
+            })
+          }
         }
       } else {
         setSelectedText(null)
@@ -244,10 +247,12 @@ export function HighlightableArticle({
         if (!domSelection || domSelection.rangeCount === 0) return
         const range = domSelection.getRangeAt(0)
         const rect = range.getBoundingClientRect()
+        const containerRect = editorRef.current?.getBoundingClientRect()
+        if (!containerRect) return
         setSelectedText({ text, from, to })
         setPopoverPosition({
-          top: rect.top + window.scrollY - 60,
-          left: rect.left + rect.width / 2,
+          top: rect.top - containerRect.top - 60,
+          left: rect.left - containerRect.left + rect.width / 2,
         })
       }, 0)
     }

--- a/components/dashboard/TipHistory.test.tsx
+++ b/components/dashboard/TipHistory.test.tsx
@@ -33,13 +33,17 @@ describe('TipHistory', () => {
 
   it('shows empty state when tips are empty or undefined', () => {
     const { unmount, container } = render(<TipHistory tips={undefined} />)
-    expect(screen.getByRole('heading', { name: 'Recent Tips' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Recent Tips' })
+    ).toBeInTheDocument()
     expect(screen.getByText('No tips yet')).toBeInTheDocument()
     expect(container.firstChild).not.toBeNull()
     unmount()
 
     render(<TipHistory tips={[]} />)
-    expect(screen.getByRole('heading', { name: 'Recent Tips' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Recent Tips' })
+    ).toBeInTheDocument()
     expect(screen.getByText('No tips yet')).toBeInTheDocument()
   })
 

--- a/components/dashboard/TipHistory.test.tsx
+++ b/components/dashboard/TipHistory.test.tsx
@@ -119,11 +119,11 @@ describe('TipHistory', () => {
     const createObjectURL = vi
       .spyOn(URL, 'createObjectURL')
       .mockImplementation(() => 'blob:mock' as unknown as string)
-    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(
-      () => {
+    const revokeObjectURL = vi
+      .spyOn(URL, 'revokeObjectURL')
+      .mockImplementation(() => {
         // noop
-      }
-    )
+      })
 
     const click = vi.fn()
     const remove = vi.fn()

--- a/components/dashboard/TipHistory.test.tsx
+++ b/components/dashboard/TipHistory.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   TipHistory,
@@ -60,9 +60,7 @@ describe('TipHistory', () => {
     render(<TipHistory tips={tips} />)
 
     expect(screen.getByText('bob')).toBeInTheDocument()
-    expect(
-      screen.getByText((_, el) => el?.textContent === 'tipped on “My Article”')
-    ).toBeInTheDocument()
+    expect(screen.getByText('My Article')).toBeInTheDocument()
     expect(screen.getByText('+$12.50')).toBeInTheDocument()
   })
 
@@ -86,5 +84,98 @@ describe('TipHistory', () => {
     expect(timeEl).toHaveAttribute('dateTime', tipDate.toISOString())
     expect(timeEl).toHaveAttribute('title', absolute)
     expect(timeEl).toHaveAttribute('aria-label', `2 days ago. ${absolute}.`)
+  })
+
+  it('toggles sort direction and shows indicator on active column', () => {
+    const tips = [
+      makeTip({
+        _id: 'a1' as Id<'tips'>,
+        amountUsd: 3,
+        createdAt: new Date('2024-03-01T00:00:00Z').getTime(),
+        tipper: { username: 'bob' },
+      }),
+      makeTip({
+        _id: 'a2' as Id<'tips'>,
+        amountUsd: 10,
+        createdAt: new Date('2024-03-02T00:00:00Z').getTime(),
+        tipper: { username: 'alice' },
+      }),
+    ]
+
+    render(<TipHistory tips={tips} />)
+
+    const amountBtn = screen.getByRole('button', { name: /amount/i })
+
+    fireEvent.click(amountBtn)
+    expect(amountBtn.textContent).toMatch(/▲|▼/)
+    expect(screen.getAllByText(/\+\$/)[0]).toHaveTextContent('+$3.00')
+
+    fireEvent.click(amountBtn)
+    expect(amountBtn.textContent).toMatch(/▲|▼/)
+    expect(screen.getAllByText(/\+\$/)[0]).toHaveTextContent('+$10.00')
+  })
+
+  it('downloads CSV in current sort order and escapes commas/quotes/newlines', () => {
+    const createObjectURL = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockImplementation(() => 'blob:mock' as unknown as string)
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(
+      () => {
+        // noop
+      }
+    )
+
+    const click = vi.fn()
+    const remove = vi.fn()
+
+    const originalCreateElement = document.createElement.bind(document)
+    vi.spyOn(document, 'createElement').mockImplementation(((tag: string) => {
+      if (tag !== 'a') return originalCreateElement(tag)
+      const a = originalCreateElement('a') as HTMLAnchorElement
+      vi.spyOn(a, 'click').mockImplementation(click)
+      vi.spyOn(a, 'remove').mockImplementation(remove)
+      return a
+    }) as typeof document.createElement)
+
+    const blobSpy = vi.spyOn(globalThis, 'Blob')
+
+    const tips = [
+      makeTip({
+        _id: 'a1' as Id<'tips'>,
+        articleTitle: 'Zeta',
+        amountUsd: 5,
+        createdAt: new Date('2024-03-01T00:00:00Z').getTime(),
+        tipper: { username: 'bob, "the"\nnew' },
+      }),
+      makeTip({
+        _id: 'a2' as Id<'tips'>,
+        articleTitle: 'Alpha',
+        amountUsd: 1,
+        createdAt: new Date('2024-03-02T00:00:00Z').getTime(),
+        tipper: { username: 'alice' },
+      }),
+    ]
+
+    render(<TipHistory tips={tips} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /article/i }))
+    fireEvent.click(screen.getByRole('button', { name: /download csv/i }))
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    const anchor = document.body.querySelector('a')
+    if (!(anchor instanceof HTMLAnchorElement)) {
+      throw new Error('Expected an anchor element to be created')
+    }
+    expect(anchor.getAttribute('href')).toBe('blob:mock')
+    expect(anchor.download).toMatch(/^tip-history-\d{4}-\d{2}-\d{2}\.csv$/)
+    expect(click).toHaveBeenCalledTimes(1)
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock')
+    expect(remove).toHaveBeenCalled()
+
+    const blobArg = blobSpy.mock.calls[0]?.[0]
+    const csvText = Array.isArray(blobArg) ? String(blobArg[0]) : ''
+    expect(csvText).toContain('Tipper,Article,AmountUsd,CreatedAt')
+    expect(csvText).toMatch(/\n.*Alpha,1\.00,/)
+    expect(csvText).toMatch(/"bob, ""the""\nnew"/)
   })
 })

--- a/components/dashboard/TipHistory.test.tsx
+++ b/components/dashboard/TipHistory.test.tsx
@@ -31,11 +31,16 @@ describe('TipHistory', () => {
     vi.useRealTimers()
   })
 
-  it('renders nothing when tips are empty or undefined', () => {
-    const { container: a } = render(<TipHistory tips={undefined} />)
-    expect(a.firstChild).toBeNull()
-    const { container: b } = render(<TipHistory tips={[]} />)
-    expect(b.firstChild).toBeNull()
+  it('shows empty state when tips are empty or undefined', () => {
+    const { unmount, container } = render(<TipHistory tips={undefined} />)
+    expect(screen.getByRole('heading', { name: 'Recent Tips' })).toBeInTheDocument()
+    expect(screen.getByText('No tips yet')).toBeInTheDocument()
+    expect(container.firstChild).not.toBeNull()
+    unmount()
+
+    render(<TipHistory tips={[]} />)
+    expect(screen.getByRole('heading', { name: 'Recent Tips' })).toBeInTheDocument()
+    expect(screen.getByText('No tips yet')).toBeInTheDocument()
   })
 
   it('shows tipper, article title, amount, and relative tip time', () => {

--- a/components/dashboard/TipHistory.test.tsx
+++ b/components/dashboard/TipHistory.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   TipHistory,
   type ReceivedTipRow,
@@ -27,6 +27,10 @@ function makeTip(overrides: Partial<ReceivedTipRow>): ReceivedTipRow {
 }
 
 describe('TipHistory', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('renders nothing when tips are empty or undefined', () => {
     const { container: a } = render(<TipHistory tips={undefined} />)
     expect(a.firstChild).toBeNull()
@@ -34,7 +38,7 @@ describe('TipHistory', () => {
     expect(b.firstChild).toBeNull()
   })
 
-  it('shows tipper, article title, amount, and formatted date', () => {
+  it('shows tipper, article title, amount, and relative tip time', () => {
     const tips = [
       makeTip({
         _id: 'a1' as Id<'tips'>,
@@ -57,5 +61,24 @@ describe('TipHistory', () => {
     const tips = [makeTip({ tipper: null })]
     render(<TipHistory tips={tips} />)
     expect(screen.getByText('Anonymous')).toBeInTheDocument()
+  })
+
+  it('shows relative time with absolute date on title and aria-label', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-05T12:00:00Z'))
+    const createdAt = new Date('2026-05-03T12:00:00Z').getTime()
+    const tipDate = new Date(createdAt)
+    const absolute = tipDate.toLocaleDateString('en-US', { dateStyle: 'long' })
+
+    render(<TipHistory tips={[makeTip({ createdAt })]} />)
+
+    const timeEl = screen.getByText('2 days ago')
+    expect(timeEl.tagName).toBe('TIME')
+    expect(timeEl).toHaveAttribute('dateTime', tipDate.toISOString())
+    expect(timeEl).toHaveAttribute('title', absolute)
+    expect(timeEl).toHaveAttribute(
+      'aria-label',
+      `2 days ago. ${absolute}.`
+    )
   })
 })

--- a/components/dashboard/TipHistory.test.tsx
+++ b/components/dashboard/TipHistory.test.tsx
@@ -76,9 +76,6 @@ describe('TipHistory', () => {
     expect(timeEl.tagName).toBe('TIME')
     expect(timeEl).toHaveAttribute('dateTime', tipDate.toISOString())
     expect(timeEl).toHaveAttribute('title', absolute)
-    expect(timeEl).toHaveAttribute(
-      'aria-label',
-      `2 days ago. ${absolute}.`
-    )
+    expect(timeEl).toHaveAttribute('aria-label', `2 days ago. ${absolute}.`)
   })
 })

--- a/components/dashboard/TipHistory.tsx
+++ b/components/dashboard/TipHistory.tsx
@@ -13,53 +13,60 @@ type TipHistoryProps = {
 }
 
 export function TipHistory({ tips }: TipHistoryProps) {
-  if (!tips || tips.length === 0) {
-    return null
-  }
+  const list = tips?.length ? tips : null
 
   return (
     <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border">
       <div className="p-6 border-b border-border">
         <h3 className="text-lg font-semibold">Recent Tips</h3>
       </div>
-      <div className="divide-y divide-border">
-        {tips.slice(0, 10).map((tip) => {
-          const tipDate = new Date(tip.createdAt)
-          const relative = formatDistanceToNow(tipDate, { addSuffix: true })
-          const absolute = tipDate.toLocaleDateString('en-US', {
-            dateStyle: 'long',
-          })
-          const a11yLabel = `${relative}. ${absolute}.`
+      {list ? (
+        <div className="divide-y divide-border">
+          {list.slice(0, 10).map((tip) => {
+            const tipDate = new Date(tip.createdAt)
+            const relative = formatDistanceToNow(tipDate, { addSuffix: true })
+            const absolute = tipDate.toLocaleDateString('en-US', {
+              dateStyle: 'long',
+            })
+            const a11yLabel = `${relative}. ${absolute}.`
 
-          return (
-            <div key={tip._id} className="p-4 hover:bg-muted/50">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="font-medium text-foreground">
-                    {tip.tipper?.name || tip.tipper?.username || 'Anonymous'}
-                  </p>
-                  <p className="text-sm text-muted-foreground">
-                    tipped on &ldquo;{tip.articleTitle}&rdquo;
-                  </p>
-                </div>
-                <div className="text-right">
-                  <p className="font-semibold text-success-foreground">
-                    +${tip.amountUsd.toFixed(2)}
-                  </p>
-                  <time
-                    dateTime={tipDate.toISOString()}
-                    title={absolute}
-                    aria-label={a11yLabel}
-                    className="text-xs text-muted-foreground"
-                  >
-                    {relative}
-                  </time>
+            return (
+              <div key={tip._id} className="p-4 hover:bg-muted/50">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium text-foreground">
+                      {tip.tipper?.name || tip.tipper?.username || 'Anonymous'}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      tipped on &ldquo;{tip.articleTitle}&rdquo;
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    <p className="font-semibold text-success-foreground">
+                      +${tip.amountUsd.toFixed(2)}
+                    </p>
+                    <time
+                      dateTime={tipDate.toISOString()}
+                      title={absolute}
+                      aria-label={a11yLabel}
+                      className="text-xs text-muted-foreground"
+                    >
+                      {relative}
+                    </time>
+                  </div>
                 </div>
               </div>
-            </div>
-          )
-        })}
-      </div>
+            )
+          })}
+        </div>
+      ) : (
+        <div className="flex min-h-[12rem] flex-col items-center justify-center gap-2 px-6 py-10 text-center">
+          <p className="font-medium text-foreground">No tips yet</p>
+          <p className="max-w-sm text-sm text-muted-foreground">
+            When readers tip your work, they will show up here.
+          </p>
+        </div>
+      )}
     </div>
   )
 }

--- a/components/dashboard/TipHistory.tsx
+++ b/components/dashboard/TipHistory.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useMemo, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import type { Doc } from '@/types/convex'
 
@@ -12,52 +13,252 @@ type TipHistoryProps = {
   tips: ReceivedTipRow[] | undefined
 }
 
+type PageSize = 10 | 25 | 50 | 'all'
+type SortKey = 'tipper' | 'articleTitle' | 'amountUsd' | 'createdAt'
+type SortDir = 'asc' | 'desc'
+
+function csvEscape(value: string) {
+  const mustQuote = /[",\n\r]/.test(value)
+  if (!mustQuote) return value
+  return `"${value.replaceAll('"', '""')}"`
+}
+
+function downloadCsv(args: { filename: string; csv: string }) {
+  const blob = new Blob([args.csv], { type: 'text/csv;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = args.filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
+}
+
 export function TipHistory({ tips }: TipHistoryProps) {
   const list = tips?.length ? tips : null
+  const [pageSize, setPageSize] = useState<PageSize>(10)
+  const [sortKey, setSortKey] = useState<SortKey>('createdAt')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+
+  const sortedTips = useMemo(() => {
+    if (!list) return null
+
+    const getTipperName = (tip: ReceivedTipRow) =>
+      tip.tipper?.name || tip.tipper?.username || 'Anonymous'
+
+    const dir = sortDir === 'asc' ? 1 : -1
+
+    const compareStrings = (a: string, b: string) =>
+      a.localeCompare(b, 'en', { sensitivity: 'base' }) * dir
+    const compareNumbers = (a: number, b: number) => (a - b) * dir
+
+    return [...list].sort((a, b) => {
+      switch (sortKey) {
+        case 'tipper':
+          return compareStrings(getTipperName(a), getTipperName(b))
+        case 'articleTitle':
+          return compareStrings(a.articleTitle, b.articleTitle)
+        case 'amountUsd':
+          return compareNumbers(a.amountUsd, b.amountUsd)
+        case 'createdAt':
+          return compareNumbers(a.createdAt, b.createdAt)
+        default: {
+          const _exhaustive: never = sortKey
+          return _exhaustive
+        }
+      }
+    })
+  }, [list, sortDir, sortKey])
+
+  const visibleTips = useMemo(() => {
+    if (!sortedTips) return null
+    if (pageSize === 'all') return sortedTips
+    return sortedTips.slice(0, pageSize)
+  }, [pageSize, sortedTips])
+
+  const setSort = (nextKey: SortKey) => {
+    if (nextKey === sortKey) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+      return
+    }
+    setSortKey(nextKey)
+    setSortDir(nextKey === 'createdAt' ? 'desc' : 'asc')
+  }
+
+  const ariaSort = (key: SortKey): 'none' | 'ascending' | 'descending' => {
+    if (key !== sortKey) return 'none'
+    return sortDir === 'asc' ? 'ascending' : 'descending'
+  }
+
+  const sortIndicator = (key: SortKey) => {
+    if (key !== sortKey) return null
+    return (
+      <span aria-hidden className="ml-1 text-xs text-muted-foreground">
+        {sortDir === 'asc' ? '▲' : '▼'}
+      </span>
+    )
+  }
+
+  const onDownloadCsv = () => {
+    if (!visibleTips?.length) return
+
+    const header = ['Tipper', 'Article', 'AmountUsd', 'CreatedAt']
+    const rows = visibleTips.map((tip) => {
+      const tipperName = tip.tipper?.name || tip.tipper?.username || 'Anonymous'
+      const createdAtIso = new Date(tip.createdAt).toISOString()
+      return [
+        tipperName,
+        tip.articleTitle,
+        tip.amountUsd.toFixed(2),
+        createdAtIso,
+      ]
+    })
+
+    const csv = [header, ...rows]
+      .map((fields) => fields.map((f) => csvEscape(f)).join(','))
+      .join('\r\n')
+      .concat('\r\n')
+
+    const date = new Date().toISOString().slice(0, 10)
+    downloadCsv({ filename: `tip-history-${date}.csv`, csv })
+  }
 
   return (
     <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border">
       <div className="p-6 border-b border-border">
-        <h3 className="text-lg font-semibold">Recent Tips</h3>
+        <div className="flex items-center justify-between gap-4">
+          <h3 className="text-lg font-semibold">Recent Tips</h3>
+          {list ? (
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={onDownloadCsv}
+                className="h-8 rounded-md border border-border bg-background px-3 text-sm text-foreground hover:bg-muted"
+              >
+                Download CSV
+              </button>
+              <label className="flex items-center gap-2 text-sm text-muted-foreground">
+                <span>Rows</span>
+                <select
+                  className="h-8 rounded-md border border-border bg-background px-2 text-foreground"
+                  value={pageSize}
+                  onChange={(e) => {
+                    const value = e.target.value
+                    setPageSize(
+                      value === 'all' ? 'all' : (Number(value) as 10 | 25 | 50)
+                    )
+                  }}
+                  aria-label="Rows per page"
+                >
+                  <option value="10">10</option>
+                  <option value="25">25</option>
+                  <option value="50">50</option>
+                  <option value="all">All</option>
+                </select>
+              </label>
+            </div>
+          ) : null}
+        </div>
       </div>
-      {list ? (
-        <div className="divide-y divide-border">
-          {list.slice(0, 10).map((tip) => {
-            const tipDate = new Date(tip.createdAt)
-            const relative = formatDistanceToNow(tipDate, { addSuffix: true })
-            const absolute = tipDate.toLocaleDateString('en-US', {
-              dateStyle: 'long',
-            })
-            const a11yLabel = `${relative}. ${absolute}.`
+      {visibleTips ? (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="border-b border-border bg-muted/30">
+              <tr>
+                <th
+                  scope="col"
+                  aria-sort={ariaSort('tipper')}
+                  className="px-4 py-3 text-left font-medium text-foreground"
+                >
+                  <button
+                    type="button"
+                    onClick={() => setSort('tipper')}
+                    className="inline-flex items-center hover:underline"
+                  >
+                    Tipper{sortIndicator('tipper')}
+                  </button>
+                </th>
+                <th
+                  scope="col"
+                  aria-sort={ariaSort('articleTitle')}
+                  className="px-4 py-3 text-left font-medium text-foreground"
+                >
+                  <button
+                    type="button"
+                    onClick={() => setSort('articleTitle')}
+                    className="inline-flex items-center hover:underline"
+                  >
+                    Article{sortIndicator('articleTitle')}
+                  </button>
+                </th>
+                <th
+                  scope="col"
+                  aria-sort={ariaSort('amountUsd')}
+                  className="px-4 py-3 text-right font-medium text-foreground"
+                >
+                  <button
+                    type="button"
+                    onClick={() => setSort('amountUsd')}
+                    className="inline-flex items-center hover:underline"
+                  >
+                    Amount{sortIndicator('amountUsd')}
+                  </button>
+                </th>
+                <th
+                  scope="col"
+                  aria-sort={ariaSort('createdAt')}
+                  className="px-4 py-3 text-right font-medium text-foreground"
+                >
+                  <button
+                    type="button"
+                    onClick={() => setSort('createdAt')}
+                    className="inline-flex items-center hover:underline"
+                  >
+                    Date{sortIndicator('createdAt')}
+                  </button>
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {visibleTips.map((tip) => {
+                const tipDate = new Date(tip.createdAt)
+                const relative = formatDistanceToNow(tipDate, {
+                  addSuffix: true,
+                })
+                const absolute = tipDate.toLocaleDateString('en-US', {
+                  dateStyle: 'long',
+                })
+                const a11yLabel = `${relative}. ${absolute}.`
+                const tipperName =
+                  tip.tipper?.name || tip.tipper?.username || 'Anonymous'
 
-            return (
-              <div key={tip._id} className="p-4 hover:bg-muted/50">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="font-medium text-foreground">
-                      {tip.tipper?.name || tip.tipper?.username || 'Anonymous'}
-                    </p>
-                    <p className="text-sm text-muted-foreground">
-                      tipped on &ldquo;{tip.articleTitle}&rdquo;
-                    </p>
-                  </div>
-                  <div className="text-right">
-                    <p className="font-semibold text-success-foreground">
+                return (
+                  <tr key={tip._id} className="hover:bg-muted/40">
+                    <td className="px-4 py-3 font-medium text-foreground">
+                      {tipperName}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {tip.articleTitle}
+                    </td>
+                    <td className="px-4 py-3 text-right font-semibold text-success-foreground">
                       +${tip.amountUsd.toFixed(2)}
-                    </p>
-                    <time
-                      dateTime={tipDate.toISOString()}
-                      title={absolute}
-                      aria-label={a11yLabel}
-                      className="text-xs text-muted-foreground"
-                    >
-                      {relative}
-                    </time>
-                  </div>
-                </div>
-              </div>
-            )
-          })}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <time
+                        dateTime={tipDate.toISOString()}
+                        title={absolute}
+                        aria-label={a11yLabel}
+                        className="text-xs text-muted-foreground"
+                      >
+                        {relative}
+                      </time>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
         </div>
       ) : (
         <div className="flex min-h-[12rem] flex-col items-center justify-center gap-2 px-6 py-10 text-center">

--- a/components/dashboard/TipHistory.tsx
+++ b/components/dashboard/TipHistory.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { formatDistanceToNow } from 'date-fns'
 import type { Doc } from '@/types/convex'
 
 export type ReceivedTipRow = Doc<'tips'> & {
@@ -22,28 +23,42 @@ export function TipHistory({ tips }: TipHistoryProps) {
         <h3 className="text-lg font-semibold">Recent Tips</h3>
       </div>
       <div className="divide-y divide-border">
-        {tips.slice(0, 10).map((tip) => (
-          <div key={tip._id} className="p-4 hover:bg-muted/50">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="font-medium text-foreground">
-                  {tip.tipper?.name || tip.tipper?.username || 'Anonymous'}
-                </p>
-                <p className="text-sm text-muted-foreground">
-                  tipped on &ldquo;{tip.articleTitle}&rdquo;
-                </p>
-              </div>
-              <div className="text-right">
-                <p className="font-semibold text-success-foreground">
-                  +${tip.amountUsd.toFixed(2)}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {new Date(tip.createdAt).toLocaleDateString()}
-                </p>
+        {tips.slice(0, 10).map((tip) => {
+          const tipDate = new Date(tip.createdAt)
+          const relative = formatDistanceToNow(tipDate, { addSuffix: true })
+          const absolute = tipDate.toLocaleDateString('en-US', {
+            dateStyle: 'long',
+          })
+          const a11yLabel = `${relative}. ${absolute}.`
+
+          return (
+            <div key={tip._id} className="p-4 hover:bg-muted/50">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="font-medium text-foreground">
+                    {tip.tipper?.name || tip.tipper?.username || 'Anonymous'}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    tipped on &ldquo;{tip.articleTitle}&rdquo;
+                  </p>
+                </div>
+                <div className="text-right">
+                  <p className="font-semibold text-success-foreground">
+                    +${tip.amountUsd.toFixed(2)}
+                  </p>
+                  <time
+                    dateTime={tipDate.toISOString()}
+                    title={absolute}
+                    aria-label={a11yLabel}
+                    className="text-xs text-muted-foreground"
+                  >
+                    {relative}
+                  </time>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )

--- a/components/dashboard/WithdrawalDialog.test.tsx
+++ b/components/dashboard/WithdrawalDialog.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { createRef } from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { WithdrawalDialog } from '@/components/dashboard/WithdrawalDialog'
@@ -8,7 +8,9 @@ import { WithdrawalDialog } from '@/components/dashboard/WithdrawalDialog'
 const validGAddress = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
 
 describe('WithdrawalDialog', () => {
-  it('calls onWithdraw with entered amount and address', async () => {
+  it(
+    'calls onWithdraw with entered amount and address',
+    async () => {
     const user = userEvent.setup()
     const onWithdraw = vi.fn().mockResolvedValue(undefined)
     const onOpenChange = vi.fn()
@@ -30,12 +32,16 @@ describe('WithdrawalDialog', () => {
     await user.type(screen.getByLabelText(/Stellar Address/i), validGAddress)
     await user.click(screen.getByRole('button', { name: /Withdraw$/i }))
 
-    expect(onWithdraw).toHaveBeenCalledWith({
-      amountUsd: 10,
-      stellarAddress: validGAddress,
+    await waitFor(() => {
+      expect(onWithdraw).toHaveBeenCalledWith({
+        amountUsd: 10,
+        stellarAddress: validGAddress,
+      })
+      expect(onOpenChange).toHaveBeenCalledWith(false)
     })
-    expect(onOpenChange).toHaveBeenCalledWith(false)
-  })
+    },
+    10_000
+  )
 
   it('uses saved Stellar address without manual entry', async () => {
     const user = userEvent.setup()

--- a/components/dashboard/WithdrawalDialog.test.tsx
+++ b/components/dashboard/WithdrawalDialog.test.tsx
@@ -8,9 +8,7 @@ import { WithdrawalDialog } from '@/components/dashboard/WithdrawalDialog'
 const validGAddress = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
 
 describe('WithdrawalDialog', () => {
-  it(
-    'calls onWithdraw with entered amount and address',
-    async () => {
+  it('calls onWithdraw with entered amount and address', async () => {
     const user = userEvent.setup()
     const onWithdraw = vi.fn().mockResolvedValue(undefined)
     const onOpenChange = vi.fn()
@@ -39,9 +37,7 @@ describe('WithdrawalDialog', () => {
       })
       expect(onOpenChange).toHaveBeenCalledWith(false)
     })
-    },
-    10_000
-  )
+  }, 10_000)
 
   it('uses saved Stellar address without manual entry', async () => {
     const user = userEvent.setup()

--- a/components/highlights/HighlightHeatmap.tsx
+++ b/components/highlights/HighlightHeatmap.tsx
@@ -5,6 +5,7 @@ import type { Id } from '@/types/convex'
 import { getHeatmapColor, formatTipAmount } from '@/lib/stellar/highlight-utils'
 import { Flame, TrendingUp, Sparkles } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useMemo, useState } from 'react'
 
 interface HighlightHeatmapProps {
   articleId: Id<'articles'>
@@ -12,13 +13,24 @@ interface HighlightHeatmapProps {
   className?: string
 }
 
+type HeatmapWindow = 'all' | '7d' | '30d'
+
 export function HighlightHeatmap({
   articleId,
   isAuthor = false,
   className,
 }: HighlightHeatmapProps) {
+  const [window, setWindow] = useState<HeatmapWindow>('all')
+
+  const sinceMs = useMemo(() => {
+    const dayMs = 24 * 60 * 60 * 1000
+    if (window === '7d') return Date.now() - 7 * dayMs
+    if (window === '30d') return Date.now() - 30 * dayMs
+    return undefined
+  }, [window])
+
   // Fetch highlight tip stats for this article
-  const stats = useArticleHighlightTipStats(articleId)
+  const stats = useArticleHighlightTipStats(articleId, { sinceMs })
 
   // Loading state
   if (stats === undefined) {
@@ -30,12 +42,15 @@ export function HighlightHeatmap({
         )}
       >
         <div className="animate-pulse space-y-4">
-          <div className="h-6 bg-muted rounded w-1/2"></div>
+          <div className="h-6 bg-muted rounded w-1/2" />
           <div className="h-20 bg-muted rounded"></div>
         </div>
       </div>
     )
   }
+
+  const windowLabel =
+    window === '7d' ? '7 days' : window === '30d' ? '30 days' : 'all time'
 
   // Empty state - No tips yet
   if (!stats || stats.totalTips === 0) {
@@ -46,17 +61,62 @@ export function HighlightHeatmap({
           className
         )}
       >
-        <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-          <Flame className="w-5 h-5 text-orange-500" />
-          Highlight Heatmap
-        </h3>
+        <div className="flex items-center justify-between gap-3 mb-4">
+          <h3 className="text-lg font-semibold flex items-center gap-2">
+            <Flame className="w-5 h-5 text-orange-500" />
+            Highlight Heatmap
+          </h3>
+
+          <div className="flex items-center rounded-md border border-border overflow-hidden bg-muted/40">
+            <button
+              type="button"
+              onClick={() => setWindow('all')}
+              className={cn(
+                'px-2.5 py-1 text-xs font-medium transition-colors',
+                window === 'all'
+                  ? 'bg-background text-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              All
+            </button>
+            <div className="w-px self-stretch bg-border" />
+            <button
+              type="button"
+              onClick={() => setWindow('7d')}
+              className={cn(
+                'px-2.5 py-1 text-xs font-medium transition-colors',
+                window === '7d'
+                  ? 'bg-background text-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              7d
+            </button>
+            <div className="w-px self-stretch bg-border" />
+            <button
+              type="button"
+              onClick={() => setWindow('30d')}
+              className={cn(
+                'px-2.5 py-1 text-xs font-medium transition-colors',
+                window === '30d'
+                  ? 'bg-background text-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              30d
+            </button>
+          </div>
+        </div>
 
         <div className="text-center py-8">
           <Sparkles className="w-12 h-12 mx-auto text-muted-foreground mb-3" />
           <p className="text-muted-foreground text-sm mb-2">
-            {isAuthor
-              ? 'No highlight tips yet'
-              : 'Be the first to tip a highlight!'}
+            {window === 'all'
+              ? isAuthor
+                ? 'No highlight tips yet'
+                : 'Be the first to tip a highlight!'
+              : `No highlight tips in the last ${windowLabel}`}
           </p>
           <p className="text-foreground/85 text-xs">
             {isAuthor
@@ -90,10 +150,53 @@ export function HighlightHeatmap({
         className
       )}
     >
-      <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-        <Flame className="w-5 h-5 text-orange-500" />
-        Highlight Heatmap
-      </h3>
+      <div className="flex items-center justify-between gap-3 mb-4">
+        <h3 className="text-lg font-semibold flex items-center gap-2">
+          <Flame className="w-5 h-5 text-orange-500" />
+          Highlight Heatmap
+        </h3>
+
+        <div className="flex items-center rounded-md border border-border overflow-hidden bg-muted/40">
+          <button
+            type="button"
+            onClick={() => setWindow('all')}
+            className={cn(
+              'px-2.5 py-1 text-xs font-medium transition-colors',
+              window === 'all'
+                ? 'bg-background text-foreground'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            All
+          </button>
+          <div className="w-px self-stretch bg-border" />
+          <button
+            type="button"
+            onClick={() => setWindow('7d')}
+            className={cn(
+              'px-2.5 py-1 text-xs font-medium transition-colors',
+              window === '7d'
+                ? 'bg-background text-foreground'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            7d
+          </button>
+          <div className="w-px self-stretch bg-border" />
+          <button
+            type="button"
+            onClick={() => setWindow('30d')}
+            className={cn(
+              'px-2.5 py-1 text-xs font-medium transition-colors',
+              window === '30d'
+                ? 'bg-background text-foreground'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            30d
+          </button>
+        </div>
+      </div>
 
       {/* Summary Stats */}
       <div className="grid grid-cols-3 gap-4 mb-6">

--- a/components/tipping/TipStats.tsx
+++ b/components/tipping/TipStats.tsx
@@ -2,6 +2,7 @@
 
 import { useArticleTipStats } from '@/hooks/convex'
 import type { Id } from '@/types/convex'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Coins, Users } from 'lucide-react'
 
 interface TipStatsProps {
@@ -12,9 +13,24 @@ interface TipStatsProps {
 export function TipStats({ articleId, className = '' }: TipStatsProps) {
   const stats = useArticleTipStats(articleId)
 
-  // Don't show anything while loading
   if (stats === undefined) {
-    return null
+    return (
+      <div
+        className={`flex items-center gap-4 text-sm text-muted-foreground ${className}`}
+        aria-hidden
+      >
+        <div className="flex items-center gap-1">
+          <Skeleton className="h-4 w-4 rounded" />
+          <Skeleton className="h-4 w-14" />
+          <Skeleton className="h-4 w-12" />
+        </div>
+        <div className="flex items-center gap-1">
+          <Skeleton className="h-4 w-4 rounded" />
+          <Skeleton className="h-4 w-6" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+      </div>
+    )
   }
 
   return (

--- a/convex/highlightTips.test.ts
+++ b/convex/highlightTips.test.ts
@@ -428,6 +428,47 @@ describe('highlightTips.create', () => {
     expect(stats.totalTips).toBe(0)
     expect(stats.totalAmountCents).toBe(0)
   })
+
+  it('filters heatmap stats by sinceMs', async () => {
+    const t = convexTest(schema, modules)
+    const { tipperId, articleId } = await seed(t)
+
+    const asTipper = t.withIdentity({ subject: tipperId })
+    const oldTipId = await asTipper.mutation(
+      api.highlightTips.create,
+      tipArgs(articleId, 'stellar-tx-old')
+    )
+    // Backdate so it falls outside the time window.
+    await t.run(async (ctx) => {
+      const tip = await ctx.db.get(oldTipId)
+      if (tip) {
+        await ctx.db.patch(oldTipId, { createdAt: tip.createdAt - 40 * 864e5 })
+      }
+    })
+    await confirmPending(t, oldTipId)
+
+    // Avoid cooldown: make the first tip older so the second insert is allowed.
+    await t.run(async (ctx) => {
+      const tip = await ctx.db.get(oldTipId)
+      if (tip) {
+        await ctx.db.patch(oldTipId, { createdAt: tip.createdAt - 60_000 })
+      }
+    })
+
+    const newTipId = await asTipper.mutation(
+      api.highlightTips.create,
+      tipArgs(articleId, 'stellar-tx-new')
+    )
+    await confirmPending(t, newTipId)
+
+    const sinceMs = Date.now() - 30 * 864e5
+    const stats = await t.query(api.highlightTips.getArticleStats, {
+      articleId,
+      sinceMs,
+    })
+    expect(stats.totalTips).toBe(1)
+    expect(stats.totalAmountCents).toBe(100)
+  })
 })
 
 describe('markHighlightTipConfirmed', () => {

--- a/convex/highlightTips.ts
+++ b/convex/highlightTips.ts
@@ -240,13 +240,21 @@ export const getByAuthor = query({
 export const getArticleStats = query({
   args: {
     articleId: v.id('articles'),
+    sinceMs: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const tips = await ctx.db
+    let tipsQuery = ctx.db
       .query('highlightTips')
       .withIndex('by_article', (q) => q.eq('articleId', args.articleId))
       .filter((q) => q.eq(q.field('status'), 'CONFIRMED'))
-      .collect()
+
+    if (args.sinceMs !== undefined) {
+      tipsQuery = tipsQuery.filter((q) =>
+        q.gte(q.field('createdAt'), args.sinceMs!)
+      )
+    }
+
+    const tips = await tipsQuery.collect()
 
     const totalTips = tips.length
     const totalAmountCents = tips.reduce((sum, tip) => sum + tip.amountCents, 0)

--- a/hooks/convex/useHighlightQueries.ts
+++ b/hooks/convex/useHighlightQueries.ts
@@ -23,15 +23,27 @@ export function useHighlightTipsByHighlight(highlightId: string) {
   return useQuery(api.highlightTips.getByHighlight, { highlightId })
 }
 
-export function useArticleHighlightTipStats(articleId: Id<'articles'>) {
-  return useQuery(api.highlightTips.getArticleStats, { articleId })
+export function useArticleHighlightTipStats(
+  articleId: Id<'articles'>,
+  opts?: { sinceMs?: number }
+) {
+  return useQuery(api.highlightTips.getArticleStats, {
+    articleId,
+    sinceMs: opts?.sinceMs,
+  })
 }
 
 export function useArticleHighlightTipStatsOptional(
-  articleId: Id<'articles'> | undefined
+  articleId: Id<'articles'> | undefined,
+  opts?: { sinceMs?: number }
 ) {
   return useQuery(
     api.highlightTips.getArticleStats,
-    articleId ? { articleId } : 'skip'
+    articleId
+      ? {
+          articleId,
+          sinceMs: opts?.sinceMs,
+        }
+      : 'skip'
   )
 }


### PR DESCRIPTION
## Summary
This PR polishes the dashboard experience by improving Tip History usability and enhancing highlights analytics.

## What changed
- Tip History: show relative timestamps for tips.
- Tip History: render a clear empty state when there are no tips.
- Tip History: add sorting + CSV download.
- Tip Stats: add a loading skeleton for better perceived performance.
- Highlight heatmap: add time-window filtering for highlight stats.
- Backend + hooks: update highlight tips query wiring and add coverage.
