### PR TITLE
fix: show wallet install links when no Stellar wallet detected

### DIFF
--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -266,141 +266,141 @@ export function HighlightTipButton({
             if (isLoading) e.preventDefault()
           }}
         >
-        <DialogHeader>
-          <DialogTitle>Tip Highlight</DialogTitle>
-          <DialogDescription className="sr-only">
-            Choose an amount to tip this highlight on the Stellar network.
-          </DialogDescription>
-        </DialogHeader>
+          <DialogHeader>
+            <DialogTitle>Tip Highlight</DialogTitle>
+            <DialogDescription className="sr-only">
+              Choose an amount to tip this highlight on the Stellar network.
+            </DialogDescription>
+          </DialogHeader>
 
-        <div className="mb-4 p-3 bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800 rounded-lg">
-          <p className="text-sm text-foreground italic">
-            &ldquo;{displayText}&rdquo;
-          </p>
-        </div>
-
-        <p className="text-muted-foreground mb-4 text-sm">
-          Tip {authorName} for this specific insight. 97.5% goes directly to the
-          author!
-        </p>
-
-        {!isConnected && (
-          <div className="mb-4 p-3 bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-lg text-sm text-amber-900 dark:text-amber-100">
-            <p>Connect your Stellar wallet to tip this highlight.</p>
-          </div>
-        )}
-
-        <div className="grid grid-cols-3 gap-3 mb-4">
-          {TIP_PRESETS_HIGHLIGHT.map((amount) => (
-            <button
-              key={amount.cents}
-              type="button"
-              onClick={() => {
-                setSelectedAmount(amount.cents)
-                setCustomAmount('')
-              }}
-              className={`focus-ring relative px-4 py-3 rounded-lg border-2 transition-all ${
-                selectedAmount === amount.cents
-                  ? 'border-orange-500 bg-orange-50 dark:bg-orange-950/30'
-                  : 'border-border hover:border-orange-300'
-              }`}
-            >
-              {amount.popular && (
-                <span className="absolute -top-2 left-1/2 transform -translate-x-1/2 px-2 py-0.5 bg-orange-500 text-white text-xs rounded-full">
-                  Popular
-                </span>
-              )}
-              <span className="font-semibold">{amount.label}</span>
-            </button>
-          ))}
-        </div>
-
-        <div className="mb-6">
-          <label
-            htmlFor="highlight-tip-custom-amount"
-            className="block text-sm font-medium text-foreground mb-2"
-          >
-            Or enter custom amount
-          </label>
-          <div className="relative">
-            <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">
-              $
-            </span>
-            <input
-              id="highlight-tip-custom-amount"
-              type="number"
-              min={TIP_MIN_USD}
-              max={TIP_MAX_USD}
-              step="0.01"
-              value={customAmount}
-              onChange={(e) => {
-                setCustomAmount(e.target.value)
-                setSelectedAmount(null)
-              }}
-              placeholder="0.00"
-              className="focus-ring w-full pl-8 pr-4 py-2 border border-input bg-background text-foreground rounded-lg"
-            />
-          </div>
-          <p className="text-xs text-muted-foreground mt-1">
-            Minimum: ${TIP_MIN_USD.toFixed(2)} • Maximum: $
-            {TIP_MAX_USD.toFixed(2)}
-          </p>
-        </div>
-
-        <div className="flex gap-3">
-          <button
-            type="button"
-            onClick={() => handleOpenChange(false)}
-            disabled={isLoading}
-            className="focus-ring flex-1 px-4 py-2 border border-input bg-background text-foreground rounded-lg hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Cancel
-          </button>
-
-          {!isConnected ? (
-            <button
-              type="button"
-              onClick={handleConnectWallet}
-              disabled={isLoading}
-              className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-blue-500 to-blue-600 text-white rounded-lg hover:from-blue-600 hover:to-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-            >
-              <Wallet className="w-4 h-4" />
-              <span>Connect Wallet</span>
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={() => void handleTip()}
-              disabled={isLoading || (!selectedAmount && !customAmount)}
-              className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-            >
-              {isLoading ? (
-                <>
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                  <span>Sending...</span>
-                </>
-              ) : (
-                <>
-                  <Heart className="w-4 h-4" />
-                  <span>Send Tip</span>
-                </>
-              )}
-            </button>
-          )}
-        </div>
-
-        {isConnected && publicKey && (
-          <div className="text-xs text-green-600 text-center mt-4">
-            <p className="flex items-center justify-center gap-1">
-              <Wallet className="w-3 h-3" />
-              Connected: {publicKey.slice(0, 6)}...{publicKey.slice(-6)}
+          <div className="mb-4 p-3 bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800 rounded-lg">
+            <p className="text-sm text-foreground italic">
+              &ldquo;{displayText}&rdquo;
             </p>
           </div>
-        )}
 
-        <p className="text-xs text-muted-foreground text-center mt-2">
-          Powered by Stellar • Instant settlement • Low fees
-        </p>
+          <p className="text-muted-foreground mb-4 text-sm">
+            Tip {authorName} for this specific insight. 97.5% goes directly to
+            the author!
+          </p>
+
+          {!isConnected && (
+            <div className="mb-4 p-3 bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-lg text-sm text-amber-900 dark:text-amber-100">
+              <p>Connect your Stellar wallet to tip this highlight.</p>
+            </div>
+          )}
+
+          <div className="grid grid-cols-3 gap-3 mb-4">
+            {TIP_PRESETS_HIGHLIGHT.map((amount) => (
+              <button
+                key={amount.cents}
+                type="button"
+                onClick={() => {
+                  setSelectedAmount(amount.cents)
+                  setCustomAmount('')
+                }}
+                className={`focus-ring relative px-4 py-3 rounded-lg border-2 transition-all ${
+                  selectedAmount === amount.cents
+                    ? 'border-orange-500 bg-orange-50 dark:bg-orange-950/30'
+                    : 'border-border hover:border-orange-300'
+                }`}
+              >
+                {amount.popular && (
+                  <span className="absolute -top-2 left-1/2 transform -translate-x-1/2 px-2 py-0.5 bg-orange-500 text-white text-xs rounded-full">
+                    Popular
+                  </span>
+                )}
+                <span className="font-semibold">{amount.label}</span>
+              </button>
+            ))}
+          </div>
+
+          <div className="mb-6">
+            <label
+              htmlFor="highlight-tip-custom-amount"
+              className="block text-sm font-medium text-foreground mb-2"
+            >
+              Or enter custom amount
+            </label>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">
+                $
+              </span>
+              <input
+                id="highlight-tip-custom-amount"
+                type="number"
+                min={TIP_MIN_USD}
+                max={TIP_MAX_USD}
+                step="0.01"
+                value={customAmount}
+                onChange={(e) => {
+                  setCustomAmount(e.target.value)
+                  setSelectedAmount(null)
+                }}
+                placeholder="0.00"
+                className="focus-ring w-full pl-8 pr-4 py-2 border border-input bg-background text-foreground rounded-lg"
+              />
+            </div>
+            <p className="text-xs text-muted-foreground mt-1">
+              Minimum: ${TIP_MIN_USD.toFixed(2)} • Maximum: $
+              {TIP_MAX_USD.toFixed(2)}
+            </p>
+          </div>
+
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={() => handleOpenChange(false)}
+              disabled={isLoading}
+              className="focus-ring flex-1 px-4 py-2 border border-input bg-background text-foreground rounded-lg hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Cancel
+            </button>
+
+            {!isConnected ? (
+              <button
+                type="button"
+                onClick={handleConnectWallet}
+                disabled={isLoading}
+                className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-blue-500 to-blue-600 text-white rounded-lg hover:from-blue-600 hover:to-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              >
+                <Wallet className="w-4 h-4" />
+                <span>Connect Wallet</span>
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => void handleTip()}
+                disabled={isLoading || (!selectedAmount && !customAmount)}
+                className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    <span>Sending...</span>
+                  </>
+                ) : (
+                  <>
+                    <Heart className="w-4 h-4" />
+                    <span>Send Tip</span>
+                  </>
+                )}
+              </button>
+            )}
+          </div>
+
+          {isConnected && publicKey && (
+            <div className="text-xs text-green-600 text-center mt-4">
+              <p className="flex items-center justify-center gap-1">
+                <Wallet className="w-3 h-3" />
+                Connected: {publicKey.slice(0, 6)}...{publicKey.slice(-6)}
+              </p>
+            </div>
+          )}
+
+          <p className="text-xs text-muted-foreground text-center mt-2">
+            Powered by Stellar • Instant settlement • Low fees
+          </p>
         </DialogContent>
       </Dialog>
 

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -29,6 +29,8 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
+import { InstallWalletDialog } from '@/components/stellar/InstallWalletDialog'
+import { NO_WALLET_AVAILABLE_ERROR_CODE } from '@/lib/stellar/wallet-adapter'
 
 interface HighlightTipButtonProps {
   articleId: Id<'articles'>
@@ -61,6 +63,7 @@ export function HighlightTipButton({
   const { isConnected, publicKey, signTransaction, connect } = useWallet()
   const router = useRouter()
   const [isOpen, setIsOpen] = useState(false)
+  const [installDialogOpen, setInstallDialogOpen] = useState(false)
   const [selectedAmount, setSelectedAmount] = useState<number | null>(null)
   const [customAmount, setCustomAmount] = useState('')
   const [isLoading, setIsLoading] = useState(false)
@@ -219,32 +222,50 @@ export function HighlightTipButton({
     }
   }
 
+  const handleConnectWallet = async () => {
+    try {
+      await connect()
+      toast.success('Wallet connected successfully!')
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to connect wallet'
+
+      if (message.startsWith(`${NO_WALLET_AVAILABLE_ERROR_CODE}:`)) {
+        setInstallDialogOpen(true)
+        return
+      }
+
+      toast.error(message)
+    }
+  }
+
   const displayText =
     highlightText.length > 60
       ? highlightText.slice(0, 60) + '...'
       : highlightText
 
   return (
-    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      <DialogTrigger asChild>
-        <button
-          type="button"
-          className={`focus-ring inline-flex items-center gap-2 px-3 py-1.5 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 transition-all transform hover:scale-105 shadow-md text-sm ${className}`}
-          title="Tip this highlight"
+    <>
+      <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+        <DialogTrigger asChild>
+          <button
+            type="button"
+            className={`focus-ring inline-flex items-center gap-2 px-3 py-1.5 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 transition-all transform hover:scale-105 shadow-md text-sm ${className}`}
+            title="Tip this highlight"
+          >
+            <Coins className="w-3.5 h-3.5" />
+            <span className="font-medium">Tip Highlight</span>
+          </button>
+        </DialogTrigger>
+        <DialogContent
+          className="max-w-md max-h-[min(90dvh,calc(100%-2rem))] overflow-y-auto"
+          onEscapeKeyDown={(e) => {
+            if (isLoading) e.preventDefault()
+          }}
+          onInteractOutside={(e) => {
+            if (isLoading) e.preventDefault()
+          }}
         >
-          <Coins className="w-3.5 h-3.5" />
-          <span className="font-medium">Tip Highlight</span>
-        </button>
-      </DialogTrigger>
-      <DialogContent
-        className="max-w-md max-h-[min(90dvh,calc(100%-2rem))] overflow-y-auto"
-        onEscapeKeyDown={(e) => {
-          if (isLoading) e.preventDefault()
-        }}
-        onInteractOutside={(e) => {
-          if (isLoading) e.preventDefault()
-        }}
-      >
         <DialogHeader>
           <DialogTitle>Tip Highlight</DialogTitle>
           <DialogDescription className="sr-only">
@@ -339,14 +360,7 @@ export function HighlightTipButton({
           {!isConnected ? (
             <button
               type="button"
-              onClick={async () => {
-                try {
-                  await connect()
-                  toast.success('Wallet connected successfully!')
-                } catch {
-                  toast.error('Failed to connect wallet')
-                }
-              }}
+              onClick={handleConnectWallet}
               disabled={isLoading}
               className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-blue-500 to-blue-600 text-white rounded-lg hover:from-blue-600 hover:to-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
             >
@@ -387,7 +401,13 @@ export function HighlightTipButton({
         <p className="text-xs text-muted-foreground text-center mt-2">
           Powered by Stellar • Instant settlement • Low fees
         </p>
-      </DialogContent>
-    </Dialog>
+        </DialogContent>
+      </Dialog>
+
+      <InstallWalletDialog
+        open={installDialogOpen}
+        onOpenChange={setInstallDialogOpen}
+      />
+    </>
   )
 }

--- a/components/nft/MintButton.tsx
+++ b/components/nft/MintButton.tsx
@@ -227,121 +227,123 @@ export function MintButton({
             if (isLoading) e.preventDefault()
           }}
         >
-        <DialogHeader>
-          <DialogTitle>Mint Article as NFT</DialogTitle>
-          <DialogDescription>
-            Convert your article into a unique NFT on the Stellar blockchain
-          </DialogDescription>
-        </DialogHeader>
+          <DialogHeader>
+            <DialogTitle>Mint Article as NFT</DialogTitle>
+            <DialogDescription>
+              Convert your article into a unique NFT on the Stellar blockchain
+            </DialogDescription>
+          </DialogHeader>
 
-        <div className="space-y-4">
-          {!wallet.isConnected && (
-            <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
-              <p className="text-sm text-amber-900">
-                Connect your wallet to mint this article as an NFT.
-              </p>
-            </div>
-          )}
-          <div className="bg-secondary p-4 rounded-lg space-y-2">
-            <h4 className="font-medium">{articleTitle}</h4>
-            <div className="text-sm space-y-1">
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Total Tips:</span>
-                <span className="font-medium">${totalTips.toFixed(2)}</span>
+          <div className="space-y-4">
+            {!wallet.isConnected && (
+              <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
+                <p className="text-sm text-amber-900">
+                  Connect your wallet to mint this article as an NFT.
+                </p>
               </div>
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Threshold Met:</span>
-                <span className="font-medium text-green-800 dark:text-green-300">
-                  ✓ Yes
-                </span>
-              </div>
-              {wallet.isConnected && wallet.publicKey ? (
-                <div className="bg-green-50 border border-green-200 rounded p-2">
-                  <div className="flex items-center justify-between text-xs">
-                    <span className="text-green-900 font-medium">
-                      ✓ Wallet Connected
-                    </span>
-                    <span className="font-mono text-green-700">
-                      {`${wallet.publicKey.slice(0, 4)}...${wallet.publicKey.slice(-4)}`}
-                    </span>
-                  </div>
+            )}
+            <div className="bg-secondary p-4 rounded-lg space-y-2">
+              <h4 className="font-medium">{articleTitle}</h4>
+              <div className="text-sm space-y-1">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Total Tips:</span>
+                  <span className="font-medium">${totalTips.toFixed(2)}</span>
                 </div>
-              ) : (
-                <div className="bg-amber-50 border border-amber-200 rounded p-2">
-                  <span className="text-xs text-amber-900">
-                    Wallet not connected
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Threshold Met:</span>
+                  <span className="font-medium text-green-800 dark:text-green-300">
+                    ✓ Yes
                   </span>
                 </div>
+                {wallet.isConnected && wallet.publicKey ? (
+                  <div className="bg-green-50 border border-green-200 rounded p-2">
+                    <div className="flex items-center justify-between text-xs">
+                      <span className="text-green-900 font-medium">
+                        ✓ Wallet Connected
+                      </span>
+                      <span className="font-mono text-green-700">
+                        {`${wallet.publicKey.slice(0, 4)}...${wallet.publicKey.slice(-4)}`}
+                      </span>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="bg-amber-50 border border-amber-200 rounded p-2">
+                    <span className="text-xs text-amber-900">
+                      Wallet not connected
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {isLoading && (
+              <div className="bg-blue-50 p-4 rounded-lg space-y-2">
+                <div className="flex items-center gap-2">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <span className="font-medium">Minting in Progress...</span>
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  {mintingStep === 'checking' && 'Verifying eligibility...'}
+                  {mintingStep === 'wallet' && 'Sign in your wallet...'}
+                  {mintingStep === 'blockchain' && 'Minting NFT...'}
+                  {mintingStep === 'database' && 'Finalizing...'}
+                </div>
+              </div>
+            )}
+
+            <div className="space-y-2 text-sm text-muted-foreground">
+              <p>By minting this NFT:</p>
+              <ul className="list-disc list-inside space-y-1">
+                <li>
+                  You&apos;ll create a unique token representing ownership
+                </li>
+                <li>The NFT can be transferred or traded</li>
+                <li>You&apos;ll retain authorship attribution</li>
+                <li>This action cannot be undone</li>
+              </ul>
+            </div>
+
+            <div className="flex gap-3">
+              <Button
+                variant="outline"
+                type="button"
+                onClick={() => setDialogOpen(false)}
+                disabled={isLoading}
+                className="flex-1"
+              >
+                Cancel
+              </Button>
+
+              {!wallet.isConnected ? (
+                <Button
+                  onClick={handleConnectWallet}
+                  disabled={isLoading}
+                  className="flex-1"
+                >
+                  <Wallet className="mr-2 h-4 w-4" />
+                  Connect Wallet
+                </Button>
+              ) : (
+                <Button
+                  onClick={handleMint}
+                  disabled={isLoading}
+                  className="flex-1"
+                >
+                  {isLoading ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Minting...
+                    </>
+                  ) : (
+                    <>
+                      <Sparkles className="mr-2 h-4 w-4" />
+                      Mint NFT
+                    </>
+                  )}
+                </Button>
               )}
             </div>
           </div>
-
-          {isLoading && (
-            <div className="bg-blue-50 p-4 rounded-lg space-y-2">
-              <div className="flex items-center gap-2">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                <span className="font-medium">Minting in Progress...</span>
-              </div>
-              <div className="text-sm text-muted-foreground">
-                {mintingStep === 'checking' && 'Verifying eligibility...'}
-                {mintingStep === 'wallet' && 'Sign in your wallet...'}
-                {mintingStep === 'blockchain' && 'Minting NFT...'}
-                {mintingStep === 'database' && 'Finalizing...'}
-              </div>
-            </div>
-          )}
-
-          <div className="space-y-2 text-sm text-muted-foreground">
-            <p>By minting this NFT:</p>
-            <ul className="list-disc list-inside space-y-1">
-              <li>You&apos;ll create a unique token representing ownership</li>
-              <li>The NFT can be transferred or traded</li>
-              <li>You&apos;ll retain authorship attribution</li>
-              <li>This action cannot be undone</li>
-            </ul>
-          </div>
-
-          <div className="flex gap-3">
-            <Button
-              variant="outline"
-              type="button"
-              onClick={() => setDialogOpen(false)}
-              disabled={isLoading}
-              className="flex-1"
-            >
-              Cancel
-            </Button>
-
-            {!wallet.isConnected ? (
-              <Button
-                onClick={handleConnectWallet}
-                disabled={isLoading}
-                className="flex-1"
-              >
-                <Wallet className="mr-2 h-4 w-4" />
-                Connect Wallet
-              </Button>
-            ) : (
-              <Button
-                onClick={handleMint}
-                disabled={isLoading}
-                className="flex-1"
-              >
-                {isLoading ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Minting...
-                  </>
-                ) : (
-                  <>
-                    <Sparkles className="mr-2 h-4 w-4" />
-                    Mint NFT
-                  </>
-                )}
-              </Button>
-            )}
-          </div>
-        </div>
         </DialogContent>
       </Dialog>
 

--- a/components/nft/MintButton.tsx
+++ b/components/nft/MintButton.tsx
@@ -19,6 +19,8 @@ import { useStellarWallet } from '@/hooks/useStellarWallet'
 import { nftClient } from '@/lib/stellar/nft-client'
 import { stellarClient } from '@/lib/stellar/client'
 import { ConvexHttpClient } from 'convex/browser'
+import { InstallWalletDialog } from '@/components/stellar/InstallWalletDialog'
+import { NO_WALLET_AVAILABLE_ERROR_CODE } from '@/lib/stellar/wallet-adapter'
 
 interface MintButtonProps {
   articleId: string | Id<'articles'>
@@ -45,6 +47,7 @@ export function MintButton({
 }: MintButtonProps) {
   const [isLoading, setIsLoading] = useState(false)
   const [dialogOpen, setDialogOpen] = useState(false)
+  const [installDialogOpen, setInstallDialogOpen] = useState(false)
   const [mintingStep, setMintingStep] = useState<
     'checking' | 'wallet' | 'blockchain' | 'database'
   >('checking')
@@ -68,6 +71,23 @@ export function MintButton({
 
   // Initialize Convex HTTP client for async calls
   const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!)
+
+  const handleConnectWallet = async () => {
+    try {
+      await wallet.connect()
+      toast.success('Wallet connected successfully!')
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to connect wallet'
+
+      if (message.startsWith(`${NO_WALLET_AVAILABLE_ERROR_CODE}:`)) {
+        setInstallDialogOpen(true)
+        return
+      }
+
+      toast.error(message)
+    }
+  }
 
   const handleMint = async () => {
     if (!wallet.isConnected || !wallet.publicKey) {
@@ -186,26 +206,27 @@ export function MintButton({
   }
 
   return (
-    <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-      <DialogTrigger asChild>
-        <Button
-          disabled={!canMint}
-          className="w-full"
-          variant="default"
-          type="button"
+    <>
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogTrigger asChild>
+          <Button
+            disabled={!canMint}
+            className="w-full"
+            variant="default"
+            type="button"
+          >
+            <Sparkles className="mr-2 h-4 w-4" />
+            Mint NFT
+          </Button>
+        </DialogTrigger>
+        <DialogContent
+          onEscapeKeyDown={(e) => {
+            if (isLoading) e.preventDefault()
+          }}
+          onInteractOutside={(e) => {
+            if (isLoading) e.preventDefault()
+          }}
         >
-          <Sparkles className="mr-2 h-4 w-4" />
-          Mint NFT
-        </Button>
-      </DialogTrigger>
-      <DialogContent
-        onEscapeKeyDown={(e) => {
-          if (isLoading) e.preventDefault()
-        }}
-        onInteractOutside={(e) => {
-          if (isLoading) e.preventDefault()
-        }}
-      >
         <DialogHeader>
           <DialogTitle>Mint Article as NFT</DialogTitle>
           <DialogDescription>
@@ -293,7 +314,7 @@ export function MintButton({
 
             {!wallet.isConnected ? (
               <Button
-                onClick={wallet.connect}
+                onClick={handleConnectWallet}
                 disabled={isLoading}
                 className="flex-1"
               >
@@ -321,7 +342,13 @@ export function MintButton({
             )}
           </div>
         </div>
-      </DialogContent>
-    </Dialog>
+        </DialogContent>
+      </Dialog>
+
+      <InstallWalletDialog
+        open={installDialogOpen}
+        onOpenChange={setInstallDialogOpen}
+      />
+    </>
   )
 }

--- a/components/stellar/InstallWalletDialog.tsx
+++ b/components/stellar/InstallWalletDialog.tsx
@@ -1,6 +1,11 @@
 'use client'
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { ExternalLink, Download } from 'lucide-react'
 
@@ -49,8 +54,9 @@ export function InstallWalletDialog({
 
         <div className="space-y-4">
           <p className="text-sm text-muted-foreground">
-            We couldn&apos;t find a Stellar wallet in your browser. Install one of
-            the options below, then reload this page and try connecting again.
+            We couldn&apos;t find a Stellar wallet in your browser. Install one
+            of the options below, then reload this page and try connecting
+            again.
           </p>
 
           <div className="grid gap-2">
@@ -66,7 +72,9 @@ export function InstallWalletDialog({
                   <div className="min-w-0">
                     <div className="font-medium text-sm">{w.name}</div>
                     {w.note ? (
-                      <div className="text-xs text-muted-foreground">{w.note}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {w.note}
+                      </div>
                     ) : null}
                   </div>
                   <span className="inline-flex items-center text-xs text-muted-foreground">
@@ -88,4 +96,3 @@ export function InstallWalletDialog({
     </Dialog>
   )
 }
-

--- a/components/stellar/InstallWalletDialog.tsx
+++ b/components/stellar/InstallWalletDialog.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { ExternalLink, Download } from 'lucide-react'
+
+type WalletInstallLink = {
+  name: string
+  href: string
+  note?: string
+}
+
+const WALLET_INSTALL_LINKS: WalletInstallLink[] = [
+  {
+    name: 'Freighter',
+    href: 'https://chromewebstore.google.com/detail/freighter/bcacfldlkkdogcmkkibnjlakofdplcbk',
+  },
+  {
+    name: 'xBull',
+    href: 'https://chromewebstore.google.com/detail/xbull-wallet/omajpeaffjgmlpmhbfdjepdejoemifpe',
+  },
+  {
+    name: 'Albedo',
+    href: 'https://chrome.google.com/webstore/detail/albedo-signer-for-stellar/kbojmmmibkfijmjgnfgfpngmmgkkpncl/',
+    note: 'Requires HTTPS for some flows',
+  },
+  {
+    name: 'HOT Wallet',
+    href: 'https://chromewebstore.google.com/detail/hot-wallet/mpeengabcnhhjjgleiodimegnkpcenbk',
+  },
+]
+
+export function InstallWalletDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Download className="h-5 w-5" />
+            Install a Stellar wallet
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            We couldn&apos;t find a Stellar wallet in your browser. Install one of
+            the options below, then reload this page and try connecting again.
+          </p>
+
+          <div className="grid gap-2">
+            {WALLET_INSTALL_LINKS.map((w) => (
+              <a
+                key={w.name}
+                href={w.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-lg border border-border bg-muted/30 p-3 hover:bg-muted/50 transition-colors"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="font-medium text-sm">{w.name}</div>
+                    {w.note ? (
+                      <div className="text-xs text-muted-foreground">{w.note}</div>
+                    ) : null}
+                  </div>
+                  <span className="inline-flex items-center text-xs text-muted-foreground">
+                    Open store
+                    <ExternalLink className="ml-2 h-3.5 w-3.5" />
+                  </span>
+                </div>
+              </a>
+            ))}
+          </div>
+
+          <div className="flex justify-end">
+            <Button variant="secondary" onClick={() => onOpenChange(false)}>
+              Close
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+

--- a/components/stellar/WalletConnectButton.tsx
+++ b/components/stellar/WalletConnectButton.tsx
@@ -6,6 +6,8 @@ import { useWallet } from '@/components/providers/WalletProvider'
 import { Wallet, Loader2, AlertCircle, CheckCircle } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
+import { InstallWalletDialog } from '@/components/stellar/InstallWalletDialog'
+import { NO_WALLET_AVAILABLE_ERROR_CODE } from '@/lib/stellar/wallet-adapter'
 
 interface WalletConnectButtonProps {
   className?: string
@@ -29,6 +31,7 @@ export function WalletConnectButton({
     disconnect,
   } = useWallet()
   const [isConnecting, setIsConnecting] = useState(false)
+  const [installDialogOpen, setInstallDialogOpen] = useState(false)
 
   const handleConnect = async () => {
     if (isConnected) {
@@ -40,8 +43,16 @@ export function WalletConnectButton({
     try {
       await connect()
     } catch (error) {
-      toast.error(
+      const message =
         error instanceof Error ? error.message : 'Failed to connect wallet'
+
+      if (message.startsWith(`${NO_WALLET_AVAILABLE_ERROR_CODE}:`)) {
+        setInstallDialogOpen(true)
+        return
+      }
+
+      toast.error(
+        message
       )
     } finally {
       setIsConnecting(false)
@@ -114,24 +125,31 @@ export function WalletConnectButton({
 
   // Show connect button
   return (
-    <Button
-      onClick={handleConnect}
-      disabled={isConnecting}
-      size={size}
-      variant={variant}
-      className={className}
-    >
-      {isConnecting ? (
-        <>
-          <Loader2 className="w-4 h-4 animate-spin mr-2" />
-          Connecting...
-        </>
-      ) : (
-        <>
-          <Wallet className="w-4 h-4 mr-2" />
-          Connect Wallet
-        </>
-      )}
-    </Button>
+    <>
+      <Button
+        onClick={handleConnect}
+        disabled={isConnecting}
+        size={size}
+        variant={variant}
+        className={className}
+      >
+        {isConnecting ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin mr-2" />
+            Connecting...
+          </>
+        ) : (
+          <>
+            <Wallet className="w-4 h-4 mr-2" />
+            Connect Wallet
+          </>
+        )}
+      </Button>
+
+      <InstallWalletDialog
+        open={installDialogOpen}
+        onOpenChange={setInstallDialogOpen}
+      />
+    </>
   )
 }

--- a/components/stellar/WalletConnectButton.tsx
+++ b/components/stellar/WalletConnectButton.tsx
@@ -51,9 +51,7 @@ export function WalletConnectButton({
         return
       }
 
-      toast.error(
-        message
-      )
+      toast.error(message)
     } finally {
       setIsConnecting(false)
     }

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -159,199 +159,202 @@ export function WalletSettings({
   return (
     <>
       <Card className={className}>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Wallet className="h-5 w-5" />
-          Stellar Wallet
-          <WalletTooltip concept="stellar" />
-        </CardTitle>
-        <CardDescription>
-          {isOwnProfile
-            ? 'Manage your Stellar wallet for sending and receiving tips'
-            : 'Send tips directly to this user&apos;s Stellar wallet'}
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {isOwnProfile && (
-          <Alert className="bg-blue-50 border-blue-200">
-            <AlertCircle className="h-4 w-4 text-blue-600" />
-            <AlertDescription className="text-blue-900">
-              <strong>This wallet is for receiving tips.</strong> When readers
-              tip your articles, payments come here. To send tips to other
-              authors, you&apos;ll connect your wallet extension directly on
-              their articles.
-            </AlertDescription>
-          </Alert>
-        )}
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Wallet className="h-5 w-5" />
+            Stellar Wallet
+            <WalletTooltip concept="stellar" />
+          </CardTitle>
+          <CardDescription>
+            {isOwnProfile
+              ? 'Manage your Stellar wallet for sending and receiving tips'
+              : 'Send tips directly to this user&apos;s Stellar wallet'}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {isOwnProfile && (
+            <Alert className="bg-blue-50 border-blue-200">
+              <AlertCircle className="h-4 w-4 text-blue-600" />
+              <AlertDescription className="text-blue-900">
+                <strong>This wallet is for receiving tips.</strong> When readers
+                tip your articles, payments come here. To send tips to other
+                authors, you&apos;ll connect your wallet extension directly on
+                their articles.
+              </AlertDescription>
+            </Alert>
+          )}
 
-        {isOwnProfile ? (
-          <>
-            {!walletAddress ? (
-              <div className="space-y-4">
-                <Alert>
-                  <AlertCircle className="h-4 w-4" />
-                  <AlertDescription>
-                    Connect your Stellar wallet to send and receive tips
-                  </AlertDescription>
-                </Alert>
+          {isOwnProfile ? (
+            <>
+              {!walletAddress ? (
+                <div className="space-y-4">
+                  <Alert>
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertDescription>
+                      Connect your Stellar wallet to send and receive tips
+                    </AlertDescription>
+                  </Alert>
 
-                <Button
-                  onClick={handleConnectWallet}
-                  disabled={isConnecting || isLoading}
-                  className="w-full"
-                  size="lg"
-                >
-                  {isConnecting ? (
-                    <>
-                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                      Connecting Wallet...
-                    </>
-                  ) : (
-                    <>
-                      <PlugZap className="w-4 h-4 mr-2" />
-                      Connect Stellar Wallet
-                    </>
-                  )}
-                </Button>
-
-                <div className="text-center text-sm text-muted-foreground">
-                  Need a wallet?{' '}
-                  <Link href="/guide" className="text-blue-600 hover:underline">
-                    Follow our setup guide
-                  </Link>
-                </div>
-              </div>
-            ) : (
-              <div className="space-y-4">
-                {/* Connected State */}
-                <div className="p-4 bg-green-50 border border-green-200 rounded-lg space-y-3">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
-                      <span className="text-sm font-medium">
-                        Wallet Connected
-                      </span>
-                    </div>
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label className="text-xs text-muted-foreground">
-                      Your Wallet Address
-                    </Label>
-                    <div className="flex gap-2">
-                      <Input
-                        value={walletAddress || ''}
-                        readOnly
-                        className="font-mono text-xs"
-                      />
-                      <Button
-                        variant="outline"
-                        size="icon"
-                        onClick={handleCopy}
-                      >
-                        {isCopied ? (
-                          <Check className="h-4 w-4" />
-                        ) : (
-                          <Copy className="h-4 w-4" />
-                        )}
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-
-                <Alert>
-                  <DollarSign className="h-4 w-4" />
-                  <AlertDescription>
-                    You can send and receive tips with this wallet. You can
-                    change it anytime by disconnecting and connecting a
-                    different account.
-                  </AlertDescription>
-                </Alert>
-
-                <div className="flex gap-2">
                   <Button
-                    variant="outline"
-                    className="flex-1"
-                    onClick={() =>
-                      walletAddress &&
-                      window.open(
-                        `https://stellar.expert/explorer/testnet/account/${walletAddress}`,
-                        '_blank'
-                      )
-                    }
-                    disabled={!walletAddress}
-                  >
-                    <ArrowUpRight className="h-4 w-4 mr-2" />
-                    View on Explorer
-                  </Button>
-                  <Button
-                    onClick={handleDisconnectWallet}
-                    disabled={isConnecting}
-                    variant="outline"
-                    className="flex-1"
+                    onClick={handleConnectWallet}
+                    disabled={isConnecting || isLoading}
+                    className="w-full"
+                    size="lg"
                   >
                     {isConnecting ? (
                       <>
                         <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                        Disconnecting...
+                        Connecting Wallet...
                       </>
                     ) : (
                       <>
-                        <Power className="w-4 h-4 mr-2" />
-                        Disconnect
+                        <PlugZap className="w-4 h-4 mr-2" />
+                        Connect Stellar Wallet
                       </>
+                    )}
+                  </Button>
+
+                  <div className="text-center text-sm text-muted-foreground">
+                    Need a wallet?{' '}
+                    <Link
+                      href="/guide"
+                      className="text-blue-600 hover:underline"
+                    >
+                      Follow our setup guide
+                    </Link>
+                  </div>
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {/* Connected State */}
+                  <div className="p-4 bg-green-50 border border-green-200 rounded-lg space-y-3">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
+                        <span className="text-sm font-medium">
+                          Wallet Connected
+                        </span>
+                      </div>
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label className="text-xs text-muted-foreground">
+                        Your Wallet Address
+                      </Label>
+                      <div className="flex gap-2">
+                        <Input
+                          value={walletAddress || ''}
+                          readOnly
+                          className="font-mono text-xs"
+                        />
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          onClick={handleCopy}
+                        >
+                          {isCopied ? (
+                            <Check className="h-4 w-4" />
+                          ) : (
+                            <Copy className="h-4 w-4" />
+                          )}
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+
+                  <Alert>
+                    <DollarSign className="h-4 w-4" />
+                    <AlertDescription>
+                      You can send and receive tips with this wallet. You can
+                      change it anytime by disconnecting and connecting a
+                      different account.
+                    </AlertDescription>
+                  </Alert>
+
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      className="flex-1"
+                      onClick={() =>
+                        walletAddress &&
+                        window.open(
+                          `https://stellar.expert/explorer/testnet/account/${walletAddress}`,
+                          '_blank'
+                        )
+                      }
+                      disabled={!walletAddress}
+                    >
+                      <ArrowUpRight className="h-4 w-4 mr-2" />
+                      View on Explorer
+                    </Button>
+                    <Button
+                      onClick={handleDisconnectWallet}
+                      disabled={isConnecting}
+                      variant="outline"
+                      className="flex-1"
+                    >
+                      {isConnecting ? (
+                        <>
+                          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                          Disconnecting...
+                        </>
+                      ) : (
+                        <>
+                          <Power className="w-4 h-4 mr-2" />
+                          Disconnect
+                        </>
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </>
+          ) : (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label>User&apos;s Wallet Address</Label>
+                <div className="flex gap-2">
+                  <Input
+                    value={walletAddress || ''}
+                    readOnly
+                    className="font-mono text-xs"
+                  />
+                  <Button variant="outline" size="icon" onClick={handleCopy}>
+                    {isCopied ? (
+                      <Check className="h-4 w-4" />
+                    ) : (
+                      <Copy className="h-4 w-4" />
                     )}
                   </Button>
                 </div>
               </div>
-            )}
-          </>
-        ) : (
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label>User&apos;s Wallet Address</Label>
-              <div className="flex gap-2">
-                <Input
-                  value={walletAddress || ''}
-                  readOnly
-                  className="font-mono text-xs"
-                />
-                <Button variant="outline" size="icon" onClick={handleCopy}>
-                  {isCopied ? (
-                    <Check className="h-4 w-4" />
-                  ) : (
-                    <Copy className="h-4 w-4" />
-                  )}
-                </Button>
-              </div>
+
+              <Button
+                variant="outline"
+                className="w-full"
+                onClick={() =>
+                  walletAddress &&
+                  window.open(
+                    `https://stellar.expert/explorer/testnet/account/${walletAddress}`,
+                    '_blank'
+                  )
+                }
+                disabled={!walletAddress}
+              >
+                <ArrowUpRight className="h-4 w-4 mr-2" />
+                View on Stellar Explorer
+              </Button>
+
+              <Alert>
+                <DollarSign className="h-4 w-4" />
+                <AlertDescription>
+                  Tips sent to this wallet go directly to the user with minimal
+                  platform fees.
+                </AlertDescription>
+              </Alert>
             </div>
-
-            <Button
-              variant="outline"
-              className="w-full"
-              onClick={() =>
-                walletAddress &&
-                window.open(
-                  `https://stellar.expert/explorer/testnet/account/${walletAddress}`,
-                  '_blank'
-                )
-              }
-              disabled={!walletAddress}
-            >
-              <ArrowUpRight className="h-4 w-4 mr-2" />
-              View on Stellar Explorer
-            </Button>
-
-            <Alert>
-              <DollarSign className="h-4 w-4" />
-              <AlertDescription>
-                Tips sent to this wallet go directly to the user with minimal
-                platform fees.
-              </AlertDescription>
-            </Alert>
-          </div>
-        )}
-      </CardContent>
+          )}
+        </CardContent>
       </Card>
 
       <InstallWalletDialog

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -29,6 +29,8 @@ import {
 import { WalletTooltip } from '@/components/guide/WalletTooltip'
 import { toast } from 'sonner'
 import { useWallet } from '@/components/providers/WalletProvider'
+import { InstallWalletDialog } from '@/components/stellar/InstallWalletDialog'
+import { NO_WALLET_AVAILABLE_ERROR_CODE } from '@/lib/stellar/wallet-adapter'
 
 interface WalletSettingsProps {
   walletAddress?: string | null
@@ -47,6 +49,7 @@ export function WalletSettings({
   const { isLoading, connect, disconnect } = useWallet()
   const [isCopied, setIsCopied] = useState(false)
   const [isConnecting, setIsConnecting] = useState(false)
+  const [installDialogOpen, setInstallDialogOpen] = useState(false)
 
   const handleCopy = async () => {
     if (!walletAddress) return
@@ -80,8 +83,18 @@ export function WalletSettings({
       } else {
         toast.error('Failed to connect wallet')
       }
-    } catch {
-      toast.error('Failed to connect and save wallet address')
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Failed to connect and save wallet address'
+
+      if (message.startsWith(`${NO_WALLET_AVAILABLE_ERROR_CODE}:`)) {
+        setInstallDialogOpen(true)
+        return
+      }
+
+      toast.error(message)
     } finally {
       setIsConnecting(false)
     }
@@ -144,7 +157,8 @@ export function WalletSettings({
   }
 
   return (
-    <Card className={className}>
+    <>
+      <Card className={className}>
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Wallet className="h-5 w-5" />
@@ -338,6 +352,12 @@ export function WalletSettings({
           </div>
         )}
       </CardContent>
-    </Card>
+      </Card>
+
+      <InstallWalletDialog
+        open={installDialogOpen}
+        onOpenChange={setInstallDialogOpen}
+      />
+    </>
   )
 }

--- a/components/stellar/WalletStatus.tsx
+++ b/components/stellar/WalletStatus.tsx
@@ -51,9 +51,7 @@ export function WalletStatus({ className }: WalletStatusProps) {
         return
       }
 
-      toast.error(
-        message
-      )
+      toast.error(message)
     } finally {
       setIsConnecting(false)
     }
@@ -155,106 +153,106 @@ export function WalletStatus({ className }: WalletStatusProps) {
   return (
     <>
       <Card className={className}>
-      <CardHeader className="pb-3">
-        <CardTitle className="flex items-center gap-2">
-          <div className="w-8 h-8 bg-green-100 dark:bg-green-950/50 rounded-full flex items-center justify-center">
-            <Wallet className="w-4 h-4 text-green-800 dark:text-green-300" />
-          </div>
-          <div className="flex flex-col">
-            <span>Wallet Connected</span>
-            {selectedWallet && (
-              <span className="text-sm font-normal text-muted-foreground">
-                via {selectedWallet.name}
-              </span>
-            )}
-          </div>
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="space-y-3">
-          <div>
-            <span className="text-sm font-medium text-muted-foreground">
-              Address
-            </span>
-            <div className="flex items-center gap-2 mt-1">
-              <code className="flex-1 text-sm bg-muted px-2 py-1 rounded truncate">
-                {publicKey}
-              </code>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => publicKey && copyToClipboard(publicKey)}
-              >
-                <Copy className="w-4 h-4" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => publicKey && openInExplorer(publicKey)}
-              >
-                <ExternalLink className="w-4 h-4" />
-              </Button>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2">
+            <div className="w-8 h-8 bg-green-100 dark:bg-green-950/50 rounded-full flex items-center justify-center">
+              <Wallet className="w-4 h-4 text-green-800 dark:text-green-300" />
             </div>
-          </div>
-
-          {network && (
+            <div className="flex flex-col">
+              <span>Wallet Connected</span>
+              {selectedWallet && (
+                <span className="text-sm font-normal text-muted-foreground">
+                  via {selectedWallet.name}
+                </span>
+              )}
+            </div>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-3">
             <div>
               <span className="text-sm font-medium text-muted-foreground">
-                Network
-              </span>
-              <div className="mt-1">
-                <Badge
-                  variant={network === 'TESTNET' ? 'secondary' : 'default'}
-                  className="capitalize"
-                >
-                  {network.toLowerCase()}
-                </Badge>
-              </div>
-            </div>
-          )}
-
-          {networkPassphrase && (
-            <div>
-              <span className="text-sm font-medium text-muted-foreground">
-                Network Passphrase
+                Address
               </span>
               <div className="flex items-center gap-2 mt-1">
-                <code className="flex-1 text-xs bg-muted px-2 py-1 rounded truncate">
-                  {networkPassphrase}
+                <code className="flex-1 text-sm bg-muted px-2 py-1 rounded truncate">
+                  {publicKey}
                 </code>
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={() => copyToClipboard(networkPassphrase)}
+                  onClick={() => publicKey && copyToClipboard(publicKey)}
                 >
-                  <Copy className="w-3 h-3" />
+                  <Copy className="w-4 h-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => publicKey && openInExplorer(publicKey)}
+                >
+                  <ExternalLink className="w-4 h-4" />
                 </Button>
               </div>
             </div>
-          )}
-        </div>
 
-        <div className="flex gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={refreshConnection}
-            className="flex-1"
-          >
-            <RefreshCw className="w-4 h-4 mr-2" />
-            Refresh Connection
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleDisconnect}
-            className="flex-1"
-          >
-            <Power className="w-4 h-4 mr-2" />
-            Disconnect
-          </Button>
-        </div>
-      </CardContent>
+            {network && (
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Network
+                </span>
+                <div className="mt-1">
+                  <Badge
+                    variant={network === 'TESTNET' ? 'secondary' : 'default'}
+                    className="capitalize"
+                  >
+                    {network.toLowerCase()}
+                  </Badge>
+                </div>
+              </div>
+            )}
+
+            {networkPassphrase && (
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">
+                  Network Passphrase
+                </span>
+                <div className="flex items-center gap-2 mt-1">
+                  <code className="flex-1 text-xs bg-muted px-2 py-1 rounded truncate">
+                    {networkPassphrase}
+                  </code>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => copyToClipboard(networkPassphrase)}
+                  >
+                    <Copy className="w-3 h-3" />
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={refreshConnection}
+              className="flex-1"
+            >
+              <RefreshCw className="w-4 h-4 mr-2" />
+              Refresh Connection
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleDisconnect}
+              className="flex-1"
+            >
+              <Power className="w-4 h-4 mr-2" />
+              Disconnect
+            </Button>
+          </div>
+        </CardContent>
       </Card>
 
       <InstallWalletDialog

--- a/components/stellar/WalletStatus.tsx
+++ b/components/stellar/WalletStatus.tsx
@@ -5,6 +5,7 @@ import { useWallet } from '@/components/providers/WalletProvider'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { InstallWalletDialog } from '@/components/stellar/InstallWalletDialog'
 import {
   Copy,
   ExternalLink,
@@ -14,6 +15,7 @@ import {
   Power,
 } from 'lucide-react'
 import { toast } from 'sonner'
+import { NO_WALLET_AVAILABLE_ERROR_CODE } from '@/lib/stellar/wallet-adapter'
 
 interface WalletStatusProps {
   className?: string
@@ -33,6 +35,7 @@ export function WalletStatus({ className }: WalletStatusProps) {
     refreshConnection,
   } = useWallet()
   const [isConnecting, setIsConnecting] = useState(false)
+  const [installDialogOpen, setInstallDialogOpen] = useState(false)
 
   const handleConnect = async () => {
     setIsConnecting(true)
@@ -40,8 +43,16 @@ export function WalletStatus({ className }: WalletStatusProps) {
       await connect()
       toast.success('Wallet connected successfully!')
     } catch (error) {
-      toast.error(
+      const message =
         error instanceof Error ? error.message : 'Failed to connect wallet'
+
+      if (message.startsWith(`${NO_WALLET_AVAILABLE_ERROR_CODE}:`)) {
+        setInstallDialogOpen(true)
+        return
+      }
+
+      toast.error(
+        message
       )
     } finally {
       setIsConnecting(false)
@@ -98,44 +109,52 @@ export function WalletStatus({ className }: WalletStatusProps) {
 
   if (!isConnected) {
     return (
-      <Card className={className}>
-        <CardContent className="pt-6">
-          <div className="flex flex-col items-center space-y-4 text-center">
-            <Wallet className="w-12 h-12 text-muted-foreground" />
-            <div>
-              <h3 className="font-semibold">Wallet Not Connected</h3>
-              <p className="text-sm text-muted-foreground">
-                Connect your Stellar wallet to start tipping authors
-              </p>
-              <p className="text-xs text-muted-foreground mt-2">
-                Supports Freighter, xBull, Albedo, Rabet, and more
-              </p>
+      <>
+        <Card className={className}>
+          <CardContent className="pt-6">
+            <div className="flex flex-col items-center space-y-4 text-center">
+              <Wallet className="w-12 h-12 text-muted-foreground" />
+              <div>
+                <h3 className="font-semibold">Wallet Not Connected</h3>
+                <p className="text-sm text-muted-foreground">
+                  Connect your Stellar wallet to start tipping authors
+                </p>
+                <p className="text-xs text-muted-foreground mt-2">
+                  Supports Freighter, xBull, Albedo, Rabet, and more
+                </p>
+              </div>
+              <Button
+                onClick={handleConnect}
+                disabled={isConnecting || isLoading}
+                className="w-full max-w-xs"
+              >
+                {isConnecting || isLoading ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                    Connecting...
+                  </>
+                ) : (
+                  <>
+                    <Wallet className="w-4 h-4 mr-2" />
+                    Connect Wallet
+                  </>
+                )}
+              </Button>
             </div>
-            <Button
-              onClick={handleConnect}
-              disabled={isConnecting || isLoading}
-              className="w-full max-w-xs"
-            >
-              {isConnecting || isLoading ? (
-                <>
-                  <Loader2 className="w-4 h-4 animate-spin mr-2" />
-                  Connecting...
-                </>
-              ) : (
-                <>
-                  <Wallet className="w-4 h-4 mr-2" />
-                  Connect Wallet
-                </>
-              )}
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+
+        <InstallWalletDialog
+          open={installDialogOpen}
+          onOpenChange={setInstallDialogOpen}
+        />
+      </>
     )
   }
 
   return (
-    <Card className={className}>
+    <>
+      <Card className={className}>
       <CardHeader className="pb-3">
         <CardTitle className="flex items-center gap-2">
           <div className="w-8 h-8 bg-green-100 dark:bg-green-950/50 rounded-full flex items-center justify-center">
@@ -236,6 +255,12 @@ export function WalletStatus({ className }: WalletStatusProps) {
           </Button>
         </div>
       </CardContent>
-    </Card>
+      </Card>
+
+      <InstallWalletDialog
+        open={installDialogOpen}
+        onOpenChange={setInstallDialogOpen}
+      />
+    </>
   )
 }

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -223,145 +223,145 @@ export function TipButton({
             if (isLoading) e.preventDefault()
           }}
         >
-        <DialogHeader className="text-left">
-          <DialogTitle className="text-xl font-bold">
-            Support {authorName}
-          </DialogTitle>
-          <DialogDescription className="text-muted-foreground">
-            Show your appreciation with a micro-tip. 97.5% goes directly to the
-            author!
-          </DialogDescription>
-        </DialogHeader>
+          <DialogHeader className="text-left">
+            <DialogTitle className="text-xl font-bold">
+              Support {authorName}
+            </DialogTitle>
+            <DialogDescription className="text-muted-foreground">
+              Show your appreciation with a micro-tip. 97.5% goes directly to
+              the author!
+            </DialogDescription>
+          </DialogHeader>
 
-        {!isConnected && (
-          <div className="p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-900">
-            <p>Connect your Stellar wallet to send tips to {authorName}.</p>
-            <p className="mt-1">
-              New to crypto?{' '}
-              <Link
-                href="/guide"
-                className="focus-ring rounded text-amber-700 underline font-medium hover:text-amber-900"
-              >
-                Follow our setup guide
-              </Link>
-            </p>
-          </div>
-        )}
-
-        <div className="grid grid-cols-3 gap-3">
-          {TIP_PRESETS_ARTICLE.map((amount) => (
-            <button
-              key={amount.cents}
-              type="button"
-              onClick={() => {
-                setSelectedAmount(amount.cents)
-                setCustomAmount('')
-              }}
-              disabled={isLoading}
-              className={`focus-ring relative px-4 py-3 rounded-lg border-2 transition-all disabled:opacity-50 ${
-                selectedAmount === amount.cents
-                  ? 'border-orange-500 bg-orange-50'
-                  : 'border-border hover:border-orange-300'
-              }`}
-            >
-              {amount.popular && (
-                <span className="absolute -top-2 left-1/2 transform -translate-x-1/2 px-2 py-0.5 bg-orange-500 text-white text-xs rounded-full">
-                  Popular
-                </span>
-              )}
-              <span className="font-semibold">{amount.label}</span>
-            </button>
-          ))}
-        </div>
-
-        <div>
-          <label
-            htmlFor="tip-custom-amount"
-            className="block text-sm font-medium text-foreground mb-2"
-          >
-            Or enter custom amount
-          </label>
-          <div className="relative">
-            <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">
-              $
-            </span>
-            <input
-              id="tip-custom-amount"
-              type="number"
-              min={TIP_MIN_USD}
-              max={TIP_MAX_USD}
-              step="0.01"
-              value={customAmount}
-              onChange={(e) => {
-                setCustomAmount(e.target.value)
-                setSelectedAmount(null)
-              }}
-              disabled={isLoading}
-              placeholder="0.00"
-              className="focus-ring w-full pl-8 pr-4 py-2 border border-input bg-background text-foreground rounded-lg disabled:opacity-50"
-            />
-          </div>
-          <p className="text-xs text-muted-foreground mt-1">
-            Minimum: ${TIP_MIN_USD.toFixed(2)} • Maximum: $
-            {TIP_MAX_USD.toFixed(2)}
-          </p>
-        </div>
-
-        <div className="flex gap-3">
-          <button
-            type="button"
-            onClick={() => handleOpenChange(false)}
-            disabled={isLoading}
-            className="focus-ring flex-1 px-4 py-2 border border-input bg-background text-foreground rounded-lg hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Cancel
-          </button>
-
-          {!isConnected ? (
-            <button
-              type="button"
-              onClick={handleConnectWallet}
-              disabled={isLoading}
-              className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-blue-500 to-blue-600 text-white rounded-lg hover:from-blue-600 hover:to-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-            >
-              <Wallet className="w-4 h-4" />
-              <span>Connect Wallet</span>
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={handleTip}
-              disabled={isLoading || (!selectedAmount && !customAmount)}
-              className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-            >
-              {isLoading ? (
-                <>
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                  <span>Sending...</span>
-                </>
-              ) : (
-                <>
-                  <Heart className="w-4 h-4" />
-                  <span>Send Tip</span>
-                </>
-              )}
-            </button>
+          {!isConnected && (
+            <div className="p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-900">
+              <p>Connect your Stellar wallet to send tips to {authorName}.</p>
+              <p className="mt-1">
+                New to crypto?{' '}
+                <Link
+                  href="/guide"
+                  className="focus-ring rounded text-amber-700 underline font-medium hover:text-amber-900"
+                >
+                  Follow our setup guide
+                </Link>
+              </p>
+            </div>
           )}
-        </div>
 
-        {isConnected && publicKey && (
-          <div className="text-xs text-green-800 dark:text-green-300 text-center">
-            <p className="flex items-center justify-center gap-1">
-              <Wallet className="w-3 h-3" />
-              Connected: {publicKey.slice(0, 6)}...{publicKey.slice(-6)}
+          <div className="grid grid-cols-3 gap-3">
+            {TIP_PRESETS_ARTICLE.map((amount) => (
+              <button
+                key={amount.cents}
+                type="button"
+                onClick={() => {
+                  setSelectedAmount(amount.cents)
+                  setCustomAmount('')
+                }}
+                disabled={isLoading}
+                className={`focus-ring relative px-4 py-3 rounded-lg border-2 transition-all disabled:opacity-50 ${
+                  selectedAmount === amount.cents
+                    ? 'border-orange-500 bg-orange-50'
+                    : 'border-border hover:border-orange-300'
+                }`}
+              >
+                {amount.popular && (
+                  <span className="absolute -top-2 left-1/2 transform -translate-x-1/2 px-2 py-0.5 bg-orange-500 text-white text-xs rounded-full">
+                    Popular
+                  </span>
+                )}
+                <span className="font-semibold">{amount.label}</span>
+              </button>
+            ))}
+          </div>
+
+          <div>
+            <label
+              htmlFor="tip-custom-amount"
+              className="block text-sm font-medium text-foreground mb-2"
+            >
+              Or enter custom amount
+            </label>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">
+                $
+              </span>
+              <input
+                id="tip-custom-amount"
+                type="number"
+                min={TIP_MIN_USD}
+                max={TIP_MAX_USD}
+                step="0.01"
+                value={customAmount}
+                onChange={(e) => {
+                  setCustomAmount(e.target.value)
+                  setSelectedAmount(null)
+                }}
+                disabled={isLoading}
+                placeholder="0.00"
+                className="focus-ring w-full pl-8 pr-4 py-2 border border-input bg-background text-foreground rounded-lg disabled:opacity-50"
+              />
+            </div>
+            <p className="text-xs text-muted-foreground mt-1">
+              Minimum: ${TIP_MIN_USD.toFixed(2)} • Maximum: $
+              {TIP_MAX_USD.toFixed(2)}
             </p>
           </div>
-        )}
 
-        <p className="text-xs text-muted-foreground text-center flex items-center justify-center gap-1">
-          Powered by Stellar <WalletTooltip concept="stellar" /> • Instant
-          settlement • Low fees
-        </p>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={() => handleOpenChange(false)}
+              disabled={isLoading}
+              className="focus-ring flex-1 px-4 py-2 border border-input bg-background text-foreground rounded-lg hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Cancel
+            </button>
+
+            {!isConnected ? (
+              <button
+                type="button"
+                onClick={handleConnectWallet}
+                disabled={isLoading}
+                className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-blue-500 to-blue-600 text-white rounded-lg hover:from-blue-600 hover:to-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              >
+                <Wallet className="w-4 h-4" />
+                <span>Connect Wallet</span>
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={handleTip}
+                disabled={isLoading || (!selectedAmount && !customAmount)}
+                className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    <span>Sending...</span>
+                  </>
+                ) : (
+                  <>
+                    <Heart className="w-4 h-4" />
+                    <span>Send Tip</span>
+                  </>
+                )}
+              </button>
+            )}
+          </div>
+
+          {isConnected && publicKey && (
+            <div className="text-xs text-green-800 dark:text-green-300 text-center">
+              <p className="flex items-center justify-center gap-1">
+                <Wallet className="w-3 h-3" />
+                Connected: {publicKey.slice(0, 6)}...{publicKey.slice(-6)}
+              </p>
+            </div>
+          )}
+
+          <p className="text-xs text-muted-foreground text-center flex items-center justify-center gap-1">
+            Powered by Stellar <WalletTooltip concept="stellar" /> • Instant
+            settlement • Low fees
+          </p>
         </DialogContent>
       </Dialog>
 

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -27,6 +27,8 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
+import { InstallWalletDialog } from '@/components/stellar/InstallWalletDialog'
+import { NO_WALLET_AVAILABLE_ERROR_CODE } from '@/lib/stellar/wallet-adapter'
 
 interface TipButtonProps {
   articleId: Id<'articles'>
@@ -45,6 +47,7 @@ export function TipButton({
   const { isConnected, publicKey, signTransaction, connect } = useWallet()
   const router = useRouter()
   const [isOpen, setIsOpen] = useState(false)
+  const [installDialogOpen, setInstallDialogOpen] = useState(false)
   const [selectedAmount, setSelectedAmount] = useState<number | null>(null)
   const [customAmount, setCustomAmount] = useState('')
   const [isLoading, setIsLoading] = useState(false)
@@ -182,26 +185,44 @@ export function TipButton({
     }
   }
 
+  const handleConnectWallet = async () => {
+    try {
+      await connect()
+      toast.success('Wallet connected successfully!')
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to connect wallet'
+
+      if (message.startsWith(`${NO_WALLET_AVAILABLE_ERROR_CODE}:`)) {
+        setInstallDialogOpen(true)
+        return
+      }
+
+      toast.error(message)
+    }
+  }
+
   return (
-    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      <DialogTrigger asChild>
-        <button
-          type="button"
-          className={`focus-ring inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 transition-all transform hover:scale-105 shadow-lg ${className}`}
+    <>
+      <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+        <DialogTrigger asChild>
+          <button
+            type="button"
+            className={`focus-ring inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 transition-all transform hover:scale-105 shadow-lg ${className}`}
+          >
+            <Coins className="w-4 h-4" />
+            <span className="font-medium">Tip Author</span>
+          </button>
+        </DialogTrigger>
+        <DialogContent
+          className="top-auto bottom-0 left-1/2 max-h-[min(90dvh,calc(100%-2rem))] max-w-md translate-x-[-50%] translate-y-0 gap-4 overflow-y-auto rounded-b-none rounded-t-xl border border-border bg-popover p-6 shadow-xl data-[state=closed]:slide-out-to-bottom-[48%] data-[state=open]:slide-in-from-bottom-[48%] sm:top-[50%] sm:bottom-auto sm:max-h-[min(90dvh,100%)] sm:translate-y-[-50%] sm:rounded-xl sm:data-[state=closed]:slide-out-to-left-1/2 sm:data-[state=closed]:slide-out-to-top-[48%] sm:data-[state=open]:slide-in-from-left-1/2 sm:data-[state=open]:slide-in-from-top-[48%]"
+          onInteractOutside={(e) => {
+            if (isLoading) e.preventDefault()
+          }}
+          onEscapeKeyDown={(e) => {
+            if (isLoading) e.preventDefault()
+          }}
         >
-          <Coins className="w-4 h-4" />
-          <span className="font-medium">Tip Author</span>
-        </button>
-      </DialogTrigger>
-      <DialogContent
-        className="top-auto bottom-0 left-1/2 max-h-[min(90dvh,calc(100%-2rem))] max-w-md translate-x-[-50%] translate-y-0 gap-4 overflow-y-auto rounded-b-none rounded-t-xl border border-border bg-popover p-6 shadow-xl data-[state=closed]:slide-out-to-bottom-[48%] data-[state=open]:slide-in-from-bottom-[48%] sm:top-[50%] sm:bottom-auto sm:max-h-[min(90dvh,100%)] sm:translate-y-[-50%] sm:rounded-xl sm:data-[state=closed]:slide-out-to-left-1/2 sm:data-[state=closed]:slide-out-to-top-[48%] sm:data-[state=open]:slide-in-from-left-1/2 sm:data-[state=open]:slide-in-from-top-[48%]"
-        onInteractOutside={(e) => {
-          if (isLoading) e.preventDefault()
-        }}
-        onEscapeKeyDown={(e) => {
-          if (isLoading) e.preventDefault()
-        }}
-      >
         <DialogHeader className="text-left">
           <DialogTitle className="text-xl font-bold">
             Support {authorName}
@@ -299,14 +320,7 @@ export function TipButton({
           {!isConnected ? (
             <button
               type="button"
-              onClick={async () => {
-                try {
-                  await connect()
-                  toast.success('Wallet connected successfully!')
-                } catch {
-                  toast.error('Failed to connect wallet')
-                }
-              }}
+              onClick={handleConnectWallet}
               disabled={isLoading}
               className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-blue-500 to-blue-600 text-white rounded-lg hover:from-blue-600 hover:to-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
             >
@@ -348,7 +362,13 @@ export function TipButton({
           Powered by Stellar <WalletTooltip concept="stellar" /> • Instant
           settlement • Low fees
         </p>
-      </DialogContent>
-    </Dialog>
+        </DialogContent>
+      </Dialog>
+
+      <InstallWalletDialog
+        open={installDialogOpen}
+        onOpenChange={setInstallDialogOpen}
+      />
+    </>
   )
 }

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -7,6 +7,23 @@
 - A free [Convex](https://convex.dev) account
 - Stellar wallet (only for blockchain features)
 
+## Wallet install / connect troubleshooting
+
+If you click **Connect Wallet** and don’t have any Stellar wallet installed, Quilltip will show an install dialog with links to supported wallets. After installing a wallet, **reload the page** and try connecting again.
+
+To test this behavior locally:
+
+- **No-wallet flow**:
+  - Open Chrome with a fresh profile (or a browser where you have no Stellar wallet extensions installed).
+  - Run `bun run dev` and open Quilltip.
+  - Click **Connect Wallet** (from the header, wallet status card, tipping modal, or minting modal).
+  - Expected: install dialog appears with links for **Freighter**, **xBull**, **Albedo**, **HOT Wallet** (and the wallet selection modal does not open empty).
+- **After install + reload**:
+  - Install one wallet from the provided link.
+  - Reload the page.
+  - Click **Connect Wallet** again.
+  - Expected: the normal wallet selection/connect flow works as before.
+
 ## Installation
 
 ```bash

--- a/hooks/useStellarWallet.ts
+++ b/hooks/useStellarWallet.ts
@@ -1,7 +1,11 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { walletAdapter, WalletInfo } from '@/lib/stellar/wallet-adapter'
+import {
+  walletAdapter,
+  WalletInfo,
+  NO_WALLET_AVAILABLE_ERROR_CODE,
+} from '@/lib/stellar/wallet-adapter'
 
 export interface StellarWalletState {
   isInstalled: boolean
@@ -124,11 +128,18 @@ export function useStellarWallet(): StellarWalletState & StellarWalletActions {
 
       return true
     } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Connection failed'
+
       setState((prev) => ({
         ...prev,
         isLoading: false,
-        error: error instanceof Error ? error.message : 'Connection failed',
+        error: message,
       }))
+
+      if (message.startsWith(`${NO_WALLET_AVAILABLE_ERROR_CODE}:`)) {
+        throw new Error(message)
+      }
       return false
     }
   }, [])

--- a/lib/stellar/wallet-adapter.ts
+++ b/lib/stellar/wallet-adapter.ts
@@ -24,6 +24,7 @@ import {
   HANA_ID,
   HOTWALLET_ID,
 } from '@creit.tech/stellar-wallets-kit'
+import { hasInstalledWalletForKitModal as supportedWalletsAllowKitModal } from '@/lib/stellar/wallet-availability'
 
 // Wallet type definitions
 export type WalletType =
@@ -46,6 +47,8 @@ export interface ConnectionResult {
   network: string
   networkPassphrase: string
 }
+
+export const NO_WALLET_AVAILABLE_ERROR_CODE = 'NO_WALLET_AVAILABLE' as const
 
 // Wallet metadata mapping
 export const WALLET_METADATA: Record<string, WalletInfo> = {
@@ -232,6 +235,13 @@ class StellarWalletAdapter {
     return this.kit
   }
 
+  private async hasInstalledWalletForKitModal(): Promise<boolean> {
+    await this.initialize()
+    const kit = this.ensureKit()
+    const supported = (await kit.getSupportedWallets()) as ISupportedWallet[]
+    return supportedWalletsAllowKitModal(supported)
+  }
+
   /**
    * Initialize the adapter (lazy initialization)
    * Note: Does NOT auto-reconnect to avoid triggering wallet popups on every page load
@@ -255,10 +265,7 @@ class StellarWalletAdapter {
    * Check if any wallet is installed/available
    */
   async isInstalled(): Promise<boolean> {
-    await this.initialize()
-    // Always return true since the kit supports multiple wallets
-    // The modal will show which wallets are actually available
-    return true
+    return await this.hasInstalledWalletForKitModal()
   }
 
   /**
@@ -268,6 +275,13 @@ class StellarWalletAdapter {
   async connect(): Promise<ConnectionResult> {
     await this.initialize()
     const kit = this.ensureKit()
+
+    const hasWallet = await this.hasInstalledWalletForKitModal()
+    if (!hasWallet) {
+      throw new Error(
+        `${NO_WALLET_AVAILABLE_ERROR_CODE}: No Stellar wallet detected`
+      )
+    }
 
     // Warn about Albedo on localhost
     if (isLocalhost()) {

--- a/lib/stellar/wallet-availability.test.ts
+++ b/lib/stellar/wallet-availability.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { hasInstalledWalletForKitModal } from '@/lib/stellar/wallet-availability'
+
+describe('hasInstalledWalletForKitModal', () => {
+  it('returns false when only web-fallback wallets are available', () => {
+    expect(
+      hasInstalledWalletForKitModal([
+        { id: 'albedo', isAvailable: true },
+        { id: 'xbull', isAvailable: true },
+        { id: 'hot-wallet', isAvailable: true },
+      ])
+    ).toBe(false)
+  })
+
+  it('returns true when an extension-style wallet is available', () => {
+    expect(
+      hasInstalledWalletForKitModal([
+        { id: 'albedo', isAvailable: true },
+        { id: 'freighter', isAvailable: true },
+      ])
+    ).toBe(true)
+  })
+
+  it('returns false when no wallets are available', () => {
+    expect(
+      hasInstalledWalletForKitModal([
+        { id: 'albedo', isAvailable: false },
+        { id: 'freighter', isAvailable: false },
+      ])
+    ).toBe(false)
+  })
+})

--- a/lib/stellar/wallet-availability.ts
+++ b/lib/stellar/wallet-availability.ts
@@ -1,0 +1,19 @@
+/**
+ * Kit modules that return `isAvailable: true` without a browser extension (web / bridge).
+ * IDs must match `productId` on @creit.tech/stellar-wallets-kit modules (albedo, xbull, hot-wallet).
+ */
+const WALLETS_ALWAYS_AVAILABLE_WITHOUT_EXTENSION = new Set<string>([
+  'albedo',
+  'xbull',
+  'hot-wallet',
+])
+
+export function hasInstalledWalletForKitModal(
+  supported: Array<{ id: string; isAvailable: boolean }>
+): boolean {
+  return supported.some(
+    (w) =>
+      w.isAvailable &&
+      !WALLETS_ALWAYS_AVAILABLE_WITHOUT_EXTENSION.has(w.id)
+  )
+}

--- a/lib/stellar/wallet-availability.ts
+++ b/lib/stellar/wallet-availability.ts
@@ -13,7 +13,6 @@ export function hasInstalledWalletForKitModal(
 ): boolean {
   return supported.some(
     (w) =>
-      w.isAvailable &&
-      !WALLETS_ALWAYS_AVAILABLE_WITHOUT_EXTENSION.has(w.id)
+      w.isAvailable && !WALLETS_ALWAYS_AVAILABLE_WITHOUT_EXTENSION.has(w.id)
   )
 }


### PR DESCRIPTION
## Summary
- Adds a pre-check before opening the Stellar wallet connect modal to detect when no wallet is available.
- Shows an in-app install dialog with official links for Freighter, xBull, Albedo, and HOT Wallet.
- Keeps existing connect flow unchanged for users who already have a wallet installed.

## Changes
- Updated lib/stellar/wallet-adapter.ts to use kit.getSupportedWallets() and throw a distinct NO_WALLET_AVAILABLE error before kit.openModal().
- Added components/stellar/InstallWalletDialog.tsx.
- Wired the install dialog into connect entrypoints:
  - components/stellar/WalletConnectButton.tsx
  - components/stellar/WalletStatus.tsx
  - components/tipping/TipButton.tsx
  - components/highlights/HighlightTipButton.tsx
  - components/nft/MintButton.tsx
  - components/stellar/WalletSettings.tsx

<img width="1195" height="718" alt="no_wallet" src="https://github.com/user-attachments/assets/efe22673-80fb-4d94-b0ae-2997a08a0c66" />

<img width="1190" height="722" alt="after" src="https://github.com/user-attachments/assets/a95fd436-773c-4f4a-9659-9d20d5e8f32e" />
