### PR TITLE
fix(withdrawal): validate Stellar destination addresses with StrKey

### DIFF
--- a/components/dashboard/WithdrawalDialog.test.tsx
+++ b/components/dashboard/WithdrawalDialog.test.tsx
@@ -93,7 +93,9 @@ describe('WithdrawalDialog', () => {
     await user.type(screen.getByLabelText(/Amount \(USD\)/i), '10')
     await user.type(screen.getByLabelText(/Stellar Address/i), invalidAddress)
 
-    expect(screen.getByRole('alert')).toHaveTextContent('Invalid Stellar address')
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Invalid Stellar address'
+    )
     const withdraw = screen.getByRole('button', { name: /Withdraw$/i })
     expect(withdraw).toBeDisabled()
     await user.click(withdraw)

--- a/components/dashboard/WithdrawalDialog.test.tsx
+++ b/components/dashboard/WithdrawalDialog.test.tsx
@@ -5,7 +5,15 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { WithdrawalDialog } from '@/components/dashboard/WithdrawalDialog'
 
-const validGAddress = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
+const VALID_TEST_PUBLIC_KEY =
+  'GC2BKLYOOYPDEFJKLKY6FNNRQMGFLVHJKQRGNSSRRGSMPGF32LHCQVGF'
+
+function corruptAccountId(address: string): string {
+  const chars = address.split('')
+  const idx = 15
+  chars[idx] = chars[idx] === 'A' ? 'B' : 'A'
+  return chars.join('')
+}
 
 describe('WithdrawalDialog', () => {
   it('calls onWithdraw with entered amount and address', async () => {
@@ -13,7 +21,6 @@ describe('WithdrawalDialog', () => {
     const onWithdraw = vi.fn().mockResolvedValue(undefined)
     const onOpenChange = vi.fn()
     const triggerRef = createRef<HTMLButtonElement>()
-
     render(
       <WithdrawalDialog
         open
@@ -27,12 +34,15 @@ describe('WithdrawalDialog', () => {
     )
 
     await user.type(screen.getByLabelText(/Amount \(USD\)/i), '10')
-    await user.type(screen.getByLabelText(/Stellar Address/i), validGAddress)
+    await user.type(
+      screen.getByLabelText(/Stellar Address/i),
+      VALID_TEST_PUBLIC_KEY
+    )
     await user.click(screen.getByRole('button', { name: /Withdraw$/i }))
 
     expect(onWithdraw).toHaveBeenCalledWith({
       amountUsd: 10,
-      stellarAddress: validGAddress,
+      stellarAddress: VALID_TEST_PUBLIC_KEY,
     })
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })
@@ -41,14 +51,13 @@ describe('WithdrawalDialog', () => {
     const user = userEvent.setup()
     const onWithdraw = vi.fn().mockResolvedValue(undefined)
     const triggerRef = createRef<HTMLButtonElement>()
-
     render(
       <WithdrawalDialog
         open
         onOpenChange={() => {}}
         availableBalanceUsd={100}
         minWithdrawalUsd={5}
-        savedStellarAddress={validGAddress}
+        savedStellarAddress={VALID_TEST_PUBLIC_KEY}
         onWithdraw={onWithdraw}
         triggerRef={triggerRef}
       />
@@ -59,14 +68,15 @@ describe('WithdrawalDialog', () => {
 
     expect(onWithdraw).toHaveBeenCalledWith({
       amountUsd: 20,
-      stellarAddress: validGAddress,
+      stellarAddress: VALID_TEST_PUBLIC_KEY,
     })
   })
 
-  it('does not call onWithdraw when amount is below minimum', async () => {
+  it('shows inline error and disables withdraw for an invalid address', async () => {
     const user = userEvent.setup()
     const onWithdraw = vi.fn().mockResolvedValue(undefined)
     const triggerRef = createRef<HTMLButtonElement>()
+    const invalidAddress = corruptAccountId(VALID_TEST_PUBLIC_KEY)
 
     render(
       <WithdrawalDialog
@@ -74,7 +84,33 @@ describe('WithdrawalDialog', () => {
         onOpenChange={() => {}}
         availableBalanceUsd={100}
         minWithdrawalUsd={5}
-        savedStellarAddress={validGAddress}
+        savedStellarAddress={null}
+        onWithdraw={onWithdraw}
+        triggerRef={triggerRef}
+      />
+    )
+
+    await user.type(screen.getByLabelText(/Amount \(USD\)/i), '10')
+    await user.type(screen.getByLabelText(/Stellar Address/i), invalidAddress)
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Invalid Stellar address')
+    const withdraw = screen.getByRole('button', { name: /Withdraw$/i })
+    expect(withdraw).toBeDisabled()
+    await user.click(withdraw)
+    expect(onWithdraw).not.toHaveBeenCalled()
+  })
+
+  it('does not call onWithdraw when amount is below minimum', async () => {
+    const user = userEvent.setup()
+    const onWithdraw = vi.fn().mockResolvedValue(undefined)
+    const triggerRef = createRef<HTMLButtonElement>()
+    render(
+      <WithdrawalDialog
+        open
+        onOpenChange={() => {}}
+        availableBalanceUsd={100}
+        minWithdrawalUsd={5}
+        savedStellarAddress={VALID_TEST_PUBLIC_KEY}
         onWithdraw={onWithdraw}
         triggerRef={triggerRef}
       />

--- a/components/dashboard/WithdrawalDialog.tsx
+++ b/components/dashboard/WithdrawalDialog.tsx
@@ -51,11 +51,7 @@ export function WithdrawalDialog({
     onOpenChange(next)
   }
 
-  const trimmedAddress = (
-    stellarAddress ||
-    savedStellarAddress ||
-    ''
-  ).trim()
+  const trimmedAddress = (stellarAddress || savedStellarAddress || '').trim()
   const showAddressError =
     trimmedAddress.length > 0 && !isValidStellarAccountId(trimmedAddress)
 

--- a/components/dashboard/WithdrawalDialog.tsx
+++ b/components/dashboard/WithdrawalDialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { isValidStellarAccountId } from '@/lib/stellar/is-valid-stellar-account-id'
 
 export type WithdrawalDialogProps = {
   open: boolean
@@ -50,7 +51,13 @@ export function WithdrawalDialog({
     onOpenChange(next)
   }
 
-  const addressForSubmit = stellarAddress || savedStellarAddress || ''
+  const trimmedAddress = (
+    stellarAddress ||
+    savedStellarAddress ||
+    ''
+  ).trim()
+  const showAddressError =
+    trimmedAddress.length > 0 && !isValidStellarAccountId(trimmedAddress)
 
   const handleSubmit = async () => {
     const amount = parseFloat(withdrawAmount)
@@ -62,7 +69,7 @@ export function WithdrawalDialog({
       return
     }
 
-    if (!addressForSubmit || !addressForSubmit.startsWith('G')) {
+    if (!isValidStellarAccountId(trimmedAddress)) {
       toast.error('Please enter a valid Stellar address')
       return
     }
@@ -76,7 +83,7 @@ export function WithdrawalDialog({
     try {
       await onWithdraw({
         amountUsd: amount,
-        stellarAddress: addressForSubmit,
+        stellarAddress: trimmedAddress,
       })
       onOpenChange(false)
     } catch {
@@ -153,16 +160,27 @@ export function WithdrawalDialog({
               type="text"
               value={stellarAddress || savedStellarAddress || ''}
               onChange={(e) => setStellarAddress(e.target.value)}
-              className="w-full px-3 py-2 border border-input bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-ring read-only:bg-muted/50"
+              aria-invalid={showAddressError}
+              className={`w-full px-3 py-2 border bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-ring read-only:bg-muted/50 ${
+                showAddressError
+                  ? 'border-destructive focus:ring-destructive'
+                  : 'border-input focus:ring-ring'
+              }`}
               placeholder="G..."
               readOnly={!!savedStellarAddress}
               disabled={isSubmitting}
             />
-            <p className="text-xs text-muted-foreground mt-1">
-              {savedStellarAddress
-                ? 'Using your saved wallet address from Wallet settings'
-                : 'Enter your Stellar wallet address'}
-            </p>
+            {showAddressError ? (
+              <p className="text-xs text-destructive mt-1" role="alert">
+                Invalid Stellar address
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground mt-1">
+                {savedStellarAddress
+                  ? 'Using your saved wallet address from Wallet settings'
+                  : 'Enter your Stellar wallet address'}
+              </p>
+            )}
           </div>
 
           <div className="bg-info border border-info/50 rounded-lg p-3">
@@ -188,8 +206,8 @@ export function WithdrawalDialog({
             disabled={
               isSubmitting ||
               !withdrawAmount ||
-              !addressForSubmit ||
-              !addressForSubmit.startsWith('G')
+              !trimmedAddress ||
+              !isValidStellarAccountId(trimmedAddress)
             }
             className="flex-1 px-4 py-2 bg-brand text-brand-foreground rounded-lg hover:bg-brand-hover disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 sm:flex-none"
           >

--- a/lib/stellar/is-valid-stellar-account-id.test.ts
+++ b/lib/stellar/is-valid-stellar-account-id.test.ts
@@ -1,0 +1,36 @@
+import { Keypair } from '@stellar/stellar-sdk'
+import { describe, expect, it } from 'vitest'
+import { isValidStellarAccountId } from '@/lib/stellar/is-valid-stellar-account-id'
+
+describe('isValidStellarAccountId', () => {
+  it('accepts a random Keypair public key', () => {
+    const address = Keypair.random().publicKey()
+    expect(isValidStellarAccountId(address)).toBe(true)
+  })
+
+  it('accepts trimmed input', () => {
+    const address = Keypair.random().publicKey()
+    expect(isValidStellarAccountId(`  ${address}  `)).toBe(true)
+  })
+
+  it('rejects empty and whitespace-only', () => {
+    expect(isValidStellarAccountId('')).toBe(false)
+    expect(isValidStellarAccountId('   ')).toBe(false)
+  })
+
+  it('rejects short strings', () => {
+    expect(isValidStellarAccountId('G')).toBe(false)
+    expect(isValidStellarAccountId('GABC')).toBe(false)
+  })
+
+  it('rejects a mid-string typo in an otherwise well-formed length', () => {
+    const address = Keypair.random().publicKey()
+    const chars = address.split('')
+    const idx = 10
+    const next = chars[idx] === 'A' ? 'B' : 'A'
+    chars[idx] = next
+    const corrupted = chars.join('')
+    expect(corrupted).not.toBe(address)
+    expect(isValidStellarAccountId(corrupted)).toBe(false)
+  })
+})

--- a/lib/stellar/is-valid-stellar-account-id.ts
+++ b/lib/stellar/is-valid-stellar-account-id.ts
@@ -1,0 +1,7 @@
+import { StrKey } from '@stellar/stellar-sdk'
+
+export function isValidStellarAccountId(value: string): boolean {
+  const trimmed = value.trim()
+  if (!trimmed) return false
+  return StrKey.isValidEd25519PublicKey(trimmed)
+}


### PR DESCRIPTION
## Summary
- Replace `startsWith('G')` checks with `StrKey.isValidEd25519PublicKey` validation for withdrawal destination addresses.
- Show an inline field error when the address is invalid and mark the input as invalid for accessibility.
- Disable Withdraw submit while the address is empty/invalid, and validate again on submit (defense in depth).
<img width="1190" height="714" alt="withdraw" src="https://github.com/user-attachments/assets/a256fc6e-a5cb-4d38-9f36-fed692af8d93" />

<img width="1434" height="858" alt="invld_add" src="https://github.com/user-attachments/assets/f3ce26a7-b1e7-4e4f-9747-a8e2e076c310" />
<img width="1439" height="854" alt="emty" src="https://github.com/user-attachments/assets/065cc427-098c-49ac-8307-e15bff668a92" />
