### PR TITLE
fix: close highlight popover on Escape and prevent listener leaks

### DIFF
--- a/components/articles/HighlightableArticle.tsx
+++ b/components/articles/HighlightableArticle.tsx
@@ -23,6 +23,15 @@ import { useAuth } from '@/components/providers/AuthContext'
 import { toast } from 'sonner'
 import { EDITOR_PROSE_CLASS } from '@/lib/constants'
 
+function getRangeEndRect(range: Range): DOMRect | null {
+  // For multi-line selections, getBoundingClientRect() can span multiple lines and
+  // won't represent the actual end point. Prefer the last client rect.
+  const rects = range.getClientRects()
+  if (rects.length > 0) return rects[rects.length - 1] ?? null
+  const r = range.getBoundingClientRect()
+  return r.width || r.height ? r : null
+}
+
 interface HighlightData {
   _id: Id<'highlights'>
   text: string
@@ -187,12 +196,15 @@ export function HighlightableArticle({
         const domSelection = window.getSelection()
         if (domSelection && domSelection.rangeCount > 0) {
           const range = domSelection.getRangeAt(0)
-          const rect = range.getBoundingClientRect()
+          const endRect = getRangeEndRect(range)
+          if (!endRect) return
 
           setSelectedText({ text, from, to })
           setPopoverPosition({
-            top: rect.top + window.scrollY - 60,
-            left: rect.left + rect.width / 2,
+            // Viewport coordinates (HighlightPopover is `position: fixed`).
+            // Anchor beside the end of the selection (near rect.right).
+            top: endRect.top + endRect.height / 2,
+            left: endRect.right + 12,
           })
         }
       } else {
@@ -243,11 +255,14 @@ export function HighlightableArticle({
         const domSelection = window.getSelection()
         if (!domSelection || domSelection.rangeCount === 0) return
         const range = domSelection.getRangeAt(0)
-        const rect = range.getBoundingClientRect()
+        const endRect = getRangeEndRect(range)
+        if (!endRect) return
         setSelectedText({ text, from, to })
         setPopoverPosition({
-          top: rect.top + window.scrollY - 60,
-          left: rect.left + rect.width / 2,
+          // Viewport coordinates (HighlightPopover is `position: fixed`).
+          // Anchor beside the end of the selection (near rect.right).
+          top: endRect.top + endRect.height / 2,
+          left: endRect.right + 12,
         })
       }, 0)
     }
@@ -313,6 +328,12 @@ export function HighlightableArticle({
   )
 
   const handlePopoverClose = useCallback(() => {
+    if (editor) {
+      const { from, to } = editor.state.selection
+      if (from !== to) {
+        editor.chain().setTextSelection(from).run()
+      }
+    }
     setSelectedText(null)
     setPopoverPosition(null)
     window.getSelection()?.removeAllRanges()
@@ -325,30 +346,18 @@ export function HighlightableArticle({
   }, [editor])
 
   useEffect(() => {
-    const hasCreationPopover = Boolean(popoverPosition && selectedText)
-    const hasDetailsPanel = highlightTooltip !== null
-    if (!hasCreationPopover && !hasDetailsPanel) return
+    if (highlightTooltip === null) return
 
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return
       e.preventDefault()
       e.stopPropagation()
-      if (hasCreationPopover) {
-        handlePopoverClose()
-      } else if (hasDetailsPanel) {
-        handleTooltipClose()
-      }
+      handleTooltipClose()
     }
 
     document.addEventListener('keydown', onKeyDown, true)
     return () => document.removeEventListener('keydown', onKeyDown, true)
-  }, [
-    popoverPosition,
-    selectedText,
-    highlightTooltip,
-    handlePopoverClose,
-    handleTooltipClose,
-  ])
+  }, [highlightTooltip, handleTooltipClose])
 
   return (
     <div

--- a/components/highlights/HighlightPopover.test.tsx
+++ b/components/highlights/HighlightPopover.test.tsx
@@ -1,0 +1,57 @@
+/** @vitest-environment jsdom */
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/components/highlights/HighlightTipButton', () => ({
+  HighlightTipButton: () => null,
+}))
+
+import { HighlightPopover } from '@/components/highlights/HighlightPopover'
+
+describe('HighlightPopover', () => {
+  it('calls onClose when Escape is pressed', () => {
+    const onClose = vi.fn()
+    render(
+      <HighlightPopover
+        position={{ top: 0, left: 0 }}
+        onCreateHighlight={vi.fn()}
+        onClose={onClose}
+        selectedText="Enough text for the preview area"
+      />
+    )
+
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('removes the Escape listener on unmount', () => {
+    const onClose = vi.fn()
+    const { unmount } = render(
+      <HighlightPopover
+        position={{ top: 0, left: 0 }}
+        onCreateHighlight={vi.fn()}
+        onClose={onClose}
+        selectedText="Enough text for the preview area"
+      />
+    )
+
+    unmount()
+
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/components/highlights/HighlightPopover.tsx
+++ b/components/highlights/HighlightPopover.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useRef, useState, useEffect } from 'react'
 import { FocusScope } from '@radix-ui/react-focus-scope'
 import { Highlighter, MessageSquare, Lock, Globe } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -79,6 +79,36 @@ export function HighlightPopover({
   const [note, setNote] = useState('')
   const [isPublic, setIsPublic] = useState(true)
   const [showNoteInput, setShowNoteInput] = useState(false)
+  const popoverRef = useRef<HTMLDivElement>(null)
+
+  const [computedPosition, setComputedPosition] = useState(position)
+
+  useEffect(() => {
+    setComputedPosition(position)
+  }, [position.top, position.left])
+
+  const clampedPosition = useMemo(() => {
+    const clamp = (v: number, min: number, max: number) =>
+      Math.min(max, Math.max(min, v))
+
+    const margin = 12
+    const rect = popoverRef.current?.getBoundingClientRect()
+    const width = rect?.width ?? 320
+    const height = rect?.height ?? 260
+
+    // `left`/`top` are popover's top-left corner.
+    const minLeft = margin
+    const maxLeft = window.innerWidth - margin - width
+    const left = clamp(computedPosition.left, minLeft, Math.max(minLeft, maxLeft))
+
+    // `position.top` comes in as the anchor Y (mid-line) next to the selection end.
+    const desiredTop = computedPosition.top - height / 2
+    const minTop = margin
+    const maxTop = window.innerHeight - margin - height
+    const top = clamp(desiredTop, minTop, Math.max(minTop, maxTop))
+
+    return { top, left }
+  }, [computedPosition.left, computedPosition.top])
 
   const handleSaveHighlight = () => {
     onCreateHighlight(selectedColor, note || undefined, isPublic)
@@ -90,14 +120,25 @@ export function HighlightPopover({
     // Just select the color, don't create highlight automatically
   }
 
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      e.preventDefault()
+      e.stopPropagation()
+      onClose()
+    }
+    document.addEventListener('keydown', onKeyDown, true)
+    return () => document.removeEventListener('keydown', onKeyDown, true)
+  }, [onClose])
+
   return (
     <FocusScope trapped loop>
       <div
-        className="highlight-popover absolute z-50 rounded-2xl p-4 min-w-[320px] outline-none"
+        ref={popoverRef}
+        className="highlight-popover fixed z-50 w-[360px] max-w-[calc(100vw-24px)] rounded-2xl p-4 outline-none"
         style={{
-          top: position.top,
-          left: position.left,
-          transform: 'translateX(-50%)',
+          top: clampedPosition.top,
+          left: clampedPosition.left,
         }}
         role="dialog"
         aria-modal="true"

--- a/components/highlights/HighlightPopover.tsx
+++ b/components/highlights/HighlightPopover.tsx
@@ -81,12 +81,6 @@ export function HighlightPopover({
   const [showNoteInput, setShowNoteInput] = useState(false)
   const popoverRef = useRef<HTMLDivElement>(null)
 
-  const [computedPosition, setComputedPosition] = useState(position)
-
-  useEffect(() => {
-    setComputedPosition(position)
-  }, [position.top, position.left])
-
   const clampedPosition = useMemo(() => {
     const clamp = (v: number, min: number, max: number) =>
       Math.min(max, Math.max(min, v))
@@ -99,16 +93,16 @@ export function HighlightPopover({
     // `left`/`top` are popover's top-left corner.
     const minLeft = margin
     const maxLeft = window.innerWidth - margin - width
-    const left = clamp(computedPosition.left, minLeft, Math.max(minLeft, maxLeft))
+    const left = clamp(position.left, minLeft, Math.max(minLeft, maxLeft))
 
     // `position.top` comes in as the anchor Y (mid-line) next to the selection end.
-    const desiredTop = computedPosition.top - height / 2
+    const desiredTop = position.top - height / 2
     const minTop = margin
     const maxTop = window.innerHeight - margin - height
     const top = clamp(desiredTop, minTop, Math.max(minTop, maxTop))
 
     return { top, left }
-  }, [computedPosition.left, computedPosition.top])
+  }, [position.left, position.top])
 
   const handleSaveHighlight = () => {
     onCreateHighlight(selectedColor, note || undefined, isPublic)


### PR DESCRIPTION
## Summary
- Close the highlight creation popover on Escape.
- Attach the Escape key listener only while the popover is mounted, and clean it up on unmount to prevent leaks.
- Prevent the popover from immediately reopening by collapsing the TipTap selection on close.

## Details
- Move Escape handling into `components/highlights/HighlightPopover.tsx` with a document `keydown` listener (capture) + cleanup.
- Update `components/articles/HighlightableArticle.tsx` to collapse editor selection in `handlePopoverClose`.
- Narrow the parent Escape listener to the highlight details panel only so other popovers are unaffected.

<img width="1438" height="855" alt="key_acclmute" src="https://github.com/user-attachments/assets/75f4f4af-6349-4368-829a-e0ada88990a0" />
<img width="1438" height="857" alt="exist_pop" src="https://github.com/user-attachments/assets/8fe647e2-c4a3-43f3-a0ff-3421c3a88098" />
<img width="1440" height="856" alt="long_txt" src="https://github.com/user-attachments/assets/c5553b21-0079-446a-8762-a927fc503134" />
<img width="1436" height="858" alt="fix_popover" src="https://github.com/user-attachments/assets/b8609512-bbd6-48ee-9d94-977879155cca" />
