### PR TITLE
fix(highlights): anchor popover using multi-line range bounding box

### DIFF
--- a/components/articles/HighlightableArticle.tsx
+++ b/components/articles/HighlightableArticle.tsx
@@ -24,7 +24,9 @@ import { toast } from 'sonner'
 import { EDITOR_PROSE_CLASS } from '@/lib/constants'
 import { getRangeBoundingBox } from '@/lib/highlights/utils'
 
-function getRangeTopCenterAnchor(range: Range): { top: number; left: number } | null {
+function getRangeTopCenterAnchor(
+  range: Range
+): { top: number; left: number } | null {
   const box = getRangeBoundingBox(range)
   if (!box) return null
   return {

--- a/components/articles/HighlightableArticle.tsx
+++ b/components/articles/HighlightableArticle.tsx
@@ -22,14 +22,15 @@ import { AnimatePresence } from 'motion/react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { toast } from 'sonner'
 import { EDITOR_PROSE_CLASS } from '@/lib/constants'
+import { getRangeBoundingBox } from '@/lib/highlights/utils'
 
-function getRangeEndRect(range: Range): DOMRect | null {
-  // For multi-line selections, getBoundingClientRect() can span multiple lines and
-  // won't represent the actual end point. Prefer the last client rect.
-  const rects = range.getClientRects()
-  if (rects.length > 0) return rects[rects.length - 1] ?? null
-  const r = range.getBoundingClientRect()
-  return r.width || r.height ? r : null
+function getRangeTopCenterAnchor(range: Range): { top: number; left: number } | null {
+  const box = getRangeBoundingBox(range)
+  if (!box) return null
+  return {
+    top: box.top,
+    left: box.left + box.width / 2,
+  }
 }
 
 interface HighlightData {
@@ -196,15 +197,15 @@ export function HighlightableArticle({
         const domSelection = window.getSelection()
         if (domSelection && domSelection.rangeCount > 0) {
           const range = domSelection.getRangeAt(0)
-          const endRect = getRangeEndRect(range)
-          if (!endRect) return
+          const anchor = getRangeTopCenterAnchor(range)
+          if (!anchor) return
 
           setSelectedText({ text, from, to })
           setPopoverPosition({
             // Viewport coordinates (HighlightPopover is `position: fixed`).
-            // Anchor beside the end of the selection (near rect.right).
-            top: endRect.top + endRect.height / 2,
-            left: endRect.right + 12,
+            // Anchor at top-center of the selection bounding box.
+            top: anchor.top,
+            left: anchor.left,
           })
         }
       } else {
@@ -246,8 +247,8 @@ export function HighlightableArticle({
     const handlePointerUp = () => {
       if (!isDraggingRef.current) return
       isDraggingRef.current = false
-      // Defer one tick so the browser and Tiptap commit the final selection.
-      setTimeout(() => {
+      // Defer one frame so the browser and Tiptap commit the final selection.
+      requestAnimationFrame(() => {
         if (!editor) return
         const { from, to } = editor.state.selection
         const text = editor.state.doc.textBetween(from, to, ' ')
@@ -255,16 +256,16 @@ export function HighlightableArticle({
         const domSelection = window.getSelection()
         if (!domSelection || domSelection.rangeCount === 0) return
         const range = domSelection.getRangeAt(0)
-        const endRect = getRangeEndRect(range)
-        if (!endRect) return
+        const anchor = getRangeTopCenterAnchor(range)
+        if (!anchor) return
         setSelectedText({ text, from, to })
         setPopoverPosition({
           // Viewport coordinates (HighlightPopover is `position: fixed`).
-          // Anchor beside the end of the selection (near rect.right).
-          top: endRect.top + endRect.height / 2,
-          left: endRect.right + 12,
+          // Anchor at top-center of the selection bounding box.
+          top: anchor.top,
+          left: anchor.left,
         })
-      }, 0)
+      })
     }
 
     container.addEventListener('mousedown', handlePointerDown)

--- a/components/editor/extensions/HighlightExtension.ts
+++ b/components/editor/extensions/HighlightExtension.ts
@@ -209,7 +209,10 @@ const HighlightExtension = Mark.create<HighlightOptions>({
 
   addProseMirrorPlugins() {
     const { onHighlightClick } = this.options
-    const tapState: { startX: number; startY: number } = { startX: 0, startY: 0 }
+    const tapState: { startX: number; startY: number } = {
+      startX: 0,
+      startY: 0,
+    }
 
     return [
       new Plugin({

--- a/components/editor/extensions/HighlightExtension.ts
+++ b/components/editor/extensions/HighlightExtension.ts
@@ -209,6 +209,7 @@ const HighlightExtension = Mark.create<HighlightOptions>({
 
   addProseMirrorPlugins() {
     const { onHighlightClick } = this.options
+    const tapState: { startX: number; startY: number } = { startX: 0, startY: 0 }
 
     return [
       new Plugin({
@@ -248,6 +249,14 @@ const HighlightExtension = Mark.create<HighlightOptions>({
             return false
           },
           handleDOMEvents: {
+            touchstart: (_view, event) => {
+              const touchEvent = event as TouchEvent
+              const touch = touchEvent.touches[0]
+              if (!touch) return false
+              tapState.startX = touch.clientX
+              tapState.startY = touch.clientY
+              return false
+            },
             // Handle touch events for mobile devices
             touchend: (view, event) => {
               if (!onHighlightClick) {
@@ -257,6 +266,11 @@ const HighlightExtension = Mark.create<HighlightOptions>({
               // Get the touch position
               const touch = event.changedTouches[0]
               if (!touch) return false
+              const dx = touch.clientX - tapState.startX
+              const dy = touch.clientY - tapState.startY
+              if (Math.hypot(dx, dy) > 10) {
+                return false
+              }
 
               // Find the position in the document
               const pos = view.posAtCoords({

--- a/components/highlights/HighlightPopover.tsx
+++ b/components/highlights/HighlightPopover.tsx
@@ -90,13 +90,13 @@ export function HighlightPopover({
     const width = rect?.width ?? 320
     const height = rect?.height ?? 260
 
-    // `left`/`top` are popover's top-left corner.
+    // `position` is the anchor point for the popover's top-center.
+    const desiredLeft = position.left - width / 2
     const minLeft = margin
     const maxLeft = window.innerWidth - margin - width
-    const left = clamp(position.left, minLeft, Math.max(minLeft, maxLeft))
+    const left = clamp(desiredLeft, minLeft, Math.max(minLeft, maxLeft))
 
-    // `position.top` comes in as the anchor Y (mid-line) next to the selection end.
-    const desiredTop = position.top - height / 2
+    const desiredTop = position.top
     const minTop = margin
     const maxTop = window.innerHeight - margin - height
     const top = clamp(desiredTop, minTop, Math.max(minTop, maxTop))

--- a/hooks/useHighlights.ts
+++ b/hooks/useHighlights.ts
@@ -13,6 +13,7 @@ import {
   HighlightRenderer,
   HighlightSegment,
 } from '@/lib/highlights/HighlightRenderer'
+import { getRangeBoundingBox } from '@/lib/highlights/utils'
 
 export interface UseHighlightsOptions {
   articleId: Id<'articles'>
@@ -67,7 +68,8 @@ export function useHighlights({
     const manager = new SelectionManager(
       containerRef.current,
       (textSelection) => {
-        const rect = textSelection.range.getBoundingClientRect()
+        const rect = getRangeBoundingBox(textSelection.range)
+        if (!rect) return
 
         setSelection({
           text: textSelection.text,

--- a/lib/highlights/utils.ts
+++ b/lib/highlights/utils.ts
@@ -94,3 +94,56 @@ export function validateTextSelection(
 
   return { isValid: true }
 }
+
+export type RangeBoundingBox = {
+  top: number
+  left: number
+  right: number
+  bottom: number
+  width: number
+  height: number
+}
+
+/**
+ * Compute a bounding box for a Range that spans multiple lines.
+ * `range.getBoundingClientRect()` can behave inconsistently across browsers for
+ * multi-line ranges; unioning `getClientRects()` is more reliable.
+ */
+export function getRangeBoundingBox(range: Range): RangeBoundingBox | null {
+  const rects = Array.from(range.getClientRects())
+
+  const usableRects = rects.filter((r) => r.width > 0 || r.height > 0)
+  if (usableRects.length > 0) {
+    let top = usableRects[0]!.top
+    let left = usableRects[0]!.left
+    let right = usableRects[0]!.right
+    let bottom = usableRects[0]!.bottom
+
+    for (const r of usableRects) {
+      top = Math.min(top, r.top)
+      left = Math.min(left, r.left)
+      right = Math.max(right, r.right)
+      bottom = Math.max(bottom, r.bottom)
+    }
+
+    return {
+      top,
+      left,
+      right,
+      bottom,
+      width: Math.max(0, right - left),
+      height: Math.max(0, bottom - top),
+    }
+  }
+
+  const r = range.getBoundingClientRect()
+  if (!r || (!r.width && !r.height)) return null
+  return {
+    top: r.top,
+    left: r.left,
+    right: r.right,
+    bottom: r.bottom,
+    width: r.width,
+    height: r.height,
+  }
+}


### PR DESCRIPTION
## Summary
- Anchor highlight popover at the top-center of a union bounding box computed from `range.getClientRects()` (fixes multi-line selections on iOS/Android).
- Replace `setTimeout(0)` with `requestAnimationFrame` so selection geometry is read after the browser selection settles.
- Improve highlight tap reliability on mobile by ignoring `touchend` when the finger moved more than 10px (tap vs drag).
<img width="1080" height="2210" alt="1" src="https://github.com/user-attachments/assets/9a8c21ef-34bf-4742-b7eb-4ad5b3354f03" />

<img width="1006" height="2250" alt="2" src="https://github.com/user-attachments/assets/d649f589-7d25-465a-8902-c02cdc54db01" />
<img width="1080" height="2274" alt="3" src="https://github.com/user-attachments/assets/956c4701-6693-4d5c-bb4f-0a35b4b4200b" />
