### PR TITLE
feat(articles): reading time, scroll progress, and table of contents (ENG-118)

### DIFF
--- a/app/[username]/[slug]/page.tsx
+++ b/app/[username]/[slug]/page.tsx
@@ -34,6 +34,8 @@ import {
   ArticleSidebarSectionFallback,
 } from '@/components/error/SectionErrorFallback'
 import { ReadingProgressBar } from '@/components/articles/ReadingProgressBar'
+import { extractH2HeadingsFromTiptapJson } from '@/lib/tiptap/headings'
+import { ArticleTableOfContents } from '@/components/articles/ArticleTableOfContents'
 
 interface ArticlePageProps {
   params: Promise<{
@@ -52,6 +54,11 @@ export default function ArticlePage({ params }: ArticlePageProps) {
   const highlights = useArticleHighlightsQuery(article?._id)
 
   const highlightTipStats = useArticleHighlightTipStatsOptional(article?._id)
+
+  const tocHeadings = useMemo(
+    () => extractH2HeadingsFromTiptapJson(article?.content),
+    [article?.content]
+  )
 
   // Build lookup map for tip badges
   const tipsByHighlight = useMemo(() => {
@@ -112,14 +119,22 @@ export default function ArticlePage({ params }: ArticlePageProps) {
             {/* Main Article Content */}
             <div className="lg:col-span-8">
               <ErrorBoundary fallback={<ArticleDisplaySectionFallback />}>
-                <ArticleDisplay article={articleForDisplay} />
+                <ArticleDisplay
+                  article={articleForDisplay}
+                  tocHeadings={tocHeadings}
+                />
               </ErrorBoundary>
             </div>
 
             {/* Engagement Sidebar */}
-            <div className="lg:col-span-4">
+            <div className="lg:col-span-4 flex flex-col gap-6">
               <ErrorBoundary fallback={<ArticleSidebarSectionFallback />}>
-                <div className="sticky top-24 space-y-6">
+                {tocHeadings.length >= 3 && (
+                  <div className="sticky top-24 z-10 w-full self-start bg-background lg:max-h-[calc(100dvh-7rem)] lg:overflow-y-auto">
+                    <ArticleTableOfContents headings={tocHeadings} />
+                  </div>
+                )}
+                <div className="space-y-6">
                   {/* Tip Section */}
                   <div className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-[var(--card-padding)]">
                     <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">

--- a/app/[username]/[slug]/page.tsx
+++ b/app/[username]/[slug]/page.tsx
@@ -33,6 +33,7 @@ import {
   ArticleDisplaySectionFallback,
   ArticleSidebarSectionFallback,
 } from '@/components/error/SectionErrorFallback'
+import { ReadingProgressBar } from '@/components/articles/ReadingProgressBar'
 
 interface ArticlePageProps {
   params: Promise<{
@@ -104,6 +105,7 @@ export default function ArticlePage({ params }: ArticlePageProps) {
   return (
     <div className="min-h-screen bg-background">
       <AppNavigation />
+      <ReadingProgressBar />
       <main className="pt-20">
         <div className="max-w-7xl mx-auto px-4 py-8">
           <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">

--- a/app/globals.css
+++ b/app/globals.css
@@ -295,6 +295,7 @@ mark[data-highlight-id] mark[data-highlight-id] {
   margin-top: 1.25rem;
   margin-bottom: 0.375rem;
   color: var(--foreground);
+  scroll-margin-top: 6rem;
 }
 
 .prose h3 {

--- a/components/articles/ArticleDisplay.tsx
+++ b/components/articles/ArticleDisplay.tsx
@@ -20,17 +20,21 @@ import { EDITOR_PROSE_CLASS } from '@/lib/constants'
 import { TagFilterLink } from '@/components/articles/TagFilterLink'
 import { extractPlainTextFromTiptapJson } from '@/lib/tiptap/plainText'
 import { estimateReadingMinutes } from '@/lib/reading-time'
+import type { TocHeading } from '@/lib/tiptap/headings'
+import { useEnsureHeadingIds } from '@/components/articles/useEnsureHeadingIds'
 
 const EMPTY_DOC: JSONContent = { type: 'doc', content: [] }
 
 interface ArticleDisplayProps {
   article: ArticleForDisplay
   showHighlights?: boolean
+  tocHeadings?: TocHeading[]
 }
 
 export default function ArticleDisplay({
   article,
   showHighlights = true,
+  tocHeadings = [],
 }: ArticleDisplayProps) {
   const [currentUrl, setCurrentUrl] = useState('')
   const { isAuthenticated } = useAuth()
@@ -79,6 +83,8 @@ export default function ArticleDisplay({
   const readingMinutes = estimateReadingMinutes(
     extractPlainTextFromTiptapJson(article.content)
   )
+
+  useEnsureHeadingIds(tocHeadings, { rootSelector: '.article-content' })
 
   return (
     <article className="max-w-4xl mx-auto px-4 py-8">
@@ -154,6 +160,7 @@ export default function ArticleDisplay({
             articleId={article.id as Id<'articles'>}
             content={article.content ?? EMPTY_DOC}
             showHighlights={showHighlights}
+            tocHeadings={tocHeadings}
           />
         ) : (
           <EditorContent editor={editor} />

--- a/components/articles/ArticleDisplay.tsx
+++ b/components/articles/ArticleDisplay.tsx
@@ -18,6 +18,8 @@ import type { Id } from '@/types/convex'
 import type { ArticleForDisplay } from '@/types/index'
 import { EDITOR_PROSE_CLASS } from '@/lib/constants'
 import { TagFilterLink } from '@/components/articles/TagFilterLink'
+import { extractPlainTextFromTiptapJson } from '@/lib/tiptap/plainText'
+import { estimateReadingMinutes } from '@/lib/reading-time'
 
 const EMPTY_DOC: JSONContent = { type: 'doc', content: [] }
 
@@ -74,6 +76,10 @@ export default function ArticleDisplay({
     ? formatDistanceToNow(new Date(article.publishedAt), { addSuffix: true })
     : null
 
+  const readingMinutes = estimateReadingMinutes(
+    extractPlainTextFromTiptapJson(article.content)
+  )
+
   return (
     <article className="max-w-4xl mx-auto px-4 py-8">
       {/* Article Header */}
@@ -98,12 +104,14 @@ export default function ArticleDisplay({
               </p>
               <p className="text-sm text-muted-foreground">
                 @{article.author.username}
+                <span className="mx-1">•</span>
                 {publishedDate && (
                   <>
-                    <span className="mx-1">•</span>
                     {publishedDate}
+                    <span className="mx-1">•</span>
                   </>
                 )}
+                {readingMinutes} min read
               </p>
             </div>
           </div>

--- a/components/articles/ArticleTableOfContents.tsx
+++ b/components/articles/ArticleTableOfContents.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import type { TocHeading } from '@/lib/tiptap/headings'
+
+const ARTICLE_ROOT_SELECTOR = '.article-content'
+/** Below fixed nav (h-16) + thin progress strip; aligns with prose scroll-margin. */
+const ACTIVE_HEADING_TOP_OFFSET_PX = 96
+
+interface ArticleTableOfContentsProps {
+  headings: TocHeading[]
+}
+
+function getHeadingElements(ids: string[]): HTMLElement[] {
+  return ids
+    .map((id) => document.getElementById(id))
+    .filter((el): el is HTMLElement => el instanceof HTMLElement)
+}
+
+function pickActiveId(ids: string[]): string | null {
+  let active: string | null = null
+  let firstFound: string | null = null
+
+  for (const id of ids) {
+    const el = document.getElementById(id)
+    if (!el) continue
+    if (firstFound == null) firstFound = id
+    if (el.getBoundingClientRect().top <= ACTIVE_HEADING_TOP_OFFSET_PX) {
+      active = id
+    }
+  }
+
+  return active ?? firstFound
+}
+
+export function ArticleTableOfContents({ headings }: ArticleTableOfContentsProps) {
+  const enabled = headings.length >= 3
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  const ids = useMemo(() => headings.map((h) => h.id), [headings])
+
+  useEffect(() => {
+    if (!enabled) return
+
+    const root =
+      document.querySelector(ARTICLE_ROOT_SELECTOR) ?? document.body
+
+    let scrollCleanup: (() => void) | null = null
+    let mo: MutationObserver | null = null
+
+    const updateActive = () => {
+      setActiveId(pickActiveId(ids))
+    }
+
+    const attachScrollListeners = () => {
+      updateActive()
+      window.addEventListener('scroll', updateActive, { passive: true })
+      window.addEventListener('resize', updateActive)
+      return () => {
+        window.removeEventListener('scroll', updateActive)
+        window.removeEventListener('resize', updateActive)
+      }
+    }
+
+    const tryAttach = (): boolean => {
+      if (getHeadingElements(ids).length === 0) return false
+      scrollCleanup?.()
+      scrollCleanup = attachScrollListeners()
+      return true
+    }
+
+    if (!tryAttach()) {
+      mo = new MutationObserver(() => {
+        if (tryAttach()) {
+          mo?.disconnect()
+          mo = null
+        }
+      })
+      mo.observe(root, { childList: true, subtree: true })
+    }
+
+    return () => {
+      mo?.disconnect()
+      scrollCleanup?.()
+    }
+  }, [enabled, ids])
+
+  if (!enabled) return null
+
+  return (
+    <div className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-[var(--card-padding)]">
+      <h3 className="text-lg font-semibold mb-3">On this page</h3>
+      <nav aria-label="Table of contents">
+        <ul className="space-y-1">
+          {headings.map((h) => {
+            const isActive = activeId === h.id
+            return (
+              <li key={h.id}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    document.getElementById(h.id)?.scrollIntoView({
+                      behavior: 'smooth',
+                      block: 'start',
+                    })
+                  }}
+                  className={[
+                    'w-full text-left text-sm rounded px-2 py-1.5 transition-colors',
+                    isActive
+                      ? 'bg-primary/10 text-foreground'
+                      : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                  ].join(' ')}
+                >
+                  {h.text}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      </nav>
+    </div>
+  )
+}

--- a/components/articles/ArticleTableOfContents.tsx
+++ b/components/articles/ArticleTableOfContents.tsx
@@ -33,7 +33,9 @@ function pickActiveId(ids: string[]): string | null {
   return active ?? firstFound
 }
 
-export function ArticleTableOfContents({ headings }: ArticleTableOfContentsProps) {
+export function ArticleTableOfContents({
+  headings,
+}: ArticleTableOfContentsProps) {
   const enabled = headings.length >= 3
   const [activeId, setActiveId] = useState<string | null>(null)
 
@@ -42,8 +44,7 @@ export function ArticleTableOfContents({ headings }: ArticleTableOfContentsProps
   useEffect(() => {
     if (!enabled) return
 
-    const root =
-      document.querySelector(ARTICLE_ROOT_SELECTOR) ?? document.body
+    const root = document.querySelector(ARTICLE_ROOT_SELECTOR) ?? document.body
 
     let scrollCleanup: (() => void) | null = null
     let mo: MutationObserver | null = null

--- a/components/articles/HighlightableArticle.tsx
+++ b/components/articles/HighlightableArticle.tsx
@@ -23,6 +23,8 @@ import { useAuth } from '@/components/providers/AuthContext'
 import { toast } from 'sonner'
 import { EDITOR_PROSE_CLASS } from '@/lib/constants'
 import { getRangeBoundingBox } from '@/lib/highlights/utils'
+import type { TocHeading } from '@/lib/tiptap/headings'
+import { useEnsureHeadingIds } from '@/components/articles/useEnsureHeadingIds'
 
 function getRangeTopCenterAnchor(
   range: Range
@@ -59,6 +61,7 @@ interface HighlightableArticleProps {
   showHighlights?: boolean
   onHighlightClick?: (highlight: HighlightData) => void
   className?: string
+  tocHeadings?: TocHeading[]
 }
 
 export function HighlightableArticle({
@@ -68,6 +71,7 @@ export function HighlightableArticle({
   showHighlights = true,
   onHighlightClick,
   className,
+  tocHeadings = [],
 }: HighlightableArticleProps) {
   const [selectedText, setSelectedText] = useState<{
     text: string
@@ -93,6 +97,8 @@ export function HighlightableArticle({
 
   // Get current user for ownership checks
   const { user } = useAuth()
+
+  useEnsureHeadingIds(tocHeadings, { rootSelector: '.highlightable-article' })
 
   // Fetch article data (for author info, Stellar address, etc.)
   const article = useArticleById(articleId)

--- a/components/articles/ReadingProgressBar.tsx
+++ b/components/articles/ReadingProgressBar.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0
+  if (n < 0) return 0
+  if (n > 1) return 1
+  return n
+}
+
+function getViewportHeight(): number {
+  return window.visualViewport?.height ?? window.innerHeight
+}
+
+function getWindowScrollY(): number {
+  return window.scrollY ?? window.pageYOffset ?? 0
+}
+
+function getWindowScrollRange(): number {
+  const doc = document.documentElement
+  const body = document.body
+  if (!body) return 0
+  const height = Math.max(
+    body.scrollHeight,
+    body.offsetHeight,
+    doc.scrollHeight,
+    doc.offsetHeight
+  )
+  return Math.max(0, height - getViewportHeight())
+}
+
+function findLikelyNestedScrollRoot(): HTMLElement | null {
+  const vh = getViewportHeight()
+  let best: HTMLElement | null = null
+  let bestCh = 0
+
+  for (const node of document.querySelectorAll('*')) {
+    if (!(node instanceof HTMLElement)) continue
+    if (node === document.body || node === document.documentElement) continue
+
+    const { overflowY } = getComputedStyle(node)
+    if (overflowY !== 'auto' && overflowY !== 'scroll' && overflowY !== 'overlay')
+      continue
+    if (node.scrollHeight <= node.clientHeight + 1) continue
+    if (node.clientHeight < vh * 0.55) continue
+
+    if (node.clientHeight > bestCh) {
+      bestCh = node.clientHeight
+      best = node
+    }
+  }
+
+  return best
+}
+
+function getScrollProgress(nested: HTMLElement | null): number {
+  const sy = getWindowScrollY()
+  const maxW = getWindowScrollRange()
+
+  let maxN = 0
+  let sn = 0
+  if (nested) {
+    maxN = Math.max(0, nested.scrollHeight - nested.clientHeight)
+    sn = nested.scrollTop
+  }
+
+  if (maxW > 1 && sy > 0) {
+    return clamp01(sy / maxW)
+  }
+
+  if (nested && maxN > 1 && sn > 0 && sy === 0) {
+    return clamp01(sn / maxN)
+  }
+
+  if (maxW > 1) {
+    return clamp01(sy / maxW)
+  }
+
+  if (nested && maxN > 1) {
+    return clamp01(sn / maxN)
+  }
+
+  return 0
+}
+
+export function ReadingProgressBar() {
+  const [progress, setProgress] = useState(0)
+  const nestedRef = useRef<HTMLElement | null>(null)
+  const frameRef = useRef(0)
+
+  useEffect(() => {
+    const refreshNested = () => {
+      nestedRef.current = findLikelyNestedScrollRoot()
+    }
+
+    refreshNested()
+
+    const ro =
+      typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(() => {
+            refreshNested()
+          })
+        : null
+    ro?.observe(document.documentElement)
+    if (document.body) ro?.observe(document.body)
+
+    const onLayout = () => refreshNested()
+    window.addEventListener('load', onLayout)
+    window.addEventListener('resize', onLayout)
+    visualViewport?.addEventListener('resize', onLayout)
+
+    let frameCount = 0
+    const tick = () => {
+      frameCount += 1
+      if (frameCount % 45 === 0) refreshNested()
+
+      const next = getScrollProgress(nestedRef.current)
+      setProgress((prev) => (Object.is(prev, next) ? prev : next))
+
+      frameRef.current = requestAnimationFrame(tick)
+    }
+    frameRef.current = requestAnimationFrame(tick)
+
+    return () => {
+      cancelAnimationFrame(frameRef.current)
+      window.removeEventListener('load', onLayout)
+      window.removeEventListener('resize', onLayout)
+      visualViewport?.removeEventListener('resize', onLayout)
+      ro?.disconnect()
+    }
+  }, [])
+
+  return (
+    <div
+      className="pointer-events-none fixed left-0 right-0 top-16 z-[100] h-1 w-full bg-border/40"
+      aria-hidden
+    >
+      <div className="relative h-full w-full">
+        <div
+          className="absolute left-0 top-0 h-full min-w-0 bg-primary"
+          style={{ width: `${progress * 100}%` }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/components/articles/ReadingProgressBar.tsx
+++ b/components/articles/ReadingProgressBar.tsx
@@ -40,7 +40,11 @@ function findLikelyNestedScrollRoot(): HTMLElement | null {
     if (node === document.body || node === document.documentElement) continue
 
     const { overflowY } = getComputedStyle(node)
-    if (overflowY !== 'auto' && overflowY !== 'scroll' && overflowY !== 'overlay')
+    if (
+      overflowY !== 'auto' &&
+      overflowY !== 'scroll' &&
+      overflowY !== 'overlay'
+    )
       continue
     if (node.scrollHeight <= node.clientHeight + 1) continue
     if (node.clientHeight < vh * 0.55) continue

--- a/components/articles/useEnsureHeadingIds.ts
+++ b/components/articles/useEnsureHeadingIds.ts
@@ -1,0 +1,56 @@
+'use client'
+
+import { useEffect } from 'react'
+import type { TocHeading } from '@/lib/tiptap/headings'
+
+interface EnsureHeadingIdsOptions {
+  /** CSS selector for the root element that contains the rendered article. */
+  rootSelector?: string
+}
+
+/**
+ * Keeps rendered <h2> ids in sync with ToC heading ids. TipTap mounts headings
+ * after the first paint and can replace the whole editor (e.g. highlightable
+ * mode), so we watch the subtree and re-apply whenever the DOM changes.
+ */
+export function useEnsureHeadingIds(
+  headings: TocHeading[],
+  { rootSelector }: EnsureHeadingIdsOptions = {}
+) {
+  useEffect(() => {
+    if (headings.length === 0) return
+
+    const root =
+      (rootSelector ? document.querySelector(rootSelector) : null) ??
+      document.body
+
+    const apply = () => {
+      const h2s = Array.from(root.querySelectorAll('h2'))
+      let i = 0
+      for (const el of h2s) {
+        const next = headings[i]
+        if (!next) break
+        if (el.id !== next.id) el.id = next.id
+        i += 1
+      }
+    }
+
+    apply()
+
+    let raf: number | null = null
+    const schedule = () => {
+      if (raf != null) return
+      raf = requestAnimationFrame(() => {
+        raf = null
+        apply()
+      })
+    }
+
+    const mo = new MutationObserver(schedule)
+    mo.observe(root, { childList: true, subtree: true })
+    return () => {
+      mo.disconnect()
+      if (raf != null) cancelAnimationFrame(raf)
+    }
+  }, [headings, rootSelector])
+}

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -14,6 +14,7 @@ import {
   Loader2,
 } from 'lucide-react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import { estimateReadingMinutes } from '@/lib/reading-time'
 
 interface EditorActionBarProps {
   editor: Editor | null
@@ -69,13 +70,7 @@ function MoreMenu({
             onSelect={(e) => e.preventDefault()}
           >
             <Clock className="w-4 h-4 shrink-0" />~
-            {Math.max(
-              1,
-              Math.ceil(
-                (editor?.getText().split(/\s+/).filter(Boolean).length ?? 0) /
-                  200
-              )
-            )}{' '}
+            {estimateReadingMinutes(editor?.getText() ?? '')}{' '}
             min read
           </DropdownMenu.Item>
           {onDelete && (

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -70,8 +70,7 @@ function MoreMenu({
             onSelect={(e) => e.preventDefault()}
           >
             <Clock className="w-4 h-4 shrink-0" />~
-            {estimateReadingMinutes(editor?.getText() ?? '')}{' '}
-            min read
+            {estimateReadingMinutes(editor?.getText() ?? '')} min read
           </DropdownMenu.Item>
           {onDelete && (
             <>

--- a/lib/reading-time.ts
+++ b/lib/reading-time.ts
@@ -1,0 +1,20 @@
+export const DEFAULT_WORDS_PER_MINUTE = 200
+
+export function countWords(text: string): number {
+  return text.split(/\s+/).filter(Boolean).length
+}
+
+export function estimateReadingMinutesFromWordCount(
+  wordCount: number,
+  wordsPerMinute: number = DEFAULT_WORDS_PER_MINUTE
+): number {
+  if (!Number.isFinite(wordCount) || wordCount <= 0) return 1
+  return Math.max(1, Math.ceil(wordCount / wordsPerMinute))
+}
+
+export function estimateReadingMinutes(
+  text: string,
+  wordsPerMinute: number = DEFAULT_WORDS_PER_MINUTE
+): number {
+  return estimateReadingMinutesFromWordCount(countWords(text), wordsPerMinute)
+}

--- a/lib/tiptap/headings.ts
+++ b/lib/tiptap/headings.ts
@@ -27,7 +27,9 @@ export type TocHeading = {
   level: 2
 }
 
-export function extractH2HeadingsFromTiptapJson(content: unknown): TocHeading[] {
+export function extractH2HeadingsFromTiptapJson(
+  content: unknown
+): TocHeading[] {
   const headings: Omit<TocHeading, 'id'>[] = []
 
   const walk = (node: unknown) => {
@@ -57,4 +59,3 @@ export function extractH2HeadingsFromTiptapJson(content: unknown): TocHeading[] 
     return { ...h, id }
   })
 }
-

--- a/lib/tiptap/headings.ts
+++ b/lib/tiptap/headings.ts
@@ -1,0 +1,60 @@
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object'
+}
+
+function slugify(input: string): string {
+  const base = input
+    .toLowerCase()
+    .trim()
+    .replace(/[^\p{L}\p{N}\s-]/gu, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+  return base || 'section'
+}
+
+function extractPlainText(node: unknown): string {
+  if (!isRecord(node)) return ''
+  if (node.type === 'text' && typeof node.text === 'string') return node.text
+  if (Array.isArray(node.content)) {
+    return node.content.map(extractPlainText).join(' ').trim()
+  }
+  return ''
+}
+
+export type TocHeading = {
+  id: string
+  text: string
+  level: 2
+}
+
+export function extractH2HeadingsFromTiptapJson(content: unknown): TocHeading[] {
+  const headings: Omit<TocHeading, 'id'>[] = []
+
+  const walk = (node: unknown) => {
+    if (!isRecord(node)) return
+
+    if (node.type === 'heading' && node.attrs && isRecord(node.attrs)) {
+      const level = node.attrs.level
+      if (level === 2) {
+        const text = extractPlainText(node).replace(/\s+/g, ' ').trim()
+        if (text) headings.push({ text, level: 2 })
+      }
+    }
+
+    if (Array.isArray(node.content)) {
+      node.content.forEach(walk)
+    }
+  }
+
+  walk(content)
+
+  const seen = new Map<string, number>()
+  return headings.map((h) => {
+    const base = slugify(h.text)
+    const count = (seen.get(base) ?? 0) + 1
+    seen.set(base, count)
+    const id = count === 1 ? base : `${base}-${count}`
+    return { ...h, id }
+  })
+}
+

--- a/lib/tiptap/plainText.ts
+++ b/lib/tiptap/plainText.ts
@@ -1,0 +1,16 @@
+export function extractPlainTextFromTiptapJson(node: unknown): string {
+  if (!node || typeof node !== 'object') return ''
+
+  const n = node as Record<string, unknown>
+  if (n.type === 'text' && typeof n.text === 'string') return n.text
+
+  if (Array.isArray(n.content)) {
+    return n.content
+      .map(extractPlainTextFromTiptapJson)
+      .join(' ')
+      .trim()
+  }
+
+  return ''
+}
+

--- a/lib/tiptap/plainText.ts
+++ b/lib/tiptap/plainText.ts
@@ -5,12 +5,8 @@ export function extractPlainTextFromTiptapJson(node: unknown): string {
   if (n.type === 'text' && typeof n.text === 'string') return n.text
 
   if (Array.isArray(n.content)) {
-    return n.content
-      .map(extractPlainTextFromTiptapJson)
-      .join(' ')
-      .trim()
+    return n.content.map(extractPlainTextFromTiptapJson).join(' ').trim()
   }
 
   return ''
 }
-


### PR DESCRIPTION
## Summary

Adds reading aids on published article pages: estimated reading time in the header, a fixed scroll progress bar under the top navigation, and a sidebar table of contents for articles with three or more H2 headings, with smooth scroll-to-section and active-section highlighting while reading.

## Changes

- **Reading time**: Shared helpers in `lib/reading-time.ts` and `lib/tiptap/plainText.ts`; editor “min read” uses the same estimate; article header shows minutes from TipTap JSON plain text.
- **Scroll progress**: `ReadingProgressBar` on the article route; window scroll with passive listeners and rAF-coalesced updates; fixed under the nav so layout does not shift.
- **Table of contents**: `lib/tiptap/headings.ts` extracts H2s and stable ids; `ArticleTableOfContents` in the sticky sidebar (only when there are 3+ H2s); `useEnsureHeadingIds` aligns DOM `h2` ids with the extracted list; `scroll-margin-top` on `.prose h2` for fixed-header scroll alignment.

<img width="1194" height="719" alt="read_min" src="https://github.com/user-attachments/assets/f5aca10e-ce6c-45ee-b972-204fd2dc29f8" />
<img width="1194" height="722" alt="scroll_bar" src="https://github.com/user-attachments/assets/5204e931-3747-4f08-94ff-685546a8a0d1" />
<img width="1181" height="719" alt="1" src="https://github.com/user-attachments/assets/c061dc26-5d16-4c54-aef0-6575212d61c0" />
<img width="1193" height="675" alt="2" src="https://github.com/user-attachments/assets/59cd5977-aa29-4ece-8760-dc642b8fcdc0" />
