### PR TITLE
fix: restore article browse scroll position on back navigation

### DIFF
--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -1,16 +1,53 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { useSearchParams, useRouter } from 'next/navigation'
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { usePathname, useSearchParams, useRouter } from 'next/navigation'
 import AppNavigation from '@/components/layout/AppNavigation'
 import SearchInput from '@/components/articles/SearchInput'
 import { ArticlesBrowseContent } from '@/components/articles/ArticlesBrowseContent'
+import {
+  buildArticlesBrowseScrollStorageKey,
+  writeBrowseScrollY,
+} from '@/lib/articles/browseListScrollStorage'
 
 export default function ArticlesPage() {
   const [searchTerm, setSearchTerm] = useState('')
+  const didSaveOnNavigateRef = useRef(false)
 
+  const pathname = usePathname()
   const searchParams = useSearchParams()
   const router = useRouter()
+
+  const searchString = searchParams?.toString() ?? ''
+  const scrollStorageKey = buildArticlesBrowseScrollStorageKey(
+    pathname,
+    searchString
+  )
+
+  useEffect(() => {
+    const previous = history.scrollRestoration
+    history.scrollRestoration = 'manual'
+    return () => {
+      history.scrollRestoration = previous
+    }
+  }, [])
+
+  useEffect(() => {
+    const onPageHide = () => {
+      // If we already saved right before a click navigation, don't overwrite it.
+      if (didSaveOnNavigateRef.current) return
+      writeBrowseScrollY(scrollStorageKey, window.scrollY)
+    }
+    window.addEventListener('pagehide', onPageHide)
+    return () => {
+      window.removeEventListener('pagehide', onPageHide)
+    }
+  }, [scrollStorageKey])
+
+  const saveBrowseScrollPosition = useCallback(() => {
+    didSaveOnNavigateRef.current = true
+    writeBrowseScrollY(scrollStorageKey, window.scrollY)
+  }, [scrollStorageKey])
 
   const currentPage = parseInt(searchParams?.get('page') || '1')
   const tag = searchParams?.get('tag') || undefined
@@ -137,6 +174,8 @@ export default function ArticlesPage() {
           tag={tag}
           author={author}
           urlSearch={urlSearch}
+          scrollStorageKey={scrollStorageKey}
+          onArticleNavigate={saveBrowseScrollPosition}
         />
       </main>
     </div>

--- a/components/articles/ArticleCard.tsx
+++ b/components/articles/ArticleCard.tsx
@@ -8,9 +8,14 @@ import { TagFilterLink } from '@/components/articles/TagFilterLink'
 interface ArticleCardProps {
   article: ArticleForDisplay
   priority?: boolean
+  onArticleNavigate?: () => void
 }
 
-export default function ArticleCard({ article, priority }: ArticleCardProps) {
+export default function ArticleCard({
+  article,
+  priority,
+  onArticleNavigate,
+}: ArticleCardProps) {
   const publishedDate = article.publishedAt
     ? formatDistanceToNow(new Date(article.publishedAt), { addSuffix: true })
     : null
@@ -21,7 +26,10 @@ export default function ArticleCard({ article, priority }: ArticleCardProps) {
       {article.coverImage && (
         <Link
           href={`/${article.author.username}/${article.slug}`}
+          scroll={false}
           className="focus-ring block rounded-t-[var(--card-radius)]"
+          onPointerDown={() => onArticleNavigate?.()}
+          onClick={() => onArticleNavigate?.()}
         >
           <div className="relative h-48 w-full overflow-hidden rounded-t-[var(--card-radius)]">
             <Image
@@ -40,7 +48,10 @@ export default function ArticleCard({ article, priority }: ArticleCardProps) {
         {/* Title */}
         <Link
           href={`/${article.author.username}/${article.slug}`}
+          scroll={false}
           className="focus-ring rounded-md"
+          onPointerDown={() => onArticleNavigate?.()}
+          onClick={() => onArticleNavigate?.()}
         >
           <h2 className="text-xl font-bold text-foreground mb-2 hover:text-brand-blue transition-colors line-clamp-2">
             {article.title}

--- a/components/articles/ArticleGrid.tsx
+++ b/components/articles/ArticleGrid.tsx
@@ -6,11 +6,13 @@ import { BookOpen } from 'lucide-react'
 interface ArticleGridProps {
   articles: ArticleForDisplay[]
   variant?: 'home' | 'articles'
+  onArticleNavigate?: () => void
 }
 
 export default function ArticleGrid({
   articles,
   variant = 'articles',
+  onArticleNavigate,
 }: ArticleGridProps) {
   if (articles.length === 0) {
     if (variant === 'home') {
@@ -78,6 +80,7 @@ export default function ArticleGrid({
           key={article.id}
           article={article}
           priority={index === 0}
+          onArticleNavigate={onArticleNavigate}
         />
       ))}
     </div>

--- a/components/articles/ArticlesBrowseContent.tsx
+++ b/components/articles/ArticlesBrowseContent.tsx
@@ -76,10 +76,7 @@ export function ArticlesBrowseContent({
 
   return (
     <>
-      <ArticleGrid
-        articles={articles}
-        onArticleNavigate={onArticleNavigate}
-      />
+      <ArticleGrid articles={articles} onArticleNavigate={onArticleNavigate} />
 
       {pagination.totalPages > 1 && (
         <div className="mt-12">

--- a/components/articles/ArticlesBrowseContent.tsx
+++ b/components/articles/ArticlesBrowseContent.tsx
@@ -1,11 +1,13 @@
 'use client'
 
+import { useLayoutEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useListArticles } from '@/hooks/convex'
 import { mapListArticlesToDisplay } from '@/lib/articles/mapListArticleToDisplay'
 import ArticleGrid from '@/components/articles/ArticleGrid'
 import Pagination from '@/components/articles/Pagination'
 import { ArticleGridSkeleton } from '@/components/articles/ArticleCardSkeleton'
+import { readBrowseScrollY } from '@/lib/articles/browseListScrollStorage'
 
 function buildPagination(result: {
   page: number
@@ -30,11 +32,15 @@ export function ArticlesBrowseContent({
   tag,
   author,
   urlSearch,
+  scrollStorageKey,
+  onArticleNavigate,
 }: {
   currentPage: number
   tag?: string
   author?: string
   urlSearch?: string
+  scrollStorageKey: string
+  onArticleNavigate?: () => void
 }) {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -45,6 +51,15 @@ export function ArticlesBrowseContent({
     author,
     search: urlSearch,
   })
+
+  const listReady = result !== undefined
+
+  useLayoutEffect(() => {
+    if (!listReady) return
+    const y = readBrowseScrollY(scrollStorageKey)
+    if (y === null) return
+    window.scrollTo(0, y)
+  }, [scrollStorageKey, listReady])
 
   if (result === undefined) {
     return <ArticleGridSkeleton count={9} />
@@ -61,7 +76,10 @@ export function ArticlesBrowseContent({
 
   return (
     <>
-      <ArticleGrid articles={articles} />
+      <ArticleGrid
+        articles={articles}
+        onArticleNavigate={onArticleNavigate}
+      />
 
       {pagination.totalPages > 1 && (
         <div className="mt-12">

--- a/lib/articles/browseListScrollStorage.test.ts
+++ b/lib/articles/browseListScrollStorage.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  ARTICLES_BROWSE_SCROLL_STORAGE_PREFIX,
+  buildArticlesBrowseScrollStorageKey,
+  readBrowseScrollY,
+  writeBrowseScrollY,
+} from './browseListScrollStorage'
+
+describe('buildArticlesBrowseScrollStorageKey', () => {
+  it('joins pathname without search when empty', () => {
+    expect(buildArticlesBrowseScrollStorageKey('/articles', '')).toBe(
+      `${ARTICLES_BROWSE_SCROLL_STORAGE_PREFIX}/articles`
+    )
+  })
+
+  it('joins pathname and search string with question mark', () => {
+    expect(
+      buildArticlesBrowseScrollStorageKey('/articles', 'page=2&tag=x')
+    ).toBe(
+      `${ARTICLES_BROWSE_SCROLL_STORAGE_PREFIX}/articles?page=2&tag=x`
+    )
+  })
+})
+
+describe('readBrowseScrollY / writeBrowseScrollY', () => {
+  const store: Record<string, string> = {}
+
+  beforeEach(() => {
+    vi.stubGlobal('window', {
+      sessionStorage: {
+        getItem: (k: string) => (k in store ? store[k] : null),
+        setItem: (k: string, v: string) => {
+          store[k] = v
+        },
+        removeItem: (k: string) => {
+          delete store[k]
+        },
+        clear: () => {
+          for (const k of Object.keys(store)) delete store[k]
+        },
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    for (const k of Object.keys(store)) delete store[k]
+  })
+
+  it('writes rounded non-negative y and reads it back', () => {
+    const key = buildArticlesBrowseScrollStorageKey('/articles', 'page=1')
+    writeBrowseScrollY(key, 120.7)
+    expect(readBrowseScrollY(key)).toBe(121)
+  })
+
+  it('returns null for missing key', () => {
+    const key = buildArticlesBrowseScrollStorageKey('/articles', '')
+    expect(readBrowseScrollY(key)).toBeNull()
+  })
+
+  it('returns null for invalid stored value', () => {
+    const key = buildArticlesBrowseScrollStorageKey('/articles', '')
+    store[key] = 'not-a-number'
+    expect(readBrowseScrollY(key)).toBeNull()
+  })
+
+  it('returns null for negative stored value', () => {
+    const key = buildArticlesBrowseScrollStorageKey('/articles', '')
+    store[key] = '-1'
+    expect(readBrowseScrollY(key)).toBeNull()
+  })
+
+  it('does not write negative or non-finite y', () => {
+    const key = buildArticlesBrowseScrollStorageKey('/articles', '')
+    writeBrowseScrollY(key, -1)
+    writeBrowseScrollY(key, Number.NaN)
+    expect(store[key]).toBeUndefined()
+  })
+})

--- a/lib/articles/browseListScrollStorage.test.ts
+++ b/lib/articles/browseListScrollStorage.test.ts
@@ -16,9 +16,7 @@ describe('buildArticlesBrowseScrollStorageKey', () => {
   it('joins pathname and search string with question mark', () => {
     expect(
       buildArticlesBrowseScrollStorageKey('/articles', 'page=2&tag=x')
-    ).toBe(
-      `${ARTICLES_BROWSE_SCROLL_STORAGE_PREFIX}/articles?page=2&tag=x`
-    )
+    ).toBe(`${ARTICLES_BROWSE_SCROLL_STORAGE_PREFIX}/articles?page=2&tag=x`)
   })
 })
 

--- a/lib/articles/browseListScrollStorage.ts
+++ b/lib/articles/browseListScrollStorage.ts
@@ -1,0 +1,36 @@
+export const ARTICLES_BROWSE_SCROLL_STORAGE_PREFIX =
+  'quilltip:articlesBrowseScroll:'
+
+export function buildArticlesBrowseScrollStorageKey(
+  pathname: string,
+  searchParamsString: string
+): string {
+  const pathAndQuery =
+    searchParamsString.length > 0
+      ? `${pathname}?${searchParamsString}`
+      : pathname
+  return `${ARTICLES_BROWSE_SCROLL_STORAGE_PREFIX}${pathAndQuery}`
+}
+
+export function writeBrowseScrollY(storageKey: string, y: number): void {
+  if (typeof window === 'undefined') return
+  if (!Number.isFinite(y) || y < 0) return
+  try {
+    window.sessionStorage.setItem(storageKey, String(Math.round(y)))
+  } catch {
+    // Quota or private mode
+  }
+}
+
+export function readBrowseScrollY(storageKey: string): number | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.sessionStorage.getItem(storageKey)
+    if (raw === null) return null
+    const n = Number.parseFloat(raw)
+    if (!Number.isFinite(n) || n < 0) return null
+    return Math.round(n)
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- Persist `/articles` scroll position in `sessionStorage` keyed by `pathname + search`
- Restore scroll on list mount after data loads (pre-paint) to avoid wrong-position flash
- Save scroll on article click and on browse page unmount; set `history.scrollRestoration` to `manual`

https://github.com/user-attachments/assets/e542a938-bd6f-4f50-b72a-70ce0a7e9947


https://github.com/user-attachments/assets/3d380cb0-3c46-43b5-a44d-7baa8096faf4

