### PR TITLE
fix: validate image uploads (type + size) across dialog and drag-and-drop

### DIFF
--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -10,9 +10,10 @@ import Youtube from '@tiptap/extension-youtube'
 import { lowlight } from '@/lib/lowlight'
 import { useEffect, useState } from 'react'
 import { ResizableImage } from './extensions/ResizableImage'
-import { uploadFile, compressImage } from '@/lib/upload'
+import { uploadFile, compressImage, validateImageUploadFile } from '@/lib/upload'
 import { EDITOR_PROSE_CLASS } from '@/lib/constants'
 import { useConvex } from 'convex/react'
+import { toast } from 'sonner'
 
 interface EditorProps {
   content?: string
@@ -140,14 +141,20 @@ export function Editor({
       return // No image files dropped
     }
 
+    const file = imageFiles[0]
+    if (!file) return
+
+    const validation = validateImageUploadFile(file)
+    if (!validation.ok) {
+      toast.error(validation.error)
+      return
+    }
+
     setIsUploading(true)
     setUploadProgress(0)
 
     try {
       // Upload the first image file
-      const file = imageFiles[0]
-      if (!file) return
-
       // Compress image before upload for better performance
       const compressedFile = await compressImage(file, 1200, 0.8)
       const result = await uploadFile(
@@ -163,9 +170,12 @@ export function Editor({
       if (result.success && result.url) {
         // Insert the image at the current cursor position
         editor.chain().focus().setResizableImage({ src: result.url }).run()
+      } else if (result.error) {
+        toast.error(result.error)
       }
     } catch (error) {
       console.error('Error uploading dropped image:', error)
+      toast.error('Upload failed. Please try again.')
     } finally {
       setIsUploading(false)
     }

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -10,7 +10,11 @@ import Youtube from '@tiptap/extension-youtube'
 import { lowlight } from '@/lib/lowlight'
 import { useEffect, useState } from 'react'
 import { ResizableImage } from './extensions/ResizableImage'
-import { uploadFile, compressImage, validateImageUploadFile } from '@/lib/upload'
+import {
+  uploadFile,
+  compressImage,
+  validateImageUploadFile,
+} from '@/lib/upload'
 import { EDITOR_PROSE_CLASS } from '@/lib/constants'
 import { useConvex } from 'convex/react'
 import { toast } from 'sonner'

--- a/components/editor/ImageUploadDialog.tsx
+++ b/components/editor/ImageUploadDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, type RefObject } from 'react'
 import { Upload, Link2, Image as ImageIcon } from 'lucide-react'
-import { uploadFile, compressImage } from '@/lib/upload'
+import { uploadFile, compressImage, validateImageUploadFile } from '@/lib/upload'
 import { useConvex } from 'convex/react'
 import {
   Dialog,
@@ -28,6 +28,7 @@ export function ImageUploadDialog({
   title = 'Add Image',
   triggerRef,
 }: ImageUploadDialogProps) {
+  const IMAGE_ACCEPT = 'image/png,image/jpeg,image/gif,image/webp'
   const [uploadMethod, setUploadMethod] = useState<'file' | 'url'>('file')
   const [imageUrl, setImageUrl] = useState('')
   const [isUploading, setIsUploading] = useState(false)
@@ -40,6 +41,13 @@ export function ImageUploadDialog({
 
   const handleFileSelect = async (file: File) => {
     setError('')
+
+    const validation = validateImageUploadFile(file)
+    if (!validation.ok) {
+      setError(validation.error)
+      return
+    }
+
     setIsUploading(true)
     setUploadProgress(0)
 
@@ -92,11 +100,12 @@ export function ImageUploadDialog({
     setDragActive(false)
 
     const file = e.dataTransfer.files?.[0]
-    if (file && file.type.startsWith('image/')) {
-      handleFileSelect(file)
-    } else {
+    if (!file) {
       setError('Please drop an image file')
+      return
     }
+
+    void handleFileSelect(file)
   }
 
   const handleUrlSubmit = async () => {
@@ -117,11 +126,12 @@ export function ImageUploadDialog({
       const blob = await response.blob()
       setUploadProgress(40)
 
-      if (!blob.type.startsWith('image/')) {
-        throw new Error('URL does not point to a valid image')
+      const file = new File([blob], 'image-from-url', { type: blob.type })
+      const validation = validateImageUploadFile(file)
+      if (!validation.ok) {
+        throw new Error(validation.error)
       }
 
-      const file = new File([blob], 'image-from-url', { type: blob.type })
       setUploadProgress(60)
 
       const compressedFile = await compressImage(file, 1200, 0.8)
@@ -282,7 +292,7 @@ export function ImageUploadDialog({
                         </button>
                       </p>
                       <p className="text-xs text-muted-foreground mt-1">
-                        PNG, JPG, GIF up to 10MB
+                        PNG, JPG, GIF, WEBP up to 10MB
                       </p>
                     </div>
                   </div>
@@ -292,7 +302,7 @@ export function ImageUploadDialog({
               <input
                 ref={fileInputRef}
                 type="file"
-                accept="image/*"
+                accept={IMAGE_ACCEPT}
                 onChange={handleFileChange}
                 className="hidden"
               />

--- a/components/editor/ImageUploadDialog.tsx
+++ b/components/editor/ImageUploadDialog.tsx
@@ -2,7 +2,11 @@
 
 import { useState, useRef, type RefObject } from 'react'
 import { Upload, Link2, Image as ImageIcon } from 'lucide-react'
-import { uploadFile, compressImage, validateImageUploadFile } from '@/lib/upload'
+import {
+  uploadFile,
+  compressImage,
+  validateImageUploadFile,
+} from '@/lib/upload'
 import { useConvex } from 'convex/react'
 import {
   Dialog,

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -42,7 +42,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { cn } from '@/lib/utils'
-import { compressImage, uploadFile } from '@/lib/upload'
+import { compressImage, uploadFile, validateImageUploadFile } from '@/lib/upload'
 
 const PUBLISH_EXCERPT_PREVIEW_MAX = 280
 const EXCERPT_MAX_CHARS = 500
@@ -422,8 +422,10 @@ export function WriteEditorWorkspace() {
 
       const file = e.dataTransfer.files?.[0]
       if (!file) return
-      if (!file.type.startsWith('image/')) {
-        toast.error('Please drop an image file')
+
+      const validation = validateImageUploadFile(file)
+      if (!validation.ok) {
+        toast.error(validation.error)
         return
       }
 
@@ -481,6 +483,12 @@ export function WriteEditorWorkspace() {
 
       const file = imageFiles[0]
       if (!file) return
+
+      const validation = validateImageUploadFile(file)
+      if (!validation.ok) {
+        toast.error(validation.error)
+        return
+      }
 
       setBodyImageUploading(true)
       setBodyImageUploadProgress(0)

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -42,7 +42,11 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { cn } from '@/lib/utils'
-import { compressImage, uploadFile, validateImageUploadFile } from '@/lib/upload'
+import {
+  compressImage,
+  uploadFile,
+  validateImageUploadFile,
+} from '@/lib/upload'
 
 const PUBLISH_EXCERPT_PREVIEW_MAX = 280
 const EXCERPT_MAX_CHARS = 500

--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -19,7 +19,9 @@ export type ImageUploadValidationResult =
   | { ok: true }
   | { ok: false; error: string }
 
-export function validateImageUploadFile(file: File): ImageUploadValidationResult {
+export function validateImageUploadFile(
+  file: File
+): ImageUploadValidationResult {
   if (!file.type || !ALLOWED_IMAGE_MIME_TYPES.has(file.type)) {
     return {
       ok: false,

--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -6,6 +6,37 @@ import { ConvexReactClient } from 'convex/react'
 import { api } from '@/convex/_generated/api'
 import { Id } from '@/convex/_generated/dataModel'
 
+export const MAX_IMAGE_UPLOAD_BYTES = 10 * 1024 * 1024
+
+export const ALLOWED_IMAGE_MIME_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+])
+
+export type ImageUploadValidationResult =
+  | { ok: true }
+  | { ok: false; error: string }
+
+export function validateImageUploadFile(file: File): ImageUploadValidationResult {
+  if (!file.type || !ALLOWED_IMAGE_MIME_TYPES.has(file.type)) {
+    return {
+      ok: false,
+      error: 'Unsupported image type. Use PNG, JPG, GIF, or WEBP.',
+    }
+  }
+
+  if (file.size > MAX_IMAGE_UPLOAD_BYTES) {
+    return {
+      ok: false,
+      error: 'Image must be 10MB or smaller',
+    }
+  }
+
+  return { ok: true }
+}
+
 interface UploadResult {
   success: boolean
   url?: string
@@ -33,21 +64,9 @@ export async function uploadFile(
   onProgress?: (progress: UploadProgress) => void
 ): Promise<UploadResult> {
   try {
-    // Validate file type
-    if (!file.type.startsWith('image/')) {
-      return {
-        success: false,
-        error: 'Please select an image file',
-      }
-    }
-
-    // Validate file size (max 10MB)
-    const maxSize = 10 * 1024 * 1024
-    if (file.size > maxSize) {
-      return {
-        success: false,
-        error: 'Image must be smaller than 10MB',
-      }
+    const validation = validateImageUploadFile(file)
+    if (!validation.ok) {
+      return { success: false, error: validation.error }
     }
 
     // Step 1: Get upload URL from Convex
@@ -143,19 +162,9 @@ export async function uploadAvatarFile(
   convexClient: ConvexReactClient,
   onProgress?: (progress: UploadProgress) => void
 ): Promise<UploadResult> {
-  if (!file.type.startsWith('image/')) {
-    return {
-      success: false,
-      error: 'Please select an image file',
-    }
-  }
-
-  const maxSize = 10 * 1024 * 1024
-  if (file.size > maxSize) {
-    return {
-      success: false,
-      error: 'Image must be smaller than 10MB',
-    }
+  const validation = validateImageUploadFile(file)
+  if (!validation.ok) {
+    return { success: false, error: validation.error }
   }
 
   try {


### PR DESCRIPTION
## Summary
- Added shared client-side validation for image uploads: max 10MB and allowed MIME types (png/jpeg/gif/webp).
- Applied the same validation to the upload dialog (file picker, dropzone, and URL upload) and all drag-and-drop entrypoints (editor body + cover placeholder).
- Added user-facing errors for invalid drops (toasts) to avoid silent “stuck” uploads.

## Validation rules
- Max size: 10MB
- Allowed types: image/png, image/jpeg, image/gif, image/webp

<img width="1213" height="723" alt="Screenshot 2026-05-07 at 9 36 02 PM" src="https://github.com/user-attachments/assets/96c22a0b-8fc1-4e16-a226-3be8f295d956" />

<img width="1198" height="717" alt="Screenshot 2026-05-07 at 9 36 19 PM" src="https://github.com/user-attachments/assets/7e4671e4-9134-43ef-bcaa-8ec0e4bcb9b0" />
<img width="1438" height="859" alt="Screenshot 2026-05-07 at 9 37 16 PM" src="https://github.com/user-attachments/assets/9b025940-c611-4f07-bcef-c93d22d7c9c8" />

