### PR TITLE
fix(editor): clear drag-drop upload overlay on failure/cancel

### DIFF
--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -8,12 +8,13 @@ import Placeholder from '@tiptap/extension-placeholder'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import Youtube from '@tiptap/extension-youtube'
 import { lowlight } from '@/lib/lowlight'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ResizableImage } from './extensions/ResizableImage'
 import {
   uploadFile,
   compressImage,
   validateImageUploadFile,
+  isAbortError,
 } from '@/lib/upload'
 import { EDITOR_PROSE_CLASS } from '@/lib/constants'
 import { useConvex } from 'convex/react'
@@ -37,9 +38,16 @@ export function Editor({
   const [isDragging, setIsDragging] = useState(false)
   const [isUploading, setIsUploading] = useState(false)
   const [uploadProgress, setUploadProgress] = useState(0)
+  const uploadAbortRef = useRef<AbortController | null>(null)
 
-  // Get Convex client for uploads
   const convex = useConvex()
+
+  useEffect(() => {
+    return () => {
+      uploadAbortRef.current?.abort()
+      uploadAbortRef.current = null
+    }
+  }, [])
 
   const editor = useEditor({
     immediatelyRender: false,
@@ -154,33 +162,50 @@ export function Editor({
       return
     }
 
+    uploadAbortRef.current?.abort()
+    const controller = new AbortController()
+    uploadAbortRef.current = controller
+
     setIsUploading(true)
     setUploadProgress(0)
 
     try {
-      // Upload the first image file
-      // Compress image before upload for better performance
-      const compressedFile = await compressImage(file, 1200, 0.8)
+      const compressedFile = await compressImage(
+        file,
+        1200,
+        0.8,
+        controller.signal
+      )
       const result = await uploadFile(
         compressedFile,
         convex,
         'article_image',
-        undefined, // no specific article
+        undefined,
         (progress) => {
           setUploadProgress(progress.percentage)
-        }
+        },
+        controller.signal
       )
 
       if (result.success && result.url) {
-        // Insert the image at the current cursor position
         editor.chain().focus().setResizableImage({ src: result.url }).run()
       } else if (result.error) {
         toast.error(result.error)
       }
     } catch (error) {
+      if (isAbortError(error)) {
+        return
+      }
       console.error('Error uploading dropped image:', error)
-      toast.error('Upload failed. Please try again.')
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : 'Upload failed. Please try again.'
+      )
     } finally {
+      if (uploadAbortRef.current === controller) {
+        uploadAbortRef.current = null
+      }
       setIsUploading(false)
     }
   }

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -46,6 +46,7 @@ import {
   compressImage,
   uploadFile,
   validateImageUploadFile,
+  isAbortError,
 } from '@/lib/upload'
 
 const PUBLISH_EXCERPT_PREVIEW_MAX = 280
@@ -115,6 +116,18 @@ export function WriteEditorWorkspace() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const { isAuthenticated } = useAuth()
+
+  const coverUploadAbortRef = useRef<AbortController | null>(null)
+  const bodyUploadAbortRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    return () => {
+      coverUploadAbortRef.current?.abort()
+      bodyUploadAbortRef.current?.abort()
+      coverUploadAbortRef.current = null
+      bodyUploadAbortRef.current = null
+    }
+  }, [])
 
   useEffect(() => {
     hasUnsavedRef.current = hasUnsavedChanges
@@ -433,15 +446,25 @@ export function WriteEditorWorkspace() {
         return
       }
 
+      coverUploadAbortRef.current?.abort()
+      const controller = new AbortController()
+      coverUploadAbortRef.current = controller
+
       setCoverDropUploading(true)
       try {
-        const compressedFile = await compressImage(file, 1200, 0.8)
+        const compressedFile = await compressImage(
+          file,
+          1200,
+          0.8,
+          controller.signal
+        )
         const result = await uploadFile(
           compressedFile,
           convex,
           'article_image',
           undefined,
-          undefined
+          undefined,
+          controller.signal
         )
         if (result.success && result.url) {
           setCoverImage(result.url)
@@ -450,9 +473,19 @@ export function WriteEditorWorkspace() {
           toast.error(result.error || 'Upload failed')
         }
       } catch (err) {
+        if (isAbortError(err)) {
+          return
+        }
         console.error('Cover drop upload error:', err)
-        toast.error('Upload failed. Please try again.')
+        toast.error(
+          err instanceof Error
+            ? err.message
+            : 'Upload failed. Please try again.'
+        )
       } finally {
+        if (coverUploadAbortRef.current === controller) {
+          coverUploadAbortRef.current = null
+        }
         setCoverDropUploading(false)
       }
     },
@@ -494,11 +527,20 @@ export function WriteEditorWorkspace() {
         return
       }
 
+      bodyUploadAbortRef.current?.abort()
+      const controller = new AbortController()
+      bodyUploadAbortRef.current = controller
+
       setBodyImageUploading(true)
       setBodyImageUploadProgress(0)
 
       try {
-        const compressedFile = await compressImage(file, 1200, 0.8)
+        const compressedFile = await compressImage(
+          file,
+          1200,
+          0.8,
+          controller.signal
+        )
         const result = await uploadFile(
           compressedFile,
           convex,
@@ -506,7 +548,8 @@ export function WriteEditorWorkspace() {
           undefined,
           (progress) => {
             setBodyImageUploadProgress(progress.percentage)
-          }
+          },
+          controller.signal
         )
 
         if (result.success && result.url) {
@@ -515,9 +558,19 @@ export function WriteEditorWorkspace() {
           toast.error(result.error || 'Upload failed')
         }
       } catch (err) {
+        if (isAbortError(err)) {
+          return
+        }
         console.error('Error uploading dropped image:', err)
-        toast.error('Upload failed. Please try again.')
+        toast.error(
+          err instanceof Error
+            ? err.message
+            : 'Upload failed. Please try again.'
+        )
       } finally {
+        if (bodyUploadAbortRef.current === controller) {
+          bodyUploadAbortRef.current = null
+        }
         setBodyImageUploading(false)
       }
     },

--- a/lib/upload.test.ts
+++ b/lib/upload.test.ts
@@ -1,0 +1,140 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { compressImage, isAbortError } from './upload'
+
+type ImageHandlers = {
+  onload: (() => void) | null
+  onerror: (() => void) | null
+  src: string
+  width: number
+  height: number
+}
+
+const liveImages: ImageHandlers[] = []
+
+function lastImage(): ImageHandlers {
+  const img = liveImages[liveImages.length - 1]
+  if (!img) throw new Error('No Image instance has been created yet')
+  return img
+}
+
+class StubImage implements ImageHandlers {
+  onload: (() => void) | null = null
+  onerror: (() => void) | null = null
+  width = 100
+  height = 100
+  private _src = ''
+
+  constructor() {
+    liveImages.push(this)
+  }
+
+  get src(): string {
+    return this._src
+  }
+
+  set src(value: string) {
+    this._src = value
+  }
+}
+
+const createObjectURL = vi.fn(() => 'blob:mock-url')
+const revokeObjectURL = vi.fn()
+
+beforeEach(() => {
+  liveImages.length = 0
+  createObjectURL.mockClear()
+  revokeObjectURL.mockClear()
+
+  vi.stubGlobal('Image', StubImage)
+  vi.stubGlobal('URL', {
+    ...URL,
+    createObjectURL,
+    revokeObjectURL,
+  })
+
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+    () => ({ drawImage: vi.fn() }) as unknown as CanvasRenderingContext2D
+  )
+  vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(function (
+    this: HTMLCanvasElement,
+    callback: BlobCallback
+  ) {
+    callback(new Blob(['x'], { type: 'image/png' }))
+  } as HTMLCanvasElement['toBlob'])
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+function makeFile(): File {
+  return new File(['x'], 'test.png', { type: 'image/png' })
+}
+
+describe('isAbortError', () => {
+  it('returns true for DOMException with name AbortError', () => {
+    expect(isAbortError(new DOMException('canceled', 'AbortError'))).toBe(true)
+  })
+
+  it('returns false for plain errors', () => {
+    expect(isAbortError(new Error('boom'))).toBe(false)
+    expect(isAbortError(null)).toBe(false)
+  })
+})
+
+describe('compressImage', () => {
+  it('rejects when the image fails to decode', async () => {
+    const promise = compressImage(makeFile())
+    await Promise.resolve()
+    lastImage().onerror?.()
+
+    await expect(promise).rejects.toThrow(
+      /could not read image|corrupt|unsupported/i
+    )
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+  })
+
+  it('revokes the object URL on the success path too', async () => {
+    const promise = compressImage(makeFile())
+    await Promise.resolve()
+    lastImage().onload?.()
+
+    await expect(promise).resolves.toBeInstanceOf(File)
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+  })
+
+  it('rejects immediately when the signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      compressImage(makeFile(), 1200, 0.8, controller.signal)
+    ).rejects.toSatisfy(isAbortError)
+  })
+
+  it('rejects with AbortError when the signal aborts during decode', async () => {
+    const controller = new AbortController()
+    const promise = compressImage(makeFile(), 1200, 0.8, controller.signal)
+    await Promise.resolve()
+
+    controller.abort()
+
+    await expect(promise).rejects.toSatisfy(isAbortError)
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+  })
+
+  it('rejects on the 30s timeout if decode never resolves', async () => {
+    vi.useFakeTimers()
+    try {
+      const promise = compressImage(makeFile())
+      const assertion = expect(promise).rejects.toThrow(/timed out/i)
+      await vi.advanceTimersByTimeAsync(30_000)
+      await assertion
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -51,8 +51,21 @@ interface UploadProgress {
   percentage: number
 }
 
+const COMPRESS_IMAGE_TIMEOUT_MS = 30_000
+
+function makeAbortError(message = 'Upload canceled'): DOMException {
+  return new DOMException(message, 'AbortError')
+}
+
+export function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError'
+}
+
 /**
- * Upload a file using Convex storage and get back the public URL
+ * Upload a file using Convex storage and get back the public URL.
+ *
+ * Throws a `DOMException('AbortError')` when the provided signal is aborted,
+ * so callers can distinguish cancellation from real failures.
  */
 export async function uploadFile(
   file: File,
@@ -63,28 +76,39 @@ export async function uploadFile(
     | 'cover_image'
     | 'article_cover' = 'article_image',
   articleId?: Id<'articles'>,
-  onProgress?: (progress: UploadProgress) => void
+  onProgress?: (progress: UploadProgress) => void,
+  signal?: AbortSignal
 ): Promise<UploadResult> {
+  if (signal?.aborted) {
+    throw makeAbortError()
+  }
+
   try {
     const validation = validateImageUploadFile(file)
     if (!validation.ok) {
       return { success: false, error: validation.error }
     }
 
-    // Step 1: Get upload URL from Convex
     const uploadUrl = await convexClient.mutation(
       api.uploads.generateUploadUrl,
       {}
     )
 
-    // Step 2: Upload file to Convex storage with progress tracking
+    if (signal?.aborted) {
+      throw makeAbortError()
+    }
+
     const result = await new Promise<{
       storageId?: Id<'_storage'>
       error?: string
+      aborted?: boolean
     }>((resolve) => {
       const xhr = new XMLHttpRequest()
 
-      // Track upload progress
+      const onAbort = () => xhr.abort()
+      signal?.addEventListener('abort', onAbort)
+      const detach = () => signal?.removeEventListener('abort', onAbort)
+
       xhr.upload.addEventListener('progress', (event) => {
         if (event.lengthComputable && onProgress) {
           const progress: UploadProgress = {
@@ -96,8 +120,8 @@ export async function uploadFile(
         }
       })
 
-      // Handle completion
-      xhr.addEventListener('load', async () => {
+      xhr.addEventListener('load', () => {
+        detach()
         if (xhr.status >= 200 && xhr.status < 300) {
           try {
             const response = JSON.parse(xhr.responseText)
@@ -110,15 +134,23 @@ export async function uploadFile(
         }
       })
 
-      // Handle errors
       xhr.addEventListener('error', () => {
+        detach()
         resolve({ error: 'Network error occurred during upload' })
       })
 
-      // Start upload
+      xhr.addEventListener('abort', () => {
+        detach()
+        resolve({ aborted: true })
+      })
+
       xhr.open('POST', uploadUrl)
       xhr.send(file)
     })
+
+    if (result.aborted) {
+      throw makeAbortError()
+    }
 
     if (result.error || !result.storageId) {
       return {
@@ -127,7 +159,6 @@ export async function uploadFile(
       }
     }
 
-    // Step 3: Store file metadata and get public URL
     const metadata = await convexClient.mutation(
       api.uploads.storeFileMetadata,
       {
@@ -145,6 +176,9 @@ export async function uploadFile(
       url: metadata.url || undefined,
     }
   } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw error
+    }
     console.error('Upload error:', error)
     return {
       success: false,
@@ -254,23 +288,59 @@ export function generateUniqueFilename(originalName: string): string {
 }
 
 /**
- * Compress image before upload (basic client-side compression)
+ * Compress image before upload (basic client-side compression).
+ *
+ * Rejects on decode failure, abort, or a 30s timeout so callers never hang.
  */
 export function compressImage(
   file: File,
   maxWidth: number = 1200,
-  quality: number = 0.8
+  quality: number = 0.8,
+  signal?: AbortSignal
 ): Promise<File> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(makeAbortError())
+      return
+    }
+
     const canvas = document.createElement('canvas')
-    const ctx = canvas.getContext('2d')!
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      reject(new Error('Failed to get 2D canvas context'))
+      return
+    }
+
     const img = new Image()
+    const objectUrl = URL.createObjectURL(file)
+    let settled = false
+
+    const cleanup = () => {
+      window.clearTimeout(timeoutId)
+      signal?.removeEventListener('abort', onAbort)
+      URL.revokeObjectURL(objectUrl)
+      img.onload = null
+      img.onerror = null
+    }
+
+    const settle = (fn: () => void) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      fn()
+    }
+
+    const onAbort = () => settle(() => reject(makeAbortError()))
+
+    const timeoutId = window.setTimeout(() => {
+      settle(() =>
+        reject(new Error('Image compression timed out. Try a smaller image.'))
+      )
+    }, COMPRESS_IMAGE_TIMEOUT_MS)
+
+    signal?.addEventListener('abort', onAbort)
 
     img.onload = () => {
-      // Revoke object URL to prevent memory leak
-      URL.revokeObjectURL(img.src)
-
-      // Calculate new dimensions
       let { width, height } = img
       if (width > maxWidth) {
         height = (height * maxWidth) / width
@@ -279,8 +349,6 @@ export function compressImage(
 
       canvas.width = width
       canvas.height = height
-
-      // Draw and compress
       ctx.drawImage(img, 0, 0, width, height)
 
       canvas.toBlob(
@@ -290,9 +358,9 @@ export function compressImage(
               type: file.type,
               lastModified: Date.now(),
             })
-            resolve(compressedFile)
+            settle(() => resolve(compressedFile))
           } else {
-            resolve(file) // Fallback to original
+            settle(() => resolve(file))
           }
         },
         file.type,
@@ -300,6 +368,16 @@ export function compressImage(
       )
     }
 
-    img.src = URL.createObjectURL(file)
+    img.onerror = () => {
+      settle(() =>
+        reject(
+          new Error(
+            'Could not read image. The file may be corrupt or unsupported.'
+          )
+        )
+      )
+    }
+
+    img.src = objectUrl
   })
 }


### PR DESCRIPTION
## Summary
- Fix stuck editor overlay when drag-drop image upload fails by ensuring the compression step can’t hang (decode error/timeout) and always clearing UI state in finally.
- Add cancellation support via AbortController/AbortSignal so navigating away mid-upload doesn’t leave the editor “frozen”.
- Add regression tests for image compression failure/abort paths.

## What changed
- `lib/upload.ts`: `compressImage` now rejects on decode error, supports abort + timeout, and always revokes object URLs; `uploadFile` supports abort (xhr.abort) and throws AbortError for clean cancellation handling.
- `components/editor/Editor.tsx`: wrap drop upload with AbortController + unmount cleanup; swallow AbortError; overlay always clears.
- `components/editor/WriteEditorWorkspace.tsx`: same AbortController + cleanup for body + cover drag-drop.
- `lib/upload.test.ts`: new unit tests covering decode error + abort + timeout.

<img width="1216" height="734" alt="cover_img" src="https://github.com/user-attachments/assets/301fc1e7-a63b-4bb3-a03c-33589704ccbd" />
<img width="1187" height="729" alt="art_img" src="https://github.com/user-attachments/assets/683c44d6-ef8d-47a5-b969-00c3e4ddeca0" />
<img width="1196" height="719" alt="abort" src="https://github.com/user-attachments/assets/1927618e-5db0-455a-b104-70a5a0e5fc96" />
