### PR TITLE
fix(editor): keyboard-accessible formatting toolbar (WAI-ARIA toolbar pattern)

### DIFF
--- a/components/editor/EditorToolbar.tsx
+++ b/components/editor/EditorToolbar.tsx
@@ -24,13 +24,7 @@ import {
   Youtube,
   MoreHorizontal,
 } from 'lucide-react'
-import {
-  useEffect,
-  useState,
-  useRef,
-  useLayoutEffect,
-  forwardRef,
-} from 'react'
+import { useEffect, useState, useRef, useLayoutEffect, forwardRef } from 'react'
 import { createPortal } from 'react-dom'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { ImageUploadDialog } from './ImageUploadDialog'
@@ -188,7 +182,13 @@ export function EditorToolbar({
     syncRovingTabIndex()
     // We intentionally do not include syncRovingTabIndex in deps.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeItemKey, showNotes, showLinkInput, showImageDialog, showYouTubeDialog])
+  }, [
+    activeItemKey,
+    showNotes,
+    showLinkInput,
+    showImageDialog,
+    showYouTubeDialog,
+  ])
 
   useEffect(() => {
     const root = toolbarRef.current

--- a/components/editor/EditorToolbar.tsx
+++ b/components/editor/EditorToolbar.tsx
@@ -24,7 +24,13 @@ import {
   Youtube,
   MoreHorizontal,
 } from 'lucide-react'
-import { useState, useRef, useLayoutEffect, forwardRef } from 'react'
+import {
+  useEffect,
+  useState,
+  useRef,
+  useLayoutEffect,
+  forwardRef,
+} from 'react'
 import { createPortal } from 'react-dom'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { ImageUploadDialog } from './ImageUploadDialog'
@@ -48,6 +54,9 @@ interface ToolbarButtonProps {
   children: React.ReactNode
   title?: string
   className?: string
+  tabIndex?: number
+  onFocus?: React.FocusEventHandler<HTMLButtonElement>
+  toolbarKey?: string
 }
 
 const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
@@ -59,6 +68,9 @@ const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
       children,
       title,
       className = '',
+      tabIndex,
+      onFocus,
+      toolbarKey,
     },
     ref
   ) {
@@ -71,8 +83,13 @@ const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
         disabled={disabled}
         title={title}
         aria-label={title}
+        tabIndex={tabIndex}
+        onFocus={onFocus}
+        data-toolbar-item="true"
+        data-toolbar-key={toolbarKey}
         className={`
         p-2 rounded hover:bg-muted transition-colors shrink-0
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background
         ${isActive ? 'bg-muted text-primary' : 'text-foreground'}
         ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
         ${className}
@@ -107,6 +124,8 @@ export function EditorToolbar({
   const [showImageDialog, setShowImageDialog] = useState(false)
   const [showYouTubeDialog, setShowYouTubeDialog] = useState(false)
   const [showNotes, setShowNotes] = useState(false)
+  const toolbarRef = useRef<HTMLDivElement>(null)
+  const [activeItemKey, setActiveItemKey] = useState<string>('heading')
   const linkAnchorRef = useRef<HTMLDivElement>(null)
   const imageDialogTriggerRef = useRef<HTMLButtonElement>(null)
   const youtubeDialogTriggerRef = useRef<HTMLButtonElement>(null)
@@ -114,6 +133,36 @@ export function EditorToolbar({
     top: number
     left: number
   } | null>(null)
+
+  const toolbarItemSelector = '[data-toolbar-item="true"]'
+
+  const isVisibleToolbarItem = (el: HTMLElement) => {
+    // Hidden via Tailwind `hidden` => display:none => no client rects.
+    if (el.getClientRects().length === 0) return false
+    const style = window.getComputedStyle(el)
+    if (style.visibility === 'hidden' || style.display === 'none') return false
+    return true
+  }
+
+  const getToolbarItems = () => {
+    const root = toolbarRef.current
+    if (!root) return []
+    return Array.from(
+      root.querySelectorAll<HTMLElement>(toolbarItemSelector)
+    ).filter((el) => !el.hasAttribute('disabled') && isVisibleToolbarItem(el))
+  }
+
+  const syncRovingTabIndex = () => {
+    const items = getToolbarItems()
+    if (items.length === 0) return
+    const activeIndex = Math.max(
+      0,
+      items.findIndex((el) => el.dataset.toolbarKey === activeItemKey)
+    )
+    items.forEach((el, i) => {
+      el.tabIndex = i === activeIndex ? 0 : -1
+    })
+  }
 
   useLayoutEffect(() => {
     if (!showLinkInput) {
@@ -134,6 +183,23 @@ export function EditorToolbar({
       window.removeEventListener('resize', update)
     }
   }, [showLinkInput])
+
+  useLayoutEffect(() => {
+    syncRovingTabIndex()
+    // We intentionally do not include syncRovingTabIndex in deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeItemKey, showNotes, showLinkInput, showImageDialog, showYouTubeDialog])
+
+  useEffect(() => {
+    const root = toolbarRef.current
+    if (!root) return
+    const ro = new ResizeObserver(() => {
+      syncRovingTabIndex()
+    })
+    ro.observe(root)
+    return () => ro.disconnect()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   if (!editor) {
     return null
@@ -251,16 +317,107 @@ export function EditorToolbar({
         )
       : null
 
+  const handleToolbarFocusCapture: React.FocusEventHandler<HTMLDivElement> = (
+    e
+  ) => {
+    const root = toolbarRef.current
+    if (!root) return
+    const target = e.target as HTMLElement | null
+    if (!target) return
+    const item = target.closest<HTMLElement>(toolbarItemSelector)
+    if (!item || !root.contains(item)) return
+    const key = item.dataset.toolbarKey
+    if (key) setActiveItemKey(key)
+  }
+
+  const moveFocus = (delta: number) => {
+    const items = getToolbarItems()
+    if (items.length === 0) return
+    const focused = document.activeElement as HTMLElement | null
+    const currentIndex =
+      focused && focused.matches(toolbarItemSelector)
+        ? items.indexOf(focused)
+        : items.findIndex((el) => el.dataset.toolbarKey === activeItemKey)
+    const from = currentIndex >= 0 ? currentIndex : 0
+    const next = (from + delta + items.length) % items.length
+    const el = items[next]
+    if (!el) return
+    el.focus()
+    const key = el.dataset.toolbarKey
+    if (key) setActiveItemKey(key)
+  }
+
+  const focusEdge = (which: 'start' | 'end') => {
+    const items = getToolbarItems()
+    if (items.length === 0) return
+    const el = which === 'start' ? items[0] : items[items.length - 1]
+    if (!el) return
+    el.focus()
+    const key = el.dataset.toolbarKey
+    if (key) setActiveItemKey(key)
+  }
+
+  const handleToolbarKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (
+    e
+  ) => {
+    const target = e.target as HTMLElement | null
+    if (!target) return
+    const isInToolbarItem = !!target.closest(toolbarItemSelector)
+    if (!isInToolbarItem) return
+
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      moveFocus(-1)
+      return
+    }
+    if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      moveFocus(1)
+      return
+    }
+    if (e.key === 'Home') {
+      e.preventDefault()
+      focusEdge('start')
+      return
+    }
+    if (e.key === 'End') {
+      e.preventDefault()
+      focusEdge('end')
+      return
+    }
+
+    const isActivation = e.key === 'Enter' || e.key === ' '
+    if (!isActivation) return
+
+    // Native <button> handles Enter/Space. For non-button elements we click defensively.
+    if (target instanceof HTMLButtonElement) return
+    e.preventDefault()
+    target.click()
+  }
+
+  const focusRing =
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+
   return (
     <div className="bg-background w-full min-w-0 flex items-stretch min-h-[44px] py-2 gap-2">
       <div className="min-w-0 flex-1 overflow-x-auto overflow-y-hidden overscroll-x-contain [scrollbar-width:thin]">
-        <div className="inline-flex min-h-[44px] flex-nowrap items-center gap-0.5 justify-start">
+        <div
+          ref={toolbarRef}
+          role="toolbar"
+          aria-label="Editor formatting"
+          onKeyDown={handleToolbarKeyDown}
+          onFocusCapture={handleToolbarFocusCapture}
+          className="inline-flex min-h-[44px] flex-nowrap items-center gap-0.5 justify-start"
+        >
           {/* Paragraph / style dropdown */}
           <DropdownMenu.Root>
             <DropdownMenu.Trigger asChild>
               <button
                 onMouseDown={(e) => e.preventDefault()}
-                className="flex items-center gap-1.5 px-2.5 py-2 rounded hover:bg-muted text-foreground text-sm shrink-0"
+                data-toolbar-item="true"
+                data-toolbar-key="heading"
+                tabIndex={-1}
+                className={`flex items-center gap-1.5 px-2.5 py-2 rounded hover:bg-muted text-foreground text-sm shrink-0 ${focusRing}`}
               >
                 <Type className="w-4 h-4 shrink-0" />
                 <span>{getCurrentHeading()}</span>
@@ -289,6 +446,9 @@ export function EditorToolbar({
             onClick={() => editor.chain().focus().toggleBold().run()}
             isActive={editor.isActive('bold')}
             title="Bold"
+            tabIndex={-1}
+            onFocus={() => setActiveItemKey('bold')}
+            toolbarKey="bold"
           >
             <Bold className="w-4 h-4" />
           </ToolbarButton>
@@ -296,6 +456,9 @@ export function EditorToolbar({
             onClick={() => editor.chain().focus().toggleItalic().run()}
             isActive={editor.isActive('italic')}
             title="Italic"
+            tabIndex={-1}
+            onFocus={() => setActiveItemKey('italic')}
+            toolbarKey="italic"
           >
             <Italic className="w-4 h-4" />
           </ToolbarButton>
@@ -303,6 +466,9 @@ export function EditorToolbar({
             onClick={() => editor.chain().focus().toggleUnderline().run()}
             isActive={editor.isActive('underline')}
             title="Underline"
+            tabIndex={-1}
+            onFocus={() => setActiveItemKey('underline')}
+            toolbarKey="underline"
           >
             <Underline className="w-4 h-4" />
           </ToolbarButton>
@@ -310,6 +476,9 @@ export function EditorToolbar({
             onClick={() => editor.chain().focus().toggleStrike().run()}
             isActive={editor.isActive('strike')}
             title="Strikethrough"
+            tabIndex={-1}
+            onFocus={() => setActiveItemKey('strike')}
+            toolbarKey="strike"
           >
             <Strikethrough className="w-4 h-4" />
           </ToolbarButton>
@@ -319,6 +488,9 @@ export function EditorToolbar({
             onClick={() => editor.chain().focus().toggleBlockquote().run()}
             isActive={editor.isActive('blockquote')}
             title="Blockquote"
+            tabIndex={-1}
+            onFocus={() => setActiveItemKey('blockquote')}
+            toolbarKey="blockquote"
           >
             <Quote className="w-4 h-4" />
           </ToolbarButton>
@@ -330,6 +502,9 @@ export function EditorToolbar({
             onClick={() => editor.chain().focus().toggleCodeBlock().run()}
             isActive={editor.isActive('codeBlock')}
             title="Code block"
+            tabIndex={-1}
+            onFocus={() => setActiveItemKey('codeBlock')}
+            toolbarKey="codeBlock"
           >
             <Code className="w-4 h-4" />
           </ToolbarButton>
@@ -337,6 +512,9 @@ export function EditorToolbar({
             onClick={() => editor.chain().focus().toggleOrderedList().run()}
             isActive={editor.isActive('orderedList')}
             title="Numbered list"
+            tabIndex={-1}
+            onFocus={() => setActiveItemKey('orderedList')}
+            toolbarKey="orderedList"
           >
             <ListOrdered className="w-4 h-4" />
           </ToolbarButton>
@@ -344,6 +522,9 @@ export function EditorToolbar({
             onClick={() => editor.chain().focus().toggleBulletList().run()}
             isActive={editor.isActive('bulletList')}
             title="Bullet list"
+            tabIndex={-1}
+            onFocus={() => setActiveItemKey('bulletList')}
+            toolbarKey="bulletList"
           >
             <List className="w-4 h-4" />
           </ToolbarButton>
@@ -356,6 +537,9 @@ export function EditorToolbar({
               onClick={() => setTextAlign('left')}
               isActive={editor.isActive({ textAlign: 'left' })}
               title="Align left"
+              tabIndex={-1}
+              onFocus={() => setActiveItemKey('alignLeft')}
+              toolbarKey="alignLeft"
             >
               <AlignLeft className="w-4 h-4" />
             </ToolbarButton>
@@ -363,6 +547,9 @@ export function EditorToolbar({
               onClick={() => setTextAlign('center')}
               isActive={editor.isActive({ textAlign: 'center' })}
               title="Align center"
+              tabIndex={-1}
+              onFocus={() => setActiveItemKey('alignCenter')}
+              toolbarKey="alignCenter"
             >
               <AlignCenter className="w-4 h-4" />
             </ToolbarButton>
@@ -370,6 +557,9 @@ export function EditorToolbar({
               onClick={() => setTextAlign('right')}
               isActive={editor.isActive({ textAlign: 'right' })}
               title="Align right"
+              tabIndex={-1}
+              onFocus={() => setActiveItemKey('alignRight')}
+              toolbarKey="alignRight"
             >
               <AlignRight className="w-4 h-4" />
             </ToolbarButton>
@@ -377,6 +567,9 @@ export function EditorToolbar({
               onClick={() => setTextAlign('justify')}
               isActive={editor.isActive({ textAlign: 'justify' })}
               title="Justify"
+              tabIndex={-1}
+              onFocus={() => setActiveItemKey('alignJustify')}
+              toolbarKey="alignJustify"
             >
               <AlignJustify className="w-4 h-4" />
             </ToolbarButton>
@@ -390,7 +583,10 @@ export function EditorToolbar({
               <button
                 type="button"
                 onMouseDown={(e) => e.preventDefault()}
-                className="p-2 rounded hover:bg-muted text-foreground transition-colors cursor-pointer shrink-0"
+                data-toolbar-item="true"
+                data-toolbar-key="add"
+                tabIndex={-1}
+                className={`p-2 rounded hover:bg-muted text-foreground transition-colors cursor-pointer shrink-0 ${focusRing}`}
                 title="Add"
                 aria-label="Add"
               >
@@ -438,13 +634,23 @@ export function EditorToolbar({
           {/* Link */}
           <div ref={linkAnchorRef} className="relative shrink-0">
             {editor.isActive('link') ? (
-              <ToolbarButton onClick={removeLink} isActive title="Remove link">
+              <ToolbarButton
+                onClick={removeLink}
+                isActive
+                title="Remove link"
+                tabIndex={-1}
+                onFocus={() => setActiveItemKey('linkRemove')}
+                toolbarKey="linkRemove"
+              >
                 <Link2 className="w-4 h-4" />
               </ToolbarButton>
             ) : (
               <ToolbarButton
                 onClick={() => setShowLinkInput(!showLinkInput)}
                 title="Insert link"
+                tabIndex={-1}
+                onFocus={() => setActiveItemKey('linkInsert')}
+                toolbarKey="linkInsert"
               >
                 <Link2 className="w-4 h-4" />
               </ToolbarButton>
@@ -458,7 +664,10 @@ export function EditorToolbar({
                 <button
                   type="button"
                   onMouseDown={(e) => e.preventDefault()}
-                  className="p-2 rounded hover:bg-muted text-foreground transition-colors cursor-pointer shrink-0"
+                  data-toolbar-item="true"
+                  data-toolbar-key="more"
+                  tabIndex={-1}
+                  className={`p-2 rounded hover:bg-muted text-foreground transition-colors cursor-pointer shrink-0 ${focusRing}`}
                   title="More formatting"
                   aria-label="More formatting"
                 >
@@ -528,6 +737,9 @@ export function EditorToolbar({
             onClick={() => setShowImageDialog(true)}
             title="Insert image"
             className="hidden md:inline-flex"
+            tabIndex={-1}
+            onFocus={() => setActiveItemKey('image')}
+            toolbarKey="image"
           >
             <Image className="w-4 h-4" />
           </ToolbarButton>
@@ -538,6 +750,9 @@ export function EditorToolbar({
             onClick={() => setShowYouTubeDialog(true)}
             title="Embed YouTube video"
             className="hidden md:inline-flex"
+            tabIndex={-1}
+            onFocus={() => setActiveItemKey('youtube')}
+            toolbarKey="youtube"
           >
             <Youtube className="w-4 h-4" />
           </ToolbarButton>
@@ -551,7 +766,10 @@ export function EditorToolbar({
           <button
             type="button"
             onMouseDown={(e) => e.preventDefault()}
-            className={`flex items-center gap-2 pl-3 pr-2 py-2 rounded hover:bg-muted text-sm font-medium ${showNotes ? 'bg-muted text-primary' : 'text-foreground'}`}
+            data-toolbar-item="true"
+            data-toolbar-key="notes"
+            tabIndex={-1}
+            className={`flex items-center gap-2 pl-3 pr-2 py-2 rounded hover:bg-muted text-sm font-medium ${focusRing} ${showNotes ? 'bg-muted text-primary' : 'text-foreground'}`}
             title="Notes"
             onClick={() => setShowNotes(!showNotes)}
           >


### PR DESCRIPTION
## Summary

Implements the WAI-ARIA toolbar pattern for the editor formatting toolbar so keyboard users can reach and use formatting controls. The toolbar is exposed as a named landmark, provides a single tab stop into the control group, uses roving tabindex with Left/Right (and Home/End) to move between items, and uses consistent focus-visible styling.


## Changes

- Add `role="toolbar"` and `aria-label="Editor formatting"` on the toolbar container.
- Roving tabindex: one toolbar item tabbable at a time; others `tabIndex={-1}`.
- Arrow keys: Left/Right wrap between visible toolbar items; Home/End jump to first/last.
- Enter/Space: native buttons unchanged; non-button items use defensive activation where needed.
- Focus ring: `focus-visible` ring on toolbar buttons and dropdown triggers (including Notes).


https://github.com/user-attachments/assets/e2537175-b177-43b0-9af3-7fbf8cf175c7


