### PR TITLE
feat(editor): register undo/redo/bold/italic/link shortcuts and show in tooltips

### DIFF
--- a/components/articles/HighlightableArticle.tsx
+++ b/components/articles/HighlightableArticle.tsx
@@ -9,6 +9,7 @@ import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import { lowlight } from '@/lib/lowlight'
 import { ResizableImage } from '@/components/editor/extensions/ResizableImage'
 import HighlightExtension from '@/components/editor/extensions/HighlightExtension'
+import { EditorKeymap } from '@/components/editor/extensions/EditorKeymap'
 import { HighlightConverter } from '@/lib/highlights/HighlightConverter'
 import { useMutation } from 'convex/react'
 import { api } from '@/convex/_generated/api'
@@ -115,6 +116,7 @@ export function HighlightableArticle({
         lowlight,
       }),
       ResizableImage,
+      ...(editable ? [EditorKeymap] : []),
       HighlightExtension.configure({
         multicolor: true,
         highlights:

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -10,6 +10,7 @@ import Youtube from '@tiptap/extension-youtube'
 import { lowlight } from '@/lib/lowlight'
 import { useEffect, useRef, useState } from 'react'
 import { ResizableImage } from './extensions/ResizableImage'
+import { EditorKeymap } from './extensions/EditorKeymap'
 import {
   uploadFile,
   compressImage,
@@ -98,6 +99,7 @@ export function Editor({
             'rounded-lg bg-muted text-foreground border border-border p-4 my-4 overflow-x-auto',
         },
       }),
+      EditorKeymap,
     ],
     content,
     editable,

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -15,6 +15,21 @@ import {
 } from 'lucide-react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 
+function useUndoRedoShortcuts() {
+  const [isApple, setIsApple] = useState(false)
+
+  useEffect(() => {
+    const platform = navigator.platform?.toLowerCase() ?? ''
+    const ua = navigator.userAgent?.toLowerCase() ?? ''
+    setIsApple(platform.includes('mac') || platform.includes('iphone') || ua.includes('mac os'))
+  }, [])
+
+  return {
+    undo: isApple ? '⌘Z' : 'Ctrl+Z',
+    redo: isApple ? '⌘⇧Z' : 'Ctrl+Shift+Z / Ctrl+Y',
+  }
+}
+
 interface EditorActionBarProps {
   editor: Editor | null
   onBack: () => void
@@ -112,6 +127,7 @@ export function EditorActionBar({
   hasUnsavedChanges = false,
 }: EditorActionBarProps) {
   const [relativeTick, setRelativeTick] = useState(0)
+  const shortcuts = useUndoRedoShortcuts()
 
   const canUndo = editor?.can().undo ?? false
   const canRedo = editor?.can().redo ?? false
@@ -213,7 +229,7 @@ export function EditorActionBar({
         onClick={() => editor?.chain().focus().undo().run()}
         disabled={!canUndo}
         className="p-2 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent transition-colors shrink-0"
-        title="Undo"
+        title={`Undo (${shortcuts.undo})`}
       >
         <Undo2 className="h-4 w-4" />
       </button>
@@ -222,7 +238,7 @@ export function EditorActionBar({
         onClick={() => editor?.chain().focus().redo().run()}
         disabled={!canRedo}
         className="p-2 rounded-md text-muted-foreground opacity-70 hover:bg-muted hover:opacity-100 disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent transition-colors shrink-0"
-        title="Redo"
+        title={`Redo (${shortcuts.redo})`}
       >
         <Redo2 className="h-4 w-4" />
       </button>

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -21,7 +21,11 @@ function useUndoRedoShortcuts() {
   useEffect(() => {
     const platform = navigator.platform?.toLowerCase() ?? ''
     const ua = navigator.userAgent?.toLowerCase() ?? ''
-    setIsApple(platform.includes('mac') || platform.includes('iphone') || ua.includes('mac os'))
+    setIsApple(
+      platform.includes('mac') ||
+        platform.includes('iphone') ||
+        ua.includes('mac os')
+    )
   }, [])
 
   return {

--- a/components/editor/EditorToolbar.tsx
+++ b/components/editor/EditorToolbar.tsx
@@ -30,6 +30,18 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { ImageUploadDialog } from './ImageUploadDialog'
 import { YouTubeEmbedDialog } from './YouTubeEmbedDialog'
 
+function useShortcutLabel() {
+  const [isApple, setIsApple] = useState(false)
+
+  useEffect(() => {
+    const platform = navigator.platform?.toLowerCase() ?? ''
+    const ua = navigator.userAgent?.toLowerCase() ?? ''
+    setIsApple(platform.includes('mac') || platform.includes('iphone') || ua.includes('mac os'))
+  }, [])
+
+  return (key: string) => (isApple ? `⌘${key}` : `Ctrl+${key}`)
+}
+
 interface EditorToolbarProps {
   editor: Editor | null
   /** When Add icon is used to jump to a field */
@@ -113,6 +125,7 @@ export function EditorToolbar({
   notes = '',
   onNotesChange,
 }: EditorToolbarProps) {
+  const shortcut = useShortcutLabel()
   const [linkUrl, setLinkUrl] = useState('')
   const [showLinkInput, setShowLinkInput] = useState(false)
   const [showImageDialog, setShowImageDialog] = useState(false)
@@ -445,7 +458,7 @@ export function EditorToolbar({
           <ToolbarButton
             onClick={() => editor.chain().focus().toggleBold().run()}
             isActive={editor.isActive('bold')}
-            title="Bold"
+            title={`Bold (${shortcut('B')})`}
             tabIndex={-1}
             onFocus={() => setActiveItemKey('bold')}
             toolbarKey="bold"
@@ -455,7 +468,7 @@ export function EditorToolbar({
           <ToolbarButton
             onClick={() => editor.chain().focus().toggleItalic().run()}
             isActive={editor.isActive('italic')}
-            title="Italic"
+            title={`Italic (${shortcut('I')})`}
             tabIndex={-1}
             onFocus={() => setActiveItemKey('italic')}
             toolbarKey="italic"
@@ -637,7 +650,7 @@ export function EditorToolbar({
               <ToolbarButton
                 onClick={removeLink}
                 isActive
-                title="Remove link"
+                title={`Remove link (${shortcut('K')})`}
                 tabIndex={-1}
                 onFocus={() => setActiveItemKey('linkRemove')}
                 toolbarKey="linkRemove"
@@ -647,7 +660,7 @@ export function EditorToolbar({
             ) : (
               <ToolbarButton
                 onClick={() => setShowLinkInput(!showLinkInput)}
-                title="Insert link"
+                title={`Insert link (${shortcut('K')})`}
                 tabIndex={-1}
                 onFocus={() => setActiveItemKey('linkInsert')}
                 toolbarKey="linkInsert"

--- a/components/editor/EditorToolbar.tsx
+++ b/components/editor/EditorToolbar.tsx
@@ -36,7 +36,11 @@ function useShortcutLabel() {
   useEffect(() => {
     const platform = navigator.platform?.toLowerCase() ?? ''
     const ua = navigator.userAgent?.toLowerCase() ?? ''
-    setIsApple(platform.includes('mac') || platform.includes('iphone') || ua.includes('mac os'))
+    setIsApple(
+      platform.includes('mac') ||
+        platform.includes('iphone') ||
+        ua.includes('mac os')
+    )
   }, [])
 
   return (key: string) => (isApple ? `⌘${key}` : `Ctrl+${key}`)

--- a/components/editor/EditorWithToolbar.tsx
+++ b/components/editor/EditorWithToolbar.tsx
@@ -11,6 +11,7 @@ import { lowlight } from '@/lib/lowlight'
 import { useEffect } from 'react'
 import { EditorToolbar } from './EditorToolbar'
 import { ResizableImage } from './extensions/ResizableImage'
+import { EditorKeymap } from './extensions/EditorKeymap'
 import { EDITOR_PROSE_CLASS } from '@/lib/constants'
 
 interface EditorWithToolbarProps {
@@ -79,6 +80,7 @@ export function EditorWithToolbar({
             'rounded-lg bg-muted text-foreground border border-border p-4 my-4 overflow-x-auto',
         },
       }),
+      EditorKeymap,
     ],
     content,
     editable,

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -11,6 +11,7 @@ import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import TextAlign from '@tiptap/extension-text-align'
 import { lowlight } from '@/lib/lowlight'
 import { ResizableImage } from '@/components/editor/extensions/ResizableImage'
+import { EditorKeymap } from '@/components/editor/extensions/EditorKeymap'
 import { EditorToolbar } from '@/components/editor/EditorToolbar'
 import { EditorActionBar } from '@/components/editor/EditorActionBar'
 import { ImageUploadDialog } from '@/components/editor/ImageUploadDialog'
@@ -174,6 +175,7 @@ export function WriteEditorWorkspace() {
         },
       }),
       TextAlign.configure({ types: ['heading', 'paragraph'] }),
+      EditorKeymap,
     ],
     content: '',
     editorProps: {

--- a/components/editor/extensions/EditorKeymap.ts
+++ b/components/editor/extensions/EditorKeymap.ts
@@ -1,0 +1,41 @@
+import { Extension } from '@tiptap/core'
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+export const EditorKeymap = Extension.create({
+  name: 'editorKeymap',
+  priority: 10_000,
+
+  addKeyboardShortcuts() {
+    const focus = () => this.editor.chain().focus()
+
+    return {
+      'Mod-z': () => focus().undo().run(),
+      'Shift-Mod-z': () => focus().redo().run(),
+      // Common redo shortcut on Windows/Linux.
+      'Mod-y': () => focus().redo().run(),
+
+      'Mod-b': () => focus().toggleBold().run(),
+      'Mod-i': () => focus().toggleItalic().run(),
+
+      'Mod-k': () => {
+        if (typeof window === 'undefined') return false
+
+        const previousUrl = this.editor.getAttributes('link')?.href
+        const url = window.prompt('Enter URL', isNonEmptyString(previousUrl) ? previousUrl : '')
+
+        if (url == null) return false
+
+        const trimmed = url.trim()
+        if (!trimmed) {
+          return focus().extendMarkRange('link').unsetLink().run()
+        }
+
+        return focus().extendMarkRange('link').setLink({ href: trimmed }).run()
+      },
+    }
+  },
+})
+

--- a/components/editor/extensions/EditorKeymap.ts
+++ b/components/editor/extensions/EditorKeymap.ts
@@ -24,7 +24,10 @@ export const EditorKeymap = Extension.create({
         if (typeof window === 'undefined') return false
 
         const previousUrl = this.editor.getAttributes('link')?.href
-        const url = window.prompt('Enter URL', isNonEmptyString(previousUrl) ? previousUrl : '')
+        const url = window.prompt(
+          'Enter URL',
+          isNonEmptyString(previousUrl) ? previousUrl : ''
+        )
 
         if (url == null) return false
 
@@ -38,4 +41,3 @@ export const EditorKeymap = Extension.create({
     }
   },
 })
-


### PR DESCRIPTION
## Summary

Adds an explicit Tiptap `EditorKeymap` extension so undo, redo, bold, italic, and link shortcuts are registered with `addKeyboardShortcuts`, and surfaces the same shortcuts in toolbar and action bar tooltips for discoverability.

## Changes

- New `components/editor/extensions/EditorKeymap.ts` with `Mod-z`, `Shift-Mod-z`, `Mod-y`, `Mod-b`, `Mod-i`, and `Mod-k` (link via prompt; empty input removes link).
- Register `EditorKeymap` in `WriteEditorWorkspace`, `Editor`, `EditorWithToolbar`, and `HighlightableArticle` (only when `editable`).
- Platform-aware tooltip text on Bold, Italic, Insert/remove link (`EditorToolbar`), and Undo/Redo (`EditorActionBar`).


https://github.com/user-attachments/assets/ffe2b3dd-044a-4328-93b1-4870a7aa4516

