### PR TITLE
fix: remove duplicate TipTap editor in article display

### DIFF
--- a/components/articles/ArticleDisplay.tsx
+++ b/components/articles/ArticleDisplay.tsx
@@ -1,13 +1,7 @@
 'use client'
 
-import { useEditor, EditorContent, type JSONContent } from '@tiptap/react'
+import { type JSONContent } from '@tiptap/react'
 import { useEffect, useState } from 'react'
-import StarterKit from '@tiptap/starter-kit'
-import Underline from '@tiptap/extension-underline'
-import Link from '@tiptap/extension-link'
-import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
-import { lowlight } from '@/lib/lowlight'
-import { ResizableImage } from '@/components/editor/extensions/ResizableImage'
 import { formatDistanceToNow } from 'date-fns'
 import Image from 'next/image'
 import { UserAvatar } from '@/components/ui/user-avatar'
@@ -16,7 +10,6 @@ import { HighlightableArticle } from '@/components/articles/HighlightableArticle
 import { useAuth } from '@/components/providers/AuthContext'
 import type { Id } from '@/types/convex'
 import type { ArticleForDisplay } from '@/types/index'
-import { EDITOR_PROSE_CLASS } from '@/lib/constants'
 import { TagFilterLink } from '@/components/articles/TagFilterLink'
 
 const EMPTY_DOC: JSONContent = { type: 'doc', content: [] }
@@ -32,43 +25,12 @@ export default function ArticleDisplay({
 }: ArticleDisplayProps) {
   const [currentUrl, setCurrentUrl] = useState('')
   const { isAuthenticated } = useAuth()
-  const [useHighlightable, setUseHighlightable] = useState(false)
 
-  // Get current URL on client side only
   useEffect(() => {
     setCurrentUrl(window.location.href)
-    // Enable highlightable article for authenticated users
-    setUseHighlightable(showHighlights && isAuthenticated)
-  }, [showHighlights, isAuthenticated])
+  }, [])
 
-  const editor = useEditor({
-    extensions: [
-      StarterKit.configure({
-        // StarterKit v3 ships codeBlock, link, and underline by default; we
-        // register customised versions of each below, so disable them here
-        // to avoid duplicate-extension warnings.
-        codeBlock: false,
-        link: false,
-        underline: false,
-      }),
-      Underline,
-      Link.configure({
-        openOnClick: false,
-      }),
-      CodeBlockLowlight.configure({
-        lowlight,
-      }),
-      ResizableImage,
-    ],
-    content: article.content ?? EMPTY_DOC,
-    editable: false,
-    immediatelyRender: false, // Fix SSR hydration issue
-    editorProps: {
-      attributes: {
-        class: `${EDITOR_PROSE_CLASS} prose-stone`,
-      },
-    },
-  })
+  const effectiveShowHighlights = showHighlights && isAuthenticated
 
   const publishedDate = article.publishedAt
     ? formatDistanceToNow(new Date(article.publishedAt), { addSuffix: true })
@@ -76,13 +38,11 @@ export default function ArticleDisplay({
 
   return (
     <article className="max-w-4xl mx-auto px-4 py-8">
-      {/* Article Header */}
       <header className="mb-8">
         <h1 className="text-3xl md:text-4xl font-semibold text-foreground mb-3 leading-snug">
           {article.title}
         </h1>
 
-        {/* Author Info */}
         <div className="flex items-center gap-4 mb-6">
           <div className="flex items-center gap-3">
             <UserAvatar
@@ -109,7 +69,6 @@ export default function ArticleDisplay({
           </div>
         </div>
 
-        {/* Cover Image */}
         {article.coverImage && (
           <div className="relative mb-8 w-full h-64 md:h-96">
             <Image
@@ -123,7 +82,6 @@ export default function ArticleDisplay({
           </div>
         )}
 
-        {/* Tags */}
         {article.tags.length > 0 && (
           <div className="flex flex-wrap gap-2 mb-6">
             {article.tags.map((tag) => (
@@ -139,20 +97,15 @@ export default function ArticleDisplay({
         )}
       </header>
 
-      {/* Article Content */}
       <div className="article-content">
-        {useHighlightable ? (
-          <HighlightableArticle
-            articleId={article.id as Id<'articles'>}
-            content={article.content ?? EMPTY_DOC}
-            showHighlights={showHighlights}
-          />
-        ) : (
-          <EditorContent editor={editor} />
-        )}
+        <HighlightableArticle
+          articleId={article.id as Id<'articles'>}
+          content={article.content ?? EMPTY_DOC}
+          editable={false}
+          showHighlights={effectiveShowHighlights}
+        />
       </div>
 
-      {/* Share Buttons */}
       {currentUrl && (
         <div className="mt-8 pt-6 border-t border-border">
           <ShareButtons

--- a/components/articles/HighlightableArticle.tsx
+++ b/components/articles/HighlightableArticle.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState, useCallback, useRef } from 'react'
-import { useEditor, EditorContent } from '@tiptap/react'
+import { useEditor, EditorContent, type JSONContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
 import Link from '@tiptap/extension-link'
@@ -18,7 +18,6 @@ import type { Id } from '@/types/convex'
 import { HighlightPopover } from '@/components/highlights/HighlightPopover'
 import { HighlightDetailsPanel } from '@/components/highlights/HighlightDetailsPanel'
 import { cn } from '@/lib/utils'
-import { JSONContent } from '@tiptap/react'
 import { AnimatePresence } from 'motion/react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { toast } from 'sonner'
@@ -73,163 +72,160 @@ export function HighlightableArticle({
   } | null>(null)
   const editorRef = useRef<HTMLDivElement>(null)
   const isApplyingHighlightsRef = useRef(false)
-  // Tracks whether the user is in the middle of a mouse/touch drag-select.
-  // During a drag, onSelectionUpdate fires on every move; if we let it mount
-  // the popover at 3 chars, HighlightPopover's FocusScope trap steals focus
-  // from the article body and the native selection collapses, capping
-  // selections at 3 characters. Defer popover display to pointerup instead.
+  // During a drag, onSelectionUpdate fires on every move; if we mount the
+  // popover at 3 chars, HighlightPopover's FocusScope trap steals focus from
+  // the article body and the native selection collapses. Defer popover to pointerup.
   const isDraggingRef = useRef(false)
 
-  // Get current user for ownership checks
   const { user } = useAuth()
 
-  // Fetch article data (for author info, Stellar address, etc.)
   const article = useArticleById(articleId)
 
-  const highlights = useArticleHighlightsQuery(articleId)
+  const highlights = useArticleHighlightsQuery(articleId, showHighlights)
 
-  // Use ref to avoid stale closure in onHighlightClick callback
   const highlightsRef = useRef(highlights)
   useEffect(() => {
     highlightsRef.current = highlights
   }, [highlights])
 
-  // Mutation to create a highlight
   const createHighlight = useMutation(api.highlights.createHighlight)
 
-  // Initialize TipTap editor with highlight extension
-  const editor = useEditor({
-    extensions: [
-      StarterKit.configure({
-        // StarterKit v3 ships codeBlock, link, and underline by default; we
-        // register customised versions of each below, so disable them here
-        // to avoid duplicate-extension warnings.
-        codeBlock: false,
-        link: false,
-        underline: false,
-      }),
-      Underline,
-      Link.configure({
-        openOnClick: false,
-      }),
-      CodeBlockLowlight.configure({
-        lowlight,
-      }),
-      ResizableImage,
-      ...(editable ? [EditorKeymap] : []),
-      HighlightExtension.configure({
-        multicolor: true,
-        highlights:
-          highlights?.map((h) => ({
-            id: h._id,
-            color: h.color || '#FFEB3B',
-            userId: h.userId,
-            userName: h.userName,
-            userAvatar: h.userAvatar,
-            note: h.note,
-            createdAt: h.createdAt,
-          })) || [],
-        onHighlightClick: (highlightAttrs, event) => {
-          // Use ref to get current highlights (avoids stale closure)
-          const currentHighlights = highlightsRef.current
+  const editor = useEditor(
+    {
+      extensions: [
+        StarterKit.configure({
+          // StarterKit v3 ships codeBlock, link, and underline by default; we
+          // register customised versions below, so disable them here.
+          codeBlock: false,
+          link: false,
+          underline: false,
+        }),
+        Underline,
+        Link.configure({
+          openOnClick: false,
+        }),
+        CodeBlockLowlight.configure({
+          lowlight,
+        }),
+        ResizableImage,
+        ...(editable ? [EditorKeymap] : []),
+        ...(showHighlights
+          ? [
+              HighlightExtension.configure({
+                multicolor: true,
+                highlights:
+                  highlights?.map((h) => ({
+                    id: h._id,
+                    color: h.color || '#FFEB3B',
+                    userId: h.userId,
+                    userName: h.userName,
+                    userAvatar: h.userAvatar,
+                    note: h.note,
+                    createdAt: h.createdAt,
+                  })) || [],
+                onHighlightClick: (highlightAttrs, event) => {
+                  const currentHighlights = highlightsRef.current
 
-          // Find the full highlight data with defensive lookup
-          // Try matching by _id first (correct way)
-          let fullHighlight = currentHighlights?.find(
-            (h) => h._id === highlightAttrs.id
-          )
+                  let fullHighlight = currentHighlights?.find(
+                    (h) => h._id === highlightAttrs.id
+                  )
 
-          // Fallback: try matching by highlightId for backwards compatibility
-          if (!fullHighlight && highlightAttrs.id) {
-            fullHighlight = currentHighlights?.find(
-              (h) => h.highlightId === highlightAttrs.id
-            )
-          }
+                  if (!fullHighlight && highlightAttrs.id) {
+                    fullHighlight = currentHighlights?.find(
+                      (h) => h.highlightId === highlightAttrs.id
+                    )
+                  }
 
-          if (fullHighlight) {
-            // Show tooltip with highlight info
-            if (onHighlightClick) {
-              onHighlightClick(fullHighlight)
-            } else {
-              // Default behavior: show tooltip using click event position
-              const target = event.target as HTMLElement
-              const rect = target.getBoundingClientRect()
-              setHighlightTooltip({
-                highlight: fullHighlight,
-                position: {
-                  top: rect.top - 10,
-                  left: rect.left + rect.width / 2,
+                  if (fullHighlight) {
+                    if (onHighlightClick) {
+                      onHighlightClick(fullHighlight)
+                    } else {
+                      const target = event.target as HTMLElement
+                      const rect = target.getBoundingClientRect()
+                      setHighlightTooltip({
+                        highlight: fullHighlight,
+                        position: {
+                          top: rect.top - 10,
+                          left: rect.left + rect.width / 2,
+                        },
+                      })
+                    }
+                  }
                 },
+              }),
+            ]
+          : []),
+      ],
+      content,
+      editable,
+      immediatelyRender: false,
+      editorProps: {
+        attributes: {
+          class: `${EDITOR_PROSE_CLASS} prose-stone`,
+        },
+      },
+      onSelectionUpdate: ({ editor }) => {
+        if (editable || isApplyingHighlightsRef.current) return
+        if (!showHighlights) return
+        // Keyboard selection (shift+arrow, ctrl+a) still runs this path.
+        if (isDraggingRef.current) return
+
+        const { selection } = editor.state
+        const { from, to } = selection
+        const text = editor.state.doc.textBetween(from, to, ' ')
+
+        if (text.trim().length >= 3) {
+          const domSelection = window.getSelection()
+          if (domSelection && domSelection.rangeCount > 0) {
+            const range = domSelection.getRangeAt(0)
+            const rect = range.getBoundingClientRect()
+            const containerRect = editorRef.current?.getBoundingClientRect()
+
+            setSelectedText({ text, from, to })
+            if (containerRect) {
+              setPopoverPosition({
+                top: rect.top - containerRect.top - 60,
+                left: rect.left - containerRect.left + rect.width / 2,
               })
             }
           }
-        },
-      }),
-    ],
-    content,
-    editable,
-    immediatelyRender: false,
-    editorProps: {
-      attributes: {
-        class: `${EDITOR_PROSE_CLASS} prose-stone`,
+        } else {
+          setSelectedText(null)
+          setPopoverPosition(null)
+        }
       },
     },
-    onSelectionUpdate: ({ editor }) => {
-      if (editable || isApplyingHighlightsRef.current) return
-      // During active mouse/touch drag, defer popover creation to pointerup.
-      // Keyboard selection (shift+arrow, ctrl+a) still runs this path.
-      if (isDraggingRef.current) return
+    [showHighlights, editable, articleId]
+  )
 
-      const { selection } = editor.state
-      const { from, to } = selection
-      const text = editor.state.doc.textBetween(from, to, ' ')
+  useEffect(() => {
+    if (!showHighlights) {
+      setSelectedText(null)
+      setPopoverPosition(null)
+      setHighlightTooltip(null)
+    }
+  }, [showHighlights])
 
-      if (text.trim().length >= 3) {
-        // Get the DOM selection for positioning
-        const domSelection = window.getSelection()
-        if (domSelection && domSelection.rangeCount > 0) {
-          const range = domSelection.getRangeAt(0)
-          const rect = range.getBoundingClientRect()
-          const containerRect = editorRef.current?.getBoundingClientRect()
-
-          setSelectedText({ text, from, to })
-          if (containerRect) {
-            setPopoverPosition({
-              top: rect.top - containerRect.top - 60,
-              left: rect.left - containerRect.left + rect.width / 2,
-            })
-          }
-        }
-      } else {
-        setSelectedText(null)
-        setPopoverPosition(null)
-      }
-    },
-  })
-
-  // Apply highlights when they change
   useEffect(() => {
     if (!editor || !highlights || !showHighlights) return
 
-    // Flag to suppress popover during programmatic highlight application
+    // Suppress popover during programmatic highlight application
     isApplyingHighlightsRef.current = true
     HighlightConverter.applyHighlightsToEditor(editor, highlights)
-    // Use requestAnimationFrame to clear flag after all selection events have fired
+    // Clear flag after selection events from apply have fired
     requestAnimationFrame(() => {
       isApplyingHighlightsRef.current = false
     })
   }, [editor, highlights, showHighlights])
 
   // Show the highlight popover only after the user releases a drag-select.
-  // Mounting it mid-drag traps focus and collapses the selection.
   useEffect(() => {
     const container = editorRef.current
-    if (!container || editable) return
+    if (!container || editable || !showHighlights) return
 
     const handlePointerDown = (e: MouseEvent | TouchEvent) => {
       const target = e.target as HTMLElement | null
-      // Ignore events originating from an open popover/details dialog so
-      // their own buttons still receive the click.
+      // Ignore events from an open popover/dialog so their buttons still click.
       if (target?.closest('[role="dialog"]')) return
       isDraggingRef.current = true
       setSelectedText(null)
@@ -239,8 +235,8 @@ export function HighlightableArticle({
     const handlePointerUp = () => {
       if (!isDraggingRef.current) return
       isDraggingRef.current = false
-      // Defer one tick so the browser and Tiptap commit the final selection.
       setTimeout(() => {
+        // Defer one tick so the browser and Tiptap commit the final selection.
         if (!editor) return
         const { from, to } = editor.state.selection
         const text = editor.state.doc.textBetween(from, to, ' ')
@@ -272,15 +268,13 @@ export function HighlightableArticle({
       document.removeEventListener('mouseup', handlePointerUp)
       document.removeEventListener('touchend', handlePointerUp)
     }
-  }, [editor, editable])
+  }, [editor, editable, showHighlights])
 
-  // Handle highlight creation
   const handleCreateHighlight = useCallback(
     async (color: string, note?: string, isPublic: boolean = true) => {
       if (!selectedText || !editor) return
 
       try {
-        // Create highlight data from selection
         const highlightData = HighlightConverter.createHighlightFromSelection(
           editor,
           {
@@ -291,20 +285,15 @@ export function HighlightableArticle({
         )
 
         if (highlightData) {
-          // Save to database and get the new highlight ID
           await createHighlight({
             articleId,
             ...highlightData,
           })
 
-          // Clear selection immediately for better UX
           setSelectedText(null)
           setPopoverPosition(null)
           window.getSelection()?.removeAllRanges()
-
-          // Note: The highlight will be applied automatically when the
-          // highlights query refetches (due to Convex reactivity)
-          // No need to manually apply a temporary highlight
+          // Highlights re-apply when the Convex query refetches.
         }
       } catch (error) {
         console.error('Error creating highlight:', error)
@@ -364,7 +353,6 @@ export function HighlightableArticle({
     >
       <EditorContent editor={editor} />
 
-      {/* Highlight creation popover */}
       <AnimatePresence>
         {popoverPosition && selectedText && article && (
           <HighlightPopover
@@ -382,7 +370,6 @@ export function HighlightableArticle({
         )}
       </AnimatePresence>
 
-      {/* Highlight details panel */}
       <AnimatePresence>
         {highlightTooltip && article && (
           <HighlightDetailsPanel


### PR DESCRIPTION
## Summary
- Fixes an issue where the article page could create two TipTap editor instances (one plain, one highlight-enabled) for authenticated readers.
- Collapses article rendering to a single editor surface (`HighlightableArticle`) with `editable={false}` and an effective `showHighlights` flag.
- Prevents highlight subscriptions + highlight UI when highlights are disabled (or the reader is logged out).

## Branch reachability (documented)
Previous behavior in `components/articles/ArticleDisplay.tsx`:

| Condition | `useHighlightable` | Visible UI | Reachable? |
|----------|---------------------|------------|------------|
| `!isAuthenticated` | `false` | Plain `EditorContent` | Yes (logged-out readers) |
| `isAuthenticated && showHighlights` | `true` | `HighlightableArticle` | Yes (logged-in readers, default path) |
| `isAuthenticated && !showHighlights` | `false` | Plain `EditorContent` | Yes (API allows it; not used by `app/[username]/[slug]/page.tsx` today) |

Conclusion: the non-highlight path is reachable, so it was preserved (not deleted), but handled by the single editor instance.

## Implementation notes
- `components/articles/ArticleDisplay.tsx`
  - Removed the always-on parent `useEditor` and conditional `EditorContent` branch.
  - Always renders `HighlightableArticle` with:
    - `editable={false}`
    - `showHighlights={showHighlights && isAuthenticated}`

- `components/articles/HighlightableArticle.tsx`
  - Highlights subscription is skipped when `showHighlights` is false.
  - Highlight extension and highlight interaction UI are gated behind `showHighlights`.

<img width="1216" height="718" alt="cmd_f" src="https://github.com/user-attachments/assets/d0d5f5c8-b3b2-4ce3-bbaa-57c8be829c00" />
<img width="1221" height="724" alt="1" src="https://github.com/user-attachments/assets/42fc3139-1fb7-470f-9893-eb3f7aaff076" />
<img width="1213" height="718" alt="3" src="https://github.com/user-attachments/assets/1e9367ad-a888-4fa5-a7bb-67bb0eb55290" />
