### PR TITLE
fix: format tip cap toast with two decimals

### DIFF
--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -108,7 +108,7 @@ export function HighlightTipButton({
     }
 
     if (amountCents > TIP_MAX_CENTS) {
-      toast.error(`Maximum tip amount is $${TIP_MAX_USD.toFixed(0)}`)
+      toast.error(`Maximum tip amount is $${TIP_MAX_USD.toFixed(2)}`)
       return
     }
 

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -83,7 +83,7 @@ export function TipButton({
     }
 
     if (amountCents > TIP_MAX_CENTS) {
-      toast.error(`Maximum tip amount is $${TIP_MAX_USD.toFixed(0)}`)
+      toast.error(`Maximum tip amount is $${TIP_MAX_USD.toFixed(2)}`)
       return
     }
 


### PR DESCRIPTION
## Summary
- Updated the “Maximum tip amount is …” cap toast in both the article tip dialog and highlight tip dialog to display the existing cap constant with two decimals (e.g. $100.00).
- Cap value is still sourced from the existing `TIP_MAX_USD` constant (not hardcoded).

<img width="1229" height="687" alt="1" src="https://github.com/user-attachments/assets/237ca5b6-af15-4a91-a450-5f37f98c7358" />
<img width="1221" height="723" alt="2" src="https://github.com/user-attachments/assets/7114d1ab-2c6f-49b7-8382-a464d826e323" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pragya-shar/codesmith/quilltip/pr/92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->