### PR TITLE
feat: show dollar split summary in tip dialogs

### DIFF
--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -12,8 +12,10 @@ import { Id } from '@/convex/_generated/dataModel'
 import { stellarClient } from '@/lib/stellar/client'
 import {
   generateHighlightId,
+  calculateTipBreakdown,
   formatTipAmount,
 } from '@/lib/stellar/highlight-utils'
+import { TipBreakdownSummaryLine } from '@/components/tipping/TipBreakdownSummaryLine'
 import {
   TIP_PRESETS_HIGHLIGHT,
   TIP_MIN_CENTS,
@@ -251,6 +253,12 @@ export function HighlightTipButton({
       ? highlightText.slice(0, 60) + '...'
       : highlightText
 
+  const previewCents = selectedAmount || parseFloat(customAmount) * 100
+  const tipBreakdownPreview =
+    Number.isFinite(previewCents) && previewCents > 0
+      ? calculateTipBreakdown(previewCents)
+      : null
+
   return (
     <>
       <Dialog open={isOpen} onOpenChange={handleOpenChange}>
@@ -353,6 +361,14 @@ export function HighlightTipButton({
               {TIP_MAX_USD.toFixed(2)}
             </p>
           </div>
+
+          {tipBreakdownPreview && (
+            <TipBreakdownSummaryLine
+              totalFormatted={formatTipAmount(previewCents)}
+              authorFormatted={tipBreakdownPreview.authorShareFormatted}
+              platformFeeFormatted={tipBreakdownPreview.platformFeeFormatted}
+            />
+          )}
 
           <div className="flex gap-3">
             <button

--- a/components/tipping/TipBreakdownSummaryLine.tsx
+++ b/components/tipping/TipBreakdownSummaryLine.tsx
@@ -1,0 +1,18 @@
+interface TipBreakdownSummaryLineProps {
+  totalFormatted: string
+  authorFormatted: string
+  platformFeeFormatted: string
+}
+
+export function TipBreakdownSummaryLine({
+  totalFormatted,
+  authorFormatted,
+  platformFeeFormatted,
+}: TipBreakdownSummaryLineProps) {
+  return (
+    <p className="mb-3 text-sm text-muted-foreground text-center">
+      Total {totalFormatted} · Author {authorFormatted} · Platform fee{' '}
+      {platformFeeFormatted}
+    </p>
+  )
+}

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -13,6 +13,11 @@ import { api } from '@/convex/_generated/api'
 import { Id } from '@/convex/_generated/dataModel'
 import { stellarClient } from '@/lib/stellar/client'
 import {
+  calculateTipBreakdown,
+  formatTipAmount,
+} from '@/lib/stellar/highlight-utils'
+import { TipBreakdownSummaryLine } from '@/components/tipping/TipBreakdownSummaryLine'
+import {
   TIP_PRESETS_ARTICLE,
   TIP_MIN_CENTS,
   TIP_MIN_USD,
@@ -188,6 +193,12 @@ export function TipButton({
     }
   }
 
+  const previewCents = selectedAmount || parseFloat(customAmount) * 100
+  const tipBreakdownPreview =
+    Number.isFinite(previewCents) && previewCents > 0
+      ? calculateTipBreakdown(previewCents)
+      : null
+
   const handleConnectWallet = async () => {
     try {
       await connect()
@@ -313,6 +324,14 @@ export function TipButton({
               {TIP_MAX_USD.toFixed(2)}
             </p>
           </div>
+
+          {tipBreakdownPreview && (
+            <TipBreakdownSummaryLine
+              totalFormatted={formatTipAmount(previewCents)}
+              authorFormatted={tipBreakdownPreview.authorShareFormatted}
+              platformFeeFormatted={tipBreakdownPreview.platformFeeFormatted}
+            />
+          )}
 
           <div className="flex gap-3">
             <button

--- a/lib/stellar/highlight-utils.test.ts
+++ b/lib/stellar/highlight-utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calculateTipBreakdown,
+  formatTipAmount,
+} from '@/lib/stellar/highlight-utils'
+import { STELLAR_CONFIG } from '@/lib/stellar/config'
+
+describe('calculateTipBreakdown', () => {
+  it('splits cents with floor on platform fee and preserves total', () => {
+    const { platformFee, authorShare } = calculateTipBreakdown(500, 250)
+    expect(platformFee).toBe(12)
+    expect(authorShare).toBe(488)
+    expect(platformFee + authorShare).toBe(500)
+  })
+
+  it('uses PLATFORM_FEE_BPS when feeBps is omitted', () => {
+    const explicit = calculateTipBreakdown(1000, STELLAR_CONFIG.PLATFORM_FEE_BPS)
+    const implicit = calculateTipBreakdown(1000)
+    expect(implicit).toEqual(explicit)
+  })
+
+  it('formats derived amounts with two decimal places', () => {
+    const b = calculateTipBreakdown(255, 250)
+    expect(b.platformFee).toBe(6)
+    expect(b.authorShare).toBe(249)
+    expect(b.platformFeeFormatted).toBe('$0.06')
+    expect(b.authorShareFormatted).toBe('$2.49')
+  })
+})
+
+describe('formatTipAmount', () => {
+  it('always shows two fraction digits', () => {
+    expect(formatTipAmount(100)).toBe('$1.00')
+    expect(formatTipAmount(1)).toBe('$0.01')
+    expect(formatTipAmount(0)).toBe('$0.00')
+  })
+})

--- a/lib/stellar/highlight-utils.test.ts
+++ b/lib/stellar/highlight-utils.test.ts
@@ -14,7 +14,10 @@ describe('calculateTipBreakdown', () => {
   })
 
   it('uses PLATFORM_FEE_BPS when feeBps is omitted', () => {
-    const explicit = calculateTipBreakdown(1000, STELLAR_CONFIG.PLATFORM_FEE_BPS)
+    const explicit = calculateTipBreakdown(
+      1000,
+      STELLAR_CONFIG.PLATFORM_FEE_BPS
+    )
     const implicit = calculateTipBreakdown(1000)
     expect(implicit).toEqual(explicit)
   })

--- a/lib/stellar/highlight-utils.ts
+++ b/lib/stellar/highlight-utils.ts
@@ -2,6 +2,8 @@
  * Utility functions for highlight tipping
  */
 
+import { STELLAR_CONFIG } from './config'
+
 /**
  * Generate deterministic highlight ID from text selection
  * This ID will be stored in Stellar memo field and used to track tips
@@ -63,6 +65,8 @@ export function formatTipAmount(amountCents: number): string {
   return new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
   }).format(dollars)
 }
 
@@ -75,7 +79,7 @@ export function formatTipAmount(amountCents: number): string {
  */
 export function calculateTipBreakdown(
   amountCents: number,
-  feeBps: number = 250
+  feeBps: number = STELLAR_CONFIG.PLATFORM_FEE_BPS
 ) {
   const platformFee = Math.floor((amountCents * feeBps) / 10_000)
   const authorShare = amountCents - platformFee


### PR DESCRIPTION
## Summary

Adds a live breakdown line above the primary action in both the article tip dialog and the highlight tip dialog: total, author share, and platform fee. Values update when the selected or custom amount changes.

## Details

- Uses `calculateTipBreakdown` with `STELLAR_CONFIG.PLATFORM_FEE_BPS` (no hardcoded percentage).
- Currency display uses two decimal places via `formatTipAmount`.
- Shared UI: `TipBreakdownSummaryLine`.
- Tests: `lib/stellar/highlight-utils.test.ts` for split math, default fee BPS, and formatting.

<img width="1216" height="713" alt="2" src="https://github.com/user-attachments/assets/f1b73db6-d65c-4f9d-bf7c-cbca997d06d5" />
<img width="1221" height="721" alt="custom_1" src="https://github.com/user-attachments/assets/4cdb2690-2640-4776-8f71-6b9ea3c71a47" />
<img width="1223" height="714" alt="6" src="https://github.com/user-attachments/assets/3678d002-bb74-4606-8383-bf27736f4d4d" />
<img width="1221" height="720" alt="custom_2" src="https://github.com/user-attachments/assets/93f6699d-ee78-4d82-9730-ca33cff7d2a2" />
<img width="1216" height="712" alt="11" src="https://github.com/user-attachments/assets/e1c86837-81cd-4360-acd4-406ee8fa755b" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pragya-shar/codesmith/quilltip/pr/93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->