### PR TITLE
feat(tipping): show USD-to-XLM reference rate in tip dialogs (ENG-127)

### DIFF
--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -16,6 +16,8 @@ import {
   formatTipAmount,
 } from '@/lib/stellar/highlight-utils'
 import { TipBreakdownSummaryLine } from '@/components/tipping/TipBreakdownSummaryLine'
+import { TipUsdXlmRateLine } from '@/components/tipping/TipUsdXlmRateLine'
+import { useTipDialogXlmUsdRate } from '@/hooks/useTipDialogXlmUsdRate'
 import {
   TIP_PRESETS_HIGHLIGHT,
   TIP_MIN_CENTS,
@@ -75,6 +77,7 @@ export function HighlightTipButton({
 
   const convex = useConvex()
   const createHighlightTip = useMutation(api.highlightTips.create)
+  const { priceUsd: displayXlmUsdRate } = useTipDialogXlmUsdRate(isOpen)
 
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
@@ -360,6 +363,7 @@ export function HighlightTipButton({
               Minimum: ${TIP_MIN_USD.toFixed(2)} • Maximum: $
               {TIP_MAX_USD.toFixed(2)}
             </p>
+            <TipUsdXlmRateLine priceUsd={displayXlmUsdRate} />
           </div>
 
           {tipBreakdownPreview && (

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -17,6 +17,8 @@ import {
   formatTipAmount,
 } from '@/lib/stellar/highlight-utils'
 import { TipBreakdownSummaryLine } from '@/components/tipping/TipBreakdownSummaryLine'
+import { TipUsdXlmRateLine } from '@/components/tipping/TipUsdXlmRateLine'
+import { useTipDialogXlmUsdRate } from '@/hooks/useTipDialogXlmUsdRate'
 import {
   TIP_PRESETS_ARTICLE,
   TIP_MIN_CENTS,
@@ -62,6 +64,7 @@ export function TipButton({
 
   const convex = useConvex()
   const sendTip = useMutation(api.tips.sendTip)
+  const { priceUsd: displayXlmUsdRate } = useTipDialogXlmUsdRate(isOpen)
 
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
@@ -323,6 +326,7 @@ export function TipButton({
               Minimum: ${TIP_MIN_USD.toFixed(2)} • Maximum: $
               {TIP_MAX_USD.toFixed(2)}
             </p>
+            <TipUsdXlmRateLine priceUsd={displayXlmUsdRate} />
           </div>
 
           {tipBreakdownPreview && (

--- a/components/tipping/TipUsdXlmRateLine.tsx
+++ b/components/tipping/TipUsdXlmRateLine.tsx
@@ -1,0 +1,16 @@
+import { formatUsdToXlmHint } from '@/lib/tipping/xlmRateDisplay'
+
+export function TipUsdXlmRateLine({
+  priceUsd,
+}: {
+  priceUsd: number | null
+}) {
+  if (priceUsd === null) return null
+  const text = formatUsdToXlmHint(priceUsd)
+  if (!text) return null
+  return (
+    <p className="text-xs text-muted-foreground/90 mt-1" aria-live="polite">
+      {text}
+    </p>
+  )
+}

--- a/components/tipping/TipUsdXlmRateLine.tsx
+++ b/components/tipping/TipUsdXlmRateLine.tsx
@@ -1,10 +1,6 @@
 import { formatUsdToXlmHint } from '@/lib/tipping/xlmRateDisplay'
 
-export function TipUsdXlmRateLine({
-  priceUsd,
-}: {
-  priceUsd: number | null
-}) {
+export function TipUsdXlmRateLine({ priceUsd }: { priceUsd: number | null }) {
   if (priceUsd === null) return null
   const text = formatUsdToXlmHint(priceUsd)
   if (!text) return null

--- a/hooks/useTipDialogXlmUsdRate.ts
+++ b/hooks/useTipDialogXlmUsdRate.ts
@@ -1,0 +1,51 @@
+'use client'
+
+import { useConvex } from 'convex/react'
+import { useEffect, useRef, useState } from 'react'
+import { api } from '@/convex/_generated/api'
+import {
+  isDisplayCacheFresh,
+  readDisplayCache,
+  writeDisplayCache,
+} from '@/lib/tipping/xlmRateDisplay'
+
+export function useTipDialogXlmUsdRate(dialogOpen: boolean): {
+  priceUsd: number | null
+} {
+  const convex = useConvex()
+  const [priceUsd, setPriceUsd] = useState<number | null>(null)
+  const fetchGenerationRef = useRef(0)
+
+  useEffect(() => {
+    if (!dialogOpen) return
+
+    const generation = ++fetchGenerationRef.current
+    const now = Date.now()
+    const cached = readDisplayCache()
+    if (cached && isDisplayCacheFresh(cached, now)) {
+      setPriceUsd(cached.priceUsd)
+      return
+    }
+
+    setPriceUsd(null)
+
+    void (async () => {
+      try {
+        const result = await convex.query(api.xlmPrice.getCachedXlmPrice, {})
+        if (fetchGenerationRef.current !== generation) return
+        if (result === null) {
+          setPriceUsd(null)
+          return
+        }
+        const fetchedAt = Date.now()
+        writeDisplayCache(result.priceUsd, fetchedAt)
+        setPriceUsd(result.priceUsd)
+      } catch {
+        if (fetchGenerationRef.current !== generation) return
+        setPriceUsd(null)
+      }
+    })()
+  }, [dialogOpen, convex])
+
+  return { priceUsd }
+}

--- a/lib/tipping/xlmRateDisplay.test.ts
+++ b/lib/tipping/xlmRateDisplay.test.ts
@@ -38,10 +38,7 @@ describe('isDisplayCacheFresh', () => {
   it('returns false for negative age (clock skew)', () => {
     const now = 1_000_000
     expect(
-      isDisplayCacheFresh(
-        { priceUsd: 0.4, clientFetchedAt: now + 1000 },
-        now
-      )
+      isDisplayCacheFresh({ priceUsd: 0.4, clientFetchedAt: now + 1000 }, now)
     ).toBe(false)
   })
 })

--- a/lib/tipping/xlmRateDisplay.test.ts
+++ b/lib/tipping/xlmRateDisplay.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  DISPLAY_CACHE_TTL_MS,
+  XLM_USD_TIP_RATE_STORAGE_KEY,
+  formatUsdToXlmHint,
+  isDisplayCacheFresh,
+  readDisplayCache,
+  writeDisplayCache,
+} from './xlmRateDisplay'
+
+describe('isDisplayCacheFresh', () => {
+  it('returns true within TTL', () => {
+    const now = 1_000_000
+    expect(
+      isDisplayCacheFresh(
+        { priceUsd: 0.4, clientFetchedAt: now - DISPLAY_CACHE_TTL_MS + 1 },
+        now
+      )
+    ).toBe(true)
+  })
+
+  it('returns false at or past TTL', () => {
+    const now = 1_000_000
+    expect(
+      isDisplayCacheFresh(
+        { priceUsd: 0.4, clientFetchedAt: now - DISPLAY_CACHE_TTL_MS },
+        now
+      )
+    ).toBe(false)
+    expect(
+      isDisplayCacheFresh(
+        { priceUsd: 0.4, clientFetchedAt: now - DISPLAY_CACHE_TTL_MS - 1 },
+        now
+      )
+    ).toBe(false)
+  })
+
+  it('returns false for negative age (clock skew)', () => {
+    const now = 1_000_000
+    expect(
+      isDisplayCacheFresh(
+        { priceUsd: 0.4, clientFetchedAt: now + 1000 },
+        now
+      )
+    ).toBe(false)
+  })
+})
+
+describe('readDisplayCache / writeDisplayCache', () => {
+  const store: Record<string, string> = {}
+
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => (k in store ? store[k] : null),
+      setItem: (k: string, v: string) => {
+        store[k] = v
+      },
+      removeItem: (k: string) => {
+        delete store[k]
+      },
+      clear: () => {
+        for (const k of Object.keys(store)) delete store[k]
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    for (const k of Object.keys(store)) delete store[k]
+  })
+
+  it('writes and reads a valid entry', () => {
+    writeDisplayCache(0.42, 99_000)
+    const read = readDisplayCache()
+    expect(read).toEqual({ priceUsd: 0.42, clientFetchedAt: 99_000 })
+  })
+
+  it('returns null for missing key', () => {
+    expect(readDisplayCache()).toBeNull()
+  })
+
+  it('returns null for invalid JSON', () => {
+    store[XLM_USD_TIP_RATE_STORAGE_KEY] = 'not-json'
+    expect(readDisplayCache()).toBeNull()
+  })
+
+  it('returns null for malformed object', () => {
+    store[XLM_USD_TIP_RATE_STORAGE_KEY] = JSON.stringify({
+      priceUsd: '0.4',
+      clientFetchedAt: 1,
+    })
+    expect(readDisplayCache()).toBeNull()
+  })
+
+  it('does not write non-finite or non-positive price', () => {
+    writeDisplayCache(Number.NaN, 1)
+    writeDisplayCache(-1, 1)
+    writeDisplayCache(0, 1)
+    expect(readDisplayCache()).toBeNull()
+  })
+})
+
+describe('formatUsdToXlmHint', () => {
+  it('formats moderate XLM per USD with two decimals', () => {
+    expect(formatUsdToXlmHint(0.5)).toBe('$1 ≈ 2.00 XLM')
+  })
+
+  it('formats small XLM per USD with four decimals', () => {
+    expect(formatUsdToXlmHint(2)).toBe('$1 ≈ 0.5000 XLM')
+  })
+
+  it('formats large XLM per USD with zero decimals', () => {
+    expect(formatUsdToXlmHint(0.01)).toBe('$1 ≈ 100 XLM')
+  })
+
+  it('returns empty string for invalid price', () => {
+    expect(formatUsdToXlmHint(Number.NaN)).toBe('')
+    expect(formatUsdToXlmHint(0)).toBe('')
+    expect(formatUsdToXlmHint(-1)).toBe('')
+  })
+})

--- a/lib/tipping/xlmRateDisplay.ts
+++ b/lib/tipping/xlmRateDisplay.ts
@@ -41,16 +41,16 @@ export function readDisplayCache(): XlmUsdTipRateDisplayCache | null {
   }
 }
 
-export function writeDisplayCache(priceUsd: number, clientFetchedAt: number): void {
+export function writeDisplayCache(
+  priceUsd: number,
+  clientFetchedAt: number
+): void {
   try {
     if (typeof localStorage === 'undefined') return
     if (!Number.isFinite(priceUsd) || priceUsd <= 0) return
     if (!Number.isFinite(clientFetchedAt)) return
     const payload: XlmUsdTipRateDisplayCache = { priceUsd, clientFetchedAt }
-    localStorage.setItem(
-      XLM_USD_TIP_RATE_STORAGE_KEY,
-      JSON.stringify(payload)
-    )
+    localStorage.setItem(XLM_USD_TIP_RATE_STORAGE_KEY, JSON.stringify(payload))
   } catch {
     // quota / private mode — display cache is optional
   }

--- a/lib/tipping/xlmRateDisplay.ts
+++ b/lib/tipping/xlmRateDisplay.ts
@@ -1,0 +1,71 @@
+export const XLM_USD_TIP_RATE_STORAGE_KEY = 'quilltip:xlm_usd_tip_rate_v1'
+
+export const DISPLAY_CACHE_TTL_MS = 4 * 60 * 60 * 1000
+
+export type XlmUsdTipRateDisplayCache = {
+  priceUsd: number
+  clientFetchedAt: number
+}
+
+function isValidCacheEntry(value: unknown): value is XlmUsdTipRateDisplayCache {
+  if (typeof value !== 'object' || value === null) return false
+  const o = value as Record<string, unknown>
+  return (
+    typeof o.priceUsd === 'number' &&
+    Number.isFinite(o.priceUsd) &&
+    o.priceUsd > 0 &&
+    typeof o.clientFetchedAt === 'number' &&
+    Number.isFinite(o.clientFetchedAt)
+  )
+}
+
+export function isDisplayCacheFresh(
+  entry: XlmUsdTipRateDisplayCache,
+  nowMs: number
+): boolean {
+  if (!Number.isFinite(nowMs)) return false
+  const age = nowMs - entry.clientFetchedAt
+  return age >= 0 && age < DISPLAY_CACHE_TTL_MS
+}
+
+export function readDisplayCache(): XlmUsdTipRateDisplayCache | null {
+  try {
+    if (typeof localStorage === 'undefined') return null
+    const raw = localStorage.getItem(XLM_USD_TIP_RATE_STORAGE_KEY)
+    if (raw === null) return null
+    const parsed: unknown = JSON.parse(raw)
+    if (!isValidCacheEntry(parsed)) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+export function writeDisplayCache(priceUsd: number, clientFetchedAt: number): void {
+  try {
+    if (typeof localStorage === 'undefined') return
+    if (!Number.isFinite(priceUsd) || priceUsd <= 0) return
+    if (!Number.isFinite(clientFetchedAt)) return
+    const payload: XlmUsdTipRateDisplayCache = { priceUsd, clientFetchedAt }
+    localStorage.setItem(
+      XLM_USD_TIP_RATE_STORAGE_KEY,
+      JSON.stringify(payload)
+    )
+  } catch {
+    // quota / private mode — display cache is optional
+  }
+}
+
+export function formatUsdToXlmHint(priceUsd: number): string {
+  if (!Number.isFinite(priceUsd) || priceUsd <= 0) return ''
+  const xlmPerUsd = 1 / priceUsd
+  let digits: string
+  if (xlmPerUsd >= 100) {
+    digits = xlmPerUsd.toFixed(0)
+  } else if (xlmPerUsd >= 1) {
+    digits = xlmPerUsd.toFixed(2)
+  } else {
+    digits = xlmPerUsd.toFixed(4)
+  }
+  return `$1 \u2248 ${digits} XLM`
+}


### PR DESCRIPTION
## Summary

Adds a subtle reference line under the tip amount controls so readers see roughly how many XLM correspond to $1 at tip time. The line uses the same Convex-backed XLM/USD cache as the rest of the app (`getCachedXlmPrice`), with a 4-hour client cache in `localStorage`. If the rate cannot be loaded, the line is hidden with no toast or error noise. Tip submission is unchanged and never waits on the rate fetch.

## Changes

- `lib/tipping/xlmRateDisplay.ts` — localStorage key, 4h TTL, read/write helpers, `$1 ≈ … XLM` formatting
- `hooks/useTipDialogXlmUsdRate.ts` — refresh when dialog opens if cache missing/stale; silent failure
- `components/tipping/TipUsdXlmRateLine.tsx` — presentational line
- Wired into `TipButton` and `HighlightTipButton` below min/max amount copy
- Unit tests for cache TTL, invalid storage, and formatting

<img width="1217" height="720" alt="1" src="https://github.com/user-attachments/assets/75c5d6f2-24c8-402e-ad1a-142f601fd09b" />
<img width="1221" height="716" alt="2" src="https://github.com/user-attachments/assets/16d2862d-f87b-4b05-8944-1c8252e7b7af" />
<img width="1219" height="715" alt="3____" src="https://github.com/user-attachments/assets/6b3feb97-ca81-4899-844b-e13dcce22a77" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pragya-shar/codesmith/quilltip/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->