### PR TITLE
fix(tipping): use 2-col preset grid and 48px tap targets on mobile

### DIFF
--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -308,7 +308,7 @@ export function HighlightTipButton({
             </div>
           )}
 
-          <div className="grid grid-cols-3 gap-3 mb-4">
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-4">
             {TIP_PRESETS_HIGHLIGHT.map((amount) => (
               <button
                 key={amount.cents}
@@ -317,7 +317,7 @@ export function HighlightTipButton({
                   setSelectedAmount(amount.cents)
                   setCustomAmount('')
                 }}
-                className={`focus-ring relative px-4 py-3 rounded-lg border-2 transition-all ${
+                className={`focus-ring relative flex min-h-12 items-center justify-center px-4 py-3 rounded-lg border-2 transition-all ${
                   selectedAmount === amount.cents
                     ? 'border-orange-500 bg-orange-50 dark:bg-orange-950/30'
                     : 'border-border hover:border-orange-300'

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -269,7 +269,7 @@ export function TipButton({
             </div>
           )}
 
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
             {TIP_PRESETS_ARTICLE.map((amount) => (
               <button
                 key={amount.cents}
@@ -279,7 +279,7 @@ export function TipButton({
                   setCustomAmount('')
                 }}
                 disabled={isLoading}
-                className={`focus-ring relative px-4 py-3 rounded-lg border-2 transition-all disabled:opacity-50 ${
+                className={`focus-ring relative flex min-h-12 items-center justify-center px-4 py-3 rounded-lg border-2 transition-all disabled:opacity-50 ${
                   selectedAmount === amount.cents
                     ? 'border-orange-500 bg-orange-50'
                     : 'border-border hover:border-orange-300'


### PR DESCRIPTION
## Summary

The tip preset buttons sat in a fixed 3-column grid that squeezed too tight on small phones. This change uses 2 columns on mobile and 3 from `sm:` (640px) up, and enforces a 48px minimum tap height so the buttons are comfortable to tap. Applied to both the article tip dialog and the highlight tip dialog.

## Changes

- `components/tipping/TipButton.tsx`: preset grid `grid-cols-2 sm:grid-cols-3`; preset buttons get `flex min-h-12 items-center justify-center`.
- `components/highlights/HighlightTipButton.tsx`: same grid and button classes.

No logic, props, or copy changes. Spacing (`gap-3`), borders, selected state, and the "Popular" badge are unchanged.


<img width="1220" height="723" alt="1" src="https://github.com/user-attachments/assets/37c5b2a0-d6fb-4d42-ab65-a0743a51bd6c" />
<img width="1218" height="716" alt="3" src="https://github.com/user-attachments/assets/4e6e3a9b-1b00-4368-a174-461f85b72bd9" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pragya-shar/codesmith/quilltip/pr/96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->