### PR TITLE
feat(tipping): show tip dialog steps for signature, submit, and confirmation

### DIFF
--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useConvex, useMutation } from 'convex/react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { useWallet } from '@/components/providers/WalletProvider'
@@ -10,6 +10,11 @@ import { Coins, Heart, Loader2, Wallet } from 'lucide-react'
 import { api } from '@/convex/_generated/api'
 import { Id } from '@/convex/_generated/dataModel'
 import { stellarClient } from '@/lib/stellar/client'
+import {
+  stellarFlowEmitter,
+  type TipFlowStep,
+  tipFlowProgressLabel,
+} from '@/lib/stellar/stellar-flow-emitter'
 import {
   generateHighlightId,
   calculateTipBreakdown,
@@ -74,10 +79,19 @@ export function HighlightTipButton({
   const [selectedAmount, setSelectedAmount] = useState<number | null>(null)
   const [customAmount, setCustomAmount] = useState('')
   const [isLoading, setIsLoading] = useState(false)
+  const [tipFlowStep, setTipFlowStep] = useState<TipFlowStep | null>(null)
 
   const convex = useConvex()
   const createHighlightTip = useMutation(api.highlightTips.create)
   const { priceUsd: displayXlmUsdRate } = useTipDialogXlmUsdRate(isOpen)
+
+  useEffect(() => {
+    return stellarFlowEmitter.subscribe((event) => {
+      if (event.flow === 'tip') {
+        setTipFlowStep(event.step)
+      }
+    })
+  }, [])
 
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
@@ -140,6 +154,7 @@ export function HighlightTipButton({
     setIsLoading(true)
 
     try {
+      stellarFlowEmitter.emit({ flow: 'tip', step: 'awaiting_signature' })
       const highlightId = await generateHighlightId(
         articleSlug,
         highlightText,
@@ -227,6 +242,7 @@ export function HighlightTipButton({
       }
     } finally {
       setIsLoading(false)
+      setTipFlowStep(null)
     }
   }
 
@@ -313,11 +329,12 @@ export function HighlightTipButton({
               <button
                 key={amount.cents}
                 type="button"
+                disabled={isLoading}
                 onClick={() => {
                   setSelectedAmount(amount.cents)
                   setCustomAmount('')
                 }}
-                className={`focus-ring relative flex min-h-12 items-center justify-center px-4 py-3 rounded-lg border-2 transition-all ${
+                className={`focus-ring relative flex min-h-12 items-center justify-center px-4 py-3 rounded-lg border-2 transition-all disabled:opacity-50 ${
                   selectedAmount === amount.cents
                     ? 'border-orange-500 bg-orange-50 dark:bg-orange-950/30'
                     : 'border-border hover:border-orange-300'
@@ -355,8 +372,9 @@ export function HighlightTipButton({
                   setCustomAmount(e.target.value)
                   setSelectedAmount(null)
                 }}
+                disabled={isLoading}
                 placeholder="0.00"
-                className="focus-ring w-full pl-8 pr-4 py-2 border border-input bg-background text-foreground rounded-lg"
+                className="focus-ring w-full pl-8 pr-4 py-2 border border-input bg-background text-foreground rounded-lg disabled:opacity-50"
               />
             </div>
             <p className="text-xs text-muted-foreground mt-1">
@@ -404,7 +422,11 @@ export function HighlightTipButton({
                 {isLoading ? (
                   <>
                     <Loader2 className="w-4 h-4 animate-spin" />
-                    <span>Sending...</span>
+                    <span>
+                      {tipFlowStep
+                        ? tipFlowProgressLabel(tipFlowStep)
+                        : 'Awaiting signature'}
+                    </span>
                   </>
                 ) : (
                   <>

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useConvex, useMutation } from 'convex/react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { useWallet } from '@/components/providers/WalletProvider'
@@ -12,6 +12,11 @@ import Link from 'next/link'
 import { api } from '@/convex/_generated/api'
 import { Id } from '@/convex/_generated/dataModel'
 import { stellarClient } from '@/lib/stellar/client'
+import {
+  stellarFlowEmitter,
+  type TipFlowStep,
+  tipFlowProgressLabel,
+} from '@/lib/stellar/stellar-flow-emitter'
 import {
   calculateTipBreakdown,
   formatTipAmount,
@@ -61,10 +66,19 @@ export function TipButton({
   const [selectedAmount, setSelectedAmount] = useState<number | null>(null)
   const [customAmount, setCustomAmount] = useState('')
   const [isLoading, setIsLoading] = useState(false)
+  const [tipFlowStep, setTipFlowStep] = useState<TipFlowStep | null>(null)
 
   const convex = useConvex()
   const sendTip = useMutation(api.tips.sendTip)
   const { priceUsd: displayXlmUsdRate } = useTipDialogXlmUsdRate(isOpen)
+
+  useEffect(() => {
+    return stellarFlowEmitter.subscribe((event) => {
+      if (event.flow === 'tip') {
+        setTipFlowStep(event.step)
+      }
+    })
+  }, [])
 
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
@@ -193,6 +207,7 @@ export function TipButton({
       }
     } finally {
       setIsLoading(false)
+      setTipFlowStep(null)
     }
   }
 
@@ -367,7 +382,11 @@ export function TipButton({
                 {isLoading ? (
                   <>
                     <Loader2 className="w-4 h-4 animate-spin" />
-                    <span>Sending...</span>
+                    <span>
+                      {tipFlowStep
+                        ? tipFlowProgressLabel(tipFlowStep)
+                        : 'Awaiting signature'}
+                    </span>
                   </>
                 ) : (
                   <>

--- a/lib/stellar/__tests__/stellar-flow-emitter.test.ts
+++ b/lib/stellar/__tests__/stellar-flow-emitter.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import {
+  stellarFlowEmitter,
+  type StellarFlowEvent,
+} from '@/lib/stellar/stellar-flow-emitter'
+
+describe('stellarFlowEmitter', () => {
+  it('delivers events to subscribers in emit order', () => {
+    const received: StellarFlowEvent[] = []
+    const unsub = stellarFlowEmitter.subscribe((e) => {
+      received.push(e)
+    })
+
+    stellarFlowEmitter.emit({ flow: 'tip', step: 'awaiting_signature' })
+    stellarFlowEmitter.emit({ flow: 'tip', step: 'submitting' })
+    stellarFlowEmitter.emit({ flow: 'tip', step: 'confirming' })
+
+    expect(received).toEqual([
+      { flow: 'tip', step: 'awaiting_signature' },
+      { flow: 'tip', step: 'submitting' },
+      { flow: 'tip', step: 'confirming' },
+    ])
+
+    unsub()
+  })
+
+  it('stops delivering after unsubscribe', () => {
+    const received: StellarFlowEvent[] = []
+    const unsub = stellarFlowEmitter.subscribe((e) => received.push(e))
+
+    stellarFlowEmitter.emit({ flow: 'nft_mint', step: 'idle' })
+    unsub()
+    stellarFlowEmitter.emit({ flow: 'tip', step: 'confirming' })
+
+    expect(received).toEqual([{ flow: 'nft_mint', step: 'idle' }])
+  })
+})

--- a/lib/stellar/client.ts
+++ b/lib/stellar/client.ts
@@ -14,6 +14,7 @@ import type {
   TipData,
   XLMPriceData,
 } from './types'
+import { stellarFlowEmitter } from './stellar-flow-emitter'
 
 /**
  * Generate a deterministic short ID from article ID using SHA256
@@ -341,9 +342,11 @@ export class StellarClient {
       this.networkPassphrase
     )
 
+    stellarFlowEmitter.emit({ flow: 'tip', step: 'submitting' })
     const result = await sorobanServer.sendTransaction(transaction)
 
     if (result.status === 'PENDING') {
+      stellarFlowEmitter.emit({ flow: 'tip', step: 'confirming' })
       let txResult = await sorobanServer.getTransaction(result.hash)
       let retries = 0
       const maxRetries = 30

--- a/lib/stellar/stellar-flow-emitter.ts
+++ b/lib/stellar/stellar-flow-emitter.ts
@@ -1,0 +1,50 @@
+export const TIP_FLOW_STEPS = [
+  'awaiting_signature',
+  'submitting',
+  'confirming',
+] as const
+
+export type TipFlowStep = (typeof TIP_FLOW_STEPS)[number]
+
+/** Extend when wiring NFT mint progress through the same emitter. */
+export type NftMintFlowStep =
+  | 'awaiting_signature'
+  | 'submitting'
+  | 'confirming'
+  | 'idle'
+
+export type StellarFlowEvent =
+  | { flow: 'tip'; step: TipFlowStep }
+  | { flow: 'nft_mint'; step: NftMintFlowStep }
+
+export type StellarFlowListener = (event: StellarFlowEvent) => void
+
+class StellarFlowEmitter {
+  private listeners = new Set<StellarFlowListener>()
+
+  subscribe(listener: StellarFlowListener): () => void {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  emit(event: StellarFlowEvent): void {
+    for (const listener of this.listeners) {
+      listener(event)
+    }
+  }
+}
+
+export const stellarFlowEmitter = new StellarFlowEmitter()
+
+export function tipFlowProgressLabel(step: TipFlowStep): string {
+  switch (step) {
+    case 'awaiting_signature':
+      return 'Awaiting signature'
+    case 'submitting':
+      return 'Submitting to Stellar'
+    case 'confirming':
+      return 'Confirming on-chain'
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the single "Sending..." loading state in article and highlight tip dialogs with three ordered labels that reflect where the user is in the Stellar flow.

## Changes

- Add `lib/stellar/stellar-flow-emitter.ts`: typed singleton emitter (`subscribe` / `emit`) with `StellarFlowEvent` for `tip` and `nft_mint`, reusable by the NFT mint flow later.
- Emit `submitting` before Soroban `sendTransaction` and `confirming` when polling for ledger inclusion in `StellarClient.submitTipTransaction`.
- `TipButton` and `HighlightTipButton`: emit `awaiting_signature` at the start of the tip attempt (build + wallet sign), subscribe for tip events, map steps to user-facing copy, reset state in `finally`.
- Add unit tests for the emitter (ordering and unsubscribe).

## UI copy

1. Awaiting signature  
2. Submitting to Stellar  
3. Confirming on-chain  



https://github.com/user-attachments/assets/ed2ad155-3865-4c75-95a2-cd445a9b26d1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pragya-shar/codesmith/quilltip/pr/97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->