### PR TITLE
feat(tipping): keep tip dialogs open on failure with Retry and inline errors

### DIFF
--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/components/providers/AuthContext'
 import { useWallet } from '@/components/providers/WalletProvider'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
-import { Coins, Heart, Loader2, Wallet } from 'lucide-react'
+import { AlertCircle, Coins, Heart, Loader2, Wallet } from 'lucide-react'
 import { api } from '@/convex/_generated/api'
 import { Id } from '@/convex/_generated/dataModel'
 import { stellarClient } from '@/lib/stellar/client'
@@ -43,6 +43,11 @@ import {
   NO_WALLET_AVAILABLE_ERROR_CODE,
   ALBEDO_INSECURE_LOCALHOST_ERROR_CODE,
 } from '@/lib/stellar/wallet-adapter'
+import {
+  formatTipFailureMessage,
+  type TipFailureMessage,
+} from '@/lib/stellar/tip-error-messages'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 
 interface HighlightTipButtonProps {
   articleId: Id<'articles'>
@@ -80,6 +85,7 @@ export function HighlightTipButton({
   const [customAmount, setCustomAmount] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [tipFlowStep, setTipFlowStep] = useState<TipFlowStep | null>(null)
+  const [tipFailure, setTipFailure] = useState<TipFailureMessage | null>(null)
 
   const convex = useConvex()
   const createHighlightTip = useMutation(api.highlightTips.create)
@@ -96,6 +102,7 @@ export function HighlightTipButton({
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
     setIsOpen(open)
+    setTipFailure(null)
     if (!open) {
       setSelectedAmount(null)
       setCustomAmount('')
@@ -151,6 +158,7 @@ export function HighlightTipButton({
       console.error('[HighlightTipButton] canTip pre-flight failed', err)
     }
 
+    setTipFailure(null)
     setIsLoading(true)
 
     try {
@@ -198,6 +206,7 @@ export function HighlightTipButton({
         authorShare: transactionData.authorReceived,
       })
 
+      setTipFailure(null)
       setIsOpen(false)
       setSelectedAmount(null)
       setCustomAmount('')
@@ -226,20 +235,7 @@ export function HighlightTipButton({
       }
     } catch (error) {
       console.error('Highlight tip error:', error)
-
-      const errorMessage =
-        error instanceof Error ? error.message : 'Failed to send tip'
-
-      if (
-        errorMessage.includes('User declined') ||
-        errorMessage.includes('rejected')
-      ) {
-        toast.error('Transaction cancelled by user')
-      } else {
-        toast.error('Transaction failed', {
-          description: errorMessage,
-        })
-      }
+      setTipFailure(formatTipFailureMessage(error))
     } finally {
       setIsLoading(false)
       setTipFlowStep(null)
@@ -306,6 +302,16 @@ export function HighlightTipButton({
               Choose an amount to tip this highlight on the Stellar network.
             </DialogDescription>
           </DialogHeader>
+
+          {tipFailure && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>{tipFailure.title}</AlertTitle>
+              {tipFailure.detail ? (
+                <AlertDescription>{tipFailure.detail}</AlertDescription>
+              ) : null}
+            </Alert>
+          )}
 
           <div className="mb-4 p-3 bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800 rounded-lg">
             <p className="text-sm text-foreground italic">
@@ -431,7 +437,7 @@ export function HighlightTipButton({
                 ) : (
                   <>
                     <Heart className="w-4 h-4" />
-                    <span>Send Tip</span>
+                    <span>{tipFailure ? 'Retry' : 'Send Tip'}</span>
                   </>
                 )}
               </button>

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/components/providers/AuthContext'
 import { useWallet } from '@/components/providers/WalletProvider'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
-import { Coins, Heart, Loader2, Wallet } from 'lucide-react'
+import { AlertCircle, Coins, Heart, Loader2, Wallet } from 'lucide-react'
 import { WalletTooltip } from '@/components/guide/WalletTooltip'
 import Link from 'next/link'
 import { api } from '@/convex/_generated/api'
@@ -44,6 +44,11 @@ import {
   NO_WALLET_AVAILABLE_ERROR_CODE,
   ALBEDO_INSECURE_LOCALHOST_ERROR_CODE,
 } from '@/lib/stellar/wallet-adapter'
+import {
+  formatTipFailureMessage,
+  type TipFailureMessage,
+} from '@/lib/stellar/tip-error-messages'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 
 interface TipButtonProps {
   articleId: Id<'articles'>
@@ -67,6 +72,8 @@ export function TipButton({
   const [customAmount, setCustomAmount] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [tipFlowStep, setTipFlowStep] = useState<TipFlowStep | null>(null)
+  const [tipFailure, setTipFailure] = useState<TipFailureMessage | null>(null)
+  const [tipMessage, setTipMessage] = useState('')
 
   const convex = useConvex()
   const sendTip = useMutation(api.tips.sendTip)
@@ -83,6 +90,7 @@ export function TipButton({
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
     setIsOpen(open)
+    setTipFailure(null)
   }
 
   const handleTip = async () => {
@@ -116,6 +124,11 @@ export function TipButton({
       return
     }
 
+    if (tipMessage.length > 500) {
+      toast.error('Message must be 500 characters or less')
+      return
+    }
+
     // Pre-flight cooldown check: avoids building a Stellar transaction that
     // the server would ultimately reject, which would otherwise leave an
     // on-chain payment with no matching DB record. This is an optimization;
@@ -136,6 +149,7 @@ export function TipButton({
       console.error('[TipButton] canTip pre-flight failed', err)
     }
 
+    setTipFailure(null)
     setIsLoading(true)
 
     try {
@@ -155,6 +169,7 @@ export function TipButton({
       await sendTip({
         articleId,
         amountUsd: amountCents / 100,
+        message: tipMessage.trim() ? tipMessage.trim() : undefined,
         stellarTxId: receipt.transactionHash ?? '',
         stellarNetwork: 'TESTNET',
         stellarLedger: undefined,
@@ -167,9 +182,11 @@ export function TipButton({
         authorShare: transactionData.authorReceived,
       })
 
+      setTipFailure(null)
       setIsOpen(false)
       setSelectedAmount(null)
       setCustomAmount('')
+      setTipMessage('')
 
       toast.success(
         `Successfully tipped ${authorName} $${(amountCents / 100).toFixed(2)} via Stellar!`,
@@ -191,20 +208,7 @@ export function TipButton({
       )
     } catch (error) {
       console.error('Stellar tip error:', error)
-
-      const errorMessage =
-        error instanceof Error ? error.message : 'Failed to send tip'
-
-      if (
-        errorMessage.includes('User declined') ||
-        errorMessage.includes('rejected')
-      ) {
-        toast.error('Transaction cancelled by user')
-      } else {
-        toast.error('Transaction failed', {
-          description: errorMessage,
-        })
-      }
+      setTipFailure(formatTipFailureMessage(error))
     } finally {
       setIsLoading(false)
       setTipFlowStep(null)
@@ -268,6 +272,16 @@ export function TipButton({
               the author!
             </DialogDescription>
           </DialogHeader>
+
+          {tipFailure && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>{tipFailure.title}</AlertTitle>
+              {tipFailure.detail ? (
+                <AlertDescription>{tipFailure.detail}</AlertDescription>
+              ) : null}
+            </Alert>
+          )}
 
           {!isConnected && (
             <div className="p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-900">
@@ -344,6 +358,28 @@ export function TipButton({
             <TipUsdXlmRateLine priceUsd={displayXlmUsdRate} />
           </div>
 
+          <div>
+            <label
+              htmlFor="tip-optional-message"
+              className="block text-sm font-medium text-foreground mb-2"
+            >
+              Message to author (optional)
+            </label>
+            <textarea
+              id="tip-optional-message"
+              value={tipMessage}
+              onChange={(e) => setTipMessage(e.target.value)}
+              disabled={isLoading}
+              maxLength={500}
+              rows={3}
+              placeholder="Say thanks or leave context for your tip..."
+              className="focus-ring w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground disabled:opacity-50"
+            />
+            <p className="mt-1 text-xs text-muted-foreground">
+              {tipMessage.length}/500 characters
+            </p>
+          </div>
+
           {tipBreakdownPreview && (
             <TipBreakdownSummaryLine
               totalFormatted={formatTipAmount(previewCents)}
@@ -391,7 +427,7 @@ export function TipButton({
                 ) : (
                   <>
                     <Heart className="w-4 h-4" />
-                    <span>Send Tip</span>
+                    <span>{tipFailure ? 'Retry' : 'Send Tip'}</span>
                   </>
                 )}
               </button>

--- a/lib/stellar/tip-error-messages.test.ts
+++ b/lib/stellar/tip-error-messages.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { formatTipFailureMessage } from './tip-error-messages'
+
+describe('formatTipFailureMessage', () => {
+  it('maps user rejection', () => {
+    const r = formatTipFailureMessage(new Error('User declined'))
+    expect(r.title).toContain('Wallet')
+    expect(r.detail).toBeDefined()
+  })
+
+  it('maps network failure', () => {
+    const r = formatTipFailureMessage(
+      new Error('Transaction failed on the network')
+    )
+    expect(r.title).toContain('network')
+  })
+
+  it('maps cooldown copy verbatim', () => {
+    const msg = 'Please wait 12s before tipping again.'
+    const r = formatTipFailureMessage(new Error(msg))
+    expect(r.title).toBe('Tip cooldown')
+    expect(r.detail).toBe(msg)
+  })
+})

--- a/lib/stellar/tip-error-messages.ts
+++ b/lib/stellar/tip-error-messages.ts
@@ -44,20 +44,14 @@ export function formatTipFailureMessage(error: unknown): TipFailureMessage {
     }
   }
 
-  if (
-    raw.startsWith('Transaction failed') ||
-    raw.includes('errorResult')
-  ) {
+  if (raw.startsWith('Transaction failed') || raw.includes('errorResult')) {
     return {
       title: 'Transaction could not be confirmed',
       detail: raw.length > 320 ? `${raw.slice(0, 317)}...` : raw,
     }
   }
 
-  if (
-    raw.includes('Please wait') &&
-    raw.includes('before tipping')
-  ) {
+  if (raw.includes('Please wait') && raw.includes('before tipping')) {
     return {
       title: 'Tip cooldown',
       detail: raw,

--- a/lib/stellar/tip-error-messages.ts
+++ b/lib/stellar/tip-error-messages.ts
@@ -1,0 +1,85 @@
+export type TipFailureMessage = {
+  title: string
+  detail?: string
+}
+
+function rawMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  return 'Something went wrong'
+}
+
+/**
+ * Maps wallet, Stellar, and Convex errors to inline dialog copy.
+ */
+export function formatTipFailureMessage(error: unknown): TipFailureMessage {
+  const raw = rawMessage(error)
+  const lower = raw.toLowerCase()
+
+  if (
+    lower.includes('user declined') ||
+    lower.includes('rejected') ||
+    lower.includes('cancelled') ||
+    lower.includes('canceled')
+  ) {
+    return {
+      title: 'Wallet prompt was dismissed',
+      detail:
+        'Approve the transaction in your wallet when you are ready to send the tip.',
+    }
+  }
+
+  if (raw.includes('Transaction failed on the network')) {
+    return {
+      title: 'Transaction failed on the network',
+      detail:
+        'The network did not accept this transaction. Check your balance and try again.',
+    }
+  }
+
+  if (raw.includes('Transaction timeout')) {
+    return {
+      title: 'Confirmation timed out',
+      detail: raw,
+    }
+  }
+
+  if (
+    raw.startsWith('Transaction failed') ||
+    raw.includes('errorResult')
+  ) {
+    return {
+      title: 'Transaction could not be confirmed',
+      detail: raw.length > 320 ? `${raw.slice(0, 317)}...` : raw,
+    }
+  }
+
+  if (
+    raw.includes('Please wait') &&
+    raw.includes('before tipping')
+  ) {
+    return {
+      title: 'Tip cooldown',
+      detail: raw,
+    }
+  }
+
+  if (raw.includes('already linked to a different tip')) {
+    return {
+      title: 'This transaction is already used',
+      detail: raw,
+    }
+  }
+
+  if (raw.includes('Not authenticated')) {
+    return {
+      title: 'Session expired',
+      detail: 'Sign in again and retry.',
+    }
+  }
+
+  return {
+    title: 'Tip could not be completed',
+    detail: raw.length > 280 ? `${raw.slice(0, 277)}...` : raw,
+  }
+}


### PR DESCRIPTION
## Summary

Implements ENG-130: when a tip fails, the dialog stays open, shows a clear inline error, and the primary action becomes **Retry** while preserving the chosen amount and optional author message (article tips).

## Changes

- Add `formatTipFailureMessage` in `lib/stellar/tip-error-messages.ts` for wallet dismissals, Stellar/network errors, cooldown, duplicate tx, and generic failures.
- **TipButton:** `tipFailure` state + destructive `Alert`; optional “Message to author” textarea (500 chars) passed to `sendTip({ message })`; clear failure state on open/close, at send start, and on success; primary label **Retry** after failure; remove failure toasts in favor of inline messaging.
- **HighlightTipButton:** same failure + Alert + **Retry** pattern.
- Unit tests for `formatTipFailureMessage` in `lib/stellar/tip-error-messages.test.ts`.
<img width="1221" height="721" alt="1" src="https://github.com/user-attachments/assets/d8c6da54-1022-4e47-ac63-836f6e69dd3f" />
<img width="1219" height="715" alt="2" src="https://github.com/user-attachments/assets/1023905e-3ce4-415a-9799-85ae5703a8b0" />

<img width="1220" height="715" alt="3" src="https://github.com/user-attachments/assets/b55a328e-bc7c-4323-8eab-c8b0e696a147" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pragya-shar/codesmith/quilltip/pr/98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->