### PR TITLE
fix(nft): reuse shared ConvexHttpClient singleton in MintButton

### DIFF
--- a/components/nft/MintButton.tsx
+++ b/components/nft/MintButton.tsx
@@ -18,7 +18,7 @@ import {
 import { useStellarWallet } from '@/hooks/useStellarWallet'
 import { nftClient } from '@/lib/stellar/nft-client'
 import { stellarClient } from '@/lib/stellar/client'
-import { ConvexHttpClient } from 'convex/browser'
+import { getConvexHttpClient } from '@/lib/convex-http-client'
 import { InstallWalletDialog } from '@/components/stellar/InstallWalletDialog'
 import {
   NO_WALLET_AVAILABLE_ERROR_CODE,
@@ -72,9 +72,6 @@ export function MintButton({
     ? Math.floor((totalTips / xlmPrice) * 10_000_000)
     : 0
 
-  // Initialize Convex HTTP client for async calls
-  const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!)
-
   const handleConnectWallet = async () => {
     try {
       await wallet.connect()
@@ -119,10 +116,13 @@ export function MintButton({
 
       // Step 2: Generate metadata using Convex
       setMintingStep('wallet')
-      const metadata = await convex.query(api.nfts.generateNFTMetadata, {
-        articleId: articleId as Id<'articles'>,
-        xlmPrice: xlmPrice!, // Pass live price for accurate conversion
-      })
+      const metadata = await getConvexHttpClient().query(
+        api.nfts.generateNFTMetadata,
+        {
+          articleId: articleId as Id<'articles'>,
+          xlmPrice: xlmPrice!, // Pass live price for accurate conversion
+        }
+      )
 
       if (!metadata) {
         throw new Error('Failed to generate NFT metadata')

--- a/lib/convex-http-client.ts
+++ b/lib/convex-http-client.ts
@@ -1,0 +1,14 @@
+import { ConvexHttpClient } from 'convex/browser'
+
+let convexHttpClient: ConvexHttpClient | null = null
+
+export function getConvexHttpClient(): ConvexHttpClient {
+  if (!convexHttpClient) {
+    const url = process.env.NEXT_PUBLIC_CONVEX_URL
+    if (!url) {
+      throw new Error('NEXT_PUBLIC_CONVEX_URL is not set')
+    }
+    convexHttpClient = new ConvexHttpClient(url)
+  }
+  return convexHttpClient
+}

--- a/lib/stellar/client.ts
+++ b/lib/stellar/client.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto'
-import { ConvexHttpClient } from 'convex/browser'
+import { getConvexHttpClient } from '@/lib/convex-http-client'
 import { STELLAR_CONFIG } from './config'
 import { loadStellarSdk } from './sdk-loader'
 import { api } from '@/convex/_generated/api'
@@ -29,18 +29,6 @@ function shortArticleId(articleId: string): string {
 let xlmPriceCache: { price: number; timestamp: number; source: string } | null =
   null
 const PRICE_CACHE_TTL = 60 * 1000 // 1 minute in-tab cache
-
-let convexHttpClient: ConvexHttpClient | null = null
-function getConvexHttpClient(): ConvexHttpClient {
-  if (!convexHttpClient) {
-    const url = process.env.NEXT_PUBLIC_CONVEX_URL
-    if (!url) {
-      throw new Error('NEXT_PUBLIC_CONVEX_URL is not set')
-    }
-    convexHttpClient = new ConvexHttpClient(url)
-  }
-  return convexHttpClient
-}
 
 /**
  * Read the latest XLM/USD price from the Convex-backed cache. The cache is


### PR DESCRIPTION
## Summary

Moves Convex HTTP client creation out of the MintButton render path into a shared lazy singleton (`lib/convex-http-client.ts`) and wires `lib/stellar/client.ts` to the same getter so only one client instance is created and reused.

## Motivation

MintButton previously instantiated `new ConvexHttpClient` in the component body, allocating a new client on every render. The stellar client module already used a separate lazy singleton for XLM price queries; consolidating both call sites avoids duplicate logic and duplicate instances.

## Changes

- Add `getConvexHttpClient()` in `lib/convex-http-client.ts` (lazy module-level cache).
- Import that getter from `lib/stellar/client.ts` instead of an inline singleton.
- Call `getConvexHttpClient().query(...)` inside MintButton’s mint handler only (no client construction during render).


https://github.com/user-attachments/assets/db1bfe7b-72e3-4eae-98d9-e85d0f073e68

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pragya-shar/codesmith/quilltip/pr/99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->