### PR TITLE
feat(nft): mint dialog step indicator aligned with stellar flow emitter

### DIFF
--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useConvex, useMutation } from 'convex/react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { useWallet } from '@/components/providers/WalletProvider'
@@ -10,6 +10,12 @@ import { Coins, Heart, Loader2, Wallet } from 'lucide-react'
 import { api } from '@/convex/_generated/api'
 import { Id } from '@/convex/_generated/dataModel'
 import { stellarClient } from '@/lib/stellar/client'
+import {
+  stellarFlowEmitter,
+  type StellarFlowEvent,
+  type TipFlowStep,
+  tipFlowProgressLabel,
+} from '@/lib/stellar/stellar-flow-emitter'
 import {
   generateHighlightId,
   formatTipAmount,
@@ -70,9 +76,18 @@ export function HighlightTipButton({
   const [selectedAmount, setSelectedAmount] = useState<number | null>(null)
   const [customAmount, setCustomAmount] = useState('')
   const [isLoading, setIsLoading] = useState(false)
+  const [tipFlowStep, setTipFlowStep] = useState<TipFlowStep | null>(null)
 
   const convex = useConvex()
   const createHighlightTip = useMutation(api.highlightTips.create)
+
+  useEffect(() => {
+    return stellarFlowEmitter.subscribe((event: StellarFlowEvent) => {
+      if (event.flow === 'tip') {
+        setTipFlowStep(event.step)
+      }
+    })
+  }, [])
 
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
@@ -135,6 +150,7 @@ export function HighlightTipButton({
     setIsLoading(true)
 
     try {
+      stellarFlowEmitter.emit({ flow: 'tip', step: 'awaiting_signature' })
       const highlightId = await generateHighlightId(
         articleSlug,
         highlightText,
@@ -221,6 +237,7 @@ export function HighlightTipButton({
         })
       }
     } finally {
+      setTipFlowStep(null)
       setIsLoading(false)
     }
   }
@@ -384,7 +401,11 @@ export function HighlightTipButton({
                 {isLoading ? (
                   <>
                     <Loader2 className="w-4 h-4 animate-spin" />
-                    <span>Sending...</span>
+                    <span>
+                      {tipFlowStep
+                        ? tipFlowProgressLabel(tipFlowStep)
+                        : 'Awaiting signature'}
+                    </span>
                   </>
                 ) : (
                   <>

--- a/components/nft/MintButton.tsx
+++ b/components/nft/MintButton.tsx
@@ -68,9 +68,8 @@ export function MintButton({
   const [isLoading, setIsLoading] = useState(false)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
-  const [nftMintFlowStep, setNftMintFlowStep] = useState<NftMintFlowStep | null>(
-    null
-  )
+  const [nftMintFlowStep, setNftMintFlowStep] =
+    useState<NftMintFlowStep | null>(null)
   const nftMintFlowStepRef = useRef<NftMintFlowStep | null>(null)
 
   const mintNFT = useMutation(api.nfts.mintNFT)
@@ -321,7 +320,8 @@ export function MintButton({
                 </p>
                 <ol className="flex w-full items-start gap-2 sm:gap-3">
                   {NFT_MINT_UI_STEPS.map((stepKey, i) => {
-                    const activeIdx = mintStepActiveIndex >= 0 ? mintStepActiveIndex : 0
+                    const activeIdx =
+                      mintStepActiveIndex >= 0 ? mintStepActiveIndex : 0
                     const isComplete = i < activeIdx
                     const isCurrent = i === activeIdx
                     return (
@@ -363,9 +363,7 @@ export function MintButton({
                             'text-center text-[10px] font-medium leading-tight sm:text-xs',
                             isCurrent && 'text-foreground',
                             isComplete && 'text-green-800 dark:text-green-300',
-                            !isCurrent &&
-                              !isComplete &&
-                              'text-muted-foreground'
+                            !isCurrent && !isComplete && 'text-muted-foreground'
                           )}
                         >
                           {nftMintFlowProgressLabel(stepKey)}

--- a/components/nft/MintButton.tsx
+++ b/components/nft/MintButton.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useMutation } from 'convex/react'
 import { api } from '@/convex/_generated/api'
 import { Id } from '@/convex/_generated/dataModel'
 import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
-import { Loader2, Sparkles, Wallet } from 'lucide-react'
+import { Check, Loader2, Sparkles, Wallet } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -24,6 +24,23 @@ import {
   NO_WALLET_AVAILABLE_ERROR_CODE,
   ALBEDO_INSECURE_LOCALHOST_ERROR_CODE,
 } from '@/lib/stellar/wallet-adapter'
+import {
+  stellarFlowEmitter,
+  type NftMintFlowStep,
+  type StellarFlowEvent,
+  nftMintFlowProgressLabel,
+} from '@/lib/stellar/stellar-flow-emitter'
+import { cn } from '@/lib/utils'
+
+const NFT_MINT_UI_STEPS: readonly NftMintFlowStep[] = [
+  'awaiting_signature',
+  'submitting',
+  'confirming',
+] as const
+
+function nftMintStepIndex(step: NftMintFlowStep): number {
+  return NFT_MINT_UI_STEPS.indexOf(step)
+}
 
 interface MintButtonProps {
   articleId: string | Id<'articles'>
@@ -51,21 +68,37 @@ export function MintButton({
   const [isLoading, setIsLoading] = useState(false)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
-  const [mintingStep, setMintingStep] = useState<
-    'checking' | 'wallet' | 'blockchain' | 'database'
-  >('checking')
+  const [nftMintFlowStep, setNftMintFlowStep] = useState<NftMintFlowStep | null>(
+    null
+  )
+  const nftMintFlowStepRef = useRef<NftMintFlowStep | null>(null)
 
   const mintNFT = useMutation(api.nfts.mintNFT)
   const wallet = useStellarWallet()
   const [xlmPrice, setXlmPrice] = useState<number | null>(null)
 
-  // Fetch real-time XLM price
+  useEffect(() => {
+    return stellarFlowEmitter.subscribe((event: StellarFlowEvent) => {
+      if (event.flow === 'nft_mint') {
+        setNftMintFlowStep(event.step)
+        nftMintFlowStepRef.current = event.step
+      }
+    })
+  }, [])
+
   useEffect(() => {
     stellarClient.getXLMPrice().then(setXlmPrice)
   }, [])
 
   const canMint = totalTips >= threshold && isAuthor
   const progress = Math.min(100, (totalTips / threshold) * 100)
+
+  const mintStepActiveIndex =
+    nftMintFlowStep != null
+      ? nftMintStepIndex(nftMintFlowStep)
+      : isLoading
+        ? 0
+        : -1
 
   // Convert USD to stroops for contract (using real-time price)
   const tipAmountInStroops = xlmPrice
@@ -100,10 +133,10 @@ export function MintButton({
     }
 
     setIsLoading(true)
-    setMintingStep('checking')
 
     try {
-      // Step 1: Check eligibility on blockchain
+      stellarFlowEmitter.emit({ flow: 'nft_mint', step: 'awaiting_signature' })
+
       const eligibility = await nftClient.checkEligibility(
         articleId as string,
         tipAmountInStroops
@@ -114,8 +147,6 @@ export function MintButton({
         )
       }
 
-      // Step 2: Generate metadata using Convex
-      setMintingStep('wallet')
       const metadata = await getConvexHttpClient().query(
         api.nfts.generateNFTMetadata,
         {
@@ -132,7 +163,6 @@ export function MintButton({
       // In the future, this will be stored on IPFS
       const metadataUrl = `data:application/json,${encodeURIComponent(JSON.stringify(metadata))}`
 
-      // Step 3: Build and sign transaction
       const { xdr } = await nftClient.buildMintTransaction(wallet.publicKey, {
         authorAddress: wallet.publicKey,
         articleId: articleId as string,
@@ -140,19 +170,14 @@ export function MintButton({
         metadataUrl,
       })
 
-      // Step 4: Sign transaction with wallet
       const signedXDR = await wallet.signTransaction(xdr)
 
-      // Step 5: Submit to blockchain
-      setMintingStep('blockchain')
       const result = await nftClient.submitMintTransaction(signedXDR)
 
       if (!result.success) {
         throw new Error(result.error || 'Blockchain transaction failed')
       }
 
-      // Step 6: Update Convex database
-      setMintingStep('database')
       const nftId = await mintNFT({
         articleId: articleId as Id<'articles'>,
         tipThreshold: threshold,
@@ -172,17 +197,19 @@ export function MintButton({
     } catch (error) {
       console.error('Minting error:', error)
 
-      let errorMessage = 'Failed to mint NFT'
-      if (mintingStep === 'wallet') {
-        errorMessage = 'Transaction cancelled or wallet error'
-      } else if (mintingStep === 'blockchain') {
-        errorMessage = 'Blockchain transaction failed. Please try again'
+      const step = nftMintFlowStepRef.current
+      let fallback = 'Failed to mint NFT'
+      if (step === 'awaiting_signature' || step === null) {
+        fallback = 'Transaction cancelled or wallet error'
+      } else if (step === 'submitting' || step === 'confirming') {
+        fallback = 'Blockchain transaction failed. Please try again'
       }
 
-      toast.error(error instanceof Error ? error.message : errorMessage)
+      toast.error(error instanceof Error ? error.message : fallback)
     } finally {
+      setNftMintFlowStep(null)
+      nftMintFlowStepRef.current = null
       setIsLoading(false)
-      setMintingStep('checking')
     }
   }
 
@@ -284,17 +311,69 @@ export function MintButton({
             </div>
 
             {isLoading && (
-              <div className="bg-blue-50 p-4 rounded-lg space-y-2">
-                <div className="flex items-center gap-2">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  <span className="font-medium">Minting in Progress...</span>
-                </div>
-                <div className="text-sm text-muted-foreground">
-                  {mintingStep === 'checking' && 'Verifying eligibility...'}
-                  {mintingStep === 'wallet' && 'Sign in your wallet...'}
-                  {mintingStep === 'blockchain' && 'Minting NFT...'}
-                  {mintingStep === 'database' && 'Finalizing...'}
-                </div>
+              <div
+                className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-900/50 dark:bg-blue-950/30"
+                aria-busy="true"
+                aria-live="polite"
+              >
+                <p className="mb-3 text-sm font-medium text-foreground">
+                  Mint in progress
+                </p>
+                <ol className="flex w-full items-start gap-2 sm:gap-3">
+                  {NFT_MINT_UI_STEPS.map((stepKey, i) => {
+                    const activeIdx = mintStepActiveIndex >= 0 ? mintStepActiveIndex : 0
+                    const isComplete = i < activeIdx
+                    const isCurrent = i === activeIdx
+                    return (
+                      <li
+                        key={stepKey}
+                        className="flex min-w-0 flex-1 flex-col items-center gap-1.5"
+                      >
+                        <div
+                          className={cn(
+                            'flex h-8 w-8 shrink-0 items-center justify-center rounded-full border-2 text-xs font-semibold transition-colors',
+                            isComplete &&
+                              'border-green-600 bg-green-100 text-green-800 dark:border-green-500 dark:bg-green-950/50 dark:text-green-300',
+                            isCurrent &&
+                              !isComplete &&
+                              'border-primary bg-primary/10 text-primary',
+                            !isComplete &&
+                              !isCurrent &&
+                              'border-muted-foreground/30 bg-muted/50 text-muted-foreground'
+                          )}
+                          aria-current={isCurrent ? 'step' : undefined}
+                        >
+                          {isComplete ? (
+                            <Check
+                              className="h-4 w-4"
+                              strokeWidth={2.5}
+                              aria-hidden
+                            />
+                          ) : isCurrent ? (
+                            <Loader2
+                              className="h-4 w-4 animate-spin"
+                              aria-hidden
+                            />
+                          ) : (
+                            <span>{i + 1}</span>
+                          )}
+                        </div>
+                        <span
+                          className={cn(
+                            'text-center text-[10px] font-medium leading-tight sm:text-xs',
+                            isCurrent && 'text-foreground',
+                            isComplete && 'text-green-800 dark:text-green-300',
+                            !isCurrent &&
+                              !isComplete &&
+                              'text-muted-foreground'
+                          )}
+                        >
+                          {nftMintFlowProgressLabel(stepKey)}
+                        </span>
+                      </li>
+                    )
+                  })}
+                </ol>
               </div>
             )}
 
@@ -339,7 +418,9 @@ export function MintButton({
                   {isLoading ? (
                     <>
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Minting...
+                      {nftMintFlowStep
+                        ? nftMintFlowProgressLabel(nftMintFlowStep)
+                        : 'Minting'}
                     </>
                   ) : (
                     <>

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useConvex, useMutation } from 'convex/react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { useWallet } from '@/components/providers/WalletProvider'
@@ -12,6 +12,12 @@ import Link from 'next/link'
 import { api } from '@/convex/_generated/api'
 import { Id } from '@/convex/_generated/dataModel'
 import { stellarClient } from '@/lib/stellar/client'
+import {
+  stellarFlowEmitter,
+  type StellarFlowEvent,
+  type TipFlowStep,
+  tipFlowProgressLabel,
+} from '@/lib/stellar/stellar-flow-emitter'
 import {
   TIP_PRESETS_ARTICLE,
   TIP_MIN_CENTS,
@@ -54,9 +60,18 @@ export function TipButton({
   const [selectedAmount, setSelectedAmount] = useState<number | null>(null)
   const [customAmount, setCustomAmount] = useState('')
   const [isLoading, setIsLoading] = useState(false)
+  const [tipFlowStep, setTipFlowStep] = useState<TipFlowStep | null>(null)
 
   const convex = useConvex()
   const sendTip = useMutation(api.tips.sendTip)
+
+  useEffect(() => {
+    return stellarFlowEmitter.subscribe((event: StellarFlowEvent) => {
+      if (event.flow === 'tip') {
+        setTipFlowStep(event.step)
+      }
+    })
+  }, [])
 
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
@@ -117,6 +132,7 @@ export function TipButton({
     setIsLoading(true)
 
     try {
+      stellarFlowEmitter.emit({ flow: 'tip', step: 'awaiting_signature' })
       const transactionData = await stellarClient.buildTipTransaction(
         publicKey,
         {
@@ -184,6 +200,7 @@ export function TipButton({
         })
       }
     } finally {
+      setTipFlowStep(null)
       setIsLoading(false)
     }
   }
@@ -344,7 +361,11 @@ export function TipButton({
                 {isLoading ? (
                   <>
                     <Loader2 className="w-4 h-4 animate-spin" />
-                    <span>Sending...</span>
+                    <span>
+                      {tipFlowStep
+                        ? tipFlowProgressLabel(tipFlowStep)
+                        : 'Awaiting signature'}
+                    </span>
                   </>
                 ) : (
                   <>

--- a/lib/stellar/__tests__/nft-client.test.ts
+++ b/lib/stellar/__tests__/nft-client.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import type { StellarFlowEvent } from '@/lib/stellar/stellar-flow-emitter'
 
 const TEST_CONTRACT_ID =
   'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC'
@@ -51,5 +52,61 @@ describe('NFTClient.buildMintTransaction', () => {
     ) as InstanceType<typeof StellarSdk.Transaction>
 
     expect(decoded.memo.type).toBe('none')
+  })
+})
+
+describe('NFTClient.submitMintTransaction', () => {
+  let emitSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(async () => {
+    const { stellarFlowEmitter } = await import(
+      '@/lib/stellar/stellar-flow-emitter'
+    )
+    emitSpy = vi.spyOn(stellarFlowEmitter, 'emit')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('emits nft_mint submitting then confirming on successful submit', async () => {
+    const StellarSdk = await import('@stellar/stellar-sdk')
+    const { NFTClient } = await import('@/lib/stellar/nft-client')
+
+    vi.spyOn(StellarSdk.TransactionBuilder, 'fromXDR').mockReturnValue(
+      {} as never
+    )
+    vi.spyOn(StellarSdk.rpc.Server.prototype, 'sendTransaction').mockResolvedValue(
+      { status: 'PENDING', hash: 'testhash' } as never
+    )
+    vi.spyOn(StellarSdk.rpc.Server.prototype, 'getTransaction').mockResolvedValue(
+      { status: 'SUCCESS', returnValue: undefined } as never
+    )
+
+    const client = new NFTClient()
+    const result = await client.submitMintTransaction('AAAAxdr')
+
+    expect(result.success).toBe(true)
+    expect(emitSpy).toHaveBeenCalledWith({
+      flow: 'nft_mint',
+      step: 'submitting',
+    })
+    expect(emitSpy).toHaveBeenCalledWith({
+      flow: 'nft_mint',
+      step: 'confirming',
+    })
+    const asFlow = (c: unknown): StellarFlowEvent | undefined => {
+      if (!Array.isArray(c) || c[0] === undefined) return undefined
+      return c[0] as StellarFlowEvent
+    }
+    const submitIdx = emitSpy.mock.calls.findIndex((c: unknown) => {
+      const e = asFlow(c)
+      return e?.flow === 'nft_mint' && e.step === 'submitting'
+    })
+    const confirmIdx = emitSpy.mock.calls.findIndex((c: unknown) => {
+      const e = asFlow(c)
+      return e?.flow === 'nft_mint' && e.step === 'confirming'
+    })
+    expect(submitIdx).toBeLessThan(confirmIdx)
   })
 })

--- a/lib/stellar/__tests__/nft-client.test.ts
+++ b/lib/stellar/__tests__/nft-client.test.ts
@@ -59,9 +59,8 @@ describe('NFTClient.submitMintTransaction', () => {
   let emitSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(async () => {
-    const { stellarFlowEmitter } = await import(
-      '@/lib/stellar/stellar-flow-emitter'
-    )
+    const { stellarFlowEmitter } =
+      await import('@/lib/stellar/stellar-flow-emitter')
     emitSpy = vi.spyOn(stellarFlowEmitter, 'emit')
   })
 
@@ -76,12 +75,14 @@ describe('NFTClient.submitMintTransaction', () => {
     vi.spyOn(StellarSdk.TransactionBuilder, 'fromXDR').mockReturnValue(
       {} as never
     )
-    vi.spyOn(StellarSdk.rpc.Server.prototype, 'sendTransaction').mockResolvedValue(
-      { status: 'PENDING', hash: 'testhash' } as never
-    )
-    vi.spyOn(StellarSdk.rpc.Server.prototype, 'getTransaction').mockResolvedValue(
-      { status: 'SUCCESS', returnValue: undefined } as never
-    )
+    vi.spyOn(
+      StellarSdk.rpc.Server.prototype,
+      'sendTransaction'
+    ).mockResolvedValue({ status: 'PENDING', hash: 'testhash' } as never)
+    vi.spyOn(
+      StellarSdk.rpc.Server.prototype,
+      'getTransaction'
+    ).mockResolvedValue({ status: 'SUCCESS', returnValue: undefined } as never)
 
     const client = new NFTClient()
     const result = await client.submitMintTransaction('AAAAxdr')

--- a/lib/stellar/__tests__/stellar-flow-emitter.test.ts
+++ b/lib/stellar/__tests__/stellar-flow-emitter.test.ts
@@ -32,8 +32,6 @@ describe('stellarFlowEmitter', () => {
     unsub()
     stellarFlowEmitter.emit({ flow: 'tip', step: 'confirming' })
 
-    expect(received).toEqual([
-      { flow: 'nft_mint', step: 'awaiting_signature' },
-    ])
+    expect(received).toEqual([{ flow: 'nft_mint', step: 'awaiting_signature' }])
   })
 })

--- a/lib/stellar/__tests__/stellar-flow-emitter.test.ts
+++ b/lib/stellar/__tests__/stellar-flow-emitter.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import {
+  stellarFlowEmitter,
+  type StellarFlowEvent,
+} from '@/lib/stellar/stellar-flow-emitter'
+
+describe('stellarFlowEmitter', () => {
+  it('delivers events to subscribers in emit order', () => {
+    const received: StellarFlowEvent[] = []
+    const unsub = stellarFlowEmitter.subscribe((e) => {
+      received.push(e)
+    })
+
+    stellarFlowEmitter.emit({ flow: 'tip', step: 'awaiting_signature' })
+    stellarFlowEmitter.emit({ flow: 'tip', step: 'submitting' })
+    stellarFlowEmitter.emit({ flow: 'tip', step: 'confirming' })
+
+    expect(received).toEqual([
+      { flow: 'tip', step: 'awaiting_signature' },
+      { flow: 'tip', step: 'submitting' },
+      { flow: 'tip', step: 'confirming' },
+    ])
+
+    unsub()
+  })
+
+  it('stops delivering after unsubscribe', () => {
+    const received: StellarFlowEvent[] = []
+    const unsub = stellarFlowEmitter.subscribe((e) => received.push(e))
+
+    stellarFlowEmitter.emit({ flow: 'nft_mint', step: 'awaiting_signature' })
+    unsub()
+    stellarFlowEmitter.emit({ flow: 'tip', step: 'confirming' })
+
+    expect(received).toEqual([
+      { flow: 'nft_mint', step: 'awaiting_signature' },
+    ])
+  })
+})

--- a/lib/stellar/client.ts
+++ b/lib/stellar/client.ts
@@ -14,6 +14,7 @@ import type {
   TipData,
   XLMPriceData,
 } from './types'
+import { stellarFlowEmitter } from './stellar-flow-emitter'
 
 /**
  * Generate a deterministic short ID from article ID using SHA256
@@ -329,9 +330,11 @@ export class StellarClient {
       this.networkPassphrase
     )
 
+    stellarFlowEmitter.emit({ flow: 'tip', step: 'submitting' })
     const result = await sorobanServer.sendTransaction(transaction)
 
     if (result.status === 'PENDING') {
+      stellarFlowEmitter.emit({ flow: 'tip', step: 'confirming' })
       let txResult = await sorobanServer.getTransaction(result.hash)
       let retries = 0
       const maxRetries = 30

--- a/lib/stellar/nft-client.ts
+++ b/lib/stellar/nft-client.ts
@@ -1,5 +1,6 @@
 import { STELLAR_CONFIG } from './config'
 import { loadStellarSdk } from './sdk-loader'
+import { stellarFlowEmitter } from './stellar-flow-emitter'
 import type { MintNFTParams, NFTOwnership, NFTTransactionResult } from './types'
 
 type StellarSdkContext = {
@@ -192,9 +193,11 @@ export class NFTClient {
         this.networkPassphrase
       )
 
+      stellarFlowEmitter.emit({ flow: 'nft_mint', step: 'submitting' })
       const result = await sorobanServer.sendTransaction(transaction)
 
       if (result.status === 'PENDING') {
+        stellarFlowEmitter.emit({ flow: 'nft_mint', step: 'confirming' })
         let txResult = await sorobanServer.getTransaction(result.hash)
         let retries = 0
         const maxRetries = 30

--- a/lib/stellar/stellar-flow-emitter.ts
+++ b/lib/stellar/stellar-flow-emitter.ts
@@ -1,0 +1,57 @@
+export const TIP_FLOW_STEPS = [
+  'awaiting_signature',
+  'submitting',
+  'confirming',
+] as const
+
+export type TipFlowStep = (typeof TIP_FLOW_STEPS)[number]
+
+/** Same step keys as tips; mint dialog maps copy via nftMintFlowProgressLabel. */
+export type NftMintFlowStep = TipFlowStep
+
+export type StellarFlowEvent =
+  | { flow: 'tip'; step: TipFlowStep }
+  | { flow: 'nft_mint'; step: NftMintFlowStep }
+
+export type StellarFlowListener = (event: StellarFlowEvent) => void
+
+class StellarFlowEmitter {
+  private listeners = new Set<StellarFlowListener>()
+
+  subscribe(listener: StellarFlowListener): () => void {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  emit(event: StellarFlowEvent): void {
+    for (const listener of this.listeners) {
+      listener(event)
+    }
+  }
+}
+
+export const stellarFlowEmitter = new StellarFlowEmitter()
+
+export function tipFlowProgressLabel(step: TipFlowStep): string {
+  switch (step) {
+    case 'awaiting_signature':
+      return 'Awaiting signature'
+    case 'submitting':
+      return 'Submitting to Stellar'
+    case 'confirming':
+      return 'Confirming on-chain'
+  }
+}
+
+export function nftMintFlowProgressLabel(step: NftMintFlowStep): string {
+  switch (step) {
+    case 'awaiting_signature':
+      return 'Wallet'
+    case 'submitting':
+      return 'Submitted'
+    case 'confirming':
+      return 'Confirmed'
+  }
+}


### PR DESCRIPTION
## Summary
- Introduce shared `stellarFlowEmitter` for Stellar UX steps (`awaiting_signature`, `submitting`, `confirming`) with separate tip vs `nft_mint` flows.
- Emit tip steps from `StellarClient.submitTipTransaction` and at the start of article/highlight tip handlers; tip buttons subscribe and show progress labels.
- Emit `nft_mint` steps from `NFTClient.submitMintTransaction` and at mint start; replace the mint dialog single-spinner block with a three-step indicator labeled Wallet, Submitted, and Confirmed (via `nftMintFlowProgressLabel`).
- Add unit tests for the emitter and for mint submit emit order.


https://github.com/user-attachments/assets/d4d9fdf3-31d0-4dfc-9103-65d2b0a6e312

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pragya-shar/codesmith/quilltip/pr/100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->