### PR TITLE
fix(nft): single message slot in Transfer modal (ENG-134)

### DIFF
--- a/components/nft/TransferModal.test.tsx
+++ b/components/nft/TransferModal.test.tsx
@@ -169,10 +169,7 @@ describe('TransferModal', () => {
 
     render(<ControlledTransferModal />)
 
-    await user.type(
-      screen.getByLabelText(/Transfer To \(Username\)/i),
-      'ab'
-    )
+    await user.type(screen.getByLabelText(/Transfer To \(Username\)/i), 'ab')
     await user.click(screen.getByRole('button', { name: /^Transfer NFT$/i }))
     await waitFor(() => {
       expect(screen.getByTestId('transfer-modal-message')).toHaveTextContent(
@@ -183,6 +180,8 @@ describe('TransferModal', () => {
     await user.click(screen.getByRole('button', { name: /^Cancel$/i }))
     await user.click(screen.getByRole('button', { name: /^Reopen$/i }))
 
-    expect(screen.queryByText(/Invalid username format/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/Invalid username format/)
+    ).not.toBeInTheDocument()
   })
 })

--- a/components/nft/TransferModal.test.tsx
+++ b/components/nft/TransferModal.test.tsx
@@ -1,0 +1,188 @@
+/** @vitest-environment jsdom */
+import { useState } from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import { TransferModal } from '@/components/nft/TransferModal'
+import type { Id } from '@/types/convex'
+
+const mockTransfer = vi.hoisted(() => vi.fn())
+
+vi.mock('convex/react', () => ({
+  useMutation: () => mockTransfer,
+}))
+
+vi.mock('@/hooks/convex', () => ({
+  useNFTByArticle: () => null,
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const articleId = 'jd7aaaaaaaaaaaaaaaa' as Id<'articles'>
+const nftId = 'jd7bbbbbbbbbbbbbbbb' as Id<'articleNFTs'>
+
+function ControlledTransferModal() {
+  const [open, setOpen] = useState(true)
+  return (
+    <>
+      <TransferModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        articleId={articleId}
+        articleTitle="Test Article"
+        currentOwner="seller"
+        nftId={nftId}
+      />
+      <button type="button" onClick={() => setOpen(true)}>
+        Reopen
+      </button>
+    </>
+  )
+}
+
+describe('TransferModal', () => {
+  beforeEach(() => {
+    mockTransfer.mockReset()
+    vi.mocked(toast.error).mockClear()
+  })
+
+  it('shows a single success message in the message slot after transfer', async () => {
+    const user = userEvent.setup()
+    mockTransfer.mockResolvedValue('transfer_id')
+
+    render(
+      <TransferModal
+        isOpen
+        onClose={() => {}}
+        articleId={articleId}
+        articleTitle="Test Article"
+        currentOwner="seller"
+        nftId={nftId}
+      />
+    )
+
+    await user.type(
+      screen.getByLabelText(/Transfer To \(Username\)/i),
+      'buyername'
+    )
+    await user.click(screen.getByRole('button', { name: /^Transfer NFT$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('transfer-modal-message')).toHaveTextContent(
+        'Transfer completed successfully!'
+      )
+    })
+    expect(
+      screen.queryByText('Transfer failed. Please try again.')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getAllByText('Transfer completed successfully!')
+    ).toHaveLength(1)
+  })
+
+  it('shows a single error message in the message slot on mutation failure', async () => {
+    const user = userEvent.setup()
+    mockTransfer.mockRejectedValue(new Error('Recipient not found'))
+
+    render(
+      <TransferModal
+        isOpen
+        onClose={() => {}}
+        articleId={articleId}
+        articleTitle="Test Article"
+        currentOwner="seller"
+        nftId={nftId}
+      />
+    )
+
+    await user.type(
+      screen.getByLabelText(/Transfer To \(Username\)/i),
+      'buyername'
+    )
+    await user.click(screen.getByRole('button', { name: /^Transfer NFT$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('transfer-modal-message')).toHaveTextContent(
+        'No account uses that username'
+      )
+    })
+    expect(
+      screen.queryByText('Transfer completed successfully!')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getAllByText(
+        'No account uses that username. Check the spelling and try again.'
+      )
+    ).toHaveLength(1)
+    expect(toast.error).toHaveBeenCalledWith(
+      'No account uses that username. Check the spelling and try again.'
+    )
+  })
+
+  it('shows progress only in the message slot while the button stays Transfer NFT', async () => {
+    const user = userEvent.setup()
+    let resolveTransfer!: (value: string) => void
+    const transferPromise = new Promise<string>((resolve) => {
+      resolveTransfer = resolve
+    })
+    mockTransfer.mockReturnValue(transferPromise)
+
+    render(
+      <TransferModal
+        isOpen
+        onClose={() => {}}
+        articleId={articleId}
+        articleTitle="Test Article"
+        currentOwner="seller"
+        nftId={nftId}
+      />
+    )
+
+    await user.type(
+      screen.getByLabelText(/Transfer To \(Username\)/i),
+      'buyername'
+    )
+    await user.click(screen.getByRole('button', { name: /^Transfer NFT$/i }))
+
+    const slot = screen.getByTestId('transfer-modal-message')
+    await waitFor(() => {
+      expect(slot).toHaveTextContent('Processing transfer...')
+    })
+
+    const submit = screen.getByRole('button', { name: /^Transfer NFT$/i })
+    expect(submit.textContent).not.toMatch(/Processing transfer/i)
+
+    resolveTransfer!('transfer_id')
+    await waitFor(() => {
+      expect(slot).toHaveTextContent('Transfer completed successfully!')
+    })
+  })
+
+  it('clears the message slot when the modal is closed and reopened', async () => {
+    const user = userEvent.setup()
+
+    render(<ControlledTransferModal />)
+
+    await user.type(
+      screen.getByLabelText(/Transfer To \(Username\)/i),
+      'ab'
+    )
+    await user.click(screen.getByRole('button', { name: /^Transfer NFT$/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('transfer-modal-message')).toHaveTextContent(
+        'Invalid username format'
+      )
+    })
+
+    await user.click(screen.getByRole('button', { name: /^Cancel$/i }))
+    await user.click(screen.getByRole('button', { name: /^Reopen$/i }))
+
+    expect(screen.queryByText(/Invalid username format/)).not.toBeInTheDocument()
+  })
+})

--- a/components/nft/TransferModal.tsx
+++ b/components/nft/TransferModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, type RefObject } from 'react'
+import { useEffect, useRef, useState, type RefObject } from 'react'
 import { useMutation } from 'convex/react'
 import { api } from '@/convex/_generated/api'
 import { useNFTByArticle } from '@/hooks/convex'
@@ -18,6 +18,16 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { userFacingTransferNftError } from '@/lib/convex/userFacingTransferNftError'
+
+type TransferMessage =
+  | { kind: 'none' }
+  | { kind: 'progress'; text: string }
+  | { kind: 'success'; text: string }
+  | { kind: 'error'; text: string }
+
+const PROGRESS_COPY = 'Processing transfer...'
+const SUCCESS_COPY = 'Transfer completed successfully!'
 
 interface TransferModalProps {
   isOpen: boolean
@@ -41,11 +51,9 @@ export function TransferModal({
   triggerRef,
 }: TransferModalProps) {
   const [recipientUsername, setRecipientUsername] = useState('')
-  const [isTransferring, setIsTransferring] = useState(false)
-  const [transferStatus, setTransferStatus] = useState<
-    'idle' | 'confirming' | 'success' | 'error'
-  >('idle')
-  const [errorMessage, setErrorMessage] = useState('')
+  const [transferMessage, setTransferMessage] = useState<TransferMessage>({
+    kind: 'none',
+  })
 
   const transferNFT = useMutation(api.nfts.transferNFT)
 
@@ -56,39 +64,58 @@ export function TransferModal({
   const actualNftId =
     nftId || (nftData && nftData.isMinted ? nftData._id : null)
 
+  const prevOpenRef = useRef(false)
+
+  useEffect(() => {
+    if (isOpen && !prevOpenRef.current) {
+      setRecipientUsername('')
+      setTransferMessage({ kind: 'none' })
+    }
+    prevOpenRef.current = isOpen
+  }, [isOpen])
+
+  const isBusy = transferMessage.kind === 'progress'
+
   const validateUsername = (username: string): boolean => {
-    // Basic username validation
     return /^[a-zA-Z0-9_-]{3,30}$/.test(username)
   }
 
   const handleTransfer = async () => {
-    setErrorMessage('')
+    setTransferMessage({ kind: 'none' })
 
-    // Validate username
     if (!recipientUsername.trim()) {
-      setErrorMessage('Please enter a recipient username')
+      setTransferMessage({
+        kind: 'error',
+        text: 'Please enter a recipient username',
+      })
       return
     }
 
     if (!validateUsername(recipientUsername)) {
-      setErrorMessage(
-        'Invalid username format. Use only letters, numbers, underscores, and hyphens (3-30 characters).'
-      )
+      setTransferMessage({
+        kind: 'error',
+        text: 'Invalid username format. Use only letters, numbers, underscores, and hyphens (3-30 characters).',
+      })
       return
     }
 
     if (recipientUsername.toLowerCase() === currentOwner.toLowerCase()) {
-      setErrorMessage('Cannot transfer to the current owner')
+      setTransferMessage({
+        kind: 'error',
+        text: 'Cannot transfer to the current owner',
+      })
       return
     }
 
     if (!actualNftId) {
-      setErrorMessage('NFT not found for this article')
+      setTransferMessage({
+        kind: 'error',
+        text: 'NFT not found for this article',
+      })
       return
     }
 
-    setIsTransferring(true)
-    setTransferStatus('confirming')
+    setTransferMessage({ kind: 'progress', text: PROGRESS_COPY })
 
     try {
       const transferId = await transferNFT({
@@ -97,19 +124,16 @@ export function TransferModal({
       })
 
       if (transferId) {
-        setTransferStatus('success')
+        setTransferMessage({ kind: 'success', text: SUCCESS_COPY })
 
-        // Show success toast
         toast.success(
           `NFT Transferred Successfully! Article NFT has been transferred to @${recipientUsername}`
         )
 
-        // Notify parent component
         if (onTransferComplete) {
           onTransferComplete(recipientUsername)
         }
 
-        // Close modal after a short delay
         setTimeout(() => {
           handleClose()
         }, 2000)
@@ -117,52 +141,36 @@ export function TransferModal({
         throw new Error('Transfer failed')
       }
     } catch (error) {
-      setTransferStatus('error')
-      setErrorMessage(
-        error instanceof Error
-          ? error.message
-          : 'Transfer failed. Please try again.'
-      )
-      toast.error(error instanceof Error ? error.message : 'Transfer failed')
-    } finally {
-      setIsTransferring(false)
+      const text = userFacingTransferNftError(error)
+      setTransferMessage({ kind: 'error', text })
+      toast.error(text)
     }
   }
 
   const handleClose = () => {
-    if (!isTransferring) {
-      setRecipientUsername('')
-      setTransferStatus('idle')
-      setErrorMessage('')
-      onClose()
-    }
+    if (isBusy) return
+    setRecipientUsername('')
+    setTransferMessage({ kind: 'none' })
+    onClose()
   }
 
-  const getStatusMessage = () => {
-    switch (transferStatus) {
-      case 'confirming':
-        return 'Processing transfer...'
-      case 'success':
-        return 'Transfer completed successfully!'
-      case 'error':
-        return errorMessage || 'Transfer failed. Please try again.'
-      default:
-        return ''
-    }
-  }
+  const messageBannerClass =
+    transferMessage.kind === 'success'
+      ? 'bg-green-50 text-green-700'
+      : transferMessage.kind === 'error'
+        ? 'bg-red-50 text-red-700'
+        : transferMessage.kind === 'progress'
+          ? 'bg-blue-50 text-blue-700'
+          : ''
 
-  const getStatusIcon = () => {
-    switch (transferStatus) {
-      case 'confirming':
-        return <Loader2 className="h-4 w-4 animate-spin" />
-      case 'success':
-        return <CheckCircle className="h-4 w-4 text-green-500" />
-      case 'error':
-        return <AlertCircle className="h-4 w-4 text-red-500" />
-      default:
-        return null
-    }
-  }
+  const messageIcon =
+    transferMessage.kind === 'progress' ? (
+      <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
+    ) : transferMessage.kind === 'success' ? (
+      <CheckCircle className="h-4 w-4 shrink-0 text-green-500" />
+    ) : transferMessage.kind === 'error' ? (
+      <AlertCircle className="h-4 w-4 shrink-0 text-red-500" />
+    ) : null
 
   return (
     <Dialog
@@ -180,10 +188,10 @@ export function TransferModal({
           }
         }}
         onEscapeKeyDown={(e) => {
-          if (isTransferring) e.preventDefault()
+          if (isBusy) e.preventDefault()
         }}
         onInteractOutside={(e) => {
-          if (isTransferring) e.preventDefault()
+          if (isBusy) e.preventDefault()
         }}
       >
         <DialogHeader>
@@ -195,7 +203,6 @@ export function TransferModal({
         </DialogHeader>
 
         <div className="space-y-4">
-          {/* Current Owner */}
           <div className="space-y-2">
             <Label className="text-sm text-muted-foreground">
               Current Owner
@@ -205,7 +212,6 @@ export function TransferModal({
             </div>
           </div>
 
-          {/* Recipient Input */}
           <div className="space-y-2">
             <Label htmlFor="recipient">Transfer To (Username)</Label>
             <Input
@@ -213,7 +219,7 @@ export function TransferModal({
               placeholder="Enter recipient username"
               value={recipientUsername}
               onChange={(e) => setRecipientUsername(e.target.value)}
-              disabled={isTransferring || transferStatus === 'success'}
+              disabled={isBusy || transferMessage.kind === 'success'}
               className="font-mono"
             />
             <p className="text-xs text-muted-foreground">
@@ -221,55 +227,48 @@ export function TransferModal({
             </p>
           </div>
 
-          {/* Status Message */}
-          {transferStatus !== 'idle' && (
-            <div
-              className={`flex items-center gap-2 p-3 rounded-lg ${
-                transferStatus === 'success'
-                  ? 'bg-green-50 text-green-700'
-                  : transferStatus === 'error'
-                    ? 'bg-red-50 text-red-700'
-                    : 'bg-blue-50 text-blue-700'
-              }`}
-            >
-              {getStatusIcon()}
-              <span className="min-w-0 text-sm break-words">
-                {getStatusMessage()}
-              </span>
-            </div>
-          )}
-
-          {/* Error Message */}
-          {errorMessage && transferStatus === 'idle' && (
-            <div className="text-sm text-red-500">{errorMessage}</div>
-          )}
+          <div
+            className="flex min-h-[3.75rem] items-center rounded-lg"
+            data-testid="transfer-modal-message"
+            aria-live="polite"
+          >
+            {transferMessage.kind === 'none' ? (
+              <span className="sr-only">No transfer status</span>
+            ) : (
+              <div
+                className={`flex w-full items-center gap-2 rounded-lg p-3 ${messageBannerClass}`}
+              >
+                {messageIcon}
+                <span className="min-w-0 text-sm break-words">
+                  {transferMessage.text}
+                </span>
+              </div>
+            )}
+          </div>
         </div>
 
         <DialogFooter>
-          <Button
-            variant="outline"
-            onClick={handleClose}
-            disabled={isTransferring}
-          >
+          <Button variant="outline" onClick={handleClose} disabled={isBusy}>
             Cancel
           </Button>
           <Button
             onClick={handleTransfer}
             disabled={
-              isTransferring ||
-              transferStatus === 'success' ||
+              isBusy ||
+              transferMessage.kind === 'success' ||
               !recipientUsername.trim()
             }
+            aria-busy={isBusy}
             className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600"
           >
-            {isTransferring ? (
+            {isBusy ? (
               <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Transferring...
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+                Transfer NFT
               </>
             ) : (
               <>
-                <Send className="mr-2 h-4 w-4" />
+                <Send className="mr-2 h-4 w-4" aria-hidden />
                 Transfer NFT
               </>
             )}

--- a/lib/convex/userFacingTransferNftError.test.ts
+++ b/lib/convex/userFacingTransferNftError.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { userFacingTransferNftError } from '@/lib/convex/userFacingTransferNftError'
+
+describe('userFacingTransferNftError', () => {
+  it('maps wrapped Convex dev Recipient not found to friendly copy', () => {
+    const raw = `[CONVEX M(nfts:transferNFT)] [Request ID: abc] Server Error Uncaught Error: Recipient not found at handler (../convex/nfts.ts:391:26) Called by client`
+    expect(userFacingTransferNftError(new Error(raw))).toBe(
+      'No account uses that username. Check the spelling and try again.'
+    )
+  })
+
+  it('maps plain Recipient not found', () => {
+    expect(userFacingTransferNftError(new Error('Recipient not found'))).toBe(
+      'No account uses that username. Check the spelling and try again.'
+    )
+  })
+
+  it('returns generic copy for unknown noisy errors', () => {
+    expect(
+      userFacingTransferNftError(
+        new Error('[CONVEX M(foo:bar)] Server Error something weird')
+      )
+    ).toBe('Transfer could not be completed. Please try again.')
+  })
+})

--- a/lib/convex/userFacingTransferNftError.ts
+++ b/lib/convex/userFacingTransferNftError.ts
@@ -1,0 +1,85 @@
+const GENERIC = 'Transfer could not be completed. Please try again.'
+
+const FRIENDLY_BY_SUBSTRING: Array<{ match: string; message: string }> = [
+  {
+    match: 'recipient not found',
+    message:
+      'No account uses that username. Check the spelling and try again.',
+  },
+  {
+    match: 'not authenticated',
+    message: 'Sign in to transfer this NFT.',
+  },
+  {
+    match: 'nft not found',
+    message: 'This NFT could not be found. Refresh the page and try again.',
+  },
+  {
+    match: "you don't own this nft",
+    message: 'Only the current owner can transfer this NFT.',
+  },
+  {
+    match: 'cannot transfer to yourself',
+    message: 'Pick a different recipient.',
+  },
+  {
+    match: 'user not found',
+    message: 'Your session could not be verified. Please sign in again.',
+  },
+]
+
+function extractRawMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  return ''
+}
+
+function extractInnerFromDevWrapper(message: string): string | null {
+  const uncaught = message.match(
+    /Uncaught Error:\s*([\s\S]+?)(?:\s+at\s+handler|\s+Called by client|$)/i
+  )
+  if (uncaught?.[1]) {
+    const inner = uncaught[1].trim()
+    if (inner.length > 0) return inner
+  }
+  return null
+}
+
+function looksLikeDevNoise(message: string): boolean {
+  if (/\[CONVEX/i.test(message)) return true
+  if (/Request ID:/i.test(message)) return true
+  if (/\bnfts:transferNFT\b/i.test(message)) return true
+  if (/\.\.\/convex\//i.test(message)) return true
+  if (/\bcalled by client\b/i.test(message)) return true
+  return /\bat\s+[\w./$-]+:\d+/i.test(message)
+}
+
+function polishKnownMessage(inner: string): string | null {
+  const n = inner.trim().toLowerCase()
+  for (const { match, message } of FRIENDLY_BY_SUBSTRING) {
+    if (n.includes(match)) return message
+  }
+  return null
+}
+
+/**
+ * Maps Convex / network errors from transferNFT into short copy for toasts.
+ * Avoids showing `[CONVEX ...]`, request IDs, or file paths to users.
+ */
+export function userFacingTransferNftError(error: unknown): string {
+  const raw = extractRawMessage(error)
+  const inner = extractInnerFromDevWrapper(raw) ?? raw.trim()
+
+  const polished = polishKnownMessage(inner)
+  if (polished) return polished
+
+  if (
+    inner.length > 0 &&
+    inner.length <= 200 &&
+    !looksLikeDevNoise(inner)
+  ) {
+    return inner
+  }
+
+  return GENERIC
+}

--- a/lib/convex/userFacingTransferNftError.ts
+++ b/lib/convex/userFacingTransferNftError.ts
@@ -3,8 +3,7 @@ const GENERIC = 'Transfer could not be completed. Please try again.'
 const FRIENDLY_BY_SUBSTRING: Array<{ match: string; message: string }> = [
   {
     match: 'recipient not found',
-    message:
-      'No account uses that username. Check the spelling and try again.',
+    message: 'No account uses that username. Check the spelling and try again.',
   },
   {
     match: 'not authenticated',
@@ -73,11 +72,7 @@ export function userFacingTransferNftError(error: unknown): string {
   const polished = polishKnownMessage(inner)
   if (polished) return polished
 
-  if (
-    inner.length > 0 &&
-    inner.length <= 200 &&
-    !looksLikeDevNoise(inner)
-  ) {
+  if (inner.length > 0 && inner.length <= 200 && !looksLikeDevNoise(inner)) {
     return inner
   }
 


### PR DESCRIPTION
## Summary

Consolidates the NFT Transfer modal to one message state and one fixed-height message area so success, in-progress, and error are never shown together. Reopening the modal resets the form and clears prior messages. The primary button keeps the label "Transfer NFT" with a spinner while progress copy lives only in the message slot.

## Changes

- Replace `transferStatus` / `errorMessage` / `isTransferring` with a discriminated `TransferMessage` (`none` | `progress` | `success` | `error`).
- Single message region with stable `min-h` to avoid layout shift; remove the separate idle error line.
- Reset on `isOpen` false→true and on close (still blocks close while `progress`).
- Add `components/nft/TransferModal.test.tsx` (success, error, progress vs button, reopen clears validation).
<img width="1220" height="719" alt="2" src="https://github.com/user-attachments/assets/ce020fa4-5628-47ce-a70b-0c3fb56c514f" />
<img width="1222" height="718" alt="3" src="https://github.com/user-attachments/assets/f9b01068-3405-42ae-ae88-6ac9b242d2de" />
<img width="1227" height="760" alt="5" src="https://github.com/user-attachments/assets/567afcdb-ebea-4604-8c17-4d3f7eeee992" />


https://github.com/user-attachments/assets/864ef229-b4fc-479c-bcf0-2bfe0d779900

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pragya-shar/codesmith/quilltip/pr/102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->