### PR TITLE
fix(navigation): replace transparent mobile menu with accessible Sheet panel (ENG-164)

### DIFF
--- a/components/landing/Navigation.test.tsx
+++ b/components/landing/Navigation.test.tsx
@@ -1,0 +1,42 @@
+/** @vitest-environment jsdom */
+import type { HTMLAttributes, ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import Navigation from '@/components/landing/Navigation'
+
+vi.mock('next/link', () => ({
+  default: (props: { href: string; children: ReactNode }) => (
+    <a href={props.href}>{props.children}</a>
+  ),
+}))
+
+vi.mock('motion/react', () => ({
+  motion: {
+    nav: (props: HTMLAttributes<HTMLElement>) => <nav {...props} />,
+    div: (props: HTMLAttributes<HTMLDivElement>) => <div {...props} />,
+  },
+  AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/components/theme/ThemeToggle', () => ({
+  ThemeToggle: () => <button type="button">Theme</button>,
+}))
+
+describe('Navigation mobile menu', () => {
+  beforeEach(() => {
+    document.body.style.pointerEvents = ''
+  })
+
+  it('closes the mobile sheet when Escape is pressed', async () => {
+    const user = userEvent.setup()
+    render(<Navigation />)
+
+    await user.click(screen.getByRole('button', { name: 'Toggle menu' }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})

--- a/components/landing/Navigation.tsx
+++ b/components/landing/Navigation.tsx
@@ -5,7 +5,6 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import {
   ArrowRight,
   Menu,
-  X,
   PenTool,
   Zap,
   Highlighter,
@@ -21,6 +20,12 @@ import {
 import { motion, AnimatePresence } from 'motion/react'
 import { LucideIcon } from 'lucide-react'
 import { ThemeToggle } from '@/components/theme/ThemeToggle'
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet'
 
 interface NavDropdownItem {
   icon: LucideIcon
@@ -230,11 +235,13 @@ export default function Navigation() {
     }
   }
 
+  const headerSolid = scrolled || isOpen
+
   return (
     <motion.nav
       className={`fixed top-0 w-full z-50 transition-all duration-500 ${
-        scrolled
-          ? 'bg-background/70 backdrop-blur-xl border-b border-border/60 shadow-sm'
+        headerSolid
+          ? 'bg-background border-b border-border shadow-sm'
           : 'bg-transparent'
       }`}
       initial={{ y: -100 }}
@@ -406,104 +413,81 @@ export default function Navigation() {
             </Link>
           </div>
 
-          {/* Mobile Menu Button */}
-          <button
-            type="button"
-            className="focus-ring md:hidden p-2 rounded-lg hover:bg-muted transition-colors"
-            onClick={() => setIsOpen(!isOpen)}
-            aria-expanded={isOpen}
-            aria-label="Toggle menu"
-          >
-            {isOpen ? (
-              <X size={22} className="text-foreground" />
-            ) : (
-              <Menu size={22} className="text-foreground" />
-            )}
-          </button>
-        </div>
-
-        {/* Mobile Navigation */}
-        <AnimatePresence>
-          {isOpen && (
-            <motion.div
-              className="md:hidden border-t border-border/60"
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: 'auto' }}
-              exit={{ opacity: 0, height: 0 }}
-              transition={{ duration: 0.25 }}
+          <Sheet open={isOpen} onOpenChange={setIsOpen}>
+            <SheetTrigger asChild>
+              <button
+                type="button"
+                className="focus-ring md:hidden p-2 rounded-lg hover:bg-muted transition-colors"
+                aria-expanded={isOpen}
+                aria-label="Toggle menu"
+              >
+                <Menu size={22} className="text-foreground" />
+              </button>
+            </SheetTrigger>
+            <SheetContent
+              side="right"
+              className="w-full sm:max-w-sm p-0 flex flex-col"
             >
-              <div className="py-4 space-y-4">
-                <Link
-                  href="/articles"
-                  className="focus-ring flex items-center gap-3 py-1.5 rounded-md text-muted-foreground hover:text-foreground text-sm font-medium transition-colors"
-                  onClick={() => setIsOpen(false)}
-                >
-                  Articles
-                </Link>
-                {navDropdowns.map((dropdown, dropdownIndex) => (
-                  <motion.div
-                    key={dropdown.label}
-                    initial={{ opacity: 0, x: -20 }}
-                    animate={{ opacity: 1, x: 0 }}
-                    transition={{ duration: 0.3, delay: dropdownIndex * 0.1 }}
-                  >
-                    <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-                      {dropdown.label}
-                    </p>
-                    <div className="space-y-0.5">
-                      {dropdown.columns.map((column) =>
-                        column.items.map((item) => (
-                          <Link
-                            key={item.title}
-                            href={item.href}
-                            className="focus-ring flex items-center gap-2.5 py-1.5 rounded-md text-muted-foreground hover:text-foreground transition-colors"
-                            onClick={(e) => {
-                              handleSmoothScroll(e, item.href)
-                              setIsOpen(false)
-                            }}
-                          >
-                            <div className="w-7 h-7 bg-muted rounded-lg flex items-center justify-center">
-                              <item.icon className="w-3.5 h-3.5 text-muted-foreground" />
-                            </div>
-                            <span className="text-sm font-medium">
-                              {item.title}
-                            </span>
-                          </Link>
-                        ))
-                      )}
-                    </div>
-                  </motion.div>
-                ))}
-
-                <motion.div
-                  initial={{ opacity: 0, x: -20 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  transition={{
-                    duration: 0.3,
-                    delay: navDropdowns.length * 0.1,
-                  }}
-                  className="pt-3 space-y-2 border-t border-border/60"
-                >
-                  <Link
-                    href="/login"
-                    className="focus-ring block rounded-md text-muted-foreground hover:text-foreground text-sm font-medium transition-colors py-1.5"
-                    onClick={() => setIsOpen(false)}
-                  >
-                    Sign In
-                  </Link>
-                  <Link
-                    href="/register"
-                    className="focus-ring inline-flex w-full items-center justify-center gap-1.5 bg-brand text-brand-foreground px-5 py-2.5 rounded-lg hover:bg-brand-hover transition-colors text-sm font-medium"
-                    onClick={() => setIsOpen(false)}
-                  >
-                    Try on Testnet
-                    <ArrowRight className="w-3.5 h-3.5 shrink-0 text-brand-foreground/80" />
-                  </Link>
-                </motion.div>
+              <SheetTitle className="sr-only">Navigation menu</SheetTitle>
+          <div className="px-4 pt-14 pb-6 space-y-4 overflow-y-auto">
+            <Link
+              href="/articles"
+              className="focus-ring flex items-center gap-3 py-2 rounded-lg text-foreground hover:bg-muted text-sm font-medium transition-colors"
+              onClick={() => setIsOpen(false)}
+            >
+              Articles
+            </Link>
+            {navDropdowns.map((dropdown) => (
+              <div key={dropdown.label}>
+                <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-2 px-1">
+                  {dropdown.label}
+                </p>
+                <div className="space-y-0.5">
+                  {dropdown.columns.map((column) =>
+                    column.items.map((item) => (
+                      <Link
+                        key={item.title}
+                        href={item.href}
+                        className="focus-ring flex items-center gap-2.5 py-2 px-1 rounded-lg text-foreground hover:bg-muted transition-colors"
+                        onClick={(e) => {
+                          handleSmoothScroll(e, item.href)
+                          setIsOpen(false)
+                        }}
+                      >
+                        <div className="w-7 h-7 bg-muted rounded-lg flex items-center justify-center shrink-0">
+                          <item.icon className="w-3.5 h-3.5 text-foreground" />
+                        </div>
+                        <span className="text-sm font-medium">
+                          {item.title}
+                        </span>
+                      </Link>
+                    ))
+                  )}
+                </div>
               </div>
-            </motion.div>
-          )}
-        </AnimatePresence>
+            ))}
+
+            <div className="pt-3 space-y-2 border-t border-border">
+              <Link
+                href="/login"
+                className="focus-ring block rounded-lg text-foreground hover:bg-muted text-sm font-medium transition-colors py-2 px-1"
+                onClick={() => setIsOpen(false)}
+              >
+                Sign In
+              </Link>
+              <Link
+                href="/register"
+                className="focus-ring inline-flex w-full items-center justify-center gap-1.5 bg-brand text-brand-foreground px-5 py-2.5 rounded-lg hover:bg-brand-hover transition-colors text-sm font-medium"
+                onClick={() => setIsOpen(false)}
+              >
+                Try on Testnet
+                <ArrowRight className="w-3.5 h-3.5 shrink-0 text-brand-foreground/80" />
+              </Link>
+            </div>
+          </div>
+            </SheetContent>
+          </Sheet>
+        </div>
       </div>
     </motion.nav>
   )

--- a/components/landing/Navigation.tsx
+++ b/components/landing/Navigation.tsx
@@ -429,62 +429,62 @@ export default function Navigation() {
               className="w-full sm:max-w-sm p-0 flex flex-col"
             >
               <SheetTitle className="sr-only">Navigation menu</SheetTitle>
-          <div className="px-4 pt-14 pb-6 space-y-4 overflow-y-auto">
-            <Link
-              href="/articles"
-              className="focus-ring flex items-center gap-3 py-2 rounded-lg text-foreground hover:bg-muted text-sm font-medium transition-colors"
-              onClick={() => setIsOpen(false)}
-            >
-              Articles
-            </Link>
-            {navDropdowns.map((dropdown) => (
-              <div key={dropdown.label}>
-                <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-2 px-1">
-                  {dropdown.label}
-                </p>
-                <div className="space-y-0.5">
-                  {dropdown.columns.map((column) =>
-                    column.items.map((item) => (
-                      <Link
-                        key={item.title}
-                        href={item.href}
-                        className="focus-ring flex items-center gap-2.5 py-2 px-1 rounded-lg text-foreground hover:bg-muted transition-colors"
-                        onClick={(e) => {
-                          handleSmoothScroll(e, item.href)
-                          setIsOpen(false)
-                        }}
-                      >
-                        <div className="w-7 h-7 bg-muted rounded-lg flex items-center justify-center shrink-0">
-                          <item.icon className="w-3.5 h-3.5 text-foreground" />
-                        </div>
-                        <span className="text-sm font-medium">
-                          {item.title}
-                        </span>
-                      </Link>
-                    ))
-                  )}
+              <div className="px-4 pt-14 pb-6 space-y-4 overflow-y-auto">
+                <Link
+                  href="/articles"
+                  className="focus-ring flex items-center gap-3 py-2 rounded-lg text-foreground hover:bg-muted text-sm font-medium transition-colors"
+                  onClick={() => setIsOpen(false)}
+                >
+                  Articles
+                </Link>
+                {navDropdowns.map((dropdown) => (
+                  <div key={dropdown.label}>
+                    <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-2 px-1">
+                      {dropdown.label}
+                    </p>
+                    <div className="space-y-0.5">
+                      {dropdown.columns.map((column) =>
+                        column.items.map((item) => (
+                          <Link
+                            key={item.title}
+                            href={item.href}
+                            className="focus-ring flex items-center gap-2.5 py-2 px-1 rounded-lg text-foreground hover:bg-muted transition-colors"
+                            onClick={(e) => {
+                              handleSmoothScroll(e, item.href)
+                              setIsOpen(false)
+                            }}
+                          >
+                            <div className="w-7 h-7 bg-muted rounded-lg flex items-center justify-center shrink-0">
+                              <item.icon className="w-3.5 h-3.5 text-foreground" />
+                            </div>
+                            <span className="text-sm font-medium">
+                              {item.title}
+                            </span>
+                          </Link>
+                        ))
+                      )}
+                    </div>
+                  </div>
+                ))}
+
+                <div className="pt-3 space-y-2 border-t border-border">
+                  <Link
+                    href="/login"
+                    className="focus-ring block rounded-lg text-foreground hover:bg-muted text-sm font-medium transition-colors py-2 px-1"
+                    onClick={() => setIsOpen(false)}
+                  >
+                    Sign In
+                  </Link>
+                  <Link
+                    href="/register"
+                    className="focus-ring inline-flex w-full items-center justify-center gap-1.5 bg-brand text-brand-foreground px-5 py-2.5 rounded-lg hover:bg-brand-hover transition-colors text-sm font-medium"
+                    onClick={() => setIsOpen(false)}
+                  >
+                    Try on Testnet
+                    <ArrowRight className="w-3.5 h-3.5 shrink-0 text-brand-foreground/80" />
+                  </Link>
                 </div>
               </div>
-            ))}
-
-            <div className="pt-3 space-y-2 border-t border-border">
-              <Link
-                href="/login"
-                className="focus-ring block rounded-lg text-foreground hover:bg-muted text-sm font-medium transition-colors py-2 px-1"
-                onClick={() => setIsOpen(false)}
-              >
-                Sign In
-              </Link>
-              <Link
-                href="/register"
-                className="focus-ring inline-flex w-full items-center justify-center gap-1.5 bg-brand text-brand-foreground px-5 py-2.5 rounded-lg hover:bg-brand-hover transition-colors text-sm font-medium"
-                onClick={() => setIsOpen(false)}
-              >
-                Try on Testnet
-                <ArrowRight className="w-3.5 h-3.5 shrink-0 text-brand-foreground/80" />
-              </Link>
-            </div>
-          </div>
             </SheetContent>
           </Sheet>
         </div>

--- a/components/layout/AppNavigation.test.tsx
+++ b/components/layout/AppNavigation.test.tsx
@@ -41,7 +41,9 @@ describe('AppNavigation mobile menu', () => {
     await user.click(screen.getByRole('button', { name: 'Toggle menu' }))
 
     expect(screen.getByRole('dialog')).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'Navigation menu' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Navigation menu' })
+    ).toBeInTheDocument()
   })
 
   it('closes the dialog when Escape is pressed', async () => {

--- a/components/layout/AppNavigation.test.tsx
+++ b/components/layout/AppNavigation.test.tsx
@@ -1,0 +1,58 @@
+/** @vitest-environment jsdom */
+import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import AppNavigation from '@/components/layout/AppNavigation'
+
+vi.mock('next/link', () => ({
+  default: (props: { href: string; children: ReactNode }) => (
+    <a href={props.href}>{props.children}</a>
+  ),
+}))
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}))
+
+vi.mock('@/components/providers/AuthContext', () => ({
+  useAuth: () => ({
+    user: null,
+    isAuthenticated: false,
+    signOut: vi.fn(),
+  }),
+}))
+
+vi.mock('@/components/theme/ThemeToggle', () => ({
+  ThemeToggle: () => <button type="button">Theme</button>,
+}))
+
+describe('AppNavigation mobile menu', () => {
+  beforeEach(() => {
+    document.body.style.pointerEvents = ''
+  })
+
+  it('opens a dialog when the menu toggle is clicked', async () => {
+    const user = userEvent.setup()
+    render(<AppNavigation />)
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Toggle menu' }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Navigation menu' })).toBeInTheDocument()
+  })
+
+  it('closes the dialog when Escape is pressed', async () => {
+    const user = userEvent.setup()
+    render(<AppNavigation />)
+
+    await user.click(screen.getByRole('button', { name: 'Toggle menu' }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})

--- a/components/layout/AppNavigation.tsx
+++ b/components/layout/AppNavigation.tsx
@@ -40,9 +40,7 @@ export default function AppNavigation() {
 
   const mobileLinkClass = (active: boolean) =>
     `focus-ring flex items-center gap-2 px-3 py-2 rounded-lg transition text-sm font-medium ${
-      active
-        ? 'bg-muted text-primary'
-        : 'text-foreground hover:bg-muted'
+      active ? 'bg-muted text-primary' : 'text-foreground hover:bg-muted'
     }`
 
   return (
@@ -149,91 +147,91 @@ export default function AppNavigation() {
               className="w-full sm:max-w-sm p-0 flex flex-col"
             >
               <SheetTitle className="sr-only">Navigation menu</SheetTitle>
-          <div className="flex flex-col gap-1 px-4 pt-14 pb-6 overflow-y-auto">
-            <Link
-              href="/"
-              className={mobileLinkClass(isActive('/'))}
-              onClick={closeMenu}
-            >
-              <Home className="w-4 h-4 shrink-0" />
-              <span>Home</span>
-            </Link>
-            <Link
-              href="/articles"
-              className={mobileLinkClass(isActive('/articles'))}
-              onClick={closeMenu}
-            >
-              <BookOpen className="w-4 h-4 shrink-0" />
-              <span>Articles</span>
-            </Link>
-            <Link
-              href="/guide"
-              className={mobileLinkClass(isActive('/guide'))}
-              onClick={closeMenu}
-            >
-              <HelpCircle className="w-4 h-4 shrink-0" />
-              <span>Guide</span>
-            </Link>
+              <div className="flex flex-col gap-1 px-4 pt-14 pb-6 overflow-y-auto">
+                <Link
+                  href="/"
+                  className={mobileLinkClass(isActive('/'))}
+                  onClick={closeMenu}
+                >
+                  <Home className="w-4 h-4 shrink-0" />
+                  <span>Home</span>
+                </Link>
+                <Link
+                  href="/articles"
+                  className={mobileLinkClass(isActive('/articles'))}
+                  onClick={closeMenu}
+                >
+                  <BookOpen className="w-4 h-4 shrink-0" />
+                  <span>Articles</span>
+                </Link>
+                <Link
+                  href="/guide"
+                  className={mobileLinkClass(isActive('/guide'))}
+                  onClick={closeMenu}
+                >
+                  <HelpCircle className="w-4 h-4 shrink-0" />
+                  <span>Guide</span>
+                </Link>
 
-            {isAuthenticated ? (
-              <>
-                <Link
-                  href="/write"
-                  className={mobileLinkClass(isActive('/write'))}
-                  onClick={closeMenu}
-                >
-                  <PenSquare className="w-4 h-4 shrink-0" />
-                  <span>Write</span>
-                </Link>
-                <Link
-                  href="/drafts"
-                  className={mobileLinkClass(isActive('/drafts'))}
-                  onClick={closeMenu}
-                >
-                  <FileText className="w-4 h-4 shrink-0" />
-                  <span>Drafts</span>
-                </Link>
-                <Link
-                  href={`/${user?.username || 'profile'}`}
-                  className={mobileLinkClass(
-                    pathname === `/${user?.username}`
-                  )}
-                  onClick={closeMenu}
-                >
-                  <User className="w-4 h-4 shrink-0" />
-                  <span>Profile</span>
-                </Link>
-                <button
-                  type="button"
-                  onClick={() => {
-                    closeMenu()
-                    signOut()
-                  }}
-                  className="focus-ring flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium text-foreground hover:bg-muted hover:text-destructive transition text-left"
-                >
-                  <LogOut className="w-4 h-4 shrink-0" />
-                  <span>Sign Out</span>
-                </button>
-              </>
-            ) : (
-              <div className="flex flex-col gap-2 pt-2 border-t border-border mt-2">
-                <Link
-                  href="/login"
-                  className="focus-ring rounded-lg px-3 py-2 text-sm font-medium text-foreground hover:bg-muted transition"
-                  onClick={closeMenu}
-                >
-                  Sign In
-                </Link>
-                <Link
-                  href="/register"
-                  className="focus-ring bg-primary text-primary-foreground px-4 py-2.5 rounded-lg hover:bg-primary/90 transition text-center text-sm font-medium"
-                  onClick={closeMenu}
-                >
-                  Get Started
-                </Link>
+                {isAuthenticated ? (
+                  <>
+                    <Link
+                      href="/write"
+                      className={mobileLinkClass(isActive('/write'))}
+                      onClick={closeMenu}
+                    >
+                      <PenSquare className="w-4 h-4 shrink-0" />
+                      <span>Write</span>
+                    </Link>
+                    <Link
+                      href="/drafts"
+                      className={mobileLinkClass(isActive('/drafts'))}
+                      onClick={closeMenu}
+                    >
+                      <FileText className="w-4 h-4 shrink-0" />
+                      <span>Drafts</span>
+                    </Link>
+                    <Link
+                      href={`/${user?.username || 'profile'}`}
+                      className={mobileLinkClass(
+                        pathname === `/${user?.username}`
+                      )}
+                      onClick={closeMenu}
+                    >
+                      <User className="w-4 h-4 shrink-0" />
+                      <span>Profile</span>
+                    </Link>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        closeMenu()
+                        signOut()
+                      }}
+                      className="focus-ring flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium text-foreground hover:bg-muted hover:text-destructive transition text-left"
+                    >
+                      <LogOut className="w-4 h-4 shrink-0" />
+                      <span>Sign Out</span>
+                    </button>
+                  </>
+                ) : (
+                  <div className="flex flex-col gap-2 pt-2 border-t border-border mt-2">
+                    <Link
+                      href="/login"
+                      className="focus-ring rounded-lg px-3 py-2 text-sm font-medium text-foreground hover:bg-muted transition"
+                      onClick={closeMenu}
+                    >
+                      Sign In
+                    </Link>
+                    <Link
+                      href="/register"
+                      className="focus-ring bg-primary text-primary-foreground px-4 py-2.5 rounded-lg hover:bg-primary/90 transition text-center text-sm font-medium"
+                      onClick={closeMenu}
+                    >
+                      Get Started
+                    </Link>
+                  </div>
+                )}
               </div>
-            )}
-          </div>
             </SheetContent>
           </Sheet>
         </div>

--- a/components/layout/AppNavigation.tsx
+++ b/components/layout/AppNavigation.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useState, useRef, useEffect } from 'react'
+import { useState } from 'react'
 import { useAuth } from '@/components/providers/AuthContext'
 import {
   PenSquare,
@@ -12,30 +12,22 @@ import {
   BookOpen,
   HelpCircle,
   Menu,
-  X,
 } from 'lucide-react'
 import { usePathname } from 'next/navigation'
 import { ThemeToggle } from '@/components/theme/ThemeToggle'
-import { motion, AnimatePresence } from 'motion/react'
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet'
 
 export default function AppNavigation() {
   const { user, isAuthenticated, signOut } = useAuth()
   const pathname = usePathname()
   const [menuOpen, setMenuOpen] = useState(false)
-  const navRef = useRef<HTMLDivElement>(null)
 
   const isActive = (path: string) => pathname === path
-
-  useEffect(() => {
-    if (!menuOpen) return
-    const handleMouseDown = (event: MouseEvent) => {
-      if (navRef.current && !navRef.current.contains(event.target as Node)) {
-        setMenuOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleMouseDown)
-    return () => document.removeEventListener('mousedown', handleMouseDown)
-  }, [menuOpen])
 
   const closeMenu = () => setMenuOpen(false)
 
@@ -50,12 +42,12 @@ export default function AppNavigation() {
     `focus-ring flex items-center gap-2 px-3 py-2 rounded-lg transition text-sm font-medium ${
       active
         ? 'bg-muted text-primary'
-        : 'text-muted-foreground hover:text-foreground'
+        : 'text-foreground hover:bg-muted'
     }`
 
   return (
     <nav className="fixed top-0 w-full bg-background/95 backdrop-blur-md z-50 border-b border-border">
-      <div ref={navRef} className="container mx-auto px-4">
+      <div className="container mx-auto px-4">
         <div className="flex items-center justify-between h-16">
           <Link
             href="/"
@@ -141,118 +133,110 @@ export default function AppNavigation() {
             )}
           </div>
 
-          <button
-            type="button"
-            className="focus-ring md:hidden p-2 rounded-lg hover:bg-muted transition-colors"
-            onClick={() => setMenuOpen((open) => !open)}
-            aria-expanded={menuOpen}
-            aria-label="Toggle menu"
-          >
-            {menuOpen ? (
-              <X size={22} className="text-foreground" />
-            ) : (
-              <Menu size={22} className="text-foreground" />
-            )}
-          </button>
-        </div>
-
-        <AnimatePresence>
-          {menuOpen && (
-            <motion.div
-              className="md:hidden overflow-hidden border-t border-border"
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: 'auto' }}
-              exit={{ opacity: 0, height: 0 }}
-              transition={{ duration: 0.25 }}
+          <Sheet open={menuOpen} onOpenChange={setMenuOpen}>
+            <SheetTrigger asChild>
+              <button
+                type="button"
+                className="focus-ring md:hidden p-2 rounded-lg hover:bg-muted transition-colors"
+                aria-expanded={menuOpen}
+                aria-label="Toggle menu"
+              >
+                <Menu size={22} className="text-foreground" />
+              </button>
+            </SheetTrigger>
+            <SheetContent
+              side="right"
+              className="w-full sm:max-w-sm p-0 flex flex-col"
             >
-              <div className="py-4 flex flex-col gap-1">
-                <Link
-                  href="/"
-                  className={mobileLinkClass(isActive('/'))}
-                  onClick={closeMenu}
-                >
-                  <Home className="w-4 h-4 shrink-0" />
-                  <span>Home</span>
-                </Link>
-                <Link
-                  href="/articles"
-                  className={mobileLinkClass(isActive('/articles'))}
-                  onClick={closeMenu}
-                >
-                  <BookOpen className="w-4 h-4 shrink-0" />
-                  <span>Articles</span>
-                </Link>
-                <Link
-                  href="/guide"
-                  className={mobileLinkClass(isActive('/guide'))}
-                  onClick={closeMenu}
-                >
-                  <HelpCircle className="w-4 h-4 shrink-0" />
-                  <span>Guide</span>
-                </Link>
+              <SheetTitle className="sr-only">Navigation menu</SheetTitle>
+          <div className="flex flex-col gap-1 px-4 pt-14 pb-6 overflow-y-auto">
+            <Link
+              href="/"
+              className={mobileLinkClass(isActive('/'))}
+              onClick={closeMenu}
+            >
+              <Home className="w-4 h-4 shrink-0" />
+              <span>Home</span>
+            </Link>
+            <Link
+              href="/articles"
+              className={mobileLinkClass(isActive('/articles'))}
+              onClick={closeMenu}
+            >
+              <BookOpen className="w-4 h-4 shrink-0" />
+              <span>Articles</span>
+            </Link>
+            <Link
+              href="/guide"
+              className={mobileLinkClass(isActive('/guide'))}
+              onClick={closeMenu}
+            >
+              <HelpCircle className="w-4 h-4 shrink-0" />
+              <span>Guide</span>
+            </Link>
 
-                {isAuthenticated ? (
-                  <>
-                    <Link
-                      href="/write"
-                      className={mobileLinkClass(isActive('/write'))}
-                      onClick={closeMenu}
-                    >
-                      <PenSquare className="w-4 h-4 shrink-0" />
-                      <span>Write</span>
-                    </Link>
-                    <Link
-                      href="/drafts"
-                      className={mobileLinkClass(isActive('/drafts'))}
-                      onClick={closeMenu}
-                    >
-                      <FileText className="w-4 h-4 shrink-0" />
-                      <span>Drafts</span>
-                    </Link>
-                    <Link
-                      href={`/${user?.username || 'profile'}`}
-                      className={mobileLinkClass(
-                        pathname === `/${user?.username}`
-                      )}
-                      onClick={closeMenu}
-                    >
-                      <User className="w-4 h-4 shrink-0" />
-                      <span>Profile</span>
-                    </Link>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        closeMenu()
-                        signOut()
-                      }}
-                      className="focus-ring flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium text-muted-foreground hover:text-destructive transition text-left"
-                    >
-                      <LogOut className="w-4 h-4 shrink-0" />
-                      <span>Sign Out</span>
-                    </button>
-                  </>
-                ) : (
-                  <div className="flex flex-col gap-2 pt-2 border-t border-border mt-2">
-                    <Link
-                      href="/login"
-                      className="focus-ring rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground transition"
-                      onClick={closeMenu}
-                    >
-                      Sign In
-                    </Link>
-                    <Link
-                      href="/register"
-                      className="focus-ring mx-3 bg-primary text-primary-foreground px-4 py-2.5 rounded-lg hover:bg-primary/90 transition text-center text-sm font-medium"
-                      onClick={closeMenu}
-                    >
-                      Get Started
-                    </Link>
-                  </div>
-                )}
+            {isAuthenticated ? (
+              <>
+                <Link
+                  href="/write"
+                  className={mobileLinkClass(isActive('/write'))}
+                  onClick={closeMenu}
+                >
+                  <PenSquare className="w-4 h-4 shrink-0" />
+                  <span>Write</span>
+                </Link>
+                <Link
+                  href="/drafts"
+                  className={mobileLinkClass(isActive('/drafts'))}
+                  onClick={closeMenu}
+                >
+                  <FileText className="w-4 h-4 shrink-0" />
+                  <span>Drafts</span>
+                </Link>
+                <Link
+                  href={`/${user?.username || 'profile'}`}
+                  className={mobileLinkClass(
+                    pathname === `/${user?.username}`
+                  )}
+                  onClick={closeMenu}
+                >
+                  <User className="w-4 h-4 shrink-0" />
+                  <span>Profile</span>
+                </Link>
+                <button
+                  type="button"
+                  onClick={() => {
+                    closeMenu()
+                    signOut()
+                  }}
+                  className="focus-ring flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium text-foreground hover:bg-muted hover:text-destructive transition text-left"
+                >
+                  <LogOut className="w-4 h-4 shrink-0" />
+                  <span>Sign Out</span>
+                </button>
+              </>
+            ) : (
+              <div className="flex flex-col gap-2 pt-2 border-t border-border mt-2">
+                <Link
+                  href="/login"
+                  className="focus-ring rounded-lg px-3 py-2 text-sm font-medium text-foreground hover:bg-muted transition"
+                  onClick={closeMenu}
+                >
+                  Sign In
+                </Link>
+                <Link
+                  href="/register"
+                  className="focus-ring bg-primary text-primary-foreground px-4 py-2.5 rounded-lg hover:bg-primary/90 transition text-center text-sm font-medium"
+                  onClick={closeMenu}
+                >
+                  Get Started
+                </Link>
               </div>
-            </motion.div>
-          )}
-        </AnimatePresence>
+            )}
+          </div>
+            </SheetContent>
+          </Sheet>
+        </div>
       </div>
     </nav>
   )

--- a/components/ui/sheet.test.tsx
+++ b/components/ui/sheet.test.tsx
@@ -1,0 +1,45 @@
+/** @vitest-environment jsdom */
+import { useState } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, beforeEach } from 'vitest'
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet'
+
+function TestSheet() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <button type="button">Open menu</button>
+      </SheetTrigger>
+      <SheetContent>
+        <SheetTitle className="sr-only">Menu</SheetTitle>
+        <p>Menu content</p>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+describe('Sheet', () => {
+  beforeEach(() => {
+    document.body.style.pointerEvents = ''
+  })
+
+  it('closes on Escape when controlled', async () => {
+    const user = userEvent.setup()
+    render(<TestSheet />)
+
+    await user.click(screen.getByRole('button', { name: 'Open menu' }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -7,7 +7,25 @@ import { X } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 
-const Sheet = SheetPrimitive.Root
+const SheetCloseContext = React.createContext<(() => void) | null>(null)
+
+const Sheet = ({
+  onOpenChange,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SheetPrimitive.Root>) => {
+  const onOpenChangeRef = React.useRef(onOpenChange)
+  onOpenChangeRef.current = onOpenChange
+
+  const close = React.useCallback(() => {
+    onOpenChangeRef.current?.(false)
+  }, [])
+
+  return (
+    <SheetCloseContext.Provider value={onOpenChange ? close : null}>
+      <SheetPrimitive.Root onOpenChange={onOpenChange} {...props} />
+    </SheetCloseContext.Provider>
+  )
+}
 
 const SheetTrigger = SheetPrimitive.Trigger
 
@@ -57,22 +75,59 @@ interface SheetContentProps
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = 'right', className, children, ...props }, ref) => (
-  <SheetPortal>
-    <SheetOverlay />
-    <SheetPrimitive.Content
-      ref={ref}
-      className={cn(sheetVariants({ side }), className)}
-      {...props}
-    >
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </SheetPrimitive.Close>
-      {children}
-    </SheetPrimitive.Content>
-  </SheetPortal>
-))
+>(({ side = 'right', className, children, onEscapeKeyDown, ...props }, ref) => {
+  const closeSheet = React.useContext(SheetCloseContext)
+  const contentRef = React.useRef<HTMLDivElement>(null)
+
+  const setContentRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      contentRef.current = node
+      if (typeof ref === 'function') {
+        ref(node)
+      } else if (ref) {
+        ref.current = node
+      }
+    },
+    [ref]
+  )
+
+  React.useEffect(() => {
+    if (!closeSheet) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      const content = contentRef.current
+      if (!content || content.getAttribute('data-state') !== 'open') return
+      closeSheet()
+    }
+
+    window.addEventListener('keydown', handleKeyDown, true)
+    return () => window.removeEventListener('keydown', handleKeyDown, true)
+  }, [closeSheet])
+
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        ref={setContentRef}
+        className={cn(sheetVariants({ side }), className)}
+        onEscapeKeyDown={(event) => {
+          onEscapeKeyDown?.(event)
+          if (!event.defaultPrevented && closeSheet) {
+            closeSheet()
+          }
+        }}
+        {...props}
+      >
+        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+        {children}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+})
 SheetContent.displayName = SheetPrimitive.Content.displayName
 
 const SheetHeader = ({


### PR DESCRIPTION
## Summary

Fixes ENG-164: the mobile menu opened as a transparent inline panel over the hero, making links hard to read and easy to confuse with page content.

- Replaced inline mobile dropdowns with a right-side `Sheet` in `AppNavigation` and landing `Navigation`
- Added a dimmed full-viewport overlay so background content no longer competes with nav links
- Updated mobile link styles to `text-foreground` with `hover:bg-muted` for stronger contrast
- Landing header uses a solid background while the menu is open (in addition to on scroll)
- Dismiss via overlay tap, built-in close button, and Escape; Radix handles focus trap and scroll lock
- Added regression tests for `AppNavigation`, landing `Navigation`, and `Sheet`


https://github.com/user-attachments/assets/2f925e36-d135-4040-b6e0-39adfd2c2940

<img width="596" height="677" alt="li" src="https://github.com/user-attachments/assets/fee68c90-b427-46a0-a04a-50eee4272c17" />
<img width="420" height="736" alt="drk" src="https://github.com/user-attachments/assets/61909699-784b-4459-b386-83163b990138" />
