### PR TITLE
fix(landing): restore visible sections and add visual regression (ENG-163)

### DIFF
--- a/components/landing/FAQSection.tsx
+++ b/components/landing/FAQSection.tsx
@@ -2,12 +2,10 @@
 
 import { useState } from 'react'
 import { ChevronDown } from 'lucide-react'
-import { motion, AnimatePresence, useInView } from 'motion/react'
-import { useRef } from 'react'
+import { motion, AnimatePresence } from 'motion/react'
+import { Reveal } from '@/components/landing/Reveal'
 
 export default function FAQSection() {
-  const ref = useRef(null)
-  const isInView = useInView(ref, { once: true, margin: '-100px' })
   const [openIndex, setOpenIndex] = useState<number | null>(0)
 
   const faqs = [
@@ -67,27 +65,20 @@ export default function FAQSection() {
   }
 
   return (
-    <section id="faq" className="py-32 px-8 bg-background">
-      <div className="container mx-auto max-w-6xl" ref={ref}>
-        {/* Section Header */}
-        <motion.h2
-          className="font-display text-4xl lg:text-5xl font-medium tracking-[-0.01em] mb-16 leading-[1.2] text-foreground"
-          initial={{ opacity: 0, y: 30 }}
-          animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 30 }}
-          transition={{ duration: 0.8 }}
-        >
-          Frequently Asked Questions
-        </motion.h2>
+    <section
+      id="faq"
+      className="scroll-mt-20 py-20 md:py-28 px-8 bg-background"
+    >
+      <div className="container mx-auto max-w-6xl">
+        <Reveal>
+          <h2 className="font-display text-4xl lg:text-5xl font-medium tracking-[-0.01em] mb-16 leading-[1.2] text-foreground">
+            Frequently Asked Questions
+          </h2>
+        </Reveal>
 
-        {/* FAQ Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-x-16 gap-y-6">
           {faqs.map((faq, index) => (
-            <motion.div
-              key={index}
-              initial={{ opacity: 0, y: 20 }}
-              animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
-              transition={{ duration: 0.5, delay: index * 0.08 }}
-            >
+            <Reveal key={index} delay={index * 0.05}>
               <button
                 onClick={() => toggleFAQ(index)}
                 className="w-full flex items-start gap-4 text-left py-2"
@@ -115,13 +106,13 @@ export default function FAQSection() {
                     transition={{ duration: 0.3 }}
                     className="overflow-hidden"
                   >
-                    <div className="ml-12 pb-4 text-[14px] text-muted-foreground leading-relaxed">
+                    <motion.div className="ml-12 pb-4 text-[14px] text-muted-foreground leading-relaxed">
                       {faq.answer}
-                    </div>
+                    </motion.div>
                   </motion.div>
                 )}
               </AnimatePresence>
-            </motion.div>
+            </Reveal>
           ))}
         </div>
       </div>

--- a/components/landing/FeaturesSection.tsx
+++ b/components/landing/FeaturesSection.tsx
@@ -9,10 +9,10 @@ import {
   TrendingUp,
   Globe,
   Sparkles,
+  type LucideIcon,
 } from 'lucide-react'
-import { motion, useInView } from 'motion/react'
-import { useRef } from 'react'
-import { LucideIcon } from 'lucide-react'
+import { motion } from 'motion/react'
+import { Reveal } from '@/components/landing/Reveal'
 
 interface Feature {
   icon: LucideIcon
@@ -63,40 +63,60 @@ const features: Feature[] = [
   },
 ]
 
-export default function FeaturesSection() {
-  const ref = useRef(null)
-  const isInView = useInView(ref, { once: true, margin: '-100px' })
+function FeatureRow({ feature }: { feature: Feature }) {
+  return (
+    <motion.div className="flex items-start gap-4">
+      <div className="shrink-0 w-10 h-10 rounded-full bg-card border-2 border-border flex items-center justify-center">
+        <feature.icon className="w-4 h-4 text-muted-foreground" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <h3 className="text-[15px] font-semibold text-foreground">
+          {feature.title}
+        </h3>
+        <p className="text-[13px] text-muted-foreground leading-relaxed mt-0.5">
+          {feature.description}
+        </p>
+      </div>
+    </motion.div>
+  )
+}
 
+export default function FeaturesSection() {
   return (
     <section
       id="features"
-      className="py-32 px-6 bg-gradient-to-b from-background via-muted/30 to-background relative overflow-hidden"
+      className="scroll-mt-20 py-20 md:py-28 px-6 bg-gradient-to-b from-background via-muted/30 to-background relative overflow-hidden"
     >
-      <div className="container mx-auto max-w-3xl relative z-10" ref={ref}>
-        {/* Header */}
-        <motion.div
-          className="text-center mb-12"
-          initial={{ opacity: 0, y: 30 }}
-          animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 30 }}
-          transition={{ duration: 0.8 }}
-        >
+      <div className="container mx-auto max-w-3xl relative z-10">
+        <Reveal className="text-center mb-12">
           <h2 className="font-display text-4xl lg:text-5xl font-medium tracking-[-0.01em] mb-3 leading-[1.15]">
             <span className="text-foreground">Core Features</span>
           </h2>
           <p className="text-[15px] text-muted-foreground leading-relaxed">
             Everything writers and readers need.
           </p>
-        </motion.div>
+        </Reveal>
 
-        {/* Vertical timeline */}
-        <div className="relative">
-          {/* Center line */}
-          <div className="absolute left-1/2 top-0 bottom-0 w-px bg-border -translate-x-1/2" />
+        <div className="md:hidden space-y-6">
+          {features.map((feature, index) => (
+            <Reveal key={feature.title} delay={0.05 + index * 0.05}>
+              <FeatureRow feature={feature} />
+            </Reveal>
+          ))}
+        </div>
+
+        <div className="hidden md:block relative">
+          <div
+            className="absolute left-1/2 top-0 bottom-0 w-px bg-border -translate-x-1/2"
+            aria-hidden
+          />
           <motion.div
             className="absolute left-1/2 top-0 bottom-0 w-px bg-brand -translate-x-1/2 origin-top"
             initial={{ scaleY: 0 }}
-            animate={isInView ? { scaleY: 1 } : { scaleY: 0 }}
+            whileInView={{ scaleY: 1 }}
+            viewport={{ once: true, amount: 0.15, margin: '0px 0px -10% 0px' }}
             transition={{ duration: 1.5, delay: 0.3, ease: 'easeOut' }}
+            aria-hidden
           />
 
           <div className="space-y-8">
@@ -104,21 +124,15 @@ export default function FeaturesSection() {
               const isLeft = index % 2 === 0
 
               return (
-                <motion.div
+                <Reveal
                   key={feature.title}
                   className="group relative flex items-center cursor-default"
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={
-                    isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }
-                  }
-                  transition={{ duration: 0.5, delay: 0.2 + index * 0.1 }}
+                  delay={0.1 + index * 0.08}
                 >
-                  {/* Center dot */}
                   <div className="absolute left-1/2 -translate-x-1/2 z-10 w-10 h-10 rounded-full bg-card border-2 border-border group-hover:border-foreground group-hover:scale-110 flex items-center justify-center transition-all duration-300">
                     <feature.icon className="w-4 h-4 text-muted-foreground group-hover:text-foreground transition-colors duration-300" />
                   </div>
 
-                  {/* Content — alternating sides */}
                   {isLeft ? (
                     <>
                       <div className="w-[calc(50%-36px)] text-right pr-2 group-hover:translate-x-[-4px] transition-transform duration-300">
@@ -129,11 +143,11 @@ export default function FeaturesSection() {
                           {feature.description}
                         </p>
                       </div>
-                      <div className="w-[calc(50%+36px)]" />
+                      <div className="w-[calc(50%+36px)]" aria-hidden />
                     </>
                   ) : (
                     <>
-                      <div className="w-[calc(50%+36px)]" />
+                      <div className="w-[calc(50%+36px)]" aria-hidden />
                       <div className="w-[calc(50%-36px)] pl-2 group-hover:translate-x-[4px] transition-transform duration-300">
                         <h3 className="text-[15px] font-semibold text-foreground">
                           {feature.title}
@@ -144,7 +158,7 @@ export default function FeaturesSection() {
                       </div>
                     </>
                   )}
-                </motion.div>
+                </Reveal>
               )
             })}
           </div>

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Heart, PenTool } from 'lucide-react'
-import { motion } from 'motion/react'
+import { Reveal } from '@/components/landing/Reveal'
 
 export default function Footer() {
   const currentYear = new Date().getFullYear()
@@ -15,13 +15,7 @@ export default function Footer() {
         {/* Main Footer Content */}
         <div className="py-16">
           {/* Brand Section */}
-          <motion.div
-            className="text-center"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.6 }}
-          >
+          <Reveal className="text-center">
             <div className="flex items-center gap-3 mb-4 justify-center">
               <div className="w-9 h-9 bg-card rounded-lg border border-border flex items-center justify-center shadow-sm">
                 <PenTool className="w-5 h-5 text-foreground" />
@@ -34,23 +28,16 @@ export default function Footer() {
               Empowering writers with blockchain-powered micro-tipping and
               content monetization.
             </p>
-          </motion.div>
+          </Reveal>
         </div>
 
-        {/* Bottom Bar */}
-        <motion.div
-          className="py-8 border-t border-spotlight-border"
-          initial={{ opacity: 0 }}
-          whileInView={{ opacity: 1 }}
-          viewport={{ once: true }}
-          transition={{ duration: 0.6 }}
-        >
+        <Reveal className="py-8 border-t border-spotlight-border">
           <div className="flex items-center justify-center gap-2 text-spotlight-muted text-[13px]">
             <span>© {currentYear} Quilltip. Built with</span>
             <Heart className="w-4 h-4 text-destructive fill-current animate-pulse" />
             <span>for writers everywhere</span>
           </div>
-        </motion.div>
+        </Reveal>
       </div>
     </footer>
   )

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -164,8 +164,7 @@ export default function HeroSection() {
           {/* Label chip */}
           <motion.div
             initial={{ opacity: 0, y: 12 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
+            animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.4, ease: 'easeOut' }}
           >
             <span className="inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full bg-muted/60 border border-border/60 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">
@@ -178,8 +177,7 @@ export default function HeroSection() {
           <motion.h1
             className="mt-6 font-display text-4xl sm:text-[2.75rem] lg:text-5xl font-medium tracking-[-0.01em] text-foreground leading-[1.2]"
             initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, amount: 0.5 }}
+            animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.05, ease: 'easeOut' }}
           >
             Reward the words that move you
@@ -189,8 +187,7 @@ export default function HeroSection() {
           <motion.p
             className="mt-4 text-[15px] sm:text-base text-muted-foreground max-w-md leading-relaxed"
             initial={{ opacity: 0, y: 14 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, amount: 0.5 }}
+            animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.1, ease: 'easeOut' }}
           >
             Highlight what resonates. Tip writers instantly. Powered by Stellar.
@@ -200,8 +197,7 @@ export default function HeroSection() {
           <motion.div
             className="mt-8 flex flex-col sm:flex-row items-center gap-2.5"
             initial={{ opacity: 0, y: 14 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, amount: 0.5 }}
+            animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.15, ease: 'easeOut' }}
           >
             <Link
@@ -224,9 +220,8 @@ export default function HeroSection() {
           <motion.div
             className="mt-14 w-full max-w-2xl"
             initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, amount: 0.3 }}
-            transition={{ duration: 0.6, delay: 0.1, ease: 'easeOut' }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.2, ease: 'easeOut' }}
           >
             <div className="relative bg-card rounded-xl border border-border shadow-[var(--card-shadow)] overflow-hidden">
               {/* Browser chrome */}
@@ -259,9 +254,8 @@ export default function HeroSection() {
           <motion.div
             className="mt-12 flex items-center justify-center gap-8 sm:gap-12"
             initial={{ opacity: 0, y: 12 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, amount: 0.5 }}
-            transition={{ duration: 0.5, delay: 0.1 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.3 }}
           >
             <div className="text-center">
               <p className="text-lg sm:text-xl font-semibold text-foreground tabular-nums">

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -13,10 +13,10 @@ import {
   Highlighter,
   Wallet,
   Heart,
+  type LucideIcon,
 } from 'lucide-react'
-import { motion, AnimatePresence, useInView } from 'motion/react'
-import { useRef } from 'react'
-import { LucideIcon } from 'lucide-react'
+import { motion, AnimatePresence } from 'motion/react'
+import { Reveal } from '@/components/landing/Reveal'
 
 interface Step {
   icon: LucideIcon
@@ -26,8 +26,6 @@ interface Step {
 }
 
 export default function HowItWorksSection() {
-  const ref = useRef(null)
-  const isInView = useInView(ref, { once: true, margin: '-100px' })
   const [activeTab, setActiveTab] = useState<'writers' | 'readers'>('writers')
   const [activeStep, setActiveStep] = useState(0)
 
@@ -105,29 +103,19 @@ export default function HowItWorksSection() {
   return (
     <section
       id="how-it-works"
-      className="py-32 px-6 bg-spotlight text-spotlight-foreground relative overflow-hidden"
+      className="scroll-mt-20 py-20 md:py-28 px-6 bg-spotlight text-spotlight-foreground relative overflow-hidden"
     >
-      {/* Subtle background grain */}
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,_color-mix(in_oklab,var(--spotlight-foreground)_6%,transparent)_0%,_transparent_60%)]" />
 
-      <div className="container mx-auto max-w-7xl relative z-10" ref={ref}>
-        {/* Section Header */}
-        <motion.div
-          className="mb-16"
-          initial={{ opacity: 0, y: 30 }}
-          animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 30 }}
-          transition={{ duration: 0.8 }}
-        >
-          <div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-8">
+      <div className="container mx-auto max-w-7xl relative z-10">
+        <Reveal className="mb-16">
+          <motion.div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-8">
             <div>
               <motion.div
                 className="inline-flex items-center gap-2 px-4 py-2 bg-foreground/5 backdrop-blur-sm rounded-full border border-foreground/10 mb-6"
                 initial={{ opacity: 0, scale: 0.9 }}
-                animate={
-                  isInView
-                    ? { opacity: 1, scale: 1 }
-                    : { opacity: 0, scale: 0.9 }
-                }
+                whileInView={{ opacity: 1, scale: 1 }}
+                viewport={{ once: true, amount: 0.15 }}
                 transition={{ duration: 0.5 }}
               >
                 <Sparkles className="w-3.5 h-3.5 text-spotlight-muted" />
@@ -150,8 +138,7 @@ export default function HowItWorksSection() {
               </p>
             </div>
 
-            {/* Writer / Reader Toggle */}
-            <div className="inline-flex items-center bg-foreground/5 rounded-lg p-1 border border-foreground/10 shrink-0">
+            <motion.div className="inline-flex items-center bg-foreground/5 rounded-lg p-1 border border-foreground/10 shrink-0">
               <button
                 onClick={() => handleTabChange('writers')}
                 className={`px-5 py-2 rounded-md text-[13px] font-medium transition-all duration-200 ${
@@ -172,17 +159,11 @@ export default function HowItWorksSection() {
               >
                 For Readers
               </button>
-            </div>
-          </div>
-        </motion.div>
+            </motion.div>
+          </motion.div>
+        </Reveal>
 
-        {/* Expandable Steps — Desktop */}
-        <motion.div
-          className="hidden md:flex gap-2 h-[340px]"
-          initial={{ opacity: 0, y: 20 }}
-          animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
-          transition={{ duration: 0.6, delay: 0.3 }}
-        >
+        <Reveal className="hidden md:flex gap-2 h-[340px]" delay={0.2}>
           {steps.map((step, index) => {
             const isActive = activeStep === index
             return (
@@ -197,7 +178,6 @@ export default function HowItWorksSection() {
                 transition={{ duration: 0.5, ease: [0.4, 0, 0.2, 1] }}
                 onMouseEnter={() => setActiveStep(index)}
               >
-                {/* Collapsed state */}
                 <AnimatePresence mode="wait">
                   {!isActive ? (
                     <motion.div
@@ -225,17 +205,15 @@ export default function HowItWorksSection() {
                       transition={{ duration: 0.3, delay: 0.15 }}
                     >
                       <div>
-                        {/* Icon + Title */}
                         <div className="flex items-center gap-4 mb-6">
-                          <div className="w-14 h-14 rounded-2xl bg-foreground/10 border border-foreground/10 flex items-center justify-center">
+                          <motion.div className="w-14 h-14 rounded-2xl bg-foreground/10 border border-foreground/10 flex items-center justify-center">
                             <step.icon className="w-6 h-6 text-spotlight-foreground" />
-                          </div>
+                          </motion.div>
                           <h3 className="text-3xl font-display font-medium text-spotlight-foreground tracking-tight">
                             {step.title}
                           </h3>
                         </div>
 
-                        {/* Description */}
                         <p className="text-[15px] text-spotlight-foreground/85 leading-relaxed mb-3 max-w-md">
                           {step.description}
                         </p>
@@ -244,7 +222,6 @@ export default function HowItWorksSection() {
                         </p>
                       </div>
 
-                      {/* Step indicator dots */}
                       <div className="flex items-center gap-2">
                         {steps.map((_, i) => (
                           <div
@@ -263,15 +240,9 @@ export default function HowItWorksSection() {
               </motion.div>
             )
           })}
-        </motion.div>
+        </Reveal>
 
-        {/* Steps — Mobile (vertical accordion) */}
-        <motion.div
-          className="md:hidden space-y-2"
-          initial={{ opacity: 0, y: 20 }}
-          animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
-          transition={{ duration: 0.6, delay: 0.3 }}
-        >
+        <Reveal className="md:hidden space-y-2" delay={0.2}>
           {steps.map((step, index) => {
             const isActive = activeStep === index
             return (
@@ -284,7 +255,6 @@ export default function HowItWorksSection() {
                 }`}
                 onClick={() => setActiveStep(index)}
               >
-                {/* Header row */}
                 <div className="flex items-center gap-4 p-5">
                   <div
                     className={`w-11 h-11 rounded-xl flex items-center justify-center transition-colors duration-300 ${
@@ -304,7 +274,6 @@ export default function HowItWorksSection() {
                   </span>
                 </div>
 
-                {/* Expandable content */}
                 <AnimatePresence>
                   {isActive && (
                     <motion.div
@@ -327,15 +296,9 @@ export default function HowItWorksSection() {
               </motion.div>
             )
           })}
-        </motion.div>
+        </Reveal>
 
-        {/* CTA */}
-        <motion.div
-          className="mt-16 text-center"
-          initial={{ opacity: 0, y: 20 }}
-          animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
-          transition={{ duration: 0.8, delay: 0.8 }}
-        >
+        <Reveal className="mt-16 text-center" delay={0.4}>
           <Link
             href="/register"
             className="group inline-flex items-center justify-center gap-2 bg-card text-card-foreground px-6 py-2.5 rounded-lg text-[13px] font-medium hover:bg-muted transition-all duration-200"
@@ -343,7 +306,7 @@ export default function HowItWorksSection() {
             Start Writing & Earning Today
             <ArrowRight className="w-3.5 h-3.5 group-hover:translate-x-0.5 transition-transform duration-200" />
           </Link>
-        </motion.div>
+        </Reveal>
       </div>
     </section>
   )

--- a/components/landing/Reveal.tsx
+++ b/components/landing/Reveal.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { motion, type HTMLMotionProps } from 'motion/react'
+
+type RevealProps = HTMLMotionProps<'div'> & {
+  delay?: number
+}
+
+export function Reveal({
+  children,
+  className,
+  delay = 0,
+  transition,
+  ...props
+}: RevealProps) {
+  return (
+    <motion.div
+      className={className}
+      initial={{ opacity: 0, y: 24 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.15, margin: '0px 0px -10% 0px' }}
+      transition={{
+        duration: 0.6,
+        delay,
+        ease: 'easeOut',
+        ...transition,
+      }}
+      {...props}
+    >
+      {children}
+    </motion.div>
+  )
+}


### PR DESCRIPTION
## What

Fixes the marketing landing page so Features, How It Works, and FAQ render visible content on mobile and desktop instead of large blank gaps or empty dark blocks. Also tightens section spacing, improves mobile Features layout, fixes anchor scroll offsets, and adds Playwright visual regression for the home page.

## Why

Sections below the hero used `useInView` with `margin: '-100px'` and an explicit `opacity: 0` fallback when the observer did not fire. Content stayed in the DOM but invisible, which looked like empty space on light sections and large dark panels on `bg-spotlight`. Hero children also used `whileInView` above the fold, which could leave headline/CTA content hidden on first paint.

## How

- Add shared `Reveal` component using `whileInView` without a hidden fallback branch
- Refactor `FeaturesSection`, `HowItWorksSection`, and `FAQSection` to use `Reveal` instead of `useInView` gating
- Switch hero above-the-fold animations to mount `animate` with staggered delays
- Use a single-column Features list on mobile; keep center timeline on `md+`
- Reduce section padding from `py-32` to `py-20 md:py-28`
- Add `scroll-mt-20` to `#features`, `#how-it-works`, and `#faq` for fixed nav offset
- Add Playwright e2e screenshots for home desktop (1280x720) and mobile (390x844)
- Add `test:e2e` / `test:e2e:update` scripts and a CI visual regression job

<img width="1280" height="3932" alt="home-full-desktop" src="https://github.com/user-attachments/assets/29afa57b-028b-4cb2-a284-1bde2803124f" />

<img width="390" height="4842" alt="home-full-mobile" src="https://github.com/user-attachments/assets/19f8a9f9-4bd4-4d39-8ce0-4303d14948c7" />


