### PR TITLE
fix: separate testnet practice from real-money copy (ENG-169)

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -247,7 +247,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
                 </h2>
                 <p className="text-muted-foreground">
                   {isOwnProfile
-                    ? 'Manage your Stellar wallet for sending and receiving tips on the network.'
+                    ? 'Manage your Stellar testnet wallet for sending and receiving practice tips.'
                     : 'View wallet address for sending tips to this user.'}
                 </p>
               </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,7 +23,7 @@ const fraunces = Fraunces({
 export const metadata: Metadata = {
   title: 'Quilltip - Decentralized Publishing Platform',
   description:
-    'Write, share, and monetize your content with Stellar-powered microtipping',
+    'Write, share, and practice micro-tipping on Stellar testnet with free test XLM',
 }
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -101,8 +101,8 @@ export default function HomePage() {
                     </h3>
                   </div>
                   <p className="text-muted-foreground">
-                    Connect a Stellar testnet wallet to send and receive practice
-                    tips
+                    Connect a Stellar testnet wallet to send and receive
+                    practice tips
                   </p>
                 </Link>
               )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -84,7 +84,7 @@ export default function HomePage() {
                     </h3>
                   </div>
                   <p className="text-muted-foreground">
-                    Track tips received and article performance
+                    Track testnet tip activity and article performance
                   </p>
                 </Link>
               ) : (
@@ -97,11 +97,12 @@ export default function HomePage() {
                       <Wallet className="w-6 h-6 text-amber-600 dark:text-amber-400" />
                     </div>
                     <h3 className="text-lg font-semibold ml-3">
-                      Set Up Wallet
+                      Set Up Testnet Wallet
                     </h3>
                   </div>
                   <p className="text-muted-foreground">
-                    Connect a Stellar wallet to send and receive tips
+                    Connect a Stellar testnet wallet to send and receive practice
+                    tips
                   </p>
                 </Link>
               )}

--- a/components/dashboard/EarningsDashboard.tsx
+++ b/components/dashboard/EarningsDashboard.tsx
@@ -39,7 +39,7 @@ export function EarningsDashboard() {
         stellarAddress: args.stellarAddress,
       })
       toast.success(
-        `Withdrawal initiated! $${args.amountUsd.toFixed(2)} will be sent to your Stellar wallet shortly.`
+        `Withdrawal initiated! $${args.amountUsd.toFixed(2)} in testnet XLM will be sent to your Stellar wallet, typically within seconds on testnet.`
       )
     } catch (error) {
       console.error('Withdrawal error:', error)
@@ -60,10 +60,10 @@ export function EarningsDashboard() {
         <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-12 text-center">
           <Coins className="w-16 h-16 text-muted-foreground mx-auto mb-4" />
           <h3 className="text-lg font-semibold text-foreground mb-2">
-            No earnings yet
+            No testnet tips yet
           </h3>
           <p className="text-muted-foreground">
-            Start earning by sharing great content that readers love!
+            Share great content and receive practice tips on Stellar testnet.
           </p>
         </div>
       </div>

--- a/components/dashboard/EarningsStats.tsx
+++ b/components/dashboard/EarningsStats.tsx
@@ -9,6 +9,8 @@ import {
   WalletSetupNotice,
   navigateToWalletTab,
 } from '@/components/dashboard/wallet-setup-notice'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
 
 export type EarningsStatsProps = {
   earnings: Doc<'authorEarnings'>
@@ -32,6 +34,12 @@ export function EarningsStats({
 
   return (
     <>
+      <Alert className="border-border bg-muted/60">
+        <AlertDescription className="text-sm text-muted-foreground">
+          {TESTNET_PRACTICE_NOTE}
+        </AlertDescription>
+      </Alert>
+
       {userProfile && !userProfile.stellarAddress && <WalletSetupNotice />}
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -44,7 +52,7 @@ export function EarningsStats({
             ${earnings.totalEarnedUsd.toFixed(2)}
           </p>
           <p className="text-sm text-muted-foreground mt-1">
-            {earnings.tipCount} tips received
+            {earnings.tipCount} testnet tips received
           </p>
         </div>
 
@@ -74,8 +82,8 @@ export function EarningsStats({
           </button>
           {showMinimumWithdrawalHelper && (
             <p className="mt-2 text-sm text-muted-foreground">
-              Withdrawals require a minimum available balance of $
-              {minWithdrawalUsd.toFixed(2)}. Add earnings until your balance
+              Testnet withdrawals require a minimum available balance of $
+              {minWithdrawalUsd.toFixed(2)}. Add testnet tips until your balance
               reaches this amount.
             </p>
           )}

--- a/components/dashboard/WithdrawEarningsDialog.tsx
+++ b/components/dashboard/WithdrawEarningsDialog.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/dialog'
 import { api } from '@/convex/_generated/api'
 import { MIN_WITHDRAWAL_USD } from '@/lib/constants'
+import { TESTNET_WITHDRAWAL_NOTE } from '@/lib/copy/network-status'
 
 interface WithdrawEarningsDialogProps {
   open: boolean
@@ -79,7 +80,7 @@ export function WithdrawEarningsDialog({
       })
 
       toast.success(
-        `Withdrawal initiated! $${amount.toFixed(2)} will be sent to your Stellar wallet shortly.`
+        `Withdrawal initiated! $${amount.toFixed(2)} in testnet XLM will be sent to your Stellar wallet, typically within seconds on testnet.`
       )
       onOpenChange(false)
     } catch (error) {
@@ -111,8 +112,10 @@ export function WithdrawEarningsDialog({
         }}
       >
         <DialogHeader>
-          <DialogTitle>Withdraw Earnings</DialogTitle>
-          <DialogDescription>Withdraw to your Stellar wallet</DialogDescription>
+          <DialogTitle>Withdraw Testnet Earnings</DialogTitle>
+          <DialogDescription>
+            Send testnet XLM to your Stellar wallet
+          </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
@@ -172,8 +175,8 @@ export function WithdrawEarningsDialog({
 
           <div className="bg-info border border-info/50 rounded-lg p-3">
             <p className="text-sm text-info-foreground">
-              Withdrawals are processed instantly on the Stellar network.
-              Transaction fees are covered by Quilltip.
+              {TESTNET_WITHDRAWAL_NOTE} Transaction fees are covered by
+              Quilltip.
             </p>
           </div>
         </div>

--- a/components/dashboard/WithdrawalDialog.tsx
+++ b/components/dashboard/WithdrawalDialog.tsx
@@ -12,6 +12,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { isValidStellarAccountId } from '@/lib/stellar/is-valid-stellar-account-id'
+import { TESTNET_WITHDRAWAL_NOTE } from '@/lib/copy/network-status'
 
 export type WithdrawalDialogProps = {
   open: boolean
@@ -109,8 +110,10 @@ export function WithdrawalDialog({
         }}
       >
         <DialogHeader>
-          <DialogTitle>Withdraw Earnings</DialogTitle>
-          <DialogDescription>Withdraw to your Stellar wallet</DialogDescription>
+          <DialogTitle>Withdraw Testnet Earnings</DialogTitle>
+          <DialogDescription>
+            Send testnet XLM to your Stellar wallet
+          </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
@@ -181,8 +184,8 @@ export function WithdrawalDialog({
 
           <div className="bg-info border border-info/50 rounded-lg p-3">
             <p className="text-sm text-info-foreground">
-              Withdrawals are processed instantly on the Stellar network.
-              Transaction fees are covered by Quilltip.
+              {TESTNET_WITHDRAWAL_NOTE} Transaction fees are covered by
+              Quilltip.
             </p>
           </div>
         </div>

--- a/components/guide/WalletGuide.tsx
+++ b/components/guide/WalletGuide.tsx
@@ -15,6 +15,8 @@ import {
   ExternalLink,
 } from 'lucide-react'
 import Link from 'next/link'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
 
 export function WalletGuide() {
   return (
@@ -25,9 +27,16 @@ export function WalletGuide() {
         </h1>
         <p className="text-muted-foreground max-w-xl mx-auto">
           Everything you need to know to start reading, highlighting, and
-          tipping writers — even if you&apos;ve never used crypto before.
+          practicing tips on Stellar testnet — even if you&apos;ve never used
+          crypto before.
         </p>
       </div>
+
+      <Alert className="mb-8 border-border bg-muted/60">
+        <AlertDescription className="text-sm text-muted-foreground">
+          {TESTNET_PRACTICE_NOTE}
+        </AlertDescription>
+      </Alert>
 
       <Tabs defaultValue="what-is-wallet" className="w-full">
         <TabsList className="grid w-full grid-cols-4 mb-8">
@@ -62,13 +71,13 @@ export function WalletGuide() {
             step={1}
             icon={Wallet}
             title="A wallet is like a digital account"
-            description="Think of it as a simple app that holds your digital currency (XLM). It's similar to a payment app like Venmo or PayPal, but it runs on the Stellar blockchain — meaning payments are instant and fees are nearly zero."
+            description="Think of it as a simple app that holds your digital currency (XLM). It's similar to a payment app like Venmo or PayPal, but it runs on the Stellar blockchain — on testnet, tips settle in seconds with near-zero fees."
           />
           <WalletStepCard
             step={2}
             icon={Key}
-            title="You control your money"
-            description="Unlike traditional banks, your wallet is fully yours. Nobody — not even Quilltip — can access your funds without your permission. When you tip a writer, you approve each transaction yourself."
+            title="You control your wallet"
+            description="Unlike traditional banks, your wallet is fully yours. Nobody — not even Quilltip — can access your testnet funds without your permission. When you tip a writer, you approve each transaction yourself."
           />
           <WalletStepCard
             step={3}
@@ -180,8 +189,9 @@ export function WalletGuide() {
               Tipping on Quilltip is simple
             </h2>
             <p className="text-sm text-muted-foreground leading-relaxed">
-              You can tip an entire article or a specific highlight. 97.5% goes
-              directly to the writer — instantly.
+              You can tip an entire article or a specific highlight with testnet
+              XLM. 97.5% goes directly to the writer — typically within seconds
+              on testnet.
             </p>
           </div>
 

--- a/components/guide/WalletTooltip.tsx
+++ b/components/guide/WalletTooltip.tsx
@@ -10,14 +10,14 @@ import {
 
 const concepts: Record<string, string> = {
   stellar:
-    'Stellar is a fast, low-cost blockchain network. Quilltip uses it to process tips in 3-5 seconds with fees under $0.01.',
-  xlm: 'XLM (Stellar Lumens) is the currency used on the Stellar network. Tips on Quilltip are sent in XLM.',
+    'Stellar is a fast, low-cost blockchain network. Quilltip uses Stellar testnet to process practice tips in 3-5 seconds with fees under $0.01.',
+  xlm: 'XLM (Stellar Lumens) is the currency used on the Stellar network. Tips on Quilltip are sent in testnet XLM for practice.',
   testnet:
     'Testnet is a practice environment with free tokens. No real money is involved — perfect for trying things out.',
   wallet:
     'A crypto wallet is a browser extension (like Freighter) that lets you hold and send digital currency securely.',
   'tip-fee':
-    'Quilltip takes only 2.5% — the writer receives 97.5% of every tip instantly.',
+    'Quilltip takes only 2.5% — the writer receives 97.5% of every testnet tip, typically within seconds.',
   highlight:
     'Highlight a passage you love, then tip it directly. The author sees exactly which words earned the tip.',
 }

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -455,8 +455,8 @@ export function HighlightTipButton({
           )}
 
           <p className="text-xs text-muted-foreground text-center mt-2 flex items-center justify-center gap-1 flex-wrap">
-            Powered by Stellar testnet <WalletTooltip concept="testnet" /> • Fast
-            testnet settlement • Low fees
+            Powered by Stellar testnet <WalletTooltip concept="testnet" /> •
+            Fast testnet settlement • Low fees
           </p>
         </DialogContent>
       </Dialog>

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -39,6 +39,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { InstallWalletDialog } from '@/components/stellar/InstallWalletDialog'
+import { WalletTooltip } from '@/components/guide/WalletTooltip'
 import {
   NO_WALLET_AVAILABLE_ERROR_CODE,
   ALBEDO_INSECURE_LOCALHOST_ERROR_CODE,
@@ -453,8 +454,9 @@ export function HighlightTipButton({
             </div>
           )}
 
-          <p className="text-xs text-muted-foreground text-center mt-2">
-            Powered by Stellar • Instant settlement • Low fees
+          <p className="text-xs text-muted-foreground text-center mt-2 flex items-center justify-center gap-1 flex-wrap">
+            Powered by Stellar testnet <WalletTooltip concept="testnet" /> • Fast
+            testnet settlement • Low fees
           </p>
         </DialogContent>
       </Dialog>

--- a/components/landing/FAQSection.tsx
+++ b/components/landing/FAQSection.tsx
@@ -4,6 +4,11 @@ import { useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 import { motion, AnimatePresence } from 'motion/react'
 import { Reveal } from '@/components/landing/Reveal'
+import { MIN_WITHDRAWAL_USD } from '@/lib/constants'
+import {
+  MAINNET_COMING_NOTE,
+  TESTNET_PRACTICE_NOTE,
+} from '@/lib/copy/network-status'
 
 export default function FAQSection() {
   const [openIndex, setOpenIndex] = useState<number | null>(0)
@@ -11,8 +16,7 @@ export default function FAQSection() {
   const faqs = [
     {
       question: 'What is Quilltip and what problem does it solve?',
-      answer:
-        'Quilltip lets writers earn money directly from readers without ads, subscriptions, or gatekeepers taking large cuts. Anyone can publish articles for free, readers tip writers instantly with cryptocurrency, and writers keep 97.5% of every tip. All payments happen through Stellar blockchain smart contracts in 3-5 seconds with no intermediaries. Writers own their content permanently through NFTs (digital certificates of ownership), and readers never pay to access articles - tipping is always voluntary.',
+      answer: `${TESTNET_PRACTICE_NOTE} Quilltip lets writers receive testnet tips directly from readers without ads, subscriptions, or gatekeepers taking large cuts. Anyone can publish articles for free, readers tip writers with test XLM, and writers keep 97.5% of every tip. Tips settle on Stellar testnet in 3-5 seconds through Soroban smart contracts with no intermediaries. Writers own their content permanently through NFTs (digital certificates of ownership), and readers never pay to access articles — tipping is always voluntary.`,
     },
     {
       question: 'Do I need cryptocurrency to read articles?',
@@ -21,8 +25,7 @@ export default function FAQSection() {
     },
     {
       question: 'How does the tipping mechanism work?',
-      answer:
-        "Readers connect a Stellar wallet (Freighter, xBull, Albedo, or hot wallet), browse articles, and click \"Tip\" to send XLM directly to the writer's wallet. The transaction completes in 3-5 seconds through Soroban smart contracts. Writers receive funds instantly in their wallet - no withdrawal process or waiting period. Minimum tip is 0.026 XLM (approximately $0.01 USD) to ensure transaction fees don't exceed the tip value. There's no maximum limit.",
+      answer: `Readers connect a Stellar testnet wallet (Freighter, xBull, Albedo, or hot wallet), browse articles, and click "Tip" to send test XLM directly to the writer's wallet. The transaction completes in 3-5 seconds through Soroban smart contracts on testnet. Tips appear in the writer's dashboard balance. Writers can withdraw testnet earnings to their Stellar wallet from the Earnings tab once their available balance reaches $${MIN_WITHDRAWAL_USD.toFixed(0)}. Minimum tip is 0.026 XLM (approximately $0.01 USD) to ensure transaction fees don't exceed the tip value. There's no maximum limit.`,
     },
     {
       question: "What's Quilltip's business model and revenue split?",
@@ -32,8 +35,7 @@ export default function FAQSection() {
     {
       question:
         'Is Quilltip live on mainnet or testnet? When can I use it with real money?',
-      answer:
-        "We're live on testnet for now and working towards our mainnet launch soon. You can test all features with free testnet XLM — no real money needed.",
+      answer: `We're live on Stellar testnet. You can try all features with free testnet XLM — no real money needed. ${MAINNET_COMING_NOTE}`,
     },
     {
       question: 'What does it cost to use Quilltip as a writer or reader?',

--- a/components/landing/FeaturesSection.tsx
+++ b/components/landing/FeaturesSection.tsx
@@ -13,6 +13,8 @@ import {
 } from 'lucide-react'
 import { motion } from 'motion/react'
 import { Reveal } from '@/components/landing/Reveal'
+import { MIN_WITHDRAWAL_USD } from '@/lib/constants'
+import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
 
 interface Feature {
   icon: LucideIcon
@@ -28,8 +30,9 @@ const features: Feature[] = [
   },
   {
     icon: DollarSign,
-    title: 'Instant Tips',
-    description: 'Payments in 3 seconds via Stellar with near-zero fees.',
+    title: 'Fast Testnet Tips',
+    description:
+      'Tips settle in about 3 seconds on Stellar testnet with near-zero fees.',
   },
   {
     icon: MessageSquare,
@@ -43,13 +46,13 @@ const features: Feature[] = [
   },
   {
     icon: TrendingUp,
-    title: 'Real-Time Analytics',
-    description: 'Track earnings and audience growth as it happens.',
+    title: 'Testnet Analytics',
+    description: 'Track testnet tip activity and audience growth as it happens.',
   },
   {
     icon: Zap,
-    title: 'Instant Withdrawals',
-    description: 'Withdraw your earnings instantly. No thresholds.',
+    title: 'Withdraw Testnet Earnings',
+    description: `Move testnet earnings to your wallet once your balance reaches $${MIN_WITHDRAWAL_USD.toFixed(0)}.`,
   },
   {
     icon: Globe,
@@ -93,7 +96,10 @@ export default function FeaturesSection() {
             <span className="text-foreground">Core Features</span>
           </h2>
           <p className="text-[15px] text-muted-foreground leading-relaxed">
-            Everything writers and readers need.
+            Everything writers and readers need on testnet.
+          </p>
+          <p className="text-[13px] text-muted-foreground leading-relaxed mt-2 max-w-lg mx-auto">
+            {TESTNET_PRACTICE_NOTE}
           </p>
         </Reveal>
 

--- a/components/landing/FeaturesSection.tsx
+++ b/components/landing/FeaturesSection.tsx
@@ -47,7 +47,8 @@ const features: Feature[] = [
   {
     icon: TrendingUp,
     title: 'Testnet Analytics',
-    description: 'Track testnet tip activity and audience growth as it happens.',
+    description:
+      'Track testnet tip activity and audience growth as it happens.',
   },
   {
     icon: Zap,

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -25,8 +25,8 @@ export default function Footer() {
               </h3>
             </div>
             <p className="text-spotlight-muted text-[15px] leading-relaxed max-w-2xl mx-auto">
-              Empowering writers with blockchain-powered micro-tipping and
-              content monetization.
+              Empowering writers with blockchain-powered micro-tipping on
+              Stellar testnet. Practice with free test XLM today.
             </p>
           </Reveal>
         </div>

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { ArrowRight, Zap } from 'lucide-react'
+import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
 import { motion, AnimatePresence } from 'motion/react'
 import { useEffect, useState, useCallback, useRef } from 'react'
 
@@ -190,7 +191,8 @@ export default function HeroSection() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.1, ease: 'easeOut' }}
           >
-            Highlight what resonates. Tip writers instantly. Powered by Stellar.
+            Highlight what resonates. Practice tipping writers on Stellar
+            testnet with free test XLM.
           </motion.p>
 
           {/* CTAs */}
@@ -212,6 +214,13 @@ export default function HeroSection() {
               className="inline-flex items-center gap-2 text-muted-foreground px-6 py-2.5 rounded-lg text-[13px] font-medium hover:text-foreground hover:bg-muted/60 transition-all duration-200"
             >
               Start Writing
+              <ArrowRight className="w-3.5 h-3.5" />
+            </Link>
+            <Link
+              href="/guide"
+              className="inline-flex items-center gap-2 text-muted-foreground px-6 py-2.5 rounded-lg text-[13px] font-medium hover:text-foreground hover:bg-muted/60 transition-all duration-200"
+            >
+              Set Up Testnet Wallet
               <ArrowRight className="w-3.5 h-3.5" />
             </Link>
           </motion.div>
@@ -284,6 +293,15 @@ export default function HeroSection() {
               </p>
             </div>
           </motion.div>
+
+          <motion.p
+            className="mt-6 text-[12px] text-muted-foreground max-w-md leading-relaxed"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.5, delay: 0.35 }}
+          >
+            {TESTNET_PRACTICE_NOTE}
+          </motion.p>
         </motion.div>
       </div>
     </section>

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -34,9 +34,9 @@ export default function HowItWorksSection() {
       icon: UserPlus,
       title: 'Sign Up',
       description:
-        'Create your account and connect your Stellar wallet in seconds',
+        'Create your account and connect your Stellar testnet wallet in seconds',
       detail:
-        'One-click registration with your email. Connect Freighter wallet to start receiving tips instantly.',
+        'One-click registration with your email. Connect a Freighter testnet wallet to start receiving practice tips.',
     },
     {
       icon: Edit3,
@@ -56,9 +56,9 @@ export default function HowItWorksSection() {
     {
       icon: Coins,
       title: 'Earn',
-      description: 'Receive instant tips from readers who value your work',
+      description: 'Receive testnet tips from readers who value your work',
       detail:
-        'Tips settle in 3 seconds via Stellar. You keep 97.5% of every tip — no waiting periods.',
+        'Tips settle in about 3 seconds on Stellar testnet. You keep 97.5% of every tip. Withdraw from your dashboard when your balance reaches $10.',
     },
   ]
 
@@ -89,7 +89,7 @@ export default function HowItWorksSection() {
       title: 'Tip',
       description: 'Send micro-tips starting at $0.01',
       detail:
-        'Tip an article or a specific highlight. 97.5% goes directly to the author — near-zero fees.',
+        'Tip an article or a specific highlight with free testnet XLM. 97.5% goes directly to the author — near-zero fees.',
     },
   ]
 
@@ -303,7 +303,7 @@ export default function HowItWorksSection() {
             href="/register"
             className="group inline-flex items-center justify-center gap-2 bg-card text-card-foreground px-6 py-2.5 rounded-lg text-[13px] font-medium hover:bg-muted transition-all duration-200"
           >
-            Start Writing & Earning Today
+            Start Writing on Testnet
             <ArrowRight className="w-3.5 h-3.5 group-hover:translate-x-0.5 transition-transform duration-200" />
           </Link>
         </Reveal>

--- a/components/landing/Navigation.tsx
+++ b/components/landing/Navigation.tsx
@@ -55,7 +55,7 @@ const navDropdowns: NavDropdown[] = [
     featured: {
       title: 'Quilltip Platform',
       description:
-        'Write, publish, and earn — all in one decentralized platform built on Stellar.',
+        'Write, publish, and receive testnet tips — all on Stellar testnet.',
       href: '#features',
       bgClass: 'bg-gradient-to-br from-muted/70 to-muted',
       icon: PenTool,
@@ -89,8 +89,8 @@ const navDropdowns: NavDropdown[] = [
         items: [
           {
             icon: Zap,
-            title: 'Instant Tips',
-            description: 'Get paid via Stellar network',
+            title: 'Testnet Tips',
+            description: 'Receive tips via Stellar testnet',
             href: '#how-it-works',
           },
           {
@@ -114,7 +114,7 @@ const navDropdowns: NavDropdown[] = [
     featured: {
       title: 'Getting Started',
       description:
-        'Set up your wallet and start earning tips in under 5 minutes.',
+        'Set up a testnet wallet and practice tipping in under 5 minutes.',
       href: '/guide',
       bgClass: 'bg-gradient-to-br from-muted/60 to-muted',
       icon: BookOpen,

--- a/components/onboarding/OnboardingDialog.tsx
+++ b/components/onboarding/OnboardingDialog.tsx
@@ -24,27 +24,27 @@ import {
   X,
 } from 'lucide-react'
 import Link from 'next/link'
+import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
 
 const steps = [
   {
     icon: Sparkles,
     title: 'Welcome to Quilltip',
-    description:
-      'A platform where readers reward writers directly. Read articles, highlight your favorite passages, and tip the authors you love — all powered by the Stellar blockchain.',
+    description: `A platform where readers reward writers directly on Stellar testnet. ${TESTNET_PRACTICE_NOTE}`,
     color: 'bg-blue-100 text-blue-700',
   },
   {
     icon: Wallet,
     title: 'Set Up Your Wallet',
     description:
-      'To tip writers, you need a Stellar wallet (like Freighter). It takes about 2 minutes to set up. Reading articles is always free — no wallet needed.',
+      'To tip writers on testnet, you need a Stellar wallet (like Freighter) set to Testnet with free test XLM. It takes about 2 minutes. Reading articles is always free — no wallet needed.',
     color: 'bg-amber-100 text-amber-700',
   },
   {
     icon: BookOpen,
     title: 'Start Exploring',
     description:
-      'Browse articles from writers, highlight passages you love, and send tips starting at just $0.01. 97.5% goes directly to the author.',
+      'Browse articles from writers, highlight passages you love, and send practice tips starting at $0.01 in testnet XLM. 97.5% goes directly to the author.',
     color: 'bg-green-100 text-green-700',
   },
 ]

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -171,11 +171,12 @@ export function WalletSettings({
             <Wallet className="h-5 w-5" />
             Stellar Wallet
             <WalletTooltip concept="stellar" />
+            <WalletTooltip concept="testnet" />
           </CardTitle>
           <CardDescription>
             {isOwnProfile
-              ? 'Manage your Stellar wallet for sending and receiving tips'
-              : 'Send tips directly to this user&apos;s Stellar wallet'}
+              ? 'Manage your Stellar testnet wallet for sending and receiving practice tips'
+              : 'Send testnet tips directly to this user&apos;s Stellar wallet'}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -198,7 +199,8 @@ export function WalletSettings({
                   <Alert>
                     <AlertCircle className="h-4 w-4" />
                     <AlertDescription>
-                      Connect your Stellar wallet to send and receive tips
+                      Connect your Stellar testnet wallet to send and receive
+                      practice tips
                     </AlertDescription>
                   </Alert>
 

--- a/components/stellar/WalletStatus.tsx
+++ b/components/stellar/WalletStatus.tsx
@@ -122,7 +122,8 @@ export function WalletStatus({ className }: WalletStatusProps) {
               <div>
                 <h3 className="font-semibold">Wallet Not Connected</h3>
                 <p className="text-sm text-muted-foreground">
-                  Connect your Stellar wallet to start tipping authors
+                  Connect your Stellar testnet wallet to start practice tipping
+                  authors
                 </p>
                 <p className="text-xs text-muted-foreground mt-2">
                   Supports Freighter, xBull, Albedo, Rabet, and more
@@ -207,13 +208,18 @@ export function WalletStatus({ className }: WalletStatusProps) {
                 <span className="text-sm font-medium text-muted-foreground">
                   Network
                 </span>
-                <div className="mt-1">
+                <div className="mt-1 space-y-1">
                   <Badge
                     variant={network === 'TESTNET' ? 'secondary' : 'default'}
                     className="capitalize"
                   >
                     {network.toLowerCase()}
                   </Badge>
+                  {network === 'TESTNET' && (
+                    <p className="text-xs text-muted-foreground">
+                      Practice network — not real money
+                    </p>
+                  )}
                 </div>
               </div>
             )}

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -444,9 +444,11 @@ export function TipButton({
             </div>
           )}
 
-          <p className="text-xs text-muted-foreground text-center flex items-center justify-center gap-1">
-            Powered by Stellar <WalletTooltip concept="stellar" /> • Instant
-            settlement • Low fees
+          <p className="text-xs text-muted-foreground text-center flex items-center justify-center gap-1 flex-wrap">
+            Powered by Stellar testnet{' '}
+            <WalletTooltip concept="stellar" />{' '}
+            <WalletTooltip concept="testnet" /> • Fast testnet settlement • Low
+            fees
           </p>
         </DialogContent>
       </Dialog>

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -445,8 +445,7 @@ export function TipButton({
           )}
 
           <p className="text-xs text-muted-foreground text-center flex items-center justify-center gap-1 flex-wrap">
-            Powered by Stellar testnet{' '}
-            <WalletTooltip concept="stellar" />{' '}
+            Powered by Stellar testnet <WalletTooltip concept="stellar" />{' '}
             <WalletTooltip concept="testnet" /> • Fast testnet settlement • Low
             fees
           </p>

--- a/lib/copy/network-status.ts
+++ b/lib/copy/network-status.ts
@@ -1,0 +1,12 @@
+import { MIN_WITHDRAWAL_USD } from '@/lib/constants'
+
+export const TESTNET_PRACTICE_NOTE =
+  'Quilltip runs on Stellar testnet. Tips use free test XLM for practice—not real money.'
+
+export const TESTNET_TIP_SPEED_NOTE =
+  'Tips settle in about 3 seconds on Stellar testnet with near-zero fees.'
+
+export const TESTNET_WITHDRAWAL_NOTE = `Move testnet earnings to your Stellar wallet once your available balance reaches $${MIN_WITHDRAWAL_USD.toFixed(0)}. Test funds only—not withdrawable as real money.`
+
+export const MAINNET_COMING_NOTE =
+  'We are working toward a mainnet launch where tips will use real funds. Until then, everything on Quilltip is testnet practice.'


### PR DESCRIPTION
## Summary

Quilltip runs on Stellar testnet, but landing, FAQ, guide, wallet, and earnings copy mixed practice tips with real-money promises (instant withdrawals, no thresholds, "earn money"). This PR aligns user-facing messaging so first-time users know they are using free test XLM, not real funds.

- Add shared copy constants in `lib/copy/network-status.ts` for consistent testnet disclaimers, withdrawal notes ($10 minimum), and mainnet-coming messaging
- Update landing (hero, features, how-it-works, nav, footer) and FAQ to lead with testnet practice and fix withdrawal contradictions
- Add testnet banner and accurate withdrawal copy on the earnings dashboard and withdraw dialog
- Align CTAs and onboarding/home cards with testnet practice expectations
- Sync guide, wallet settings, tip modals, and site meta with the same testnet-first story
<img width="1216" height="710" alt="Screenshot 2026-05-18 at 7 37 38 PM" src="https://github.com/user-attachments/assets/5892bb16-ccaa-46dc-8849-f848ae8dafcb" />
<img width="1216" height="718" alt="Screenshot 2026-05-18 at 7 41 26 PM" src="https://github.com/user-attachments/assets/6448bb5a-63ac-4990-8440-27b3ee0fd91b" />

<img width="1222" height="719" alt="Screenshot 2026-05-18 at 8 03 34 PM" src="https://github.com/user-attachments/assets/9f60d544-ce7b-461d-b0ed-3fdee219349c" />


