### PR TITLE
fix(landing): show visible content for all public nav hash targets (ENG-170)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,13 +7,31 @@ import HeroSection from '@/components/landing/HeroSection'
 import FeaturesSection from '@/components/landing/FeaturesSection'
 import HowItWorksSection from '@/components/landing/HowItWorksSection'
 import FAQSection from '@/components/landing/FAQSection'
+import TrustSection from '@/components/landing/TrustSection'
 import Footer from '@/components/landing/Footer'
+import { useLandingHashScroll } from '@/components/landing/useLandingHashScroll'
 import { OnboardingDialog } from '@/components/onboarding/OnboardingDialog'
 import { HomeRecentArticlesSection } from '@/components/articles/HomeRecentArticlesSection'
 import { ErrorBoundary } from '@/components/error/ErrorBoundary'
 import { DashboardRecentArticlesFallback } from '@/components/error/SectionErrorFallback'
 import Link from 'next/link'
 import { PenSquare, BookOpen, Wallet, TrendingUp } from 'lucide-react'
+
+function PublicLandingPage() {
+  useLandingHashScroll()
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-background via-muted/30 to-background">
+      <Navigation />
+      <HeroSection />
+      <FeaturesSection />
+      <HowItWorksSection />
+      <TrustSection />
+      <FAQSection />
+      <Footer />
+    </div>
+  )
+}
 
 export default function HomePage() {
   const { user, isAuthenticated } = useAuth()
@@ -131,14 +149,5 @@ export default function HomePage() {
     )
   }
 
-  return (
-    <div className="min-h-screen bg-gradient-to-b from-background via-muted/30 to-background">
-      <Navigation />
-      <HeroSection />
-      <FeaturesSection />
-      <HowItWorksSection />
-      <FAQSection />
-      <Footer />
-    </div>
-  )
+  return <PublicLandingPage />
 }

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import {
   UserPlus,
   Edit3,
@@ -16,7 +16,7 @@ import {
   type LucideIcon,
 } from 'lucide-react'
 import { motion, AnimatePresence } from 'motion/react'
-import { Reveal } from '@/components/landing/Reveal'
+import { Reveal, LANDING_REVEAL_EVENT } from '@/components/landing/Reveal'
 
 interface Step {
   icon: LucideIcon
@@ -99,6 +99,30 @@ export default function HowItWorksSection() {
     setActiveTab(tab)
     setActiveStep(0)
   }
+
+  useEffect(() => {
+    const section = document.getElementById('how-it-works')
+    if (!section) return
+
+    const resetSteps = () => {
+      setActiveTab('writers')
+      setActiveStep(0)
+    }
+
+    const onHashChange = () => {
+      if (window.location.hash === '#how-it-works') resetSteps()
+    }
+
+    if (window.location.hash === '#how-it-works') resetSteps()
+
+    section.addEventListener(LANDING_REVEAL_EVENT, resetSteps)
+    window.addEventListener('hashchange', onHashChange)
+
+    return () => {
+      section.removeEventListener(LANDING_REVEAL_EVENT, resetSteps)
+      window.removeEventListener('hashchange', onHashChange)
+    }
+  }, [])
 
   return (
     <section

--- a/components/landing/Navigation.tsx
+++ b/components/landing/Navigation.tsx
@@ -21,6 +21,12 @@ import {
 import { motion, AnimatePresence } from 'motion/react'
 import { LucideIcon } from 'lucide-react'
 import { ThemeToggle } from '@/components/theme/ThemeToggle'
+import {
+  handleLandingHashClick,
+  scrollToLandingSection,
+} from '@/lib/landing/scroll-to-section'
+
+const MOBILE_MENU_CLOSE_MS = 280
 
 interface NavDropdownItem {
   icon: LucideIcon
@@ -144,13 +150,13 @@ const navDropdowns: NavDropdown[] = [
             icon: Shield,
             title: 'Security',
             description: 'Blockchain security overview',
-            href: '#faq',
+            href: '#security',
           },
           {
             icon: Globe,
             title: 'Arweave Storage',
             description: 'How permanent storage works',
-            href: '#faq',
+            href: '#arweave-storage',
           },
         ],
       },
@@ -210,24 +216,25 @@ export default function Navigation() {
     return () => document.removeEventListener('keydown', handleEscape)
   }, [openDropdown])
 
-  const handleSmoothScroll = (
+  const onHashNavClick = (
     e: React.MouseEvent<HTMLAnchorElement>,
     href: string
   ) => {
-    if (href.startsWith('#')) {
-      e.preventDefault()
-      const element = document.querySelector(href)
-      if (element) {
-        const offsetTop =
-          element.getBoundingClientRect().top + window.pageYOffset - 80
-        window.scrollTo({
-          top: offsetTop,
-          behavior: 'smooth',
-        })
-      }
+    if (handleLandingHashClick(e, href)) {
       setIsOpen(false)
       setOpenDropdown(null)
     }
+  }
+
+  const onMobileHashNavClick = (
+    e: React.MouseEvent<HTMLAnchorElement>,
+    href: string
+  ) => {
+    if (!href.startsWith('#')) return
+
+    e.preventDefault()
+    setIsOpen(false)
+    window.setTimeout(() => scrollToLandingSection(href), MOBILE_MENU_CLOSE_MS)
   }
 
   return (
@@ -317,7 +324,7 @@ export default function Navigation() {
                           <Link
                             href={dropdown.featured.href}
                             onClick={(e) =>
-                              handleSmoothScroll(e, dropdown.featured.href)
+                              onHashNavClick(e, dropdown.featured.href)
                             }
                             className={`focus-ring w-[200px] shrink-0 p-5 ${dropdown.featured.bgClass} flex flex-col justify-between group/featured rounded-l-2xl`}
                           >
@@ -351,7 +358,7 @@ export default function Navigation() {
                                       key={item.title}
                                       href={item.href}
                                       onClick={(e) => {
-                                        handleSmoothScroll(e, item.href)
+                                        onHashNavClick(e, item.href)
                                         setOpenDropdown(null)
                                       }}
                                       className="focus-ring flex items-start gap-2.5 px-2.5 py-2 rounded-xl hover:bg-muted/50 transition-colors duration-150 group/item"
@@ -458,7 +465,10 @@ export default function Navigation() {
                             href={item.href}
                             className="focus-ring flex items-center gap-2.5 py-1.5 rounded-md text-muted-foreground hover:text-foreground transition-colors"
                             onClick={(e) => {
-                              handleSmoothScroll(e, item.href)
+                              if (item.href.startsWith('#')) {
+                                onMobileHashNavClick(e, item.href)
+                                return
+                              }
                               setIsOpen(false)
                             }}
                           >

--- a/components/landing/Reveal.tsx
+++ b/components/landing/Reveal.tsx
@@ -1,6 +1,21 @@
 'use client'
 
-import { motion, type HTMLMotionProps } from 'motion/react'
+import { useEffect, useRef, useState } from 'react'
+import { motion, useReducedMotion, type HTMLMotionProps } from 'motion/react'
+
+export const LANDING_REVEAL_EVENT = 'landing:reveal-section'
+
+export function revealSection(hash: string) {
+  const id = hash.startsWith('#') ? hash.slice(1) : hash
+  const target = document.getElementById(id)
+  if (!target) return
+
+  const section = target.closest('section') ?? target
+  section.setAttribute('data-landing-revealed', 'true')
+  section.dispatchEvent(
+    new CustomEvent(LANDING_REVEAL_EVENT, { bubbles: true })
+  )
+}
 
 type RevealProps = HTMLMotionProps<'div'> & {
   delay?: number
@@ -13,12 +28,40 @@ export function Reveal({
   transition,
   ...props
 }: RevealProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const prefersReducedMotion = useReducedMotion()
+  const [forceVisible, setForceVisible] = useState(false)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const section = el.closest('section')
+    if (!section) return
+
+    const reveal = () => setForceVisible(true)
+
+    if (section.getAttribute('data-landing-revealed') === 'true') {
+      reveal()
+    }
+
+    section.addEventListener(LANDING_REVEAL_EVENT, reveal)
+    return () => section.removeEventListener(LANDING_REVEAL_EVENT, reveal)
+  }, [])
+
+  const isVisible = prefersReducedMotion === true || forceVisible
+
   return (
     <motion.div
+      ref={ref}
+      data-reveal
       className={className}
-      initial={{ opacity: 0, y: 24 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, amount: 0.15, margin: '0px 0px -10% 0px' }}
+      initial={isVisible ? false : { opacity: 0, y: 24 }}
+      animate={isVisible ? { opacity: 1, y: 0 } : undefined}
+      whileInView={
+        isVisible ? undefined : { opacity: 1, y: 0 }
+      }
+      viewport={{ once: true, amount: 0.05 }}
       transition={{
         duration: 0.6,
         delay,

--- a/components/landing/Reveal.tsx
+++ b/components/landing/Reveal.tsx
@@ -58,9 +58,7 @@ export function Reveal({
       className={className}
       initial={isVisible ? false : { opacity: 0, y: 24 }}
       animate={isVisible ? { opacity: 1, y: 0 } : undefined}
-      whileInView={
-        isVisible ? undefined : { opacity: 1, y: 0 }
-      }
+      whileInView={isVisible ? undefined : { opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.05 }}
       transition={{
         duration: 0.6,

--- a/components/landing/TrustSection.tsx
+++ b/components/landing/TrustSection.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { Shield, Globe } from 'lucide-react'
+import { Reveal } from '@/components/landing/Reveal'
+
+const trustTopics = [
+  {
+    id: 'security',
+    icon: Shield,
+    title: 'Security on testnet',
+    description:
+      'Quilltip never holds your funds. Tips move wallet-to-wallet on Stellar testnet through audited Soroban contracts. You approve every transaction in your own wallet app before it is sent.',
+    bullets: [
+      'Practice with free testnet XLM only — no real money at risk',
+      'Wallet apps like Freighter sign transactions locally on your device',
+      'Platform fees are enforced on-chain, not by manual transfers',
+    ],
+  },
+  {
+    id: 'arweave-storage',
+    icon: Globe,
+    title: 'Permanent storage with Arweave',
+    description:
+      'Published articles are stored on Arweave, a decentralized network designed for permanent data. Your writing survives independently of Quilltip servers.',
+    bullets: [
+      'One-time upload — no recurring hosting bills for writers',
+      'Readers access content through Quilltip while copies persist on Arweave',
+      'Optional NFT minting adds an on-chain ownership record on Stellar',
+    ],
+  },
+] as const
+
+export default function TrustSection() {
+  return (
+    <section className="scroll-mt-20 py-20 md:py-28 px-6 bg-background border-t border-border/60">
+      <div className="container mx-auto max-w-6xl">
+        <h2 className="font-display text-4xl lg:text-5xl font-medium tracking-[-0.01em] mb-4 leading-[1.15] text-foreground">
+          Trust and permanence
+        </h2>
+        <p className="text-[15px] text-muted-foreground leading-relaxed mb-12 max-w-2xl">
+          How Quilltip protects writers and readers on testnet, and how your
+          articles stay available long term.
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          {trustTopics.map((topic, index) => (
+            <Reveal key={topic.id} delay={index * 0.08}>
+              <article
+                id={topic.id}
+                className="scroll-mt-24 h-full rounded-2xl border border-border bg-card p-8 shadow-sm"
+              >
+                <div className="w-11 h-11 rounded-xl bg-muted flex items-center justify-center mb-5">
+                  <topic.icon className="w-5 h-5 text-foreground" />
+                </div>
+                <h3 className="text-xl font-semibold text-foreground mb-3">
+                  {topic.title}
+                </h3>
+                <p className="text-[14px] text-muted-foreground leading-relaxed mb-5">
+                  {topic.description}
+                </p>
+                <ul className="space-y-2">
+                  {topic.bullets.map((bullet) => (
+                    <li
+                      key={bullet}
+                      className="text-[13px] text-muted-foreground leading-relaxed flex gap-2"
+                    >
+                      <span
+                        className="text-brand mt-1.5 shrink-0"
+                        aria-hidden
+                      >
+                        •
+                      </span>
+                      <span>{bullet}</span>
+                    </li>
+                  ))}
+                </ul>
+              </article>
+            </Reveal>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/landing/TrustSection.tsx
+++ b/components/landing/TrustSection.tsx
@@ -64,10 +64,7 @@ export default function TrustSection() {
                       key={bullet}
                       className="text-[13px] text-muted-foreground leading-relaxed flex gap-2"
                     >
-                      <span
-                        className="text-brand mt-1.5 shrink-0"
-                        aria-hidden
-                      >
+                      <span className="text-brand mt-1.5 shrink-0" aria-hidden>
                         •
                       </span>
                       <span>{bullet}</span>

--- a/components/landing/useLandingHashScroll.ts
+++ b/components/landing/useLandingHashScroll.ts
@@ -1,0 +1,27 @@
+'use client'
+
+import { useEffect } from 'react'
+import { scrollToLandingSection } from '@/lib/landing/scroll-to-section'
+
+export function useLandingHashScroll() {
+  useEffect(() => {
+    const hash = window.location.hash
+    if (!hash) return
+
+    const frame = requestAnimationFrame(() => {
+      scrollToLandingSection(hash)
+    })
+
+    return () => cancelAnimationFrame(frame)
+  }, [])
+
+  useEffect(() => {
+    const onHashChange = () => {
+      const hash = window.location.hash
+      if (hash) scrollToLandingSection(hash)
+    }
+
+    window.addEventListener('hashchange', onHashChange)
+    return () => window.removeEventListener('hashchange', onHashChange)
+  }, [])
+}

--- a/e2e/home-visual.spec.ts
+++ b/e2e/home-visual.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test'
+
+async function scrollSectionIntoView(
+  page: import('@playwright/test').Page,
+  selector: string
+) {
+  const section = page.locator(selector).first()
+  await section.scrollIntoViewIfNeeded()
+  await page.waitForTimeout(200)
+}
+
+async function assertRevealContentVisible(
+  page: import('@playwright/test').Page,
+  selector: string
+) {
+  const section = page.locator(selector).first()
+  await expect(section).toBeVisible()
+  const reveal = section.locator('[data-reveal]').first()
+  await expect(reveal).toBeVisible()
+  await expect(reveal).toHaveCSS('opacity', /^(?!0$)/)
+}
+
+test.describe('home landing visual regression', () => {
+  test.setTimeout(90_000)
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await expect(
+      page.getByRole('heading', { name: 'Reward the words that move you' })
+    ).toBeVisible()
+  })
+
+  test('full page screenshot', async ({ page }) => {
+    await scrollSectionIntoView(page, '#features')
+    await expect(page.getByRole('heading', { name: 'Core Features' })).toBeVisible()
+
+    await scrollSectionIntoView(page, '#how-it-works')
+    await expect(
+      page.getByRole('heading', { name: /From idea to impact/ })
+    ).toBeVisible()
+
+    await scrollSectionIntoView(page, '#security')
+    await expect(
+      page.getByRole('heading', { name: 'Security on testnet' })
+    ).toBeVisible()
+
+    await scrollSectionIntoView(page, '#faq')
+    await expect(
+      page.getByRole('heading', { name: 'Frequently Asked Questions' })
+    ).toBeVisible()
+
+    await page.evaluate(() => window.scrollTo(0, 0))
+    await page.waitForTimeout(400)
+
+    const snapshotName = `home-full-${test.info().project.name}.png`
+    await expect(page).toHaveScreenshot(snapshotName, {
+      fullPage: true,
+      animations: 'disabled',
+      timeout: 60_000,
+    })
+  })
+})
+
+test.describe('landing nav hash navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await expect(
+      page.getByRole('heading', { name: 'Reward the words that move you' })
+    ).toBeVisible()
+  })
+
+  test('desktop menu links reveal section content', async ({ page }) => {
+    test.skip(test.info().project.name === 'mobile', 'desktop nav only')
+
+    await page.getByRole('button', { name: 'Product' }).click()
+    await page.getByRole('link', { name: 'Rich Editor' }).click()
+    await page.waitForTimeout(900)
+    await assertRevealContentVisible(page, '#features')
+
+    await page.getByRole('button', { name: 'Resources' }).click()
+    await page.getByRole('link', { name: 'Security' }).click()
+    await page.waitForTimeout(900)
+    await expect(
+      page.getByRole('heading', { name: 'Security on testnet' })
+    ).toBeVisible()
+    await assertRevealContentVisible(page, '#security')
+  })
+
+  test('mobile menu links reveal section content', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+
+    await page.getByRole('button', { name: 'Toggle menu' }).click()
+    await page.getByRole('link', { name: 'Testnet Tips' }).click()
+    await page.waitForTimeout(900)
+    await assertRevealContentVisible(page, '#how-it-works')
+
+    await page.getByRole('button', { name: 'Toggle menu' }).click()
+    await page.getByRole('link', { name: 'FAQ' }).click()
+    await page.waitForTimeout(900)
+    await expect(
+      page.getByRole('heading', { name: 'Frequently Asked Questions' })
+    ).toBeVisible()
+    await assertRevealContentVisible(page, '#faq')
+
+    await page.getByRole('button', { name: 'Toggle menu' }).click()
+    await page.getByRole('link', { name: 'Arweave Storage' }).click()
+    await page.waitForTimeout(900)
+    await expect(
+      page.getByRole('heading', { name: 'Permanent storage with Arweave' })
+    ).toBeVisible()
+    await assertRevealContentVisible(page, '#arweave-storage')
+  })
+})

--- a/e2e/home-visual.spec.ts
+++ b/e2e/home-visual.spec.ts
@@ -32,7 +32,9 @@ test.describe('home landing visual regression', () => {
 
   test('full page screenshot', async ({ page }) => {
     await scrollSectionIntoView(page, '#features')
-    await expect(page.getByRole('heading', { name: 'Core Features' })).toBeVisible()
+    await expect(
+      page.getByRole('heading', { name: 'Core Features' })
+    ).toBeVisible()
 
     await scrollSectionIntoView(page, '#how-it-works')
     await expect(

--- a/lib/landing/nav-targets.ts
+++ b/lib/landing/nav-targets.ts
@@ -1,0 +1,17 @@
+export const LANDING_SECTION_IDS = [
+  'features',
+  'how-it-works',
+  'security',
+  'arweave-storage',
+  'faq',
+] as const
+
+export type LandingSectionId = (typeof LANDING_SECTION_IDS)[number]
+
+export const LANDING_NAV_HASHES = [
+  '#features',
+  '#how-it-works',
+  '#faq',
+  '#security',
+  '#arweave-storage',
+] as const

--- a/lib/landing/scroll-to-section.test.ts
+++ b/lib/landing/scroll-to-section.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { LANDING_NAV_HASHES, LANDING_SECTION_IDS } from './nav-targets'
+
+describe('landing nav targets', () => {
+  it('maps every nav hash to a known section id', () => {
+    for (const hash of LANDING_NAV_HASHES) {
+      const id = hash.slice(1)
+      expect(LANDING_SECTION_IDS).toContain(id)
+    }
+  })
+
+  it('includes security and arweave storage anchors', () => {
+    expect(LANDING_SECTION_IDS).toContain('security')
+    expect(LANDING_SECTION_IDS).toContain('arweave-storage')
+  })
+})

--- a/lib/landing/scroll-to-section.ts
+++ b/lib/landing/scroll-to-section.ts
@@ -1,0 +1,50 @@
+import type { MouseEvent } from 'react'
+import { revealSection } from '@/components/landing/Reveal'
+
+const SCROLL_END_FALLBACK_MS = 800
+
+function waitForScrollEnd(): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false
+
+    const finish = () => {
+      if (settled) return
+      settled = true
+      window.removeEventListener('scrollend', onScrollEnd)
+      clearTimeout(fallback)
+      resolve()
+    }
+
+    const onScrollEnd = () => finish()
+    const fallback = setTimeout(finish, SCROLL_END_FALLBACK_MS)
+
+    if ('onscrollend' in window) {
+      window.addEventListener('scrollend', onScrollEnd, { once: true })
+    } else {
+      finish()
+    }
+  })
+}
+
+export function scrollToLandingSection(hash: string): void {
+  const normalized = hash.startsWith('#') ? hash : `#${hash}`
+  const element = document.querySelector(normalized)
+  if (!element || !(element instanceof HTMLElement)) return
+
+  element.scrollIntoView({ behavior: 'smooth', block: 'start' })
+
+  void waitForScrollEnd().then(() => {
+    revealSection(normalized)
+  })
+}
+
+export function handleLandingHashClick(
+  e: MouseEvent<HTMLAnchorElement>,
+  href: string
+): boolean {
+  if (!href.startsWith('#')) return false
+
+  e.preventDefault()
+  scrollToLandingSection(href)
+  return true
+}


### PR DESCRIPTION
## Summary

Fixes ENG-170: public landing navigation links no longer scroll users into blank-looking sections. Hash targets now land on visible, stable content on both desktop and mobile.

## Problem

- `Reveal` animations started at `opacity: 0` and only appeared on `whileInView`, which often did not fire after programmatic hash scrolls.
- Security and Arweave Storage nav items pointed to `#faq`, so users did not get topic-specific content.
- Direct URLs like `/#features` had no hash-on-load handling to force content visible.

## Solution

- **`Reveal`**: respect `prefers-reduced-motion`, loosen viewport detection, add `data-reveal` and `revealSection()` to force visibility when a section is the scroll target.
- **`scrollToLandingSection`**: shared scroll helper used by desktop/mobile nav; reveals content after scroll completes (with timeout fallback).
- **`useLandingHashScroll`**: handles hash on initial page load and `hashchange`.
- **`TrustSection`**: new education blocks with `#security` and `#arweave-storage`; nav hrefs updated.
- **`HowItWorksSection`**: resets to writers / step 0 when arrived via `#how-it-works`.


https://github.com/user-attachments/assets/c82a61a5-fb57-4817-8aee-e8aca0751459

<img width="1221" height="727" alt="Screenshot 2026-05-18 at 9 41 25 PM" src="https://github.com/user-attachments/assets/5cfb6609-6c8d-4b1a-9e73-334602569f19" />


