### PR TITLE
fix(editor): only clear unsaved state after confirmed save (ENG-166)

### DIFF
--- a/components/editor/EditorActionBar.test.tsx
+++ b/components/editor/EditorActionBar.test.tsx
@@ -47,6 +47,35 @@ describe('EditorActionBar autosave status', () => {
     }
   })
 
+  it('shows Saving... in status and on Save button while isSaving with unsaved edits', () => {
+    render(<EditorActionBar {...baseProps} isSaving hasUnsavedChanges />)
+    const statuses = screen.getAllByRole('status')
+    for (const status of statuses) {
+      expect(status).toHaveTextContent('Saving...')
+    }
+    const saveButtons = screen.getAllByRole('button', { name: 'Saving...' })
+    expect(saveButtons.length).toBeGreaterThanOrEqual(1)
+    for (const button of saveButtons) {
+      expect(button).toBeDisabled()
+    }
+  })
+
+  it('shows Could not save with destructive Draft pill when error and dirty', () => {
+    const { container } = render(
+      <EditorActionBar
+        {...baseProps}
+        error="Network error"
+        hasUnsavedChanges
+      />
+    )
+    const statuses = screen.getAllByRole('status')
+    for (const status of statuses) {
+      expect(status).toHaveTextContent("Couldn't save")
+    }
+    expect(container.querySelector('.bg-destructive\\/15')).not.toBeNull()
+    expect(screen.getByText('Save failed')).toBeInTheDocument()
+  })
+
   it('shows relative saved label when lastSavedAt is set and not dirty', () => {
     const t = new Date('2020-01-01T12:00:00.000Z')
     render(

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -176,7 +176,7 @@ export function EditorActionBar({
       className="px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent rounded transition-colors shrink-0"
       title={isSaving ? 'Saving draft...' : 'Save draft'}
     >
-      Save
+      {isSaving ? 'Saving...' : 'Save'}
     </button>
   )
 

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -213,6 +213,7 @@ export function WriteEditorWorkspace() {
     },
     onSaveError: (error) => {
       console.error('Auto-save error:', error)
+      setHasUnsavedChanges(true)
     },
   })
 
@@ -313,8 +314,7 @@ export function WriteEditorWorkspace() {
     const handler = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 's') {
         e.preventDefault()
-        saveNow()
-        setHasUnsavedChanges(false)
+        void saveNow()
       }
     }
     window.addEventListener('keydown', handler)
@@ -623,8 +623,7 @@ export function WriteEditorWorkspace() {
         editor={editor}
         onBack={handleBack}
         onSave={() => {
-          saveNow()
-          setHasUnsavedChanges(false)
+          void saveNow()
         }}
         onPublish={requestPublish}
         isSaving={isSaving}

--- a/hooks/useAutoSave.test.ts
+++ b/hooks/useAutoSave.test.ts
@@ -1,0 +1,177 @@
+/** @vitest-environment jsdom */
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { JSONContent } from '@tiptap/react'
+import { useAutoSave } from './useAutoSave'
+
+const mockSaveDraft = vi.hoisted(() => vi.fn())
+
+vi.mock('convex/react', () => ({
+  useMutation: () => mockSaveDraft,
+}))
+
+const sampleContent: JSONContent = {
+  type: 'doc',
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello' }] }],
+}
+
+describe('useAutoSave', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSaveDraft.mockResolvedValue('article-123')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('sets isSaving during saveNow and lastSavedAt only after success', async () => {
+    let resolveSave: (id: string) => void = () => {}
+    mockSaveDraft.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveSave = resolve
+        })
+    )
+
+    const { result } = renderHook(() =>
+      useAutoSave({
+        content: sampleContent,
+        title: 'My draft',
+        enabled: false,
+      })
+    )
+
+    expect(result.current.isSaving).toBe(false)
+    expect(result.current.lastSavedAt).toBeNull()
+
+    let savePromise: Promise<void>
+    act(() => {
+      savePromise = result.current.saveNow()
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSaving).toBe(true)
+    })
+    expect(result.current.lastSavedAt).toBeNull()
+
+    await act(async () => {
+      resolveSave('article-123')
+      await savePromise!
+    })
+
+    expect(result.current.isSaving).toBe(false)
+    expect(result.current.lastSavedAt).toBeInstanceOf(Date)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('sets error on failure and does not update lastSavedAt', async () => {
+    const previousSavedAt = new Date('2020-01-01T12:00:00.000Z')
+    mockSaveDraft.mockRejectedValue(new Error('Network error'))
+
+    const { result } = renderHook(() =>
+      useAutoSave({
+        content: sampleContent,
+        title: 'My draft',
+        enabled: false,
+      })
+    )
+
+    await act(async () => {
+      await result.current.saveNow()
+    })
+
+    expect(result.current.isSaving).toBe(false)
+    expect(result.current.error?.message).toBe('Network error')
+    expect(result.current.lastSavedAt).toBeNull()
+
+    mockSaveDraft.mockResolvedValue('article-123')
+
+    await act(async () => {
+      await result.current.saveNow()
+    })
+
+    expect(result.current.lastSavedAt).not.toEqual(previousSavedAt)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('rejects with timeout message when save exceeds SAVE_DRAFT_TIMEOUT_MS', async () => {
+    vi.useFakeTimers()
+    mockSaveDraft.mockImplementation(
+      () => new Promise<string>(() => {})
+    )
+
+    const { result } = renderHook(() =>
+      useAutoSave({
+        content: sampleContent,
+        title: 'My draft',
+        enabled: false,
+      })
+    )
+
+    let savePromise: Promise<void>
+    act(() => {
+      savePromise = result.current.saveNow()
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000)
+      await savePromise!
+    })
+
+    expect(result.current.isSaving).toBe(false)
+    expect(result.current.error?.message).toBe(
+      'Save timed out. Check your connection.'
+    )
+    expect(result.current.lastSavedAt).toBeNull()
+  })
+
+  it('calls onSaveSuccess only after a successful save', async () => {
+    const onSaveSuccess = vi.fn()
+    mockSaveDraft.mockResolvedValue('article-456')
+
+    const { result } = renderHook(() =>
+      useAutoSave({
+        content: sampleContent,
+        title: 'My draft',
+        enabled: false,
+        onSaveSuccess,
+      })
+    )
+
+    await act(async () => {
+      await result.current.saveNow()
+    })
+
+    expect(onSaveSuccess).toHaveBeenCalledTimes(1)
+    expect(onSaveSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'article-456',
+        title: 'My draft',
+      })
+    )
+  })
+
+  it('calls onSaveError when save fails', async () => {
+    const onSaveError = vi.fn()
+    mockSaveDraft.mockRejectedValue(new Error('Offline'))
+
+    const { result } = renderHook(() =>
+      useAutoSave({
+        content: sampleContent,
+        title: 'My draft',
+        enabled: false,
+        onSaveError,
+      })
+    )
+
+    await act(async () => {
+      await result.current.saveNow()
+    })
+
+    expect(onSaveError).toHaveBeenCalledTimes(1)
+    const errorArg = onSaveError.mock.calls[0]?.[0]
+    expect(errorArg).toBeInstanceOf(Error)
+    expect((errorArg as Error).message).toBe('Offline')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes ENG-166: Manual Save and Cmd/Ctrl+S no longer clear the unsaved-changes state before the Convex save completes. Writers only see a saved draft after a confirmed successful save; failed or slow saves keep the unsaved warning and navigation guards active.

- Remove optimistic `setHasUnsavedChanges(false)` from Save button and Cmd/Ctrl+S handlers
- Clear dirty state only in `onSaveSuccess` (after `saveDraft` succeeds)
- Re-assert `hasUnsavedChanges` on `onSaveError` so failed saves keep the red Draft pill and leave warnings
- Show **Saving...** on the Save button while `isSaving` is true
- Add regression tests for `useAutoSave` and `EditorActionBar` save status states
<img width="1214" height="713" alt="1" src="https://github.com/user-attachments/assets/01f13270-5a2b-4b23-91cc-3dc309ab7e63" />
<img width="1220" height="716" alt="2" src="https://github.com/user-attachments/assets/0024b096-d3fc-4d4e-a68e-629118ed00f0" />
<img width="1440" height="900" alt="3" src="https://github.com/user-attachments/assets/298b1a8c-ecc3-4009-9e42-fbbac1894259" />
<img width="1224" height="718" alt="4" src="https://github.com/user-attachments/assets/ef76a6a7-cbda-4a0a-8000-51a232943bcf" />

