### PR TITLE
fix(editor): prompt before clearing local draft backup (ENG-165)

### DIFF
--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -49,6 +49,15 @@ import {
   validateImageUploadFile,
   isAbortError,
 } from '@/lib/upload'
+import {
+  type DraftBackup,
+  clearDraftBackup,
+  formatBackupSavedAt,
+  readDraftBackup,
+  shouldOfferDraftRecovery,
+  shouldPersistDraftBackup,
+  writeDraftBackup,
+} from '@/lib/draftBackup'
 
 const PUBLISH_EXCERPT_PREVIEW_MAX = 280
 const EXCERPT_MAX_CHARS = 500
@@ -102,6 +111,8 @@ export function WriteEditorWorkspace() {
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
   const [navConfirm, setNavConfirm] = useState<NavConfirmState>(null)
   const hasUnsavedRef = useRef(hasUnsavedChanges)
+  /** When true, user dismissed recovery (Not now / Esc); keep local backup until Restore/Discard. */
+  const recoveryDeferredRef = useRef(false)
   const [excerptOpen, setExcerptOpen] = useState(false)
   const excerptTextareaRef = useRef<HTMLTextAreaElement>(null)
   const tagsInputRef = useRef<HTMLInputElement>(null)
@@ -113,6 +124,10 @@ export function WriteEditorWorkspace() {
     publishedAt: null,
   })
   const [publishConfirmOpen, setPublishConfirmOpen] = useState(false)
+  const [backupPrompt, setBackupPrompt] = useState<DraftBackup | null>(null)
+  const [backupRecoveryStatus, setBackupRecoveryStatus] = useState<
+    'pending' | 'resolved'
+  >('pending')
 
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -210,6 +225,9 @@ export function WriteEditorWorkspace() {
         setArticleId(response.id)
       }
       setHasUnsavedChanges(false)
+      if (!recoveryDeferredRef.current) {
+        clearDraftBackup()
+      }
     },
     onSaveError: (error) => {
       console.error('Auto-save error:', error)
@@ -227,54 +245,176 @@ export function WriteEditorWorkspace() {
     articleId ? (articleId as Id<'articles'>) : undefined
   )
 
-  useEffect(() => {
-    if (draft && editor) {
-      setArticleId(draft._id)
-      setTitle(draft.title)
-      setExcerpt(draft.excerpt || '')
-      setTags(draft.tags?.join(', ') ?? '')
-      setCoverImage(draft.coverImage || '')
-      setPublishStatus({
-        published: draft.published,
-        publishedAt: draft.publishedAt ? new Date(draft.publishedAt) : null,
-      })
-      if (draft.content) {
-        queueMicrotask(() => {
-          editor.commands.setContent(draft.content)
-        })
-        setEditorContent(draft.content)
-      }
-      setHasUnsavedChanges(false)
+  const buildDraftBackup = useCallback((): DraftBackup => {
+    const tagsArr = tags
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean)
+    return {
+      title: title || 'Untitled',
+      content: editorContent ?? EMPTY_DOC,
+      excerpt: excerpt || undefined,
+      tags: tagsArr.length ? tagsArr : undefined,
+      coverImage: coverImage || undefined,
+      articleId,
+      savedAt: Date.now(),
     }
-  }, [draft, editor])
+  }, [editorContent, title, excerpt, tags, coverImage, articleId])
+
+  const persistDraftBackup = useCallback(() => {
+    const hasContent = !!editorContent
+    const hasMetadata = !!(title?.trim() || coverImage)
+    if (
+      !shouldPersistDraftBackup(
+        isAuthenticated,
+        hasUnsavedChanges,
+        hasContent,
+        hasMetadata
+      )
+    ) {
+      return
+    }
+    writeDraftBackup(buildDraftBackup())
+  }, [
+    buildDraftBackup,
+    editorContent,
+    title,
+    coverImage,
+    hasUnsavedChanges,
+    isAuthenticated,
+  ])
+
+  useEffect(() => {
+    if (!editor || !isAuthenticated) return
+
+    const draftLoadSettled = !draftIdParam || draft !== undefined
+    if (!draftLoadSettled) return
+    if (backupRecoveryStatus !== 'pending') return
+
+    const backup = readDraftBackup()
+    if (!backup) {
+      setBackupRecoveryStatus('resolved')
+      return
+    }
+
+    const serverDraft =
+      draft && draft !== null
+        ? {
+            title: draft.title,
+            content: draft.content,
+            excerpt: draft.excerpt,
+            tags: draft.tags,
+            coverImage: draft.coverImage,
+            updatedAt: draft.updatedAt,
+          }
+        : undefined
+
+    if (
+      shouldOfferDraftRecovery(backup, serverDraft, {
+        urlArticleId: draftIdParam ?? undefined,
+        stateArticleId: articleId,
+      })
+    ) {
+      setBackupPrompt(backup)
+    } else {
+      clearDraftBackup()
+    }
+    setBackupRecoveryStatus('resolved')
+  }, [
+    editor,
+    isAuthenticated,
+    draft,
+    draftIdParam,
+    articleId,
+    backupRecoveryStatus,
+  ])
+
+  useEffect(() => {
+    if (backupRecoveryStatus !== 'resolved' || backupPrompt !== null) return
+    if (!draft || !editor) return
+
+    setArticleId(draft._id)
+    setTitle(draft.title)
+    setExcerpt(draft.excerpt || '')
+    setTags(draft.tags?.join(', ') ?? '')
+    setCoverImage(draft.coverImage || '')
+    setPublishStatus({
+      published: draft.published,
+      publishedAt: draft.publishedAt ? new Date(draft.publishedAt) : null,
+    })
+    if (draft.content) {
+      queueMicrotask(() => {
+        editor.commands.setContent(draft.content)
+      })
+      setEditorContent(draft.content)
+    }
+    setHasUnsavedChanges(false)
+  }, [draft, editor, backupRecoveryStatus, backupPrompt])
+
+  const applyDraftBackup = useCallback(
+    (backup: DraftBackup) => {
+      if (!editor) return
+      setArticleId(backup.articleId)
+      setTitle(backup.title)
+      setExcerpt(backup.excerpt || '')
+      setTags(backup.tags?.join(', ') ?? '')
+      setCoverImage(backup.coverImage || '')
+      queueMicrotask(() => {
+        editor.commands.setContent(backup.content)
+      })
+      setEditorContent(backup.content)
+      setHasUnsavedChanges(true)
+    },
+    [editor]
+  )
+
+  const handleRestoreBackup = useCallback(() => {
+    if (!backupPrompt) return
+    recoveryDeferredRef.current = false
+    applyDraftBackup(backupPrompt)
+    clearDraftBackup()
+    setBackupPrompt(null)
+    setBackupRecoveryStatus('resolved')
+  }, [backupPrompt, applyDraftBackup])
+
+  const handleDiscardBackup = useCallback(() => {
+    recoveryDeferredRef.current = false
+    clearDraftBackup()
+    setBackupPrompt(null)
+    setBackupRecoveryStatus('resolved')
+  }, [])
+
+  useEffect(() => {
+    const onPageHide = () => {
+      persistDraftBackup()
+    }
+    window.addEventListener('pagehide', onPageHide)
+    return () => window.removeEventListener('pagehide', onPageHide)
+  }, [persistDraftBackup])
+
+  useEffect(() => {
+    if (!isAuthenticated || !hasUnsavedChanges) return
+    const hasContent = !!editorContent
+    const hasMetadata = !!(title?.trim() || coverImage)
+    if (!hasContent && !hasMetadata) return
+
+    const timeoutId = setTimeout(() => {
+      persistDraftBackup()
+    }, 2000)
+
+    return () => clearTimeout(timeoutId)
+  }, [
+    persistDraftBackup,
+    isAuthenticated,
+    hasUnsavedChanges,
+    editorContent,
+    title,
+    coverImage,
+  ])
 
   useEffect(() => {
     const handler = (e: BeforeUnloadEvent) => {
-      const hasContent = !!editorContent
-      const hasMetadata = !!(title?.trim() || coverImage)
-      const autoSaveEnabled = isAuthenticated && (hasUnsavedChanges || !!title)
-      if (autoSaveEnabled && (hasContent || hasMetadata)) {
-        try {
-          const tagsArr = tags
-            .split(',')
-            .map((t) => t.trim())
-            .filter(Boolean)
-          localStorage.setItem(
-            'quilltip_draft_backup',
-            JSON.stringify({
-              title: title || 'Untitled',
-              content: editorContent ?? EMPTY_DOC,
-              excerpt,
-              tags: tagsArr.length ? tagsArr : undefined,
-              coverImage: coverImage || undefined,
-              articleId,
-              savedAt: Date.now(),
-            })
-          )
-        } catch {
-          // localStorage unavailable or full
-        }
-      }
+      persistDraftBackup()
       if (hasUnsavedChanges) {
         e.preventDefault()
         e.returnValue = ''
@@ -282,16 +422,7 @@ export function WriteEditorWorkspace() {
     }
     window.addEventListener('beforeunload', handler)
     return () => window.removeEventListener('beforeunload', handler)
-  }, [
-    hasUnsavedChanges,
-    isAuthenticated,
-    editorContent,
-    title,
-    coverImage,
-    excerpt,
-    tags,
-    articleId,
-  ])
+  }, [hasUnsavedChanges, persistDraftBackup])
 
   useEffect(() => {
     const onDocumentClick = (e: MouseEvent) => {
@@ -978,6 +1109,43 @@ export function WriteEditorWorkspace() {
               }}
             >
               Publish
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={backupPrompt !== null}
+        onOpenChange={(open) => {
+          if (!open && backupPrompt !== null) {
+            if (readDraftBackup()) {
+              recoveryDeferredRef.current = true
+            }
+            setBackupPrompt(null)
+            setBackupRecoveryStatus('resolved')
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Recover unsaved draft?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {backupPrompt
+                ? `${formatBackupSavedAt(backupPrompt.savedAt)}. Restore this version or discard the local backup.`
+                : 'A local backup of your draft was found.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel type="button">Not now</AlertDialogCancel>
+            <AlertDialogAction
+              type="button"
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={handleDiscardBackup}
+            >
+              Discard backup
+            </AlertDialogAction>
+            <AlertDialogAction type="button" onClick={handleRestoreBackup}>
+              Restore
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/hooks/useAutoSave.test.ts
+++ b/hooks/useAutoSave.test.ts
@@ -3,6 +3,7 @@ import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { JSONContent } from '@tiptap/react'
 import { useAutoSave } from './useAutoSave'
+import { DRAFT_BACKUP_STORAGE_KEY } from '@/lib/draftBackup'
 
 const mockSaveDraft = vi.hoisted(() => vi.fn())
 
@@ -19,6 +20,11 @@ describe('useAutoSave', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockSaveDraft.mockResolvedValue('article-123')
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
   })
 
   afterEach(() => {
@@ -148,6 +154,27 @@ describe('useAutoSave', () => {
         title: 'My draft',
       })
     )
+  })
+
+  it('does not remove local draft backup on mount', () => {
+    localStorage.setItem(
+      DRAFT_BACKUP_STORAGE_KEY,
+      JSON.stringify({
+        title: 'Kept',
+        content: sampleContent,
+        savedAt: Date.now(),
+      })
+    )
+
+    renderHook(() =>
+      useAutoSave({
+        content: sampleContent,
+        title: 'My draft',
+        enabled: false,
+      })
+    )
+
+    expect(localStorage.getItem(DRAFT_BACKUP_STORAGE_KEY)).not.toBeNull()
   })
 
   it('calls onSaveError when save fails', async () => {

--- a/hooks/useAutoSave.ts
+++ b/hooks/useAutoSave.ts
@@ -200,20 +200,6 @@ export function useAutoSave({
     await saveDraft()
   }, [saveDraft])
 
-  // On mount, check for localStorage backup and restore if present
-  useEffect(() => {
-    try {
-      const backup = localStorage.getItem('quilltip_draft_backup')
-      if (backup) {
-        // Backup exists but we only use it if there's no current content
-        // The parent component can read this key if needed
-        localStorage.removeItem('quilltip_draft_backup')
-      }
-    } catch {
-      // localStorage unavailable — ignore
-    }
-  }, [])
-
   return {
     ...state,
     saveNow,

--- a/lib/draftBackup.test.ts
+++ b/lib/draftBackup.test.ts
@@ -63,15 +63,11 @@ describe('draftBackup', () => {
 
   describe('shouldPersistDraftBackup', () => {
     it('returns false when there are no unsaved changes (synced draft)', () => {
-      expect(
-        shouldPersistDraftBackup(true, false, true, true)
-      ).toBe(false)
+      expect(shouldPersistDraftBackup(true, false, true, true)).toBe(false)
     })
 
     it('returns true when there are unsaved changes and content', () => {
-      expect(
-        shouldPersistDraftBackup(true, true, true, false)
-      ).toBe(true)
+      expect(shouldPersistDraftBackup(true, true, true, false)).toBe(true)
     })
   })
 

--- a/lib/draftBackup.test.ts
+++ b/lib/draftBackup.test.ts
@@ -1,0 +1,218 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { JSONContent } from '@tiptap/react'
+import {
+  DRAFT_BACKUP_STORAGE_KEY,
+  backupMatchesSession,
+  clearDraftBackup,
+  hasMeaningfulBackupContent,
+  readDraftBackup,
+  shouldOfferDraftRecovery,
+  shouldPersistDraftBackup,
+  writeDraftBackup,
+  type DraftBackup,
+} from './draftBackup'
+
+const EMPTY_DOC: JSONContent = { type: 'doc', content: [] }
+
+const sampleContent: JSONContent = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'Recovery test body' }],
+    },
+  ],
+}
+
+function makeBackup(overrides: Partial<DraftBackup> = {}): DraftBackup {
+  return {
+    title: 'My draft',
+    content: sampleContent,
+    savedAt: Date.now(),
+    ...overrides,
+  }
+}
+
+describe('draftBackup', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('reads and writes a valid backup', () => {
+    const backup = makeBackup({ savedAt: 1_700_000_000_000 })
+    writeDraftBackup(backup)
+    expect(readDraftBackup()).toEqual(backup)
+  })
+
+  it('returns null for malformed backup JSON', () => {
+    localStorage.setItem(DRAFT_BACKUP_STORAGE_KEY, '{"title":123}')
+    expect(readDraftBackup()).toBeNull()
+  })
+
+  it('clears backup only when clearDraftBackup is called', () => {
+    writeDraftBackup(makeBackup())
+    expect(readDraftBackup()).not.toBeNull()
+    clearDraftBackup()
+    expect(readDraftBackup()).toBeNull()
+  })
+
+  describe('shouldPersistDraftBackup', () => {
+    it('returns false when there are no unsaved changes (synced draft)', () => {
+      expect(
+        shouldPersistDraftBackup(true, false, true, true)
+      ).toBe(false)
+    })
+
+    it('returns true when there are unsaved changes and content', () => {
+      expect(
+        shouldPersistDraftBackup(true, true, true, false)
+      ).toBe(true)
+    })
+  })
+
+  describe('hasMeaningfulBackupContent', () => {
+    it('returns false for empty doc and default title', () => {
+      expect(
+        hasMeaningfulBackupContent(
+          makeBackup({ title: 'Untitled', content: EMPTY_DOC })
+        )
+      ).toBe(false)
+    })
+
+    it('returns true when body has text', () => {
+      expect(hasMeaningfulBackupContent(makeBackup())).toBe(true)
+    })
+
+    it('returns true when only metadata is set', () => {
+      expect(
+        hasMeaningfulBackupContent(
+          makeBackup({
+            title: 'Untitled',
+            content: EMPTY_DOC,
+            excerpt: 'Short summary',
+          })
+        )
+      ).toBe(true)
+    })
+  })
+
+  describe('backupMatchesSession', () => {
+    it('matches two new-draft sessions', () => {
+      expect(
+        backupMatchesSession(makeBackup(), {
+          urlArticleId: undefined,
+          stateArticleId: undefined,
+        })
+      ).toBe(true)
+    })
+
+    it('matches when URL id equals backup articleId', () => {
+      expect(
+        backupMatchesSession(makeBackup({ articleId: 'art-1' }), {
+          urlArticleId: 'art-1',
+          stateArticleId: undefined,
+        })
+      ).toBe(true)
+    })
+
+    it('does not match when URL id differs from backup articleId', () => {
+      expect(
+        backupMatchesSession(makeBackup({ articleId: 'art-1' }), {
+          urlArticleId: 'art-2',
+          stateArticleId: undefined,
+        })
+      ).toBe(false)
+    })
+
+    it('matches backup with articleId when URL has no id yet', () => {
+      expect(
+        backupMatchesSession(makeBackup({ articleId: 'art-1' }), {
+          urlArticleId: undefined,
+          stateArticleId: undefined,
+        })
+      ).toBe(true)
+    })
+  })
+
+  describe('shouldOfferDraftRecovery', () => {
+    it('offers recovery when backup is newer than server draft', () => {
+      const backup = makeBackup({
+        articleId: 'art-1',
+        savedAt: 2_000,
+      })
+      const server = {
+        title: 'My draft',
+        content: sampleContent,
+        updatedAt: 1_000,
+      }
+      expect(
+        shouldOfferDraftRecovery(backup, server, {
+          urlArticleId: 'art-1',
+        })
+      ).toBe(true)
+    })
+
+    it('does not offer recovery when snapshots match and backup is not newer', () => {
+      const backup = makeBackup({
+        articleId: 'art-1',
+        savedAt: 1_000,
+      })
+      const server = {
+        title: 'My draft',
+        content: sampleContent,
+        updatedAt: 2_000,
+      }
+      expect(
+        shouldOfferDraftRecovery(backup, server, {
+          urlArticleId: 'art-1',
+        })
+      ).toBe(false)
+    })
+
+    it('offers recovery when content differs from server', () => {
+      const backup = makeBackup({
+        articleId: 'art-1',
+        savedAt: 1_000,
+      })
+      const server = {
+        title: 'My draft',
+        content: EMPTY_DOC,
+        updatedAt: 9_000,
+      }
+      expect(
+        shouldOfferDraftRecovery(backup, server, {
+          urlArticleId: 'art-1',
+        })
+      ).toBe(true)
+    })
+
+    it('does not offer recovery for empty backup', () => {
+      expect(
+        shouldOfferDraftRecovery(
+          makeBackup({ title: 'Untitled', content: EMPTY_DOC }),
+          undefined,
+          {}
+        )
+      ).toBe(false)
+    })
+
+    it('does not offer recovery when session does not match', () => {
+      expect(
+        shouldOfferDraftRecovery(
+          makeBackup({ articleId: 'art-1' }),
+          undefined,
+          { urlArticleId: 'art-2' }
+        )
+      ).toBe(false)
+    })
+
+    it('offers recovery for meaningful backup with no server draft', () => {
+      expect(shouldOfferDraftRecovery(makeBackup(), undefined, {})).toBe(true)
+    })
+  })
+})

--- a/lib/draftBackup.ts
+++ b/lib/draftBackup.ts
@@ -1,0 +1,190 @@
+import type { JSONContent } from '@tiptap/react'
+import { z } from 'zod'
+
+export const DRAFT_BACKUP_STORAGE_KEY = 'quilltip_draft_backup'
+
+const jsonContentSchema: z.ZodType<JSONContent> = z
+  .object({
+    type: z.string(),
+  })
+  .passthrough()
+
+export const draftBackupSchema = z.object({
+  title: z.string(),
+  content: jsonContentSchema,
+  excerpt: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  coverImage: z.string().optional(),
+  articleId: z.string().optional(),
+  savedAt: z.number(),
+})
+
+export type DraftBackup = z.infer<typeof draftBackupSchema>
+
+export type ServerDraftSnapshot = {
+  title: string
+  content?: JSONContent | null
+  excerpt?: string
+  tags?: string[]
+  coverImage?: string
+  updatedAt: number
+}
+
+export type BackupSessionContext = {
+  urlArticleId?: string
+  stateArticleId?: string
+}
+
+type DraftSnapshotFields = {
+  title: string
+  content: JSONContent
+  excerpt?: string
+  tags?: string[]
+  coverImage?: string
+}
+
+function normalizeSnapshot(fields: DraftSnapshotFields): string {
+  return JSON.stringify({
+    title: fields.title.trim() || 'Untitled',
+    content: fields.content,
+    excerpt: (fields.excerpt ?? '').trim(),
+    tags: [...(fields.tags ?? [])].sort(),
+    coverImage: (fields.coverImage ?? '').trim(),
+  })
+}
+
+function isEmptyDoc(doc: JSONContent): boolean {
+  const nodes = doc.content
+  if (!nodes || nodes.length === 0) return true
+  if (nodes.length === 1 && nodes[0]?.type === 'paragraph') {
+    const paragraph = nodes[0]
+    const inline = paragraph.content
+    if (!inline || inline.length === 0) return true
+    return inline.every(
+      (node) =>
+        node.type === 'text' &&
+        typeof node.text === 'string' &&
+        node.text.trim() === ''
+    )
+  }
+  return false
+}
+
+export function shouldPersistDraftBackup(
+  isAuthenticated: boolean,
+  hasUnsavedChanges: boolean,
+  hasContent: boolean,
+  hasMetadata: boolean
+): boolean {
+  return (
+    isAuthenticated && hasUnsavedChanges && (hasContent || hasMetadata)
+  )
+}
+
+export function hasMeaningfulBackupContent(backup: DraftBackup): boolean {
+  const hasCustomTitle =
+    backup.title.trim() !== '' && backup.title.trim() !== 'Untitled'
+  const hasCover = !!backup.coverImage?.trim()
+  const hasExcerpt = !!backup.excerpt?.trim()
+  const hasTags = (backup.tags?.length ?? 0) > 0
+  if (hasCustomTitle || hasCover || hasExcerpt || hasTags) return true
+  return !isEmptyDoc(backup.content)
+}
+
+export function backupMatchesSession(
+  backup: DraftBackup,
+  { urlArticleId, stateArticleId }: BackupSessionContext
+): boolean {
+  const sessionId = urlArticleId ?? stateArticleId
+  const backupId = backup.articleId
+
+  if (!sessionId && !backupId) return true
+  if (sessionId && backupId) return sessionId === backupId
+  if (!sessionId && backupId) return true
+  return false
+}
+
+function snapshotsEqual(
+  backup: DraftBackup,
+  server: ServerDraftSnapshot
+): boolean {
+  return (
+    normalizeSnapshot({
+      title: backup.title,
+      content: backup.content,
+      excerpt: backup.excerpt,
+      tags: backup.tags,
+      coverImage: backup.coverImage,
+    }) ===
+    normalizeSnapshot({
+      title: server.title,
+      content: server.content ?? { type: 'doc', content: [] },
+      excerpt: server.excerpt,
+      tags: server.tags,
+      coverImage: server.coverImage,
+    })
+  )
+}
+
+export function shouldOfferDraftRecovery(
+  backup: DraftBackup,
+  serverDraft: ServerDraftSnapshot | null | undefined,
+  session: BackupSessionContext
+): boolean {
+  if (!hasMeaningfulBackupContent(backup)) return false
+  if (!backupMatchesSession(backup, session)) return false
+
+  if (!serverDraft) return true
+
+  if (snapshotsEqual(backup, serverDraft)) {
+    return backup.savedAt > serverDraft.updatedAt
+  }
+
+  return true
+}
+
+export function readDraftBackup(): DraftBackup | null {
+  if (typeof localStorage === 'undefined') return null
+  try {
+    const raw = localStorage.getItem(DRAFT_BACKUP_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = draftBackupSchema.safeParse(JSON.parse(raw))
+    return parsed.success ? parsed.data : null
+  } catch {
+    return null
+  }
+}
+
+export function writeDraftBackup(backup: DraftBackup): void {
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.setItem(DRAFT_BACKUP_STORAGE_KEY, JSON.stringify(backup))
+  } catch {
+    // localStorage unavailable or full
+  }
+}
+
+export function clearDraftBackup(): void {
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.removeItem(DRAFT_BACKUP_STORAGE_KEY)
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+export function formatBackupSavedAt(savedAt: number): string {
+  const diffMs = Math.max(0, Date.now() - savedAt)
+  const diffSec = Math.floor(diffMs / 1000)
+  if (diffSec < 60) return 'Saved locally just now'
+  const diffMin = Math.floor(diffSec / 60)
+  if (diffMin < 60) {
+    return `Saved locally ${diffMin} minute${diffMin === 1 ? '' : 's'} ago`
+  }
+  const diffHr = Math.floor(diffMin / 60)
+  if (diffHr < 24) {
+    return `Saved locally ${diffHr} hour${diffHr === 1 ? '' : 's'} ago`
+  }
+  const diffDay = Math.floor(diffHr / 24)
+  return `Saved locally ${diffDay} day${diffDay === 1 ? '' : 's'} ago`
+}

--- a/lib/draftBackup.ts
+++ b/lib/draftBackup.ts
@@ -76,9 +76,7 @@ export function shouldPersistDraftBackup(
   hasContent: boolean,
   hasMetadata: boolean
 ): boolean {
-  return (
-    isAuthenticated && hasUnsavedChanges && (hasContent || hasMetadata)
-  )
+  return isAuthenticated && hasUnsavedChanges && (hasContent || hasMetadata)
 }
 
 export function hasMeaningfulBackupContent(backup: DraftBackup): boolean {


### PR DESCRIPTION
## Summary

Fixes [ENG-165](https://linear.app) — local draft backups were written on refresh/tab close but silently deleted on the next visit, with no way to recover recent writing.

- Add `lib/draftBackup.ts` with Zod-validated read/write/clear helpers, session matching, and recovery decision logic
- Remove silent `localStorage` deletion from `useAutoSave` on mount
- Show a recovery dialog in `WriteEditorWorkspace` before any backup is cleared
- Persist backups via debounced writes (2s), `pagehide`, and `beforeunload`
- Clear backup only after explicit **Restore** or **Discard backup**, or after a successful server save

## Problem

On `/write`, unsaved content was stored in `quilltip_draft_backup` when leaving the page, but `useAutoSave` removed that key on load without prompting. Users lost recent edits after refresh, tab close, or interrupted connectivity.

## Solution

| Checklist | How |
|-----------|-----|
| Prompt before clear | Recovery `AlertDialog` runs before `clearDraftBackup()` |
| Refresh / tab-close recovery | `pagehide`, `beforeunload`, and 2s debounced backup while editing |
| Explicit opt-out | **Discard backup** clears storage; **Not now** / Esc keeps backup for a later visit |
| Verification | `lib/draftBackup.test.ts`, `hooks/useAutoSave.test.ts` |

## User flow

1. User types unsaved content → local backup is written periodically and on leave
2. User returns to `/write` → if backup is newer or differs from server, show **Recover unsaved draft?**
3. **Restore** → apply backup to editor, clear local storage
4. **Discard backup** → load server draft, clear local storage
5. **Not now** / dismiss → backup stays; prompt can appear again on next load

Wrong-draft protection: backups only offered when session IDs match (or both are new drafts).
<img width="1222" height="721" alt="1" src="https://github.com/user-attachments/assets/783d67b7-bbdb-4979-94fa-b58cc9c699fe" />
<img width="1221" height="719" alt="2" src="https://github.com/user-attachments/assets/028116e8-18d4-4967-9be3-046681be93e4" />

<img width="1216" height="717" alt="3" src="https://github.com/user-attachments/assets/c54601f5-2047-4068-a8ca-cebeff41a49c" />

<img width="1219" height="713" alt="5" src="https://github.com/user-attachments/assets/6721daa8-7cd4-45dc-b27c-de4d238f6709" />
