### PR TITLE
feat(editor): persist personal notes with drafts (ENG-177)

### DIFF
--- a/components/editor/EditorToolbar.tsx
+++ b/components/editor/EditorToolbar.tsx
@@ -795,8 +795,14 @@ export function EditorToolbar({
           </button>
           {showNotes && (
             <div className="absolute top-full right-0 mt-1 bg-popover border border-border rounded-lg shadow-lg z-50 w-72">
-              <div className="px-3 py-2 border-b border-border text-xs font-medium text-muted-foreground">
-                Personal Notes
+              <div className="px-3 py-2 border-b border-border">
+                <p className="text-xs font-medium text-muted-foreground">
+                  Personal Notes
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground/80 leading-snug">
+                  Private planning notes for you only. They are saved with this
+                  draft and are not published with your article.
+                </p>
               </div>
               <textarea
                 value={notes}

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -222,8 +222,7 @@ export function WriteEditorWorkspace() {
     coverImage: coverImage || undefined,
     writerNotes,
     enabled:
-      isAuthenticated &&
-      (hasUnsavedChanges || !!title || !!writerNotes.trim()),
+      isAuthenticated && (hasUnsavedChanges || !!title || !!writerNotes.trim()),
     onSaveSuccess: (response) => {
       if (!articleId && response.id) {
         setArticleId(response.id)

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -108,6 +108,7 @@ export function WriteEditorWorkspace() {
   const [isPublishing, setIsPublishing] = useState(false)
   const [articleId, setArticleId] = useState<string | undefined>()
   const [editorContent, setEditorContent] = useState<JSONContent | null>(null)
+  const [writerNotes, setWriterNotes] = useState('')
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
   const [navConfirm, setNavConfirm] = useState<NavConfirmState>(null)
   const hasUnsavedRef = useRef(hasUnsavedChanges)
@@ -219,7 +220,10 @@ export function WriteEditorWorkspace() {
       .map((t) => t.trim())
       .filter(Boolean),
     coverImage: coverImage || undefined,
-    enabled: isAuthenticated && (hasUnsavedChanges || !!title),
+    writerNotes,
+    enabled:
+      isAuthenticated &&
+      (hasUnsavedChanges || !!title || !!writerNotes.trim()),
     onSaveSuccess: (response) => {
       if (!articleId && response.id) {
         setArticleId(response.id)
@@ -256,14 +260,15 @@ export function WriteEditorWorkspace() {
       excerpt: excerpt || undefined,
       tags: tagsArr.length ? tagsArr : undefined,
       coverImage: coverImage || undefined,
+      writerNotes: writerNotes.trim() ? writerNotes : undefined,
       articleId,
       savedAt: Date.now(),
     }
-  }, [editorContent, title, excerpt, tags, coverImage, articleId])
+  }, [editorContent, title, excerpt, tags, coverImage, writerNotes, articleId])
 
   const persistDraftBackup = useCallback(() => {
     const hasContent = !!editorContent
-    const hasMetadata = !!(title?.trim() || coverImage)
+    const hasMetadata = !!(title?.trim() || coverImage || writerNotes.trim())
     if (
       !shouldPersistDraftBackup(
         isAuthenticated,
@@ -280,6 +285,7 @@ export function WriteEditorWorkspace() {
     editorContent,
     title,
     coverImage,
+    writerNotes,
     hasUnsavedChanges,
     isAuthenticated,
   ])
@@ -305,6 +311,7 @@ export function WriteEditorWorkspace() {
             excerpt: draft.excerpt,
             tags: draft.tags,
             coverImage: draft.coverImage,
+            writerNotes: draft.writerNotes,
             updatedAt: draft.updatedAt,
           }
         : undefined
@@ -338,6 +345,7 @@ export function WriteEditorWorkspace() {
     setExcerpt(draft.excerpt || '')
     setTags(draft.tags?.join(', ') ?? '')
     setCoverImage(draft.coverImage || '')
+    setWriterNotes(draft.writerNotes ?? '')
     setPublishStatus({
       published: draft.published,
       publishedAt: draft.publishedAt ? new Date(draft.publishedAt) : null,
@@ -359,6 +367,7 @@ export function WriteEditorWorkspace() {
       setExcerpt(backup.excerpt || '')
       setTags(backup.tags?.join(', ') ?? '')
       setCoverImage(backup.coverImage || '')
+      setWriterNotes(backup.writerNotes ?? '')
       queueMicrotask(() => {
         editor.commands.setContent(backup.content)
       })
@@ -771,6 +780,11 @@ export function WriteEditorWorkspace() {
           <div className="mx-auto w-full max-w-4xl px-4 sm:px-6">
             <EditorToolbar
               editor={editor}
+              notes={writerNotes}
+              onNotesChange={(value) => {
+                setWriterNotes(value)
+                setHasUnsavedChanges(true)
+              }}
               onFocusCoverImage={() => {
                 document
                   .getElementById('field-cover-image')
@@ -1162,7 +1176,7 @@ export function WriteEditorWorkspace() {
             <AlertDialogTitle>Discard unsaved changes?</AlertDialogTitle>
             <AlertDialogDescription>
               Your draft is not saved to the server yet. If you leave now,
-              recent edits may be lost.
+              recent edits and notes may be lost.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/convex/articles.saveDraft.test.ts
+++ b/convex/articles.saveDraft.test.ts
@@ -1,0 +1,94 @@
+/// <reference types="vite/client" />
+import { convexTest } from 'convex-test'
+import { describe, expect, it } from 'vitest'
+import { api } from './_generated/api'
+import schema from './schema'
+import type { Id } from './_generated/dataModel'
+
+const emptyDoc = { type: 'doc', content: [] }
+
+const modules = import.meta.glob(['./**/*.ts', '!./**/*.test.ts'])
+
+async function seedAuthor(t: ReturnType<typeof convexTest>) {
+  return await t.run(async (ctx) => {
+    const now = Date.now()
+    const userId = await ctx.db.insert('users', {
+      email: 'writer@x.test',
+      username: 'writer',
+      createdAt: now,
+      updatedAt: now,
+    })
+    return { userId, now }
+  })
+}
+
+describe('saveDraft writerNotes', () => {
+  it('persists writerNotes and returns them to the author via getArticleById', async () => {
+    const t = convexTest(schema, modules)
+    const { userId } = await seedAuthor(t)
+    const asAuthor = t.withIdentity({ subject: userId })
+
+    const draftId = await asAuthor.mutation(api.articles.saveDraft, {
+      title: 'Draft with notes',
+      content: emptyDoc,
+      writerNotes: 'ENG-177 private note',
+    })
+
+    const loaded = await asAuthor.query(api.articles.getArticleById, {
+      id: draftId,
+    })
+    expect(loaded?.writerNotes).toBe('ENG-177 private note')
+  })
+
+  it('omits writerNotes from getArticleBySlug for published articles', async () => {
+    const t = convexTest(schema, modules)
+    const { userId, now } = await seedAuthor(t)
+    const asAuthor = t.withIdentity({ subject: userId })
+
+    const articleId = await t.run(async (ctx) => {
+      return await ctx.db.insert('articles', {
+        slug: 'published-with-notes',
+        title: 'Published',
+        content: emptyDoc,
+        writerNotes: 'Secret planning',
+        published: true,
+        publishedAt: now,
+        authorId: userId,
+        authorUsername: 'writer',
+        tags: [],
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+    })
+
+    const bySlug = await t.query(api.articles.getArticleBySlug, {
+      username: 'writer',
+      slug: 'published-with-notes',
+    })
+    expect(bySlug).not.toBeNull()
+    expect(bySlug).not.toHaveProperty('writerNotes')
+
+    const byIdAsAuthor = await asAuthor.query(api.articles.getArticleById, {
+      id: articleId as Id<'articles'>,
+    })
+    expect(byIdAsAuthor?.writerNotes).toBe('Secret planning')
+  })
+
+  it('rejects writerNotes longer than 5000 characters', async () => {
+    const t = convexTest(schema, modules)
+    const { userId } = await seedAuthor(t)
+    const asAuthor = t.withIdentity({ subject: userId })
+
+    await expect(
+      asAuthor.mutation(api.articles.saveDraft, {
+        title: 'Too long notes',
+        content: emptyDoc,
+        writerNotes: 'x'.repeat(5001),
+      })
+    ).rejects.toThrow('Writer notes must be 5000 characters or less')
+  })
+})

--- a/convex/articles.ts
+++ b/convex/articles.ts
@@ -18,11 +18,21 @@ import {
   tiptapJsonHasNonEmptyText,
 } from './lib/tiptapContent'
 
+const WRITER_NOTES_MAX_LENGTH = 5000
+
+function stripWriterNotes<T extends { writerNotes?: string }>(
+  article: T
+): Omit<T, 'writerNotes'> {
+  const { writerNotes: _writerNotes, ...rest } = article
+  return rest
+}
+
 // Validation helper for article input
 function validateArticleInput(args: {
   title: string
   excerpt?: string
   tags?: string[]
+  writerNotes?: string
 }) {
   if (!args.title || args.title.trim().length === 0) {
     throw new Error('Title is required')
@@ -42,6 +52,11 @@ function validateArticleInput(args: {
         throw new Error('Each tag must be 50 characters or less')
       }
     }
+  }
+  if (args.writerNotes && args.writerNotes.length > WRITER_NOTES_MAX_LENGTH) {
+    throw new Error(
+      `Writer notes must be ${WRITER_NOTES_MAX_LENGTH} characters or less`
+    )
   }
 }
 
@@ -107,7 +122,7 @@ export const listArticles = query({
       const slice = rows.slice(offset, offset + limit)
       const enrichedArticles = await Promise.all(
         slice.map(async (article) => ({
-          ...article,
+          ...stripWriterNotes(article),
           author: await enrichWithUser(ctx, article.authorId),
         }))
       )
@@ -144,7 +159,7 @@ export const listArticles = query({
       )
       const enrichedArticles = await Promise.all(
         articles.map(async (article) => ({
-          ...article,
+          ...stripWriterNotes(article),
           author: await enrichWithUser(ctx, article.authorId),
         }))
       )
@@ -171,7 +186,7 @@ export const listArticles = query({
     const slice = rows.slice(offset, offset + limit)
     const enrichedArticles = await Promise.all(
       slice.map(async (article) => ({
-        ...article,
+        ...stripWriterNotes(article),
         author: await enrichWithUser(ctx, article.authorId),
       }))
     )
@@ -230,7 +245,7 @@ export const getArticleBySlug = query({
     }
 
     return {
-      ...article,
+      ...stripWriterNotes(article),
       author: {
         id: author._id,
         name: author.name,
@@ -250,15 +265,16 @@ export const getArticleById = query({
     const article = await ctx.db.get(args.id)
     if (!article) return null
 
+    const userId = await getAuthUserId(ctx)
+    const isAuthor = userId === article.authorId
+
     // If unpublished, only the author can view it
-    if (!article.published) {
-      const userId = await getAuthUserId(ctx)
-      if (userId !== article.authorId) return null
-    }
+    if (!article.published && !isAuthor) return null
 
     const author = await ctx.db.get(article.authorId)
     return {
-      ...article,
+      ...stripWriterNotes(article),
+      ...(isAuthor ? { writerNotes: article.writerNotes } : {}),
       author: author
         ? {
             id: author._id,
@@ -588,6 +604,7 @@ export const saveDraft = mutation({
     excerpt: v.optional(v.string()),
     coverImage: v.optional(v.string()),
     tags: v.optional(v.array(v.string())),
+    writerNotes: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx)
@@ -608,6 +625,7 @@ export const saveDraft = mutation({
         excerpt?: string
         coverImage?: string
         tags?: string[]
+        writerNotes?: string
         updatedAt: number
         slug?: string
         searchContent: string
@@ -617,6 +635,7 @@ export const saveDraft = mutation({
         excerpt: args.excerpt,
         coverImage: args.coverImage,
         tags: args.tags,
+        writerNotes: args.writerNotes,
         updatedAt: Date.now(),
         searchContent: buildSearchContent(args.title, args.excerpt, {
           tags: args.tags,
@@ -660,6 +679,7 @@ export const saveDraft = mutation({
         content: args.content,
         excerpt: args.excerpt,
         coverImage: args.coverImage,
+        writerNotes: args.writerNotes,
         published: false,
         authorId: userId,
         authorUsername: user.username,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -50,6 +50,8 @@ export default defineSchema({
     content: v.any(), // TipTap JSON content
     excerpt: v.optional(v.string()),
     coverImage: v.optional(v.string()),
+    /** Author-only planning notes; never exposed on public article reads */
+    writerNotes: v.optional(v.string()),
 
     // Publishing
     published: v.boolean(),

--- a/hooks/useAutoSave.test.ts
+++ b/hooks/useAutoSave.test.ts
@@ -177,6 +177,38 @@ describe('useAutoSave', () => {
     expect(localStorage.getItem(DRAFT_BACKUP_STORAGE_KEY)).not.toBeNull()
   })
 
+  it('debounces save when only writerNotes changes', async () => {
+    vi.useFakeTimers()
+    mockSaveDraft.mockResolvedValue('article-123')
+
+    const { rerender } = renderHook(
+      ({ writerNotes }: { writerNotes: string }) =>
+        useAutoSave({
+          content: null,
+          title: '',
+          writerNotes,
+          enabled: true,
+        }),
+      { initialProps: { writerNotes: '' } }
+    )
+
+    rerender({ writerNotes: 'Planning note' })
+
+    expect(mockSaveDraft).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000)
+    })
+
+    expect(mockSaveDraft).toHaveBeenCalledTimes(1)
+    expect(mockSaveDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        writerNotes: 'Planning note',
+        title: 'Untitled',
+      })
+    )
+  })
+
   it('calls onSaveError when save fails', async () => {
     const onSaveError = vi.fn()
     mockSaveDraft.mockRejectedValue(new Error('Offline'))

--- a/hooks/useAutoSave.ts
+++ b/hooks/useAutoSave.ts
@@ -26,6 +26,7 @@ interface UseAutoSaveOptions {
   excerpt?: string
   tags?: string[]
   coverImage?: string
+  writerNotes?: string
   enabled?: boolean
   onSaveSuccess?: (response: DraftResponse) => void
   onSaveError?: (error: Error) => void
@@ -44,6 +45,7 @@ export function useAutoSave({
   excerpt,
   tags,
   coverImage,
+  writerNotes,
   enabled = true,
   onSaveSuccess,
   onSaveError,
@@ -60,6 +62,7 @@ export function useAutoSave({
   const previousCoverImageRef = useRef<string | undefined>(undefined)
   const previousExcerptRef = useRef<string | undefined>(undefined)
   const previousTagsRef = useRef<string | undefined>(undefined)
+  const previousNotesRef = useRef<string | undefined>(undefined)
 
   // Convex mutation for saving drafts
   const saveDraftMutation = useMutation(api.articles.saveDraft)
@@ -67,7 +70,7 @@ export function useAutoSave({
   const saveDraft = useCallback(async () => {
     // Allow save when we have content OR (title or coverImage) for metadata-only drafts
     const hasContent = !!content
-    const hasMetadata = !!(title?.trim() || coverImage)
+    const hasMetadata = !!(title?.trim() || coverImage || writerNotes?.trim())
     if (!hasContent && !hasMetadata) return
 
     setState((prev) => {
@@ -83,6 +86,7 @@ export function useAutoSave({
       excerpt,
       tags: tags?.length ? tags : undefined,
       coverImage: coverImage || undefined,
+      writerNotes: writerNotes?.trim() ? writerNotes : undefined,
     })
 
     let timeoutId: ReturnType<typeof setTimeout> | undefined
@@ -136,6 +140,7 @@ export function useAutoSave({
     excerpt,
     tags,
     coverImage,
+    writerNotes,
     onSaveSuccess,
     onSaveError,
     saveDraftMutation,
@@ -154,7 +159,7 @@ export function useAutoSave({
   // Effect to handle content, title, coverImage, and excerpt changes
   useEffect(() => {
     const hasContent = !!content
-    const hasMetadata = !!(title?.trim() || coverImage)
+    const hasMetadata = !!(title?.trim() || coverImage || writerNotes?.trim())
     if (!enabled || (!hasContent && !hasMetadata)) return
 
     const contentString = content ? JSON.stringify(content) : ''
@@ -162,25 +167,29 @@ export function useAutoSave({
     const coverImageVal = coverImage ?? ''
     const excerptVal = excerpt ?? ''
     const tagsVal = tags?.join(',') ?? ''
+    const notesVal = writerNotes ?? ''
 
     const contentChanged = previousContentRef.current !== contentString
     const titleChanged = previousTitleRef.current !== titleVal
     const coverImageChanged = previousCoverImageRef.current !== coverImageVal
     const excerptChanged = previousExcerptRef.current !== excerptVal
     const tagsChanged = previousTagsRef.current !== tagsVal
+    const notesChanged = previousNotesRef.current !== notesVal
 
     if (
       contentChanged ||
       titleChanged ||
       coverImageChanged ||
       excerptChanged ||
-      tagsChanged
+      tagsChanged ||
+      notesChanged
     ) {
       previousContentRef.current = contentString
       previousTitleRef.current = titleVal
       previousCoverImageRef.current = coverImageVal
       previousExcerptRef.current = excerptVal
       previousTagsRef.current = tagsVal
+      previousNotesRef.current = notesVal
       debouncedSave()
     }
 
@@ -190,7 +199,7 @@ export function useAutoSave({
         clearTimeout(timeoutRef.current)
       }
     }
-  }, [content, title, coverImage, excerpt, tags, enabled, debouncedSave])
+  }, [content, title, coverImage, excerpt, tags, writerNotes, enabled, debouncedSave])
 
   // Save immediately function for manual triggers
   const saveNow = useCallback(async () => {

--- a/hooks/useAutoSave.ts
+++ b/hooks/useAutoSave.ts
@@ -199,7 +199,16 @@ export function useAutoSave({
         clearTimeout(timeoutRef.current)
       }
     }
-  }, [content, title, coverImage, excerpt, tags, writerNotes, enabled, debouncedSave])
+  }, [
+    content,
+    title,
+    coverImage,
+    excerpt,
+    tags,
+    writerNotes,
+    enabled,
+    debouncedSave,
+  ])
 
   // Save immediately function for manual triggers
   const saveNow = useCallback(async () => {

--- a/lib/draftBackup.test.ts
+++ b/lib/draftBackup.test.ts
@@ -95,6 +95,18 @@ describe('draftBackup', () => {
         )
       ).toBe(true)
     })
+
+    it('returns true when only writer notes are set', () => {
+      expect(
+        hasMeaningfulBackupContent(
+          makeBackup({
+            title: 'Untitled',
+            content: EMPTY_DOC,
+            writerNotes: 'Private planning',
+          })
+        )
+      ).toBe(true)
+    })
   })
 
   describe('backupMatchesSession', () => {
@@ -168,6 +180,25 @@ describe('draftBackup', () => {
           urlArticleId: 'art-1',
         })
       ).toBe(false)
+    })
+
+    it('offers recovery when writer notes differ from server', () => {
+      const backup = makeBackup({
+        articleId: 'art-1',
+        savedAt: 1_000,
+        writerNotes: 'Local note',
+      })
+      const server = {
+        title: 'My draft',
+        content: sampleContent,
+        writerNotes: 'Server note',
+        updatedAt: 9_000,
+      }
+      expect(
+        shouldOfferDraftRecovery(backup, server, {
+          urlArticleId: 'art-1',
+        })
+      ).toBe(true)
     })
 
     it('offers recovery when content differs from server', () => {

--- a/lib/draftBackup.ts
+++ b/lib/draftBackup.ts
@@ -15,6 +15,7 @@ export const draftBackupSchema = z.object({
   excerpt: z.string().optional(),
   tags: z.array(z.string()).optional(),
   coverImage: z.string().optional(),
+  writerNotes: z.string().optional(),
   articleId: z.string().optional(),
   savedAt: z.number(),
 })
@@ -27,6 +28,7 @@ export type ServerDraftSnapshot = {
   excerpt?: string
   tags?: string[]
   coverImage?: string
+  writerNotes?: string
   updatedAt: number
 }
 
@@ -41,6 +43,7 @@ type DraftSnapshotFields = {
   excerpt?: string
   tags?: string[]
   coverImage?: string
+  writerNotes?: string
 }
 
 function normalizeSnapshot(fields: DraftSnapshotFields): string {
@@ -50,6 +53,7 @@ function normalizeSnapshot(fields: DraftSnapshotFields): string {
     excerpt: (fields.excerpt ?? '').trim(),
     tags: [...(fields.tags ?? [])].sort(),
     coverImage: (fields.coverImage ?? '').trim(),
+    writerNotes: (fields.writerNotes ?? '').trim(),
   })
 }
 
@@ -85,7 +89,9 @@ export function hasMeaningfulBackupContent(backup: DraftBackup): boolean {
   const hasCover = !!backup.coverImage?.trim()
   const hasExcerpt = !!backup.excerpt?.trim()
   const hasTags = (backup.tags?.length ?? 0) > 0
-  if (hasCustomTitle || hasCover || hasExcerpt || hasTags) return true
+  const hasWriterNotes = !!backup.writerNotes?.trim()
+  if (hasCustomTitle || hasCover || hasExcerpt || hasTags || hasWriterNotes)
+    return true
   return !isEmptyDoc(backup.content)
 }
 
@@ -113,6 +119,7 @@ function snapshotsEqual(
       excerpt: backup.excerpt,
       tags: backup.tags,
       coverImage: backup.coverImage,
+      writerNotes: backup.writerNotes,
     }) ===
     normalizeSnapshot({
       title: server.title,
@@ -120,6 +127,7 @@ function snapshotsEqual(
       excerpt: server.excerpt,
       tags: server.tags,
       coverImage: server.coverImage,
+      writerNotes: server.writerNotes,
     })
   )
 }


### PR DESCRIPTION
## Summary

- Persist writer-only personal notes on articles via a new `writerNotes` field, saved through `saveDraft` and autosave.
- Wire the write editor Notes panel to parent state so notes load on draft open, survive reload, and back up to localStorage.
- Strip `writerNotes` from public article queries; only the author receives notes from `getArticleById`.
- Warn before leaving when notes (or other edits) are unsaved, and add UI copy explaining notes are private and not published.

## Changes

**Backend**
- `writerNotes` optional field on `articles` (max 5,000 chars)
- `saveDraft` accepts and stores `writerNotes`
- Omitted from `getArticleBySlug` and `listArticles`; returned to author only in `getArticleById`

**Frontend**
- `WriteEditorWorkspace`: `writerNotes` state, toolbar wiring, draft hydration, local backup
- `useAutoSave`: debounce and save notes-only edits
- `EditorToolbar`: helper text for persistence behavior
- Leave dialog mentions notes in unsaved-changes copy
<img width="1221" height="718" alt="1" src="https://github.com/user-attachments/assets/b511e307-4782-4f4d-a462-520ce874a43a" />
<img width="1215" height="714" alt="2" src="https://github.com/user-attachments/assets/96fd0c23-df76-416b-8415-ce4f63d1ba76" />



