### PR TITLE
fix(drafts): show pending state during draft deletion (ENG-210)

### DIFF
--- a/app/drafts/page.tsx
+++ b/app/drafts/page.tsx
@@ -49,9 +49,7 @@ export default function DraftsPage() {
     if (!deleteTarget || isDeleting) return
     setIsDeleting(true)
     try {
-      await mutationWithTimeout(
-        deleteArticleMutation({ id: deleteTarget })
-      )
+      await mutationWithTimeout(deleteArticleMutation({ id: deleteTarget }))
       toast.success('Draft deleted')
       setDeleteTarget(null)
       setIsDeleting(false)

--- a/app/drafts/page.tsx
+++ b/app/drafts/page.tsx
@@ -29,7 +29,8 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Skeleton } from '@/components/ui/skeleton'
-import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react'
+import { Loader2, MoreHorizontal, Pencil, Trash2 } from 'lucide-react'
+import { mutationWithTimeout } from '@/lib/convexMutationWithTimeout'
 
 export default function DraftsPage() {
   const router = useRouter()
@@ -42,6 +43,24 @@ export default function DraftsPage() {
   // Convex mutation for deleting articles
   const deleteArticleMutation = useMutation(api.articles.deleteArticle)
   const [deleteTarget, setDeleteTarget] = useState<Id<'articles'> | null>(null)
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const handleConfirmDelete = async () => {
+    if (!deleteTarget || isDeleting) return
+    setIsDeleting(true)
+    try {
+      await mutationWithTimeout(
+        deleteArticleMutation({ id: deleteTarget })
+      )
+      toast.success('Draft deleted')
+      setDeleteTarget(null)
+      setIsDeleting(false)
+    } catch (error) {
+      console.error('Failed to delete draft:', error)
+      toast.error('Failed to delete draft. Please try again.')
+      setIsDeleting(false)
+    }
+  }
 
   useEffect(() => {
     if (isLoading || isAuthenticated) return
@@ -142,8 +161,12 @@ export default function DraftsPage() {
                             </Link>
                           </DropdownMenuItem>
                           <DropdownMenuItem
-                            className="cursor-pointer gap-2 text-destructive focus:text-destructive"
-                            onSelect={() => setDeleteTarget(draft._id)}
+                            className="cursor-pointer gap-2 text-destructive focus:text-destructive disabled:opacity-50 disabled:pointer-events-none"
+                            disabled={isDeleting}
+                            onSelect={() => {
+                              if (isDeleting) return
+                              setDeleteTarget(draft._id)
+                            }}
                           >
                             <Trash2 className="h-4 w-4" />
                             Delete
@@ -186,8 +209,10 @@ export default function DraftsPage() {
                       Edit
                     </Link>
                     <button
+                      type="button"
+                      disabled={isDeleting}
                       onClick={() => setDeleteTarget(draft._id)}
-                      className="px-4 py-2 rounded-lg border border-destructive text-destructive bg-destructive/5 hover:bg-destructive/10 transition-colors"
+                      className="px-4 py-2 rounded-lg border border-destructive text-destructive bg-destructive/5 hover:bg-destructive/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       Delete
                     </button>
@@ -216,6 +241,7 @@ export default function DraftsPage() {
       <AlertDialog
         open={!!deleteTarget}
         onOpenChange={(open) => {
+          if (isDeleting) return
           if (!open) setDeleteTarget(null)
         }}
       >
@@ -228,23 +254,23 @@ export default function DraftsPage() {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
             <AlertDialogAction
-              className="bg-red-600 hover:bg-red-700 text-white"
-              onClick={async () => {
-                if (!deleteTarget) return
-                try {
-                  await deleteArticleMutation({ id: deleteTarget })
-                  toast.success('Draft deleted')
-                } catch (error) {
-                  console.error('Failed to delete draft:', error)
-                  toast.error('Failed to delete draft. Please try again.')
-                } finally {
-                  setDeleteTarget(null)
-                }
+              disabled={isDeleting}
+              className="bg-red-600 hover:bg-red-700 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              onClick={(e) => {
+                e.preventDefault()
+                void handleConfirmDelete()
               }}
             >
-              Delete
+              {isDeleting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Deleting...
+                </>
+              ) : (
+                'Delete'
+              )}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -48,6 +48,7 @@ interface EditorActionBarProps {
   canPublish: boolean
   lastSavedAt?: Date | null
   onDelete?: () => void
+  isDeleting?: boolean
   hasUnsavedChanges?: boolean
 }
 
@@ -56,9 +57,11 @@ const RELATIVE_TIME_INTERVAL_MS = 30_000
 function MoreMenu({
   editor,
   onDelete,
+  isDeleting = false,
 }: {
   editor: Editor | null
   onDelete?: () => void
+  isDeleting?: boolean
 }) {
   return (
     <DropdownMenu.Root>
@@ -95,11 +98,27 @@ function MoreMenu({
             <>
               <DropdownMenu.Separator className="h-px bg-border my-1" />
               <DropdownMenu.Item
-                onSelect={onDelete}
-                className="px-4 py-2.5 text-sm text-destructive hover:bg-destructive/10 focus:bg-destructive/10 cursor-pointer outline-none flex items-center gap-2"
+                disabled={isDeleting}
+                onSelect={(e) => {
+                  if (isDeleting) {
+                    e.preventDefault()
+                    return
+                  }
+                  onDelete?.()
+                }}
+                className="px-4 py-2.5 text-sm text-destructive hover:bg-destructive/10 focus:bg-destructive/10 cursor-pointer outline-none flex items-center gap-2 disabled:opacity-50 disabled:pointer-events-none"
               >
-                <Trash2 className="w-4 h-4 shrink-0" />
-                Delete draft
+                {isDeleting ? (
+                  <>
+                    <Loader2 className="w-4 h-4 shrink-0 animate-spin" />
+                    Deleting...
+                  </>
+                ) : (
+                  <>
+                    <Trash2 className="w-4 h-4 shrink-0" />
+                    Delete draft
+                  </>
+                )}
               </DropdownMenu.Item>
             </>
           )}
@@ -122,6 +141,7 @@ export function EditorActionBar({
   canPublish,
   lastSavedAt,
   onDelete,
+  isDeleting = false,
   hasUnsavedChanges = false,
 }: EditorActionBarProps) {
   const [relativeTick, setRelativeTick] = useState(0)
@@ -272,7 +292,11 @@ export function EditorActionBar({
           <div className="flex min-w-0 items-center justify-end gap-1.5">
             {saveButton}
             {publishControl}
-            <MoreMenu editor={editor} onDelete={onDelete} />
+            <MoreMenu
+              editor={editor}
+              onDelete={onDelete}
+              isDeleting={isDeleting}
+            />
           </div>
         </div>
         <div className="flex min-w-0 items-center gap-2 overflow-x-auto overflow-y-hidden overscroll-x-contain [-webkit-overflow-scrolling:touch] pb-0.5 [scrollbar-width:thin]">
@@ -335,7 +359,11 @@ export function EditorActionBar({
 
           {publishControl}
 
-          <MoreMenu editor={editor} onDelete={onDelete} />
+          <MoreMenu
+            editor={editor}
+            onDelete={onDelete}
+            isDeleting={isDeleting}
+          />
         </div>
       </div>
 

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -25,13 +25,14 @@ import type { Id } from '@/types/convex'
 import { toast } from 'sonner'
 import Image from 'next/image'
 import { EDITOR_PROSE_CLASS } from '@/lib/constants'
+import { mutationWithTimeout } from '@/lib/convexMutationWithTimeout'
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
 import { Textarea } from '@/components/ui/textarea'
-import { ChevronDown } from 'lucide-react'
+import { ChevronDown, Loader2 } from 'lucide-react'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -125,6 +126,8 @@ export function WriteEditorWorkspace() {
     publishedAt: null,
   })
   const [publishConfirmOpen, setPublishConfirmOpen] = useState(false)
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
   const [backupPrompt, setBackupPrompt] = useState<DraftBackup | null>(null)
   const [backupRecoveryStatus, setBackupRecoveryStatus] = useState<
     'pending' | 'resolved'
@@ -536,20 +539,27 @@ export function WriteEditorWorkspace() {
     editor,
   ])
 
-  const handleDelete = useCallback(async () => {
-    if (!window.confirm('Are you sure you want to delete this draft?')) return
+  const handleRequestDelete = useCallback(() => {
+    if (!articleId || isDeleting) return
+    setDeleteDialogOpen(true)
+  }, [articleId, isDeleting])
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!articleId || isDeleting) return
+    setIsDeleting(true)
     try {
-      if (articleId) {
-        await deleteArticleMutation({ id: articleId as Id<'articles'> })
-        router.push('/')
-      }
+      await mutationWithTimeout(
+        deleteArticleMutation({ id: articleId as Id<'articles'> })
+      )
+      toast.success('Draft deleted')
+      setDeleteDialogOpen(false)
+      router.push('/')
     } catch (error) {
       console.error('Delete error:', error)
-      toast.error(
-        error instanceof Error ? error.message : 'Failed to delete draft'
-      )
+      toast.error('Failed to delete draft. Please try again.')
+      setIsDeleting(false)
     }
-  }, [articleId, deleteArticleMutation, router])
+  }, [articleId, deleteArticleMutation, isDeleting, router])
 
   const handleBack = useCallback(() => {
     if (hasUnsavedChanges) {
@@ -771,7 +781,8 @@ export function WriteEditorWorkspace() {
         isPublishing={isPublishing}
         canPublish={!!editor}
         lastSavedAt={lastSavedAt ?? undefined}
-        onDelete={handleDelete}
+        onDelete={handleRequestDelete}
+        isDeleting={isDeleting}
         hasUnsavedChanges={hasUnsavedChanges}
       />
       <div className="flex min-w-0 flex-1 flex-col pb-8">
@@ -1159,6 +1170,44 @@ export function WriteEditorWorkspace() {
             </AlertDialogAction>
             <AlertDialogAction type="button" onClick={handleRestoreBackup}>
               Restore
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={deleteDialogOpen}
+        onOpenChange={(open) => {
+          if (isDeleting) return
+          if (!open) setDeleteDialogOpen(false)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this draft?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. The draft will be permanently
+              deleted.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 disabled:cursor-not-allowed"
+              onClick={(e) => {
+                e.preventDefault()
+                void handleConfirmDelete()
+              }}
+            >
+              {isDeleting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Deleting...
+                </>
+              ) : (
+                'Delete'
+              )}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/lib/convexMutationWithTimeout.test.ts
+++ b/lib/convexMutationWithTimeout.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { mutationWithTimeout } from './convexMutationWithTimeout'
+
+describe('mutationWithTimeout', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('resolves when the mutation completes first', async () => {
+    await expect(mutationWithTimeout(Promise.resolve('ok'))).resolves.toBe('ok')
+  })
+
+  it('rejects when the mutation exceeds the timeout', async () => {
+    vi.useFakeTimers()
+    const pending = new Promise<string>(() => {})
+    const result = mutationWithTimeout(pending, {
+      timeoutMs: 1000,
+      message: 'timed out',
+    })
+    const expectation = expect(result).rejects.toThrow('timed out')
+    await vi.advanceTimersByTimeAsync(1000)
+    await expectation
+  })
+})

--- a/lib/convexMutationWithTimeout.ts
+++ b/lib/convexMutationWithTimeout.ts
@@ -1,0 +1,25 @@
+/** Convex may retry for a long time when offline; cap wait so the UI can show an error. */
+export const CONVEX_MUTATION_TIMEOUT_MS = 30_000
+
+export async function mutationWithTimeout<T>(
+  mutationPromise: Promise<T>,
+  options?: { timeoutMs?: number; message?: string }
+): Promise<T> {
+  const timeoutMs = options?.timeoutMs ?? CONVEX_MUTATION_TIMEOUT_MS
+  const message =
+    options?.message ?? 'Request timed out. Check your connection.'
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new Error(message))
+    }, timeoutMs)
+  })
+
+  try {
+    return await Promise.race([mutationPromise, timeoutPromise])
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId)
+    void mutationPromise.catch(() => {})
+  }
+}


### PR DESCRIPTION
## Summary

Fixes ENG-210 by adding clear in-progress, success, and failure feedback when users delete drafts. Delete actions now show a disabled pending state until the mutation completes or fails, repeated clicks cannot trigger duplicate deletions, and the drafts list updates reactively via Convex after a successful delete.

## Changes

### Drafts list (`/drafts`)
- Added `isDeleting` state and `handleConfirmDelete` with duplicate-submit guard
- Confirm dialog shows spinner + "Deleting..." while the mutation runs
- Cancel, list delete buttons, and dialog dismiss are disabled/blocked during delete
- Dialog stays open on failure so the user can retry; closes only on success
- Success and error toasts unchanged in copy, behavior improved on failure
- Wrapped delete mutation in `mutationWithTimeout` so offline/slow networks surface an error instead of hanging indefinitely

### Write editor
- Replaced `window.confirm` with an `AlertDialog` matching the drafts list UX
- Added `deleteDialogOpen` and `isDeleting` state with the same pending pattern
- Success toast + redirect home on success; error toast + dialog stays open on failure
- `EditorActionBar` / `MoreMenu` show "Deleting..." and disable the menu item while in flight
<img width="1220" height="720" alt="1" src="https://github.com/user-attachments/assets/e81e5600-afb6-4ea5-b841-0f84ca1327f1" />

https://github.com/user-attachments/assets/14c0e69f-47c1-4db4-9d20-0fb5cde4eec6

<img width="1440" height="900" alt="3" src="https://github.com/user-attachments/assets/7318cb09-7590-422c-9f34-144d4efd4993" />

