### PR TITLE
fix: align auto-save copy with 10s debounce cadence (ENG-219)

### DIFF
--- a/app/drafts/page.tsx
+++ b/app/drafts/page.tsx
@@ -21,6 +21,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { DraftsListSkeleton } from '@/components/drafts/DraftsListSkeleton'
+import { AUTO_SAVE_GUIDANCE } from '@/lib/autosave'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -228,7 +229,7 @@ export default function DraftsPage() {
               • All your unpublished articles are saved here automatically
             </li>
             <li>• Click &quot;Edit&quot; to continue working on any draft</li>
-            <li>• Drafts are auto-saved every 30 seconds while you write</li>
+            <li>• {AUTO_SAVE_GUIDANCE}</li>
             <li>
               • Delete drafts you no longer need to keep your workspace clean
             </li>

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -14,7 +14,25 @@ import {
   Loader2,
 } from 'lucide-react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import { AUTO_SAVE_GUIDANCE } from '@/lib/autosave'
 import { estimateReadingMinutes } from '@/lib/reading-time'
+
+function draftStatusTitle(
+  lastSavedAt: Date | null | undefined,
+  isSaving: boolean,
+  error: string | null
+): string {
+  if (error) {
+    return `${error} · ${AUTO_SAVE_GUIDANCE}`
+  }
+  if (isSaving) {
+    return AUTO_SAVE_GUIDANCE
+  }
+  if (lastSavedAt) {
+    return `Saved at ${lastSavedAt.toLocaleString()} · ${AUTO_SAVE_GUIDANCE}`
+  }
+  return AUTO_SAVE_GUIDANCE
+}
 
 function useUndoRedoShortcuts() {
   const [isApple, setIsApple] = useState(false)
@@ -228,11 +246,7 @@ export function EditorActionBar({
         Draft
       </span>
       <span
-        title={
-          lastSavedAt && !isSaving && !error
-            ? lastSavedAt.toLocaleString()
-            : error || undefined
-        }
+        title={draftStatusTitle(lastSavedAt, isSaving, error)}
         className={`flex items-center text-xs sm:text-sm truncate ${statusClassName} ${isSaving ? 'gap-2' : 'gap-1.5'}`}
       >
         {statusText}
@@ -269,11 +283,7 @@ export function EditorActionBar({
         role="status"
         aria-live="polite"
         data-relative-tick={relativeTick}
-        title={
-          lastSavedAt && !isSaving && !error
-            ? lastSavedAt.toLocaleString()
-            : error || undefined
-        }
+        title={draftStatusTitle(lastSavedAt, isSaving, error)}
         className="sr-only"
       >
         {statusText}

--- a/hooks/useAutoSave.test.ts
+++ b/hooks/useAutoSave.test.ts
@@ -101,7 +101,7 @@ describe('useAutoSave', () => {
     expect(result.current.error).toBeNull()
   })
 
-  it('rejects with timeout message when save exceeds SAVE_DRAFT_TIMEOUT_MS', async () => {
+  it('rejects with timeout message when save exceeds CONVEX_MUTATION_TIMEOUT_MS', async () => {
     vi.useFakeTimers()
     mockSaveDraft.mockImplementation(() => new Promise<string>(() => {}))
 

--- a/hooks/useAutoSave.ts
+++ b/hooks/useAutoSave.ts
@@ -3,11 +3,10 @@ import { JSONContent } from '@tiptap/react'
 import { useMutation } from 'convex/react'
 import { api } from '@/convex/_generated/api'
 import { Id } from '@/convex/_generated/dataModel'
+import { AUTO_SAVE_DEBOUNCE_MS } from '@/lib/autosave'
+import { CONVEX_MUTATION_TIMEOUT_MS } from '@/lib/convexMutationWithTimeout'
 
 const EMPTY_DOC: JSONContent = { type: 'doc', content: [] }
-
-/** Convex may retry for a long time when offline; cap wait so the UI can show an error. */
-const SAVE_DRAFT_TIMEOUT_MS = 30_000
 
 interface DraftResponse {
   id: string
@@ -93,7 +92,7 @@ export function useAutoSave({
     const timeoutPromise = new Promise<never>((_, reject) => {
       timeoutId = setTimeout(() => {
         reject(new Error('Save timed out. Check your connection.'))
-      }, SAVE_DRAFT_TIMEOUT_MS)
+      }, CONVEX_MUTATION_TIMEOUT_MS)
     })
 
     try {
@@ -153,7 +152,7 @@ export function useAutoSave({
 
     timeoutRef.current = setTimeout(() => {
       saveDraft()
-    }, 10000) // 10 seconds
+    }, AUTO_SAVE_DEBOUNCE_MS)
   }, [saveDraft])
 
   // Effect to handle content, title, coverImage, and excerpt changes

--- a/lib/autosave.test.ts
+++ b/lib/autosave.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import {
-  AUTO_SAVE_DEBOUNCE_SECONDS,
-  AUTO_SAVE_GUIDANCE,
-} from './autosave'
+import { AUTO_SAVE_DEBOUNCE_SECONDS, AUTO_SAVE_GUIDANCE } from './autosave'
 
 describe('autosave copy', () => {
   it('guidance includes debounce seconds from AUTO_SAVE_DEBOUNCE_MS', () => {

--- a/lib/autosave.test.ts
+++ b/lib/autosave.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AUTO_SAVE_DEBOUNCE_SECONDS,
+  AUTO_SAVE_GUIDANCE,
+} from './autosave'
+
+describe('autosave copy', () => {
+  it('guidance includes debounce seconds from AUTO_SAVE_DEBOUNCE_MS', () => {
+    expect(AUTO_SAVE_GUIDANCE).toContain(String(AUTO_SAVE_DEBOUNCE_SECONDS))
+  })
+})

--- a/lib/autosave.ts
+++ b/lib/autosave.ts
@@ -1,0 +1,7 @@
+/** Idle delay before persisting draft changes to Convex. */
+export const AUTO_SAVE_DEBOUNCE_MS = 10_000
+
+export const AUTO_SAVE_DEBOUNCE_SECONDS = AUTO_SAVE_DEBOUNCE_MS / 1000
+
+/** User-facing line for drafts help and editor tooltips. Keep in sync with AUTO_SAVE_DEBOUNCE_MS. */
+export const AUTO_SAVE_GUIDANCE = `Drafts auto-save about ${AUTO_SAVE_DEBOUNCE_SECONDS} seconds after your last edit`


### PR DESCRIPTION
## Summary

Fixes ENG-219. Drafts help text claimed auto-save every 30 seconds, but the editor debounces saves 10 seconds after the last edit. User-facing copy now matches behavior and is driven from a single source of truth so timing and guidance stay in sync.

## Changes

- Add `lib/autosave.ts` with `AUTO_SAVE_DEBOUNCE_MS` (10s) and shared `AUTO_SAVE_GUIDANCE` copy
- Wire `useAutoSave` to `AUTO_SAVE_DEBOUNCE_MS`; use `CONVEX_MUTATION_TIMEOUT_MS` for save timeout (not user copy)
- Update `/drafts` About Drafts bullet to use `AUTO_SAVE_GUIDANCE`
- Add matching auto-save guidance to editor draft status tooltips in `EditorActionBar`
- Add `lib/autosave.test.ts` regression test so guidance must include the debounce seconds
<img width="1440" height="900" alt="1" src="https://github.com/user-attachments/assets/943451ae-d9ea-4a2c-8dcb-ff324fcf6553" />
<img width="1216" height="717" alt="2" src="https://github.com/user-attachments/assets/d17d3428-2a9f-4ce3-aeab-9d3d45aba9ed" />
<img width="1219" height="717" alt="3" src="https://github.com/user-attachments/assets/c5d9e5ed-55cf-4492-9081-1aa54fc2cd38" />
<img width="1221" height="719" alt="4" src="https://github.com/user-attachments/assets/34a2a18f-a5be-4568-987a-f50ab3817b4b" />

