### PR TITLE
perf: defer wallet, editor, and animation bundles on public pages (ENG-191)

### DIFF
--- a/app/[username]/[slug]/page.tsx
+++ b/app/[username]/[slug]/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import nextDynamic from 'next/dynamic'
 import { notFound } from 'next/navigation'
 import { use, useState, useMemo } from 'react'
 import {
@@ -11,8 +12,26 @@ import ArticleDisplay from '@/components/articles/ArticleDisplay'
 import { ArticlePageLoadingSkeleton } from '@/components/articles/ArticlePageLoadingSkeleton'
 import AppNavigation from '@/components/layout/AppNavigation'
 import { TipStats } from '@/components/tipping/TipStats'
-import { TipButton } from '@/components/tipping/TipButton'
-import { NFTIntegration } from '@/components/nft/NFTIntegration'
+import {
+  TipButtonSkeleton,
+  NftSidebarSkeleton,
+} from '@/components/articles/ArticleEngagementSkeleton'
+
+const TipButton = nextDynamic(
+  () =>
+    import('@/components/tipping/TipButton').then((mod) => ({
+      default: mod.TipButton,
+    })),
+  { ssr: false, loading: () => <TipButtonSkeleton /> }
+)
+
+const NFTIntegration = nextDynamic(
+  () =>
+    import('@/components/nft/NFTIntegration').then((mod) => ({
+      default: mod.NFTIntegration,
+    })),
+  { ssr: false, loading: () => <NftSidebarSkeleton /> }
+)
 import {
   DollarSign,
   Trophy,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,15 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { useAuth } from '@/components/providers/AuthContext'
 import Navigation from '@/components/landing/Navigation'
 import AppNavigation from '@/components/layout/AppNavigation'
 import HeroSection from '@/components/landing/HeroSection'
-import FeaturesSection from '@/components/landing/FeaturesSection'
-import HowItWorksSection from '@/components/landing/HowItWorksSection'
-import FAQSection from '@/components/landing/FAQSection'
-import TrustSection from '@/components/landing/TrustSection'
-import Footer from '@/components/landing/Footer'
+
+const LandingBelowFold = dynamic(
+  () => import('@/components/landing/LandingBelowFold'),
+  { ssr: false }
+)
 import { useLandingHashScroll } from '@/components/landing/useLandingHashScroll'
 import { OnboardingDialog } from '@/components/onboarding/OnboardingDialog'
 import { HomeRecentArticlesSection } from '@/components/articles/HomeRecentArticlesSection'
@@ -24,11 +25,7 @@ function PublicLandingPage() {
     <div className="min-h-screen bg-gradient-to-b from-background via-muted/30 to-background">
       <Navigation />
       <HeroSection />
-      <FeaturesSection />
-      <HowItWorksSection />
-      <TrustSection />
-      <FAQSection />
-      <Footer />
+      <LandingBelowFold />
     </div>
   )
 }

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
         "@tiptap/extension-text-align": "^3.20.0",
         "@tiptap/extension-underline": "^3.20.0",
         "@tiptap/extension-youtube": "^3.20.0",
+        "@tiptap/html": "^3.20.0",
         "@tiptap/pm": "^3.20.0",
         "@tiptap/react": "^3.20.0",
         "@tiptap/starter-kit": "^3.20.0",
@@ -1100,6 +1101,8 @@
 
     "@tiptap/extensions": ["@tiptap/extensions@3.20.0", "", { "peerDependencies": { "@tiptap/core": "^3.20.0", "@tiptap/pm": "^3.20.0" } }, "sha512-HIsXX942w3nbxEQBlMAAR/aa6qiMBEP7CsSMxaxmTIVAmW35p6yUASw6GdV1u0o3lCZjXq2OSRMTskzIqi5uLg=="],
 
+    "@tiptap/html": ["@tiptap/html@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5", "happy-dom": "^20.8.9" } }, "sha512-lFJbuL3mFHvqe9BaFbEd43cb/lHKAoM0O69opFJLlIYn3dre6kt64Qr7UOXQ3dp6mRU0ptVUwBV3R1eG9EPpUQ=="],
+
     "@tiptap/pm": ["@tiptap/pm@3.20.0", "", { "dependencies": { "prosemirror-changeset": "^2.3.0", "prosemirror-collab": "^1.3.1", "prosemirror-commands": "^1.6.2", "prosemirror-dropcursor": "^1.8.1", "prosemirror-gapcursor": "^1.3.2", "prosemirror-history": "^1.4.1", "prosemirror-inputrules": "^1.4.0", "prosemirror-keymap": "^1.2.2", "prosemirror-markdown": "^1.13.1", "prosemirror-menu": "^1.2.4", "prosemirror-model": "^1.24.1", "prosemirror-schema-basic": "^1.2.3", "prosemirror-schema-list": "^1.5.0", "prosemirror-state": "^1.4.3", "prosemirror-tables": "^1.6.4", "prosemirror-trailing-node": "^3.0.0", "prosemirror-transform": "^1.10.2", "prosemirror-view": "^1.38.1" } }, "sha512-jn+2KnQZn+b+VXr8EFOJKsnjVNaA4diAEr6FOazupMt8W8ro1hfpYtZ25JL87Kao/WbMze55sd8M8BDXLUKu1A=="],
 
     "@tiptap/react": ["@tiptap/react@3.20.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "fast-equals": "^5.3.3", "use-sync-external-store": "^1.4.0" }, "optionalDependencies": { "@tiptap/extension-bubble-menu": "^3.20.0", "@tiptap/extension-floating-menu": "^3.20.0" }, "peerDependencies": { "@tiptap/core": "^3.20.0", "@tiptap/pm": "^3.20.0", "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-jFLNzkmn18zqefJwPje0PPd9VhZ7Oy28YHiSvSc7YpBnQIbuN/HIxZ2lrOsKyEHta0WjRZjfU5X1pGxlbcGwOA=="],
@@ -1212,7 +1215,9 @@
 
     "@types/web": ["@types/web@0.0.197", "", {}, "sha512-V4sOroWDADFx9dLodWpKm298NOJ1VJ6zoDVgaP+WBb/utWxqQ6gnMzd9lvVDAr/F3ibiKaxH9i45eS0gQPSTaQ=="],
 
-    "@types/ws": ["@types/ws@7.4.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww=="],
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.56.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.56.1", "@typescript-eslint/type-utils": "8.56.1", "@typescript-eslint/utils": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.56.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A=="],
 
@@ -1927,6 +1932,8 @@
     "gzip-size": ["gzip-size@6.0.0", "", { "dependencies": { "duplexer": "^0.1.2" } }, "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q=="],
 
     "h3": ["h3@1.15.5", "", { "dependencies": { "cookie-es": "^1.2.2", "crossws": "^0.3.5", "defu": "^6.1.4", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg=="],
+
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -3564,6 +3571,12 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "happy-dom/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "happy-dom/whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
+    "happy-dom/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
     "hash-base/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "http-errors/depd": ["depd@1.1.2", "", {}, "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="],
@@ -3573,6 +3586,8 @@
     "is-bun-module/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "jayson/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
+
+    "jayson/@types/ws": ["@types/ws@7.4.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww=="],
 
     "jayson/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
@@ -3623,8 +3638,6 @@
     "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "rpc-websockets/@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "secp256k1/node-addon-api": ["node-addon-api@5.1.0", "", {}, "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="],
 
@@ -4145,6 +4158,8 @@
     "hash-base/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "hash-base/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "jayson/@types/ws/@types/node": ["@types/node@25.3.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw=="],
 
     "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 

--- a/components/articles/ArticleBodySkeleton.tsx
+++ b/components/articles/ArticleBodySkeleton.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+export function ArticleBodySkeleton() {
+  return (
+    <div className="space-y-4 py-2" aria-hidden>
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-5/6" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-4/5" />
+    </div>
+  )
+}

--- a/components/articles/ArticleDisplay.tsx
+++ b/components/articles/ArticleDisplay.tsx
@@ -1,12 +1,22 @@
 'use client'
 
-import { type JSONContent } from '@tiptap/react'
+import dynamic from 'next/dynamic'
+import { type JSONContent } from '@tiptap/core'
 import { useEffect, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import Image from 'next/image'
 import { UserAvatar } from '@/components/ui/user-avatar'
 import ShareButtons from './ShareButtons'
-import { HighlightableArticle } from '@/components/articles/HighlightableArticle'
+import { ArticleReadOnlyBody } from '@/components/articles/ArticleReadOnlyBody'
+import { ArticleBodySkeleton } from '@/components/articles/ArticleBodySkeleton'
+
+const HighlightableArticle = dynamic(
+  () =>
+    import('@/components/articles/HighlightableArticle').then((mod) => ({
+      default: mod.HighlightableArticle,
+    })),
+  { ssr: false, loading: () => <ArticleBodySkeleton /> }
+)
 import { useAuth } from '@/components/providers/AuthContext'
 import type { Id } from '@/types/convex'
 import type { ArticleForDisplay } from '@/types/index'
@@ -112,13 +122,20 @@ export default function ArticleDisplay({
       </header>
 
       <div className="article-content">
-        <HighlightableArticle
-          articleId={article.id as Id<'articles'>}
-          content={article.content ?? EMPTY_DOC}
-          editable={false}
-          showHighlights={effectiveShowHighlights}
-          tocHeadings={tocHeadings}
-        />
+        {effectiveShowHighlights ? (
+          <HighlightableArticle
+            articleId={article.id as Id<'articles'>}
+            content={article.content ?? EMPTY_DOC}
+            editable={false}
+            showHighlights={effectiveShowHighlights}
+            tocHeadings={tocHeadings}
+          />
+        ) : (
+          <ArticleReadOnlyBody
+            content={article.content ?? EMPTY_DOC}
+            tocHeadings={tocHeadings}
+          />
+        )}
       </div>
 
       {currentUrl && (

--- a/components/articles/ArticleEngagementSkeleton.tsx
+++ b/components/articles/ArticleEngagementSkeleton.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+export function TipButtonSkeleton() {
+  return (
+    <div className="space-y-3">
+      <Skeleton className="h-10 w-full" />
+      <Skeleton className="h-4 w-3/4" />
+    </div>
+  )
+}
+
+export function NftSidebarSkeleton() {
+  return (
+    <div className="space-y-3">
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-5/6" />
+      <Skeleton className="h-10 w-full" />
+    </div>
+  )
+}

--- a/components/articles/ArticleReadOnlyBody.tsx
+++ b/components/articles/ArticleReadOnlyBody.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useMemo } from 'react'
+import { generateHTML } from '@tiptap/html'
+import type { JSONContent } from '@tiptap/core'
+import { getReadOnlyExtensions } from '@/lib/tiptap/readExtensions'
+import { EDITOR_PROSE_CLASS } from '@/lib/constants'
+import { cn } from '@/lib/utils'
+import { useEnsureHeadingIds } from '@/components/articles/useEnsureHeadingIds'
+import type { TocHeading } from '@/lib/tiptap/headings'
+
+interface ArticleReadOnlyBodyProps {
+  content: JSONContent
+  tocHeadings?: TocHeading[]
+  className?: string
+}
+
+export function ArticleReadOnlyBody({
+  content,
+  tocHeadings = [],
+  className,
+}: ArticleReadOnlyBodyProps) {
+  const extensions = useMemo(() => getReadOnlyExtensions(), [])
+
+  const html = useMemo(
+    () => generateHTML(content, extensions),
+    [content, extensions]
+  )
+
+  useEnsureHeadingIds(tocHeadings, { rootSelector: '.article-content' })
+
+  return (
+    <div
+      className={cn(
+        EDITOR_PROSE_CLASS,
+        'prose-stone highlightable-article',
+        className
+      )}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+}

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useConvex, useMutation } from 'convex/react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { useWallet } from '@/components/providers/WalletProvider'
+import { useWalletActivation } from '@/components/providers/WalletActivationContext'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 import { AlertCircle, Coins, Heart, Loader2, Wallet } from 'lucide-react'
@@ -79,6 +80,7 @@ export function HighlightTipButton({
 }: HighlightTipButtonProps) {
   const { isAuthenticated } = useAuth()
   const { isConnected, publicKey, signTransaction, connect } = useWallet()
+  const { activateWallet } = useWalletActivation()
   const router = useRouter()
   const [isOpen, setIsOpen] = useState(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
@@ -102,6 +104,9 @@ export function HighlightTipButton({
 
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
+    if (open) {
+      activateWallet()
+    }
     setIsOpen(open)
     setTipFailure(null)
     if (!open) {

--- a/components/landing/LandingBelowFold.tsx
+++ b/components/landing/LandingBelowFold.tsx
@@ -1,0 +1,17 @@
+import FeaturesSection from '@/components/landing/FeaturesSection'
+import HowItWorksSection from '@/components/landing/HowItWorksSection'
+import TrustSection from '@/components/landing/TrustSection'
+import FAQSection from '@/components/landing/FAQSection'
+import Footer from '@/components/landing/Footer'
+
+export default function LandingBelowFold() {
+  return (
+    <>
+      <FeaturesSection />
+      <HowItWorksSection />
+      <TrustSection />
+      <FAQSection />
+      <Footer />
+    </>
+  )
+}

--- a/components/nft/MintButton.tsx
+++ b/components/nft/MintButton.tsx
@@ -15,7 +15,8 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import { useStellarWallet } from '@/hooks/useStellarWallet'
+import { useWallet } from '@/components/providers/WalletProvider'
+import { useWalletActivation } from '@/components/providers/WalletActivationContext'
 import { nftClient } from '@/lib/stellar/nft-client'
 import { stellarClient } from '@/lib/stellar/client'
 import { InstallWalletDialog } from '@/components/stellar/InstallWalletDialog'
@@ -93,7 +94,8 @@ export function MintButton({
   const uploadNftMetadataForMint = useAction(
     api.nftMetadataUpload.uploadNftMetadataForMint
   )
-  const wallet = useStellarWallet()
+  const wallet = useWallet()
+  const { activateWallet } = useWalletActivation()
   const [xlmPrice, setXlmPrice] = useState<number | null>(null)
 
   useEffect(() => {
@@ -250,7 +252,13 @@ export function MintButton({
 
   return (
     <>
-      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+      <Dialog
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          if (open) activateWallet()
+          setDialogOpen(open)
+        }}
+      >
         <DialogTrigger asChild>
           <Button
             disabled={!canMint}

--- a/components/providers/Providers.tsx
+++ b/components/providers/Providers.tsx
@@ -1,19 +1,21 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { ConvexAuthProvider } from '@convex-dev/auth/react'
 import { ConvexReactClient } from 'convex/react'
-import { WalletProvider } from './WalletProvider'
 import { Toaster } from '@/components/ui/sonner'
 import { ErrorBoundary } from '@/components/error/ErrorBoundary'
 import { ThemeProvider } from '@/components/theme/ThemeProvider'
+import {
+  WalletActivationProvider,
+  useWalletActivation,
+} from './WalletActivationContext'
 
-/**
- * Global Providers
- *
- * Wraps the application with ConvexAuthProvider for authentication,
- * Convex database access, and Stellar wallet connection.
- * Provides real-time subscriptions and type-safe queries throughout the app.
- */
+const LazyWalletProvider = dynamic(
+  () =>
+    import('./WalletProvider').then((mod) => ({ default: mod.WalletProvider })),
+  { ssr: false }
+)
 
 const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!)
 
@@ -30,16 +32,28 @@ const WalletErrorFallback = (
   </div>
 )
 
+function WalletBoundary({ children }: { children: React.ReactNode }) {
+  const { isWalletActive } = useWalletActivation()
+
+  if (!isWalletActive) {
+    return <>{children}</>
+  }
+
+  return <LazyWalletProvider>{children}</LazyWalletProvider>
+}
+
 export default function Providers({ children }: ProvidersProps) {
   return (
     <ConvexAuthProvider client={convex}>
       <ThemeProvider>
-        <ErrorBoundary fallback={WalletErrorFallback}>
-          <WalletProvider>
-            {children}
-            <Toaster />
-          </WalletProvider>
-        </ErrorBoundary>
+        <WalletActivationProvider>
+          <ErrorBoundary fallback={WalletErrorFallback}>
+            <WalletBoundary>
+              {children}
+              <Toaster />
+            </WalletBoundary>
+          </ErrorBoundary>
+        </WalletActivationProvider>
       </ThemeProvider>
     </ConvexAuthProvider>
   )

--- a/components/providers/WalletActivationContext.tsx
+++ b/components/providers/WalletActivationContext.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  type ReactNode,
+} from 'react'
+
+type WalletActivationContextValue = {
+  isWalletActive: boolean
+  activateWallet: () => void
+}
+
+const WalletActivationContext =
+  createContext<WalletActivationContextValue | undefined>(undefined)
+
+export function WalletActivationProvider({ children }: { children: ReactNode }) {
+  const [isWalletActive, setIsWalletActive] = useState(false)
+  const activateWallet = useCallback(() => setIsWalletActive(true), [])
+
+  return (
+    <WalletActivationContext.Provider
+      value={{ isWalletActive, activateWallet }}
+    >
+      {children}
+    </WalletActivationContext.Provider>
+  )
+}
+
+export function useWalletActivation(): WalletActivationContextValue {
+  const context = useContext(WalletActivationContext)
+  if (context === undefined) {
+    throw new Error(
+      'useWalletActivation must be used within WalletActivationProvider'
+    )
+  }
+  return context
+}

--- a/components/providers/WalletActivationContext.tsx
+++ b/components/providers/WalletActivationContext.tsx
@@ -13,10 +13,15 @@ type WalletActivationContextValue = {
   activateWallet: () => void
 }
 
-const WalletActivationContext =
-  createContext<WalletActivationContextValue | undefined>(undefined)
+const WalletActivationContext = createContext<
+  WalletActivationContextValue | undefined
+>(undefined)
 
-export function WalletActivationProvider({ children }: { children: ReactNode }) {
+export function WalletActivationProvider({
+  children,
+}: {
+  children: ReactNode
+}) {
   const [isWalletActive, setIsWalletActive] = useState(false)
   const activateWallet = useCallback(() => setIsWalletActive(true), [])
 

--- a/components/providers/WalletProvider.tsx
+++ b/components/providers/WalletProvider.tsx
@@ -1,15 +1,43 @@
 'use client'
 
-import { createContext, useContext, ReactNode } from 'react'
+import {
+  createContext,
+  useContext,
+  useEffect,
+  type ReactNode,
+} from 'react'
 import {
   useStellarWallet,
   StellarWalletState,
   StellarWalletActions,
 } from '@/hooks/useStellarWallet'
+import { useWalletActivation } from './WalletActivationContext'
 
 type WalletContextType = StellarWalletState & StellarWalletActions
 
 const WalletContext = createContext<WalletContextType | undefined>(undefined)
+
+const INACTIVE_WALLET_STUB: WalletContextType = {
+  isInstalled: false,
+  isConnected: false,
+  isLoading: false,
+  publicKey: null,
+  network: null,
+  networkPassphrase: null,
+  error: null,
+  selectedWallet: null,
+  connect: async () => false,
+  disconnect: () => {},
+  signTransaction: async () => {
+    throw new Error('Wallet not activated')
+  },
+  refreshConnection: async () => {},
+}
+
+const LOADING_WALLET_STUB: WalletContextType = {
+  ...INACTIVE_WALLET_STUB,
+  isLoading: true,
+}
 
 interface WalletProviderProps {
   children: ReactNode
@@ -23,10 +51,34 @@ export function WalletProvider({ children }: WalletProviderProps) {
   )
 }
 
-export function useWallet(): WalletContextType {
+type UseWalletOptions = {
+  /** Load wallet subsystem when this component mounts (profile, wallet settings). */
+  activateOnMount?: boolean
+}
+
+export function useWallet(options?: UseWalletOptions): WalletContextType {
+  const { isWalletActive, activateWallet } = useWalletActivation()
   const context = useContext(WalletContext)
-  if (context === undefined) {
-    throw new Error('useWallet must be used within a WalletProvider')
+
+  useEffect(() => {
+    if (options?.activateOnMount) {
+      activateWallet()
+    }
+  }, [options?.activateOnMount, activateWallet])
+
+  if (!isWalletActive) {
+    return {
+      ...INACTIVE_WALLET_STUB,
+      connect: async () => {
+        activateWallet()
+        return false
+      },
+    }
   }
+
+  if (context === undefined) {
+    return LOADING_WALLET_STUB
+  }
+
   return context
 }

--- a/components/providers/WalletProvider.tsx
+++ b/components/providers/WalletProvider.tsx
@@ -1,11 +1,6 @@
 'use client'
 
-import {
-  createContext,
-  useContext,
-  useEffect,
-  type ReactNode,
-} from 'react'
+import { createContext, useContext, useEffect, type ReactNode } from 'react'
 import {
   useStellarWallet,
   StellarWalletState,

--- a/components/stellar/WalletConnectButton.tsx
+++ b/components/stellar/WalletConnectButton.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { useWallet } from '@/components/providers/WalletProvider'
+import { useWalletActivation } from '@/components/providers/WalletActivationContext'
 import { Wallet, Loader2, AlertCircle, CheckCircle } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
@@ -32,7 +33,8 @@ export function WalletConnectButton({
     selectedWallet,
     connect,
     disconnect,
-  } = useWallet()
+  } = useWallet({ activateOnMount: true })
+  const { activateWallet } = useWalletActivation()
   const [isConnecting, setIsConnecting] = useState(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
 
@@ -42,6 +44,7 @@ export function WalletConnectButton({
       return
     }
 
+    activateWallet()
     setIsConnecting(true)
     try {
       await connect()

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -50,7 +50,7 @@ export function WalletSettings({
   className = '',
 }: WalletSettingsProps) {
   const updateProfile = useMutation(api.users.updateProfile)
-  const { isLoading, connect, disconnect } = useWallet()
+  const { isLoading, connect, disconnect } = useWallet({ activateOnMount: true })
   const [isCopied, setIsCopied] = useState(false)
   const [isConnecting, setIsConnecting] = useState(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -50,7 +50,9 @@ export function WalletSettings({
   className = '',
 }: WalletSettingsProps) {
   const updateProfile = useMutation(api.users.updateProfile)
-  const { isLoading, connect, disconnect } = useWallet({ activateOnMount: true })
+  const { isLoading, connect, disconnect } = useWallet({
+    activateOnMount: true,
+  })
   const [isCopied, setIsCopied] = useState(false)
   const [isConnecting, setIsConnecting] = useState(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)

--- a/components/stellar/WalletStatus.tsx
+++ b/components/stellar/WalletStatus.tsx
@@ -36,7 +36,7 @@ export function WalletStatus({ className }: WalletStatusProps) {
     connect,
     disconnect,
     refreshConnection,
-  } = useWallet()
+  } = useWallet({ activateOnMount: true })
   const [isConnecting, setIsConnecting] = useState(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
 

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useConvex, useMutation } from 'convex/react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { useWallet } from '@/components/providers/WalletProvider'
+import { useWalletActivation } from '@/components/providers/WalletActivationContext'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 import { AlertCircle, Coins, Heart, Loader2, Wallet } from 'lucide-react'
@@ -65,6 +66,7 @@ export function TipButton({
 }: TipButtonProps) {
   const { isAuthenticated } = useAuth()
   const { isConnected, publicKey, signTransaction, connect } = useWallet()
+  const { activateWallet } = useWalletActivation()
   const router = useRouter()
   const [isOpen, setIsOpen] = useState(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
@@ -89,6 +91,9 @@ export function TipButton({
 
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
+    if (open) {
+      activateWallet()
+    }
     setIsOpen(open)
     setTipFailure(null)
   }

--- a/hooks/useStellarWallet.ts
+++ b/hooks/useStellarWallet.ts
@@ -30,7 +30,7 @@ export function useStellarWallet(): StellarWalletState & StellarWalletActions {
   const [state, setState] = useState<StellarWalletState>({
     isInstalled: false,
     isConnected: false,
-    isLoading: true,
+    isLoading: false,
     publicKey: null,
     network: null,
     networkPassphrase: null,
@@ -188,9 +188,9 @@ export function useStellarWallet(): StellarWalletState & StellarWalletActions {
     await checkWalletStatus()
   }, [checkWalletStatus])
 
-  // Initialize wallet check on mount
+  // Run status check when the wallet provider mounts (after activation).
   useEffect(() => {
-    checkWalletStatus()
+    void checkWalletStatus()
   }, [checkWalletStatus])
 
   // NOTE: Removed automatic wallet detail fetching to prevent unwanted popups

--- a/lib/stellar/wallet-adapter.ts
+++ b/lib/stellar/wallet-adapter.ts
@@ -12,20 +12,25 @@
  * - Better error messages for all wallet types
  */
 
-import {
-  StellarWalletsKit,
-  WalletNetwork,
-  allowAllModules,
+import type {
   ISupportedWallet,
+  WalletNetwork as WalletNetworkValue,
+} from '@creit.tech/stellar-wallets-kit'
+import { toast } from 'sonner'
+import { hasInstalledWalletForKitModal as supportedWalletsAllowKitModal } from '@/lib/stellar/wallet-availability'
+import { loadWalletKit } from '@/lib/stellar/wallet-kit-loader'
+import {
   FREIGHTER_ID,
   XBULL_ID,
   ALBEDO_ID,
   RABET_ID,
   HANA_ID,
   HOTWALLET_ID,
-} from '@creit.tech/stellar-wallets-kit'
-import { toast } from 'sonner'
-import { hasInstalledWalletForKitModal as supportedWalletsAllowKitModal } from '@/lib/stellar/wallet-availability'
+} from '@/lib/stellar/wallet-ids'
+
+type StellarWalletsKit = InstanceType<
+  Awaited<ReturnType<typeof loadWalletKit>>['StellarWalletsKit']
+>
 
 // Wallet type definitions
 export type WalletType =
@@ -200,8 +205,12 @@ class StellarWalletAdapter {
   /**
    * Create or recreate the wallet kit instance
    */
-  private createKit(network?: WalletNetwork): StellarWalletsKit {
-    const targetNetwork = network || this.getNetworkFromEnv()
+  private async createKit(
+    network?: WalletNetworkValue
+  ): Promise<StellarWalletsKit> {
+    const { StellarWalletsKit, allowAllModules, WalletNetwork } =
+      await loadWalletKit()
+    const targetNetwork = network ?? this.getNetworkFromEnv(WalletNetwork)
     const savedWalletId = this.getStoredWalletId()
 
     return new StellarWalletsKit({
@@ -214,7 +223,9 @@ class StellarWalletAdapter {
   /**
    * Get network from environment variable
    */
-  private getNetworkFromEnv(): WalletNetwork {
+  private getNetworkFromEnv(
+    WalletNetwork: Awaited<ReturnType<typeof loadWalletKit>>['WalletNetwork']
+  ): WalletNetworkValue {
     const envNetwork = process.env.NEXT_PUBLIC_STELLAR_NETWORK
     return envNetwork === 'PUBLIC'
       ? WalletNetwork.PUBLIC
@@ -250,13 +261,13 @@ class StellarWalletAdapter {
   /**
    * Ensure kit is initialized (client-side only)
    */
-  private ensureKit(): StellarWalletsKit {
+  private async ensureKit(): Promise<StellarWalletsKit> {
     if (typeof window === 'undefined') {
       throw new Error('Wallet adapter can only be used in the browser')
     }
 
     if (!this.kit) {
-      this.kit = this.createKit()
+      this.kit = await this.createKit()
     }
 
     return this.kit
@@ -264,7 +275,7 @@ class StellarWalletAdapter {
 
   private async hasInstalledWalletForKitModal(): Promise<boolean> {
     await this.initialize()
-    const kit = this.ensureKit()
+    const kit = await this.ensureKit()
     const supported = (await kit.getSupportedWallets()) as ISupportedWallet[]
     return supportedWalletsAllowKitModal(supported)
   }
@@ -277,7 +288,7 @@ class StellarWalletAdapter {
     if (this.isInitialized) return
 
     // Ensure kit exists
-    this.ensureKit()
+    await this.ensureKit()
 
     // Only restore the wallet ID from storage, don't trigger connection
     const storedWalletId = this.getStoredWalletId()
@@ -301,7 +312,7 @@ class StellarWalletAdapter {
    */
   async connect(): Promise<ConnectionResult> {
     await this.initialize()
-    const kit = this.ensureKit()
+    const kit = await this.ensureKit()
 
     const hasWallet = await this.hasInstalledWalletForKitModal()
     if (!hasWallet) {
@@ -408,7 +419,7 @@ class StellarWalletAdapter {
     walletId: string,
     maxRetries = 3
   ): Promise<void> {
-    const kit = this.ensureKit()
+    const kit = await this.ensureKit()
     const walletInfo = this.getWalletInfo(walletId)
 
     // For wallets requiring eager connection (xBull, Hot, Hana), reduce retries to avoid multiple popups
@@ -478,7 +489,7 @@ class StellarWalletAdapter {
    */
   async connectToWallet(walletId: string): Promise<ConnectionResult> {
     await this.initialize()
-    const kit = this.ensureKit()
+    const kit = await this.ensureKit()
 
     // Check cache first
     const cached = this.connectionCache.get(walletId)
@@ -596,7 +607,7 @@ class StellarWalletAdapter {
    */
   async getPublicKey(): Promise<string> {
     await this.initialize()
-    const kit = this.ensureKit()
+    const kit = await this.ensureKit()
 
     // Check cache first
     if (this.selectedWalletId) {
@@ -628,7 +639,7 @@ class StellarWalletAdapter {
    */
   async getNetwork(): Promise<{ network: string; networkPassphrase: string }> {
     await this.initialize()
-    const kit = this.ensureKit()
+    const kit = await this.ensureKit()
 
     // Check cache first
     if (this.selectedWalletId) {
@@ -687,7 +698,7 @@ class StellarWalletAdapter {
     networkPassphrase: string
   ): Promise<string> {
     await this.initialize()
-    const kit = this.ensureKit()
+    const kit = await this.ensureKit()
 
     if (!this.selectedWalletId) {
       throw new Error('No wallet connected')
@@ -751,12 +762,12 @@ class StellarWalletAdapter {
 
     let lastAddress: string | null = null
     let isActive = true
-    const kit = this.ensureKit()
 
     const poll = async () => {
       if (!isActive) return
 
       try {
+        const kit = await this.ensureKit()
         const { address } = await kit.getAddress()
         if (address !== lastAddress) {
           lastAddress = address
@@ -796,12 +807,12 @@ class StellarWalletAdapter {
 
     let lastNetwork: string | null = null
     let isActive = true
-    const kit = this.ensureKit()
 
     const poll = async () => {
       if (!isActive) return
 
       try {
+        const kit = await this.ensureKit()
         const network = await kit.getNetwork()
         if (network.network !== lastNetwork) {
           lastNetwork = network.network
@@ -830,7 +841,7 @@ class StellarWalletAdapter {
    */
   async refresh(): Promise<void> {
     await this.initialize()
-    const kit = this.ensureKit()
+    const kit = await this.ensureKit()
 
     if (this.selectedWalletId) {
       try {
@@ -847,7 +858,7 @@ class StellarWalletAdapter {
 // Export singleton instance
 export const walletAdapter = new StellarWalletAdapter()
 
-// Export wallet IDs for direct reference
+// Re-export wallet IDs for direct reference
 export {
   FREIGHTER_ID,
   XBULL_ID,
@@ -855,5 +866,4 @@ export {
   RABET_ID,
   HANA_ID,
   HOTWALLET_ID,
-  WalletNetwork,
-}
+} from '@/lib/stellar/wallet-ids'

--- a/lib/stellar/wallet-ids.ts
+++ b/lib/stellar/wallet-ids.ts
@@ -1,0 +1,7 @@
+/** Wallet product IDs from @creit.tech/stellar-wallets-kit (stable string constants). */
+export const FREIGHTER_ID = 'freighter'
+export const XBULL_ID = 'xbull'
+export const ALBEDO_ID = 'albedo'
+export const RABET_ID = 'rabet'
+export const HANA_ID = 'hana'
+export const HOTWALLET_ID = 'hot-wallet'

--- a/lib/stellar/wallet-kit-loader.ts
+++ b/lib/stellar/wallet-kit-loader.ts
@@ -1,0 +1,17 @@
+type WalletKitModule = typeof import('@creit.tech/stellar-wallets-kit')
+
+let walletKitModule: WalletKitModule | null = null
+let walletKitLoadPromise: Promise<WalletKitModule> | null = null
+
+export async function loadWalletKit(): Promise<WalletKitModule> {
+  if (walletKitModule) return walletKitModule
+  if (!walletKitLoadPromise) {
+    walletKitLoadPromise = import('@creit.tech/stellar-wallets-kit').then(
+      (mod) => {
+        walletKitModule = mod
+        return mod
+      }
+    )
+  }
+  return walletKitLoadPromise
+}

--- a/lib/tiptap/readExtensions.ts
+++ b/lib/tiptap/readExtensions.ts
@@ -1,0 +1,47 @@
+import { Node, mergeAttributes } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import Underline from '@tiptap/extension-underline'
+import Link from '@tiptap/extension-link'
+import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
+import { lowlight } from '@/lib/lowlight'
+
+/** Read-only image node matching editor `resizableImage` output (no React node view). */
+const ReadOnlyResizableImage = Node.create({
+  name: 'resizableImage',
+  group: 'block',
+  draggable: false,
+  addAttributes() {
+    return {
+      src: { default: null },
+      alt: { default: null },
+      title: { default: null },
+      width: { default: null },
+      height: { default: null },
+    }
+  },
+  parseHTML() {
+    return [{ tag: 'img[src]:not([src^="data:"])' }]
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['img', mergeAttributes(HTMLAttributes)]
+  },
+})
+
+export function getReadOnlyExtensions() {
+  return [
+    StarterKit.configure({
+      codeBlock: false,
+      link: false,
+      underline: false,
+    }),
+    Underline,
+    Link.configure({
+      openOnClick: true,
+      HTMLAttributes: { rel: 'noopener noreferrer', target: '_blank' },
+    }),
+    CodeBlockLowlight.configure({
+      lowlight,
+    }),
+    ReadOnlyResizableImage,
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@tiptap/extension-text-align": "^3.20.0",
     "@tiptap/extension-underline": "^3.20.0",
     "@tiptap/extension-youtube": "^3.20.0",
+    "@tiptap/html": "^3.20.0",
     "@tiptap/pm": "^3.20.0",
     "@tiptap/react": "^3.20.0",
     "@tiptap/starter-kit": "^3.20.0",


### PR DESCRIPTION
## Summary

Reduces startup cost on read-only public routes by deferring wallet, blockchain, tipping/NFT, TipTap, and below-the-fold landing bundles until they are needed.

- **Wallet:** Opt-in `WalletActivationContext` mounts `WalletProvider` only after activation; `@creit.tech/stellar-wallets-kit` loads via `wallet-kit-loader` instead of on every page load.
- **Article page:** `TipButton` and `NFTIntegration` are lazy-loaded with skeletons; `TipStats` stays eager (Convex-only).
- **Article body:** Logged-out readers use `ArticleReadOnlyBody` (`@tiptap/html`); logged-in highlight flow lazy-loads `HighlightableArticle`.
- **Landing:** Below-fold sections load via dynamic `LandingBelowFold` so hero/nav paint first.



