### PR TITLE
fix(ui): add dark-mode styling for wallet, NFT, onboarding, and status surfaces (ENG-207)

### DIFF
--- a/components/articles/ShareButtons.tsx
+++ b/components/articles/ShareButtons.tsx
@@ -128,7 +128,7 @@ export default function ShareButtons({
     <div className={`${className}`}>
       {/* Error message */}
       {error && (
-        <div className="mb-2 text-sm text-red-600 bg-red-50 border border-red-200 rounded px-3 py-1">
+        <div className="mb-2 text-sm text-red-600 dark:text-red-300 bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-900/50 rounded px-3 py-1">
           {error}
         </div>
       )}

--- a/components/error/ErrorBoundary.tsx
+++ b/components/error/ErrorBoundary.tsx
@@ -45,11 +45,11 @@ export class ErrorBoundary extends Component<Props, State> {
       }
       return (
         fallback || (
-          <div className="p-4 border border-red-200 bg-red-50 rounded-lg">
-            <p className="text-red-800">Something went wrong.</p>
+          <div className="p-4 border border-destructive/30 bg-destructive/10 rounded-lg">
+            <p className="text-destructive">Something went wrong.</p>
             <button
               onClick={this.reset}
-              className="mt-2 text-sm text-red-600 underline"
+              className="mt-2 text-sm text-destructive underline"
             >
               Try again
             </button>

--- a/components/highlights/HighlightDetailsPanel.tsx
+++ b/components/highlights/HighlightDetailsPanel.tsx
@@ -298,7 +298,7 @@ export function HighlightDetailsPanel({
                 <>
                   <button
                     onClick={() => setIsEditing(true)}
-                    className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-blue-50 text-blue-700 rounded-lg hover:bg-blue-100 transition-colors text-sm font-medium"
+                    className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-300 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-950/50 transition-colors text-sm font-medium"
                   >
                     <Edit className="w-4 h-4" />
                     <span>Edit Note</span>
@@ -310,7 +310,7 @@ export function HighlightDetailsPanel({
                       'w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg transition-colors text-sm font-medium',
                       isDeleting
                         ? 'bg-muted text-muted-foreground cursor-not-allowed'
-                        : 'bg-red-50 text-red-700 hover:bg-red-100'
+                        : 'bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-300 hover:bg-red-100 dark:hover:bg-red-950/50'
                     )}
                   >
                     {isDeleting ? (

--- a/components/highlights/HighlightNotes.tsx
+++ b/components/highlights/HighlightNotes.tsx
@@ -109,7 +109,7 @@ export function HighlightNotes({
             if (!tipData?.count) return null
             return (
               <div className="mb-2">
-                <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-yellow-100 text-yellow-800 text-xs rounded-full">
+                <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-yellow-100 dark:bg-yellow-950/50 text-yellow-800 dark:text-yellow-200 text-xs rounded-full">
                   <Coins className="w-3 h-3" />
                   {tipData.count} tip{tipData.count > 1 ? 's' : ''}
                   {' · '}${tipData.totalUsd.toFixed(2)}

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -451,7 +451,7 @@ export function HighlightTipButton({
           </div>
 
           {isConnected && publicKey && (
-            <div className="text-xs text-green-600 text-center mt-4">
+            <div className="text-xs text-green-600 dark:text-green-300 text-center mt-4">
               <p className="flex items-center justify-center gap-1">
                 <Wallet className="w-3 h-3" />
                 Connected: {publicKey.slice(0, 6)}...{publicKey.slice(-6)}

--- a/components/nft/MintButton.tsx
+++ b/components/nft/MintButton.tsx
@@ -287,8 +287,8 @@ export function MintButton({
 
           <div className="space-y-4">
             {!wallet.isConnected && (
-              <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
-                <p className="text-sm text-amber-900">
+              <div className="bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3">
+                <p className="text-sm text-amber-900 dark:text-amber-100">
                   Connect your wallet to mint this article as an NFT.
                 </p>
               </div>
@@ -307,19 +307,19 @@ export function MintButton({
                   </span>
                 </div>
                 {wallet.isConnected && wallet.publicKey ? (
-                  <div className="bg-green-50 border border-green-200 rounded p-2">
+                  <div className="bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800 rounded p-2">
                     <div className="flex items-center justify-between text-xs">
-                      <span className="text-green-900 font-medium">
+                      <span className="text-green-900 dark:text-green-200 font-medium">
                         ✓ Wallet Connected
                       </span>
-                      <span className="font-mono text-green-700">
+                      <span className="font-mono text-green-700 dark:text-green-300">
                         {`${wallet.publicKey.slice(0, 4)}...${wallet.publicKey.slice(-4)}`}
                       </span>
                     </div>
                   </div>
                 ) : (
-                  <div className="bg-amber-50 border border-amber-200 rounded p-2">
-                    <span className="text-xs text-amber-900">
+                  <div className="bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded p-2">
+                    <span className="text-xs text-amber-900 dark:text-amber-100">
                       Wallet not connected
                     </span>
                   </div>

--- a/components/nft/TransferModal.tsx
+++ b/components/nft/TransferModal.tsx
@@ -156,11 +156,11 @@ export function TransferModal({
 
   const messageBannerClass =
     transferMessage.kind === 'success'
-      ? 'bg-green-50 text-green-700'
+      ? 'bg-green-50 text-green-700 dark:bg-green-950/50 dark:text-green-200'
       : transferMessage.kind === 'error'
-        ? 'bg-red-50 text-red-700'
+        ? 'bg-red-50 text-red-700 dark:bg-red-950/50 dark:text-red-200'
         : transferMessage.kind === 'progress'
-          ? 'bg-blue-50 text-blue-700'
+          ? 'bg-blue-50 text-blue-700 dark:bg-blue-950/50 dark:text-blue-200'
           : ''
 
   const messageIcon =

--- a/components/onboarding/OnboardingDialog.tsx
+++ b/components/onboarding/OnboardingDialog.tsx
@@ -31,21 +31,24 @@ const steps = [
     icon: Sparkles,
     title: 'Welcome to Quilltip',
     description: `A platform where readers reward writers directly on Stellar testnet. ${TESTNET_PRACTICE_NOTE}`,
-    color: 'bg-blue-100 text-blue-700',
+    color:
+      'bg-blue-100 text-blue-700 dark:bg-blue-950/50 dark:text-blue-300',
   },
   {
     icon: Wallet,
     title: 'Set Up Your Wallet',
     description:
       'To tip writers on testnet, you need a Stellar wallet (like Freighter) set to Testnet with free test XLM. It takes about 2 minutes. Reading articles is always free — no wallet needed.',
-    color: 'bg-amber-100 text-amber-700',
+    color:
+      'bg-amber-100 text-amber-700 dark:bg-amber-950/50 dark:text-amber-300',
   },
   {
     icon: BookOpen,
     title: 'Start Exploring',
     description:
       'Browse articles from writers, highlight passages you love, and send practice tips starting at $0.01 in testnet XLM. 97.5% goes directly to the author.',
-    color: 'bg-green-100 text-green-700',
+    color:
+      'bg-green-100 text-green-700 dark:bg-green-950/50 dark:text-green-300',
   },
 ]
 
@@ -127,7 +130,7 @@ export function OnboardingDialog() {
             <div
               key={i}
               className={`h-1.5 rounded-full transition-all duration-300 ${
-                i === currentStep ? 'w-8 bg-neutral-900' : 'w-4 bg-neutral-200'
+                i === currentStep ? 'w-8 bg-foreground' : 'w-4 bg-muted'
               }`}
             />
           ))}
@@ -145,10 +148,10 @@ export function OnboardingDialog() {
             <div className={`inline-flex p-4 rounded-2xl ${step.color} mb-4`}>
               <StepIcon className="w-8 h-8" />
             </div>
-            <h3 className="text-xl font-bold text-neutral-900 mb-2">
+            <h3 className="text-xl font-bold text-foreground mb-2">
               {step.title}
             </h3>
-            <p className="text-sm text-neutral-600 leading-relaxed max-w-sm mx-auto">
+            <p className="text-sm text-muted-foreground leading-relaxed max-w-sm mx-auto">
               {step.description}
             </p>
           </motion.div>

--- a/components/onboarding/OnboardingDialog.tsx
+++ b/components/onboarding/OnboardingDialog.tsx
@@ -31,8 +31,7 @@ const steps = [
     icon: Sparkles,
     title: 'Welcome to Quilltip',
     description: `A platform where readers reward writers directly on Stellar testnet. ${TESTNET_PRACTICE_NOTE}`,
-    color:
-      'bg-blue-100 text-blue-700 dark:bg-blue-950/50 dark:text-blue-300',
+    color: 'bg-blue-100 text-blue-700 dark:bg-blue-950/50 dark:text-blue-300',
   },
   {
     icon: Wallet,

--- a/components/stellar/WalletConnectButton.tsx
+++ b/components/stellar/WalletConnectButton.tsx
@@ -97,7 +97,10 @@ export function WalletConnectButton({
         onClick={handleConnect}
         size={size}
         variant="outline"
-        className={cn('text-red-600 border-red-300', className)}
+        className={cn(
+          'text-destructive border-destructive/50 dark:text-red-300 dark:border-red-800',
+          className
+        )}
       >
         <AlertCircle className="w-4 h-4 mr-2" />
         Wallet Error

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -184,9 +184,9 @@ export function WalletSettings({
         </CardHeader>
         <CardContent className="space-y-4">
           {isOwnProfile && (
-            <Alert className="bg-blue-50 border-blue-200">
-              <AlertCircle className="h-4 w-4 text-blue-600" />
-              <AlertDescription className="text-blue-900">
+            <Alert className="border-info/50 bg-info">
+              <AlertCircle className="h-4 w-4 text-info-foreground" />
+              <AlertDescription className="text-info-foreground">
                 <strong>This wallet is for receiving tips.</strong> When readers
                 tip your articles, payments come here. To send tips to other
                 authors, you&apos;ll connect your wallet extension directly on
@@ -230,7 +230,7 @@ export function WalletSettings({
                     Need a wallet?{' '}
                     <Link
                       href="/guide"
-                      className="text-blue-600 hover:underline"
+                      className="text-info-foreground hover:underline"
                     >
                       Follow our setup guide
                     </Link>
@@ -239,11 +239,11 @@ export function WalletSettings({
               ) : (
                 <div className="space-y-4">
                   {/* Connected State */}
-                  <div className="p-4 bg-green-50 border border-green-200 rounded-lg space-y-3">
+                  <div className="p-4 bg-success border border-success/50 rounded-lg space-y-3">
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-2">
                         <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
-                        <span className="text-sm font-medium">
+                        <span className="text-sm font-medium text-success-foreground">
                           Wallet Connected
                         </span>
                       </div>

--- a/components/stellar/WalletStatus.tsx
+++ b/components/stellar/WalletStatus.tsx
@@ -93,14 +93,14 @@ export function WalletStatus({ className }: WalletStatusProps) {
       <Card className={className}>
         <CardContent className="pt-6">
           <div className="flex flex-col items-center space-y-4 text-center">
-            <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
-              <Wallet className="w-6 h-6 text-red-600" />
+            <div className="w-12 h-12 bg-red-100 dark:bg-red-950/50 rounded-full flex items-center justify-center">
+              <Wallet className="w-6 h-6 text-red-600 dark:text-red-300" />
             </div>
             <div>
-              <h3 className="font-semibold text-red-900">
+              <h3 className="font-semibold text-red-900 dark:text-red-200">
                 Wallet Connection Error
               </h3>
-              <p className="text-sm text-red-600">{error}</p>
+              <p className="text-sm text-red-600 dark:text-red-300">{error}</p>
             </div>
             <Button variant="outline" onClick={refreshConnection}>
               <RefreshCw className="w-4 h-4 mr-2" />

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -290,13 +290,13 @@ export function TipButton({
           )}
 
           {!isConnected && (
-            <div className="p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-900">
+            <div className="p-3 bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-lg text-sm text-amber-900 dark:text-amber-100">
               <p>Connect your Stellar wallet to send tips to {authorName}.</p>
               <p className="mt-1">
                 New to crypto?{' '}
                 <Link
                   href="/guide"
-                  className="focus-ring rounded text-amber-700 underline font-medium hover:text-amber-900"
+                  className="focus-ring rounded text-amber-700 dark:text-amber-300 underline font-medium hover:text-amber-900 dark:hover:text-amber-100"
                 >
                   Follow our setup guide
                 </Link>
@@ -316,7 +316,7 @@ export function TipButton({
                 disabled={isLoading}
                 className={`focus-ring relative flex min-h-12 items-center justify-center px-4 py-3 rounded-lg border-2 transition-all disabled:opacity-50 ${
                   selectedAmount === amount.cents
-                    ? 'border-orange-500 bg-orange-50'
+                    ? 'border-orange-500 bg-orange-50 dark:bg-orange-950/30'
                     : 'border-border hover:border-orange-300'
                 }`}
               >


### PR DESCRIPTION
## Summary

Fixes inconsistent light-only panels in dark mode across wallet, NFT, onboarding, and status/tipping surfaces. Applies existing theme patterns (semantic tokens and `dark:` utility pairs) so banners, alerts, and status chips stay readable with proper contrast.

- **Wallet:** `WalletSettings`, `WalletStatus`, `WalletConnectButton` — info/success alerts use semantic tokens; error states get dark-mode contrast pairs
- **NFT:** `MintButton` wallet prompts and `TransferModal` status banners get dark-mode styling
- **Onboarding:** `OnboardingDialog` step icons, progress dots, and copy use theme-aware foreground/muted tokens
- **Status/tipping:** `TipButton`, `HighlightTipButton`, `HighlightDetailsPanel`, `HighlightNotes`, `ShareButtons`, and `ErrorBoundary` updated for dark mode
<img width="1224" height="718" alt="1" src="https://github.com/user-attachments/assets/fdbe18f9-2c66-4925-9048-5a32c26df145" />
<img width="1216" height="716" alt="10" src="https://github.com/user-attachments/assets/089303bc-f08c-4449-8ef4-35cc52c55371" />
<img width="1232" height="852" alt="quilltip-point4-contrast" src="https://github.com/user-attachments/assets/6104ec2f-672b-48b8-b61a-f8701fd301b3" />



