### PR TITLE
fix: align error and not-found pages with app theme (ENG-208)

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useEffect } from 'react'
 
 import { ErrorPageIllustration } from '@/components/error/ErrorPageIllustration'
+import { FailurePageShell } from '@/components/error/FailurePageShell'
 import { Button } from '@/components/ui/button'
 
 export default function Error({
@@ -22,24 +23,28 @@ export default function Error({
   }, [error])
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-brand-cream px-4 py-8">
-      <div className="mx-auto w-full max-w-md rounded-2xl border border-quill-200 bg-white/90 p-8 text-center shadow-sm backdrop-blur-sm">
-        <ErrorPageIllustration className="mb-6" />
-        <h1 className="font-display text-2xl font-semibold text-brand-blue">
+    <FailurePageShell
+      illustration={<ErrorPageIllustration className="mb-6" />}
+      heading={
+        <h1 className="font-display text-2xl font-semibold text-foreground">
           Something went wrong
         </h1>
-        <p className="mt-3 text-sm text-quill-600">
-          This page ran into a problem. Try again, or go back to the home page.
-        </p>
-        <div className="mt-8 flex w-full flex-col gap-3 sm:flex-row sm:justify-center">
-          <Button type="button" onClick={reset} className="w-full sm:w-auto">
+      }
+      description="This page ran into a problem. Try again, or go back to the home page."
+      actions={
+        <>
+          <Button
+            type="button"
+            onClick={reset}
+            className="w-full sm:w-auto"
+          >
             Try again
           </Button>
           <Button variant="outline" asChild className="w-full sm:w-auto">
             <Link href="/">Go Home</Link>
           </Button>
-        </div>
-      </div>
-    </div>
+        </>
+      }
+    />
   )
 }

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -33,11 +33,7 @@ export default function Error({
       description="This page ran into a problem. Try again, or go back to the home page."
       actions={
         <>
-          <Button
-            type="button"
-            onClick={reset}
-            className="w-full sm:w-auto"
-          >
+          <Button type="button" onClick={reset} className="w-full sm:w-auto">
             Try again
           </Button>
           <Button variant="outline" asChild className="w-full sm:w-auto">

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,10 +1,11 @@
 import Link from 'next/link'
 
+import { FailurePageShell } from '@/components/error/FailurePageShell'
 import { Button } from '@/components/ui/button'
 
 function NotFoundIllustration() {
   return (
-    <div className="mx-auto w-full max-w-[220px]">
+    <div className="mx-auto mb-6 w-full max-w-[220px]">
       <svg
         viewBox="0 0 200 168"
         className="h-auto w-full"
@@ -17,12 +18,12 @@ function NotFoundIllustration() {
           width="116"
           height="92"
           rx="8"
-          className="fill-brand-cream stroke-brand-blue"
+          className="fill-card stroke-border"
           strokeWidth="2"
         />
         <path
           d="M132 28h36v36l-36-36z"
-          className="fill-brand-accent/20 stroke-brand-blue"
+          className="fill-brand-accent/20 stroke-border"
           strokeWidth="1.5"
           strokeLinejoin="round"
         />
@@ -31,7 +32,7 @@ function NotFoundIllustration() {
           y1="52"
           x2="118"
           y2="52"
-          className="stroke-quill-300"
+          className="stroke-muted-foreground/60"
           strokeWidth="3"
           strokeLinecap="round"
         />
@@ -40,7 +41,7 @@ function NotFoundIllustration() {
           y1="68"
           x2="104"
           y2="68"
-          className="stroke-quill-300"
+          className="stroke-muted-foreground/60"
           strokeWidth="3"
           strokeLinecap="round"
         />
@@ -49,7 +50,7 @@ function NotFoundIllustration() {
           y1="84"
           x2="110"
           y2="84"
-          className="stroke-quill-300"
+          className="stroke-muted-foreground/60"
           strokeWidth="3"
           strokeLinecap="round"
         />
@@ -61,11 +62,11 @@ function NotFoundIllustration() {
         />
         <path
           d="M142 80l-10 26 8 4 10-24c4-10 3-22-4-30"
-          className="fill-brand-blue/15 stroke-brand-blue"
+          className="fill-primary/15 stroke-primary"
           strokeWidth="1.75"
           strokeLinejoin="round"
         />
-        <circle cx="139" cy="74" r="2" className="fill-brand-blue" />
+        <circle cx="139" cy="74" r="2" className="fill-primary" />
       </svg>
     </div>
   )
@@ -73,36 +74,33 @@ function NotFoundIllustration() {
 
 export default function NotFound() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center px-6 py-12">
-      <div className="mx-auto flex w-full max-w-md flex-col items-center gap-6 text-center">
-        <NotFoundIllustration />
-        <div className="space-y-2">
-          <h1 className="font-display text-5xl font-medium tracking-[-0.01em] text-brand-blue sm:text-6xl">
+    <FailurePageShell
+      illustration={<NotFoundIllustration />}
+      heading={
+        <>
+          <h1 className="font-display text-5xl font-medium tracking-[-0.01em] text-foreground sm:text-6xl">
             404
           </h1>
           <h2 className="font-display text-2xl font-medium text-foreground">
             Page not found
           </h2>
-          <p className="font-sans text-quill-700">
-            Sorry, we couldn&apos;t find the page you&apos;re looking for.
-          </p>
-        </div>
-        <div className="flex w-full flex-col items-center gap-4 sm:w-auto">
-          <Button
-            asChild
-            size="lg"
-            className="bg-brand-blue text-white shadow hover:bg-brand-accent focus-visible:ring-brand-blue"
-          >
+        </>
+      }
+      description="Sorry, we couldn't find the page you're looking for."
+      actionsClassName="flex flex-col items-center gap-4 sm:flex-col"
+      actions={
+        <>
+          <Button asChild size="lg" className="w-full sm:w-auto">
             <Link href="/">Go Home</Link>
           </Button>
           <Link
             href="/articles"
-            className="text-sm text-brand-blue underline-offset-4 transition-colors hover:text-brand-accent hover:underline"
+            className="text-sm font-medium text-primary underline-offset-4 transition-colors hover:underline"
           >
             Browse articles
           </Link>
-        </div>
-      </div>
-    </div>
+        </>
+      }
+    />
   )
 }

--- a/components/error/ErrorPageIllustration.tsx
+++ b/components/error/ErrorPageIllustration.tsx
@@ -21,18 +21,18 @@ export function ErrorPageIllustration({
         width="88"
         height="112"
         rx="6"
-        className="fill-white stroke-quill-200"
+        className="fill-card stroke-border"
         strokeWidth="2"
       />
       <path
         d="M44 48h56M44 64h48M44 80h52M44 96h40"
-        className="stroke-quill-300"
+        className="stroke-muted-foreground/60"
         strokeWidth="2"
         strokeLinecap="round"
       />
       <path
         d="M44 112h28"
-        className="stroke-quill-200"
+        className="stroke-muted-foreground/40"
         strokeWidth="2"
         strokeLinecap="round"
       />
@@ -44,13 +44,13 @@ export function ErrorPageIllustration({
       />
       <path
         d="M88 102l-6 14 8-4 6-14-8 4Z"
-        className="fill-brand-blue stroke-brand-blue"
+        className="fill-primary/15 stroke-primary"
         strokeWidth="1.5"
         strokeLinejoin="round"
       />
       <path
         d="M96 94c-2 4-6 10-10 14"
-        className="stroke-brand-blue"
+        className="stroke-primary"
         strokeWidth="2"
         strokeLinecap="round"
       />

--- a/components/error/FailurePageShell.tsx
+++ b/components/error/FailurePageShell.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react'
+
+import { cn } from '@/lib/utils'
+
+type FailurePageShellProps = {
+  illustration?: ReactNode
+  heading: ReactNode
+  description?: ReactNode
+  actions: ReactNode
+  actionsClassName?: string
+  className?: string
+}
+
+export function FailurePageShell({
+  illustration,
+  heading,
+  description,
+  actions,
+  actionsClassName,
+  className,
+}: FailurePageShellProps) {
+  return (
+    <div
+      className={cn(
+        'flex min-h-screen flex-col items-center justify-center bg-background px-4 py-8 sm:px-6 sm:py-12',
+        className
+      )}
+    >
+      <div className="mx-auto w-full max-w-md rounded-[var(--card-radius)] border border-border bg-card p-6 text-center shadow-[var(--card-shadow)] sm:p-8">
+        {illustration}
+        <div className="space-y-2">{heading}</div>
+        {description ? (
+          <div className="mt-3 text-sm text-muted-foreground">{description}</div>
+        ) : null}
+        <div
+          className={cn(
+            'mt-8 flex w-full flex-col items-center gap-3 sm:flex-row sm:justify-center',
+            actionsClassName
+          )}
+        >
+          {actions}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/error/FailurePageShell.tsx
+++ b/components/error/FailurePageShell.tsx
@@ -30,7 +30,9 @@ export function FailurePageShell({
         {illustration}
         <div className="space-y-2">{heading}</div>
         {description ? (
-          <div className="mt-3 text-sm text-muted-foreground">{description}</div>
+          <div className="mt-3 text-sm text-muted-foreground">
+            {description}
+          </div>
         ) : null}
         <div
           className={cn(


### PR DESCRIPTION
## Summary

Route-level failure pages (`error.tsx`, `not-found.tsx`) used light-only branding (`bg-brand-cream`, `bg-white/90`, fixed quill colors) that clashed with dark mode and felt inconsistent with the rest of the app. This PR rethemes both pages to use semantic design tokens and a shared layout shell.

## Changes

- Add `FailurePageShell` — shared layout with `bg-background`, `bg-card`, `border-border`, and responsive padding
- Update `app/error.tsx` — use shell; replace cream/white surfaces with theme tokens; keep Try again + Go Home actions
- Update `app/not-found.tsx` — use shell; default shadcn Button for Go Home; `text-primary` link for Browse articles
- Update `ErrorPageIllustration` and inline 404 SVG — `fill-card`, `stroke-border`, `stroke-muted-foreground`, `stroke-primary` for dark-mode-safe illustrations
<img width="1221" height="716" alt="1" src="https://github.com/user-attachments/assets/ce1e1f65-5f0c-468a-9b4c-2d0d726aa2d4" />
<img width="1221" height="722" alt="4" src="https://github.com/user-attachments/assets/442cb7d3-0c9f-4f6e-9bf5-299734b114c2" />
<img width="586" height="674" alt="mob" src="https://github.com/user-attachments/assets/7894db35-845e-40f8-868e-ae0c9d79c5a1" />
<img width="589" height="676" alt="tab" src="https://github.com/user-attachments/assets/063668f1-22a3-45ce-90e9-898145a4307f" />


