### PR TITLE
feat: add public footer trust and support links (ENG-215)

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { LegalLinks } from '@/components/legal/LegalLinks'
+import { AUTH_FOOTER_LINKS } from '@/lib/copy/footer-links'
 
 /**
  * Auth Layout
@@ -53,13 +54,30 @@ export default function AuthLayout({
           </div>
 
           {/* Footer Links */}
-          <div className="mt-8 text-center text-sm text-muted-foreground">
+          <div className="mt-8 space-y-3 text-center text-sm text-muted-foreground">
             <p>
               By continuing, you agree to Quilltip&apos;s{' '}
               <LegalLinks
                 conjunction="and"
                 linkClassName="text-primary hover:underline"
               />
+            </p>
+            <p>
+              {AUTH_FOOTER_LINKS.map((link, index) => (
+                <span key={link.href}>
+                  {index > 0 ? (
+                    <span className="mx-1.5 text-muted-foreground" aria-hidden>
+                      |
+                    </span>
+                  ) : null}
+                  <Link
+                    href={link.href}
+                    className="text-primary hover:underline underline-offset-4"
+                  >
+                    {link.label}
+                  </Link>
+                </span>
+              ))}
             </p>
           </div>
         </div>

--- a/app/[username]/[slug]/page.tsx
+++ b/app/[username]/[slug]/page.tsx
@@ -11,6 +11,7 @@ import {
 import ArticleDisplay from '@/components/articles/ArticleDisplay'
 import { ArticlePageLoadingSkeleton } from '@/components/articles/ArticlePageLoadingSkeleton'
 import AppNavigation from '@/components/layout/AppNavigation'
+import { SiteFooter } from '@/components/layout/SiteFooter'
 import { TipStats } from '@/components/tipping/TipStats'
 import {
   TipButtonSkeleton,
@@ -129,10 +130,10 @@ export default function ArticlePage({ params }: ArticlePageProps) {
   }
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="flex min-h-screen flex-col bg-background">
       <AppNavigation />
       <ReadingProgressBar />
-      <main className="pt-20">
+      <main className="flex-1 pt-20 w-full">
         <div className="max-w-7xl mx-auto px-4 py-8">
           <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
             {/* Main Article Content */}
@@ -291,6 +292,7 @@ export default function ArticlePage({ params }: ArticlePageProps) {
           </div>
         </div>
       </main>
+      <SiteFooter variant="default" />
     </div>
   )
 }

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -6,6 +6,7 @@ import { use, useState, useEffect } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { useAuth } from '@/components/providers/AuthContext'
 import AppNavigation from '@/components/layout/AppNavigation'
+import { SiteFooter } from '@/components/layout/SiteFooter'
 import ProfileHeader from '@/components/profile/ProfileHeader'
 import { ProfileArticlesTabContent } from '@/components/profile/ProfileArticlesTabContent'
 import { ProfileNftsTabContent } from '@/components/profile/ProfileNftsTabContent'
@@ -122,10 +123,10 @@ export default function ProfilePage({ params }: ProfilePageProps) {
   ]
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="flex min-h-screen flex-col bg-background">
       <AppNavigation />
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12">
+      <main className="flex-1 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12 w-full">
         {/* Profile Header */}
         <div className="mb-8">
           <ProfileHeader user={userWithStats} isOwnProfile={isOwnProfile} />
@@ -267,6 +268,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
           )}
         </div>
       </main>
+      <SiteFooter variant="default" />
     </div>
   )
 }

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { usePathname, useSearchParams, useRouter } from 'next/navigation'
 import AppNavigation from '@/components/layout/AppNavigation'
+import { SiteFooter } from '@/components/layout/SiteFooter'
 import SearchInput from '@/components/articles/SearchInput'
 import { ArticlesBrowseContent } from '@/components/articles/ArticlesBrowseContent'
 import {
@@ -75,10 +76,10 @@ export default function ArticlesPage() {
   }
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="flex min-h-screen flex-col bg-background">
       <AppNavigation />
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12">
+      <main className="flex-1 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12 w-full">
         {/* Page Header */}
         <div className="mb-8">
           <h1 className="text-4xl font-bold text-foreground mb-2">
@@ -178,6 +179,7 @@ export default function ArticlesPage() {
           onArticleNavigate={saveBrowseScrollPosition}
         />
       </main>
+      <SiteFooter variant="default" />
     </div>
   )
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from 'next'
+import { InfoPageLayout } from '@/components/layout/InfoPageLayout'
+import {
+  contactChannels,
+  contactIntro,
+  contactNotes,
+} from '@/lib/copy/contact-page'
+
+export const metadata: Metadata = {
+  title: 'Contact | Quilltip',
+  description:
+    'Contact Quilltip for legal, privacy, and security questions about the Stellar testnet platform.',
+}
+
+export default function ContactPage() {
+  return (
+    <InfoPageLayout title="Contact" description={contactIntro}>
+      <div className="space-y-10 text-foreground">
+        {contactChannels.map((channel) => (
+          <section key={channel.id} id={channel.id}>
+            <h2 className="text-lg font-semibold text-foreground mb-3">
+              {channel.title}
+            </h2>
+            <p className="text-sm leading-relaxed text-muted-foreground mb-3">
+              {channel.description}
+            </p>
+            <a
+              href={`mailto:${channel.email}`}
+              className="text-sm text-primary hover:underline underline-offset-4"
+            >
+              {channel.email}
+            </a>
+          </section>
+        ))}
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-3">
+            Important notes
+          </h2>
+          <div className="space-y-3 text-sm leading-relaxed text-muted-foreground">
+            {contactNotes.map((note, index) => (
+              <p key={`note-${index}`}>{note}</p>
+            ))}
+          </div>
+        </section>
+      </div>
+    </InfoPageLayout>
+  )
+}

--- a/app/guide/page.tsx
+++ b/app/guide/page.tsx
@@ -4,16 +4,18 @@ import { useAuth } from '@/components/providers/AuthContext'
 import Navigation from '@/components/landing/Navigation'
 import AppNavigation from '@/components/layout/AppNavigation'
 import { WalletGuide } from '@/components/guide/WalletGuide'
+import { SiteFooter } from '@/components/layout/SiteFooter'
 
 export default function GuidePage() {
   const { isAuthenticated } = useAuth()
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="flex min-h-screen flex-col bg-background">
       {isAuthenticated ? <AppNavigation /> : <Navigation />}
-      <div className="pt-24 pb-16 px-4">
+      <div className="flex-1 pt-24 pb-16 px-4">
         <WalletGuide />
       </div>
+      <SiteFooter variant="default" />
     </div>
   )
 }

--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -1,0 +1,66 @@
+import type { Metadata } from 'next'
+import { InfoPageLayout } from '@/components/layout/InfoPageLayout'
+import {
+  statusBanner,
+  statusIntro,
+  statusNotes,
+  statusServices,
+} from '@/lib/copy/status-page'
+
+export const metadata: Metadata = {
+  title: 'Platform Status | Quilltip',
+  description:
+    'Quilltip platform status on Stellar testnet. Beta launch scope and service availability.',
+}
+
+export default function StatusPage() {
+  return (
+    <InfoPageLayout title="Platform Status" description={statusIntro}>
+      <div className="space-y-10 text-foreground">
+        <div
+          role="status"
+          className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm leading-relaxed text-amber-950 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-100"
+        >
+          {statusBanner}
+        </div>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-4">
+            Services
+          </h2>
+          <ul className="divide-y divide-border rounded-lg border border-border">
+            {statusServices.map((service) => (
+              <li
+                key={service.id}
+                className="flex flex-col gap-1 px-4 py-4 sm:flex-row sm:items-start sm:justify-between"
+              >
+                <div>
+                  <p className="text-sm font-medium text-foreground">
+                    {service.name}
+                  </p>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {service.detail}
+                  </p>
+                </div>
+                <span className="shrink-0 text-sm font-medium text-green-700 dark:text-green-400">
+                  {service.status}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-3">
+            Launch scope
+          </h2>
+          <div className="space-y-3 text-sm leading-relaxed text-muted-foreground">
+            {statusNotes.map((note, index) => (
+              <p key={`status-note-${index}`}>{note}</p>
+            ))}
+          </div>
+        </section>
+      </div>
+    </InfoPageLayout>
+  )
+}

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { InfoPageLayout } from '@/components/layout/InfoPageLayout'
+import {
+  supportIntro,
+  supportResourceLinks,
+  supportSections,
+} from '@/lib/copy/support-page'
+
+export const metadata: Metadata = {
+  title: 'Help & Support | Quilltip',
+  description:
+    'Get help using Quilltip on Stellar testnet. Wallet setup, practice tipping, and support channels.',
+}
+
+export default function SupportPage() {
+  return (
+    <InfoPageLayout title="Help & Support" description={supportIntro}>
+      <div className="space-y-10 text-foreground">
+        {supportSections.map((section) => (
+          <section key={section.id} id={section.id}>
+            <h2 className="text-lg font-semibold text-foreground mb-3">
+              {section.title}
+            </h2>
+            <div className="space-y-3 text-sm leading-relaxed text-muted-foreground">
+              {section.paragraphs.map((paragraph, index) => (
+                <p key={`${section.id}-${index}`}>{paragraph}</p>
+              ))}
+            </div>
+          </section>
+        ))}
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-3">
+            Quick links
+          </h2>
+          <ul className="space-y-2 text-sm">
+            {supportResourceLinks.map((link) => (
+              <li key={link.href}>
+                <Link
+                  href={link.href}
+                  className="text-primary hover:underline underline-offset-4"
+                >
+                  {link.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </InfoPageLayout>
+  )
+}

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -1,48 +1,7 @@
 'use client'
 
-import { Heart, PenTool } from 'lucide-react'
-import { Reveal } from '@/components/landing/Reveal'
-import { LegalLinks } from '@/components/legal/LegalLinks'
+import { SiteFooter } from '@/components/layout/SiteFooter'
 
 export default function Footer() {
-  const currentYear = new Date().getFullYear()
-
-  return (
-    <footer className="bg-spotlight text-spotlight-foreground relative overflow-hidden">
-      {/* Background decoration */}
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_30%,color-mix(in_oklab,var(--spotlight-foreground)_6%,transparent),transparent_50%)]" />
-
-      <div className="container mx-auto max-w-7xl px-8 relative z-10">
-        {/* Main Footer Content */}
-        <div className="py-16">
-          {/* Brand Section */}
-          <Reveal className="text-center">
-            <div className="flex items-center gap-3 mb-4 justify-center">
-              <div className="w-9 h-9 bg-card rounded-lg border border-border flex items-center justify-center shadow-sm">
-                <PenTool className="w-5 h-5 text-foreground" />
-              </div>
-              <h3 className="text-2xl font-display font-medium tracking-[-0.01em]">
-                Quilltip
-              </h3>
-            </div>
-            <p className="text-spotlight-muted text-[15px] leading-relaxed max-w-2xl mx-auto">
-              Empowering writers with blockchain-powered micro-tipping on
-              Stellar testnet. Practice with free test XLM today.
-            </p>
-          </Reveal>
-        </div>
-
-        <Reveal className="py-8 border-t border-spotlight-border space-y-4">
-          <div className="flex justify-center">
-            <LegalLinks linkClassName="text-spotlight-muted hover:text-spotlight-foreground text-[13px]" />
-          </div>
-          <div className="flex items-center justify-center gap-2 text-spotlight-muted text-[13px]">
-            <span>© {currentYear} Quilltip. Built with</span>
-            <Heart className="w-4 h-4 text-destructive fill-current animate-pulse" />
-            <span>for writers everywhere</span>
-          </div>
-        </Reveal>
-      </div>
-    </footer>
-  )
+  return <SiteFooter variant="landing" />
 }

--- a/components/layout/FooterNav.tsx
+++ b/components/layout/FooterNav.tsx
@@ -1,0 +1,73 @@
+import Link from 'next/link'
+import { cn } from '@/lib/utils'
+import {
+  FOOTER_LINK_CATEGORIES,
+  FOOTER_LINK_GROUP_LABELS,
+  FOOTER_LINKS,
+  type FooterLinkCategory,
+} from '@/lib/copy/footer-links'
+
+type FooterNavProps = {
+  className?: string
+  linkClassName?: string
+  groupLabelClassName?: string
+  variant?: 'landing' | 'default'
+}
+
+function linksForCategory(category: FooterLinkCategory) {
+  return FOOTER_LINKS.filter((link) => link.category === category)
+}
+
+export function FooterNav({
+  className,
+  linkClassName,
+  groupLabelClassName,
+  variant = 'default',
+}: FooterNavProps) {
+  const defaultLinkStyles =
+    variant === 'landing'
+      ? 'text-spotlight-muted hover:text-spotlight-foreground text-[13px]'
+      : 'text-muted-foreground hover:text-foreground text-sm'
+
+  const defaultGroupLabelStyles =
+    variant === 'landing'
+      ? 'text-spotlight-foreground text-xs font-semibold uppercase tracking-wide'
+      : 'text-foreground text-xs font-semibold uppercase tracking-wide'
+
+  const linkStyles = cn(
+    'hover:underline underline-offset-4 transition-colors',
+    linkClassName ?? defaultLinkStyles
+  )
+
+  const groupLabelStyles = cn(
+    'mb-2 block',
+    groupLabelClassName ?? defaultGroupLabelStyles
+  )
+
+  return (
+    <nav
+      aria-label="Footer"
+      className={cn(
+        'grid grid-cols-2 gap-6 sm:grid-cols-4 sm:gap-8',
+        className
+      )}
+    >
+      {FOOTER_LINK_CATEGORIES.map((category) => (
+        <div key={category}>
+          <span className={groupLabelStyles}>
+            {FOOTER_LINK_GROUP_LABELS[category]}
+          </span>
+          <ul className="space-y-2">
+            {linksForCategory(category).map((link) => (
+              <li key={link.href}>
+                <Link href={link.href} className={linkStyles}>
+                  {link.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </nav>
+  )
+}

--- a/components/layout/InfoPageLayout.tsx
+++ b/components/layout/InfoPageLayout.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useAuth } from '@/components/providers/AuthContext'
+import Navigation from '@/components/landing/Navigation'
+import AppNavigation from '@/components/layout/AppNavigation'
+import { SiteFooter } from '@/components/layout/SiteFooter'
+
+type InfoPageLayoutProps = {
+  title: string
+  description?: string
+  children: React.ReactNode
+}
+
+export function InfoPageLayout({
+  title,
+  description,
+  children,
+}: InfoPageLayoutProps) {
+  const { isAuthenticated } = useAuth()
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      {isAuthenticated ? <AppNavigation /> : <Navigation />}
+      <div className="flex-1 pt-24 pb-16 px-4">
+        <div className="mx-auto max-w-3xl">
+          <header className="mb-10 border-b border-border pb-8">
+            <h1 className="font-display text-3xl lg:text-4xl font-medium tracking-[-0.01em] text-foreground">
+              {title}
+            </h1>
+            {description ? (
+              <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                {description}
+              </p>
+            ) : null}
+          </header>
+          {children}
+        </div>
+      </div>
+      <SiteFooter variant="default" />
+    </div>
+  )
+}

--- a/components/layout/SiteFooter.tsx
+++ b/components/layout/SiteFooter.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { Heart, PenTool } from 'lucide-react'
+import { Reveal } from '@/components/landing/Reveal'
+import { FooterNav } from '@/components/layout/FooterNav'
+import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
+import { cn } from '@/lib/utils'
+
+type SiteFooterProps = {
+  variant?: 'landing' | 'default'
+}
+
+export function SiteFooter({ variant = 'default' }: SiteFooterProps) {
+  const currentYear = new Date().getFullYear()
+  const isLanding = variant === 'landing'
+
+  if (isLanding) {
+    return (
+      <footer className="bg-spotlight text-spotlight-foreground relative overflow-hidden">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_30%,color-mix(in_oklab,var(--spotlight-foreground)_6%,transparent),transparent_50%)]" />
+
+        <div className="container mx-auto max-w-7xl px-8 relative z-10">
+          <div className="py-16">
+            <Reveal className="text-center">
+              <div className="flex items-center gap-3 mb-4 justify-center">
+                <div className="w-9 h-9 bg-card rounded-lg border border-border flex items-center justify-center shadow-sm">
+                  <PenTool className="w-5 h-5 text-foreground" />
+                </div>
+                <h3 className="text-2xl font-display font-medium tracking-[-0.01em]">
+                  Quilltip
+                </h3>
+              </div>
+              <p className="text-spotlight-muted text-[15px] leading-relaxed max-w-2xl mx-auto">
+                {TESTNET_PRACTICE_NOTE}
+              </p>
+            </Reveal>
+          </div>
+
+          <Reveal className="py-8 border-t border-spotlight-border space-y-6">
+            <FooterNav variant="landing" className="max-w-3xl mx-auto" />
+            <div className="flex items-center justify-center gap-2 text-spotlight-muted text-[13px]">
+              <span>© {currentYear} Quilltip. Built with</span>
+              <Heart className="w-4 h-4 text-destructive fill-current animate-pulse" />
+              <span>for writers everywhere</span>
+            </div>
+          </Reveal>
+        </div>
+      </footer>
+    )
+  }
+
+  return (
+    <footer className={cn('border-t border-border bg-background mt-auto')}>
+      <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-10 space-y-6">
+        <div className="max-w-3xl">
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            {TESTNET_PRACTICE_NOTE}
+          </p>
+        </div>
+        <FooterNav variant="default" className="max-w-3xl" />
+        <p className="text-sm text-muted-foreground">
+          © {currentYear} Quilltip. All rights reserved.
+        </p>
+      </div>
+    </footer>
+  )
+}

--- a/components/legal/LegalPageLayout.tsx
+++ b/components/legal/LegalPageLayout.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '@/components/providers/AuthContext'
 import Navigation from '@/components/landing/Navigation'
 import AppNavigation from '@/components/layout/AppNavigation'
 import { Button } from '@/components/ui/button'
+import { SiteFooter } from '@/components/layout/SiteFooter'
 import type { LegalSection } from '@/lib/copy/legal-shared'
 
 type LegalPageLayoutProps = {
@@ -26,9 +27,9 @@ export function LegalPageLayout({
   const { isAuthenticated } = useAuth()
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="flex min-h-screen flex-col bg-background">
       {isAuthenticated ? <AppNavigation /> : <Navigation />}
-      <div className="pt-24 pb-16 px-4">
+      <div className="flex-1 pt-24 pb-16 px-4">
         <article className="mx-auto max-w-3xl">
           <header className="mb-10 border-b border-border pb-8">
             <p className="text-sm text-muted-foreground mb-2">
@@ -76,6 +77,7 @@ export function LegalPageLayout({
           </footer>
         </article>
       </div>
+      <SiteFooter variant="default" />
     </div>
   )
 }

--- a/e2e/home-visual.spec.ts
+++ b/e2e/home-visual.spec.ts
@@ -113,3 +113,28 @@ test.describe('landing nav hash navigation', () => {
     await assertRevealContentVisible(page, '#arweave-storage')
   })
 })
+
+test.describe('home landing footer links', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await expect(
+      page.getByRole('heading', { name: 'Reward the words that move you' })
+    ).toBeVisible()
+  })
+
+  test('footer includes trust and support destinations', async ({ page }) => {
+    const footer = page.getByRole('navigation', { name: 'Footer' })
+    await footer.scrollIntoViewIfNeeded()
+
+    for (const label of [
+      'Terms of Service',
+      'Privacy Policy',
+      'Help & Support',
+      'Wallet Guide',
+      'Contact',
+      'Platform Status',
+    ]) {
+      await expect(footer.getByRole('link', { name: label })).toBeVisible()
+    }
+  })
+})

--- a/lib/copy/contact-page.ts
+++ b/lib/copy/contact-page.ts
@@ -1,0 +1,41 @@
+import { LEGAL_CONTACT_EMAIL } from '@/lib/copy/legal-shared'
+import {
+  MAINNET_COMING_NOTE,
+  TESTNET_PRACTICE_NOTE,
+} from '@/lib/copy/network-status'
+
+export const SECURITY_CONTACT_EMAIL = 'security@quilltip.me'
+
+export type ContactChannel = {
+  id: string
+  title: string
+  email: string
+  description: string
+}
+
+export const contactIntro =
+  'Reach the Quilltip team for legal, privacy, security, and general questions about the testnet product.'
+
+export const contactChannels: ContactChannel[] = [
+  {
+    id: 'legal',
+    title: 'Legal and privacy',
+    email: LEGAL_CONTACT_EMAIL,
+    description:
+      'Questions about our Terms of Service, Privacy Policy, data requests, or account-related legal matters.',
+  },
+  {
+    id: 'security',
+    title: 'Security reports',
+    email: SECURITY_CONTACT_EMAIL,
+    description:
+      'Report vulnerabilities privately. Do not open public GitHub issues for security concerns.',
+  },
+]
+
+export const contactNotes = [
+  TESTNET_PRACTICE_NOTE,
+  MAINNET_COMING_NOTE,
+  'Quilltip does not process real-money payments today. Billing, refund, or chargeback requests do not apply to testnet practice funds.',
+  'We aim to respond to general inquiries within a few business days. Security reports receive acknowledgment within 48 hours per our security policy.',
+]

--- a/lib/copy/footer-links.test.ts
+++ b/lib/copy/footer-links.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import {
+  AUTH_FOOTER_LINKS,
+  FOOTER_LINKS,
+  FOOTER_LINK_CATEGORIES,
+  FOOTER_LINK_GROUP_LABELS,
+  INTERNAL_FOOTER_ROUTES,
+} from '@/lib/copy/footer-links'
+
+describe('footer-links', () => {
+  it('includes legal, support, contact, and status categories', () => {
+    expect(FOOTER_LINK_CATEGORIES).toEqual([
+      'legal',
+      'support',
+      'contact',
+      'status',
+    ])
+
+    for (const category of FOOTER_LINK_CATEGORIES) {
+      expect(FOOTER_LINK_GROUP_LABELS[category]).toBeTruthy()
+      expect(FOOTER_LINKS.some((link) => link.category === category)).toBe(
+        true
+      )
+    }
+  })
+
+  it('uses only known internal routes for footer destinations', () => {
+    for (const link of FOOTER_LINKS) {
+      expect(link.href.startsWith('/')).toBe(true)
+      expect(INTERNAL_FOOTER_ROUTES).toContain(
+        link.href as (typeof INTERNAL_FOOTER_ROUTES)[number]
+      )
+    }
+  })
+
+  it('excludes legal links from auth footer compact row', () => {
+    expect(AUTH_FOOTER_LINKS.every((link) => link.category !== 'legal')).toBe(
+      true
+    )
+    expect(AUTH_FOOTER_LINKS.map((link) => link.label)).toEqual([
+      'Help & Support',
+      'Wallet Guide',
+      'Contact',
+      'Platform Status',
+    ])
+  })
+})

--- a/lib/copy/footer-links.test.ts
+++ b/lib/copy/footer-links.test.ts
@@ -18,9 +18,7 @@ describe('footer-links', () => {
 
     for (const category of FOOTER_LINK_CATEGORIES) {
       expect(FOOTER_LINK_GROUP_LABELS[category]).toBeTruthy()
-      expect(FOOTER_LINKS.some((link) => link.category === category)).toBe(
-        true
-      )
+      expect(FOOTER_LINKS.some((link) => link.category === category)).toBe(true)
     }
   })
 

--- a/lib/copy/footer-links.ts
+++ b/lib/copy/footer-links.ts
@@ -1,0 +1,43 @@
+export type FooterLinkCategory = 'legal' | 'support' | 'contact' | 'status'
+
+export type FooterLink = {
+  label: string
+  href: string
+  category: FooterLinkCategory
+}
+
+export const FOOTER_LINKS: FooterLink[] = [
+  { label: 'Terms of Service', href: '/terms', category: 'legal' },
+  { label: 'Privacy Policy', href: '/privacy', category: 'legal' },
+  { label: 'Help & Support', href: '/support', category: 'support' },
+  { label: 'Wallet Guide', href: '/guide', category: 'support' },
+  { label: 'Contact', href: '/contact', category: 'contact' },
+  { label: 'Platform Status', href: '/status', category: 'status' },
+]
+
+export const FOOTER_LINK_GROUP_LABELS: Record<FooterLinkCategory, string> = {
+  legal: 'Legal',
+  support: 'Support',
+  contact: 'Contact',
+  status: 'Status',
+}
+
+export const FOOTER_LINK_CATEGORIES: FooterLinkCategory[] = [
+  'legal',
+  'support',
+  'contact',
+  'status',
+]
+
+export const AUTH_FOOTER_LINKS = FOOTER_LINKS.filter(
+  (link) => link.category !== 'legal'
+)
+
+export const INTERNAL_FOOTER_ROUTES = [
+  '/terms',
+  '/privacy',
+  '/guide',
+  '/support',
+  '/contact',
+  '/status',
+] as const

--- a/lib/copy/status-page.ts
+++ b/lib/copy/status-page.ts
@@ -1,0 +1,49 @@
+import {
+  MAINNET_COMING_NOTE,
+  TESTNET_PRACTICE_NOTE,
+} from '@/lib/copy/network-status'
+
+export type StatusService = {
+  id: string
+  name: string
+  status: string
+  detail: string
+}
+
+export const statusIntro =
+  'Current platform scope for Quilltip. This page describes our testnet launch status—not a live uptime dashboard for mainnet production payments.'
+
+export const statusBanner = TESTNET_PRACTICE_NOTE
+
+export const statusServices: StatusService[] = [
+  {
+    id: 'website',
+    name: 'Quilltip website',
+    status: 'Operational',
+    detail: 'Beta on Vercel. Reading, publishing, and account features are available.',
+  },
+  {
+    id: 'backend',
+    name: 'Convex backend',
+    status: 'Operational',
+    detail: 'Real-time articles, tips, and user data on Convex Cloud.',
+  },
+  {
+    id: 'stellar',
+    name: 'Stellar testnet tipping',
+    status: 'Operational on testnet',
+    detail:
+      'Tips and withdrawals use test XLM only. Not connected to mainnet or real funds.',
+  },
+  {
+    id: 'arweave',
+    name: 'Arweave storage',
+    status: 'Operational',
+    detail: 'Published articles may be stored permanently on Arweave.',
+  },
+]
+
+export const statusNotes = [
+  MAINNET_COMING_NOTE,
+  'Stage: Beta. Network: Stellar Testnet. Tips have no real-world monetary value.',
+]

--- a/lib/copy/status-page.ts
+++ b/lib/copy/status-page.ts
@@ -20,7 +20,8 @@ export const statusServices: StatusService[] = [
     id: 'website',
     name: 'Quilltip website',
     status: 'Operational',
-    detail: 'Beta on Vercel. Reading, publishing, and account features are available.',
+    detail:
+      'Beta on Vercel. Reading, publishing, and account features are available.',
   },
   {
     id: 'backend',

--- a/lib/copy/support-page.ts
+++ b/lib/copy/support-page.ts
@@ -1,0 +1,56 @@
+import {
+  MAINNET_COMING_NOTE,
+  TESTNET_PRACTICE_NOTE,
+} from '@/lib/copy/network-status'
+
+export const SUPPORT_GITHUB_URL =
+  'https://github.com/pragya-shar/quilltip/issues'
+
+export type InfoSection = {
+  id: string
+  title: string
+  paragraphs: string[]
+}
+
+export const supportIntro =
+  'Help for using Quilltip on Stellar testnet. Tips use free test XLM for practice—not real money.'
+
+export const supportSections: InfoSection[] = [
+  {
+    id: 'scope',
+    title: 'What we support today',
+    paragraphs: [
+      TESTNET_PRACTICE_NOTE,
+      MAINNET_COMING_NOTE,
+      'On testnet, writers keep 97.5% of each practice tip and Quilltip retains 2.5% to cover platform operations. Testnet balances have no real-world monetary value.',
+    ],
+  },
+  {
+    id: 'wallet',
+    title: 'Wallet and tipping help',
+    paragraphs: [
+      'If you are new to Stellar wallets or testnet XLM, start with our step-by-step wallet guide. It covers connecting Freighter, xBull, Albedo, or hot wallet, funding with test XLM, and sending your first practice tip.',
+    ],
+  },
+  {
+    id: 'bugs',
+    title: 'Bug reports and feature requests',
+    paragraphs: [
+      'For technical issues, broken flows, or product feedback, open a GitHub issue. Include what you tried, what you expected, and any error messages or transaction IDs if relevant.',
+    ],
+  },
+  {
+    id: 'other',
+    title: 'Other questions',
+    paragraphs: [
+      'For legal, privacy, or account-related questions, use the contact page. Do not post security vulnerabilities in public issues—email security@quilltip.me instead.',
+    ],
+  },
+]
+
+export const supportResourceLinks = [
+  { label: 'Wallet Guide', href: '/guide' },
+  { label: 'FAQ on homepage', href: '/#faq' },
+  { label: 'GitHub Issues', href: SUPPORT_GITHUB_URL },
+  { label: 'Contact', href: '/contact' },
+]


### PR DESCRIPTION
## Summary

- Add grouped footer navigation (Legal, Support, Contact, Status) with shared link config and reusable `SiteFooter` / `FooterNav` components.
- Add launch-ready `/support`, `/contact`, and `/status` pages with testnet-aligned trust copy from `lib/copy/network-status.ts`.
- Show the footer on all public-readable pages (`/articles`, profiles, articles, legal pages, guide) and compact support links on auth pages.
<img width="1223" height="715" alt="1" src="https://github.com/user-attachments/assets/aaabe395-6a14-4f29-9e55-f2eda9dc5a4b" />

<img width="1223" height="716" alt="2" src="https://github.com/user-attachments/assets/043d737f-5c5c-4428-b8d4-2085a1765899" />
<img width="1224" height="719" alt="1" src="https://github.com/user-attachments/assets/b1a6f1b4-42cb-47e0-9c1b-9800e6009d3d" />
<img width="1221" height="716" alt="2" src="https://github.com/user-attachments/assets/383ebf63-7051-41c9-bbbc-c5d2d7481217" />
