### PR TITLE
fix: remove development-mode console warnings on public pages (ENG-224)

### DIFF
--- a/e2e/eng-224-console.spec.ts
+++ b/e2e/eng-224-console.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test'
+
+const DEV_CONSOLE_PATTERN = /development|dev mode|devtools|development build/i
+
+const PUBLIC_PAGES = [
+  { name: 'home', path: '/' },
+  { name: 'articles', path: '/articles' },
+  { name: 'guide', path: '/guide' },
+] as const
+
+function collectDevConsoleMessages(
+  entries: { type: string; text: string }[]
+): { type: string; text: string }[] {
+  return entries.filter((e) => DEV_CONSOLE_PATTERN.test(e.text))
+}
+
+async function captureConsoleForPath(
+  page: import('@playwright/test').Page,
+  path: string
+) {
+  const entries: { type: string; text: string }[] = []
+  page.on('console', (msg) => {
+    entries.push({ type: msg.type(), text: msg.text() })
+  })
+  await page.goto(path, { waitUntil: 'networkidle', timeout: 60_000 })
+  await page.waitForTimeout(2000)
+  return entries
+}
+
+test.describe('ENG-224 public pages console', () => {
+  test.setTimeout(120_000)
+
+  for (const pageDef of PUBLIC_PAGES) {
+    test(`${pageDef.name} has no development-mode console messages`, async ({
+      page,
+    }) => {
+      const entries = await captureConsoleForPath(page, pageDef.path)
+      const devMatches = collectDevConsoleMessages(entries)
+      expect(
+        devMatches,
+        devMatches.map((m) => `[${m.type}] ${m.text}`).join('\n')
+      ).toEqual([])
+    })
+  }
+
+  test('article detail has no development-mode console messages', async ({
+    page,
+  }) => {
+    await page.goto('/articles', {
+      waitUntil: 'networkidle',
+      timeout: 60_000,
+    })
+    const articleLink = page
+      .locator('a[href^="/"]')
+      .filter({ has: page.locator('article, [data-article], h2, h3') })
+      .first()
+    const href = await articleLink.getAttribute('href').catch(() => null)
+
+    const fallbackLink = page.locator('main a[href*="/"]').nth(1)
+    const resolvedHref =
+      href &&
+      href.startsWith('/') &&
+      href.split('/').filter(Boolean).length >= 2
+        ? href
+        : await fallbackLink.getAttribute('href').catch(() => null)
+
+    test.skip(
+      !resolvedHref ||
+        !resolvedHref.startsWith('/') ||
+        resolvedHref.split('/').filter(Boolean).length < 2,
+      'No published article link on /articles to test article detail'
+    )
+
+    const entries = await captureConsoleForPath(page, resolvedHref!)
+    const devMatches = collectDevConsoleMessages(entries)
+    expect(
+      devMatches,
+      devMatches.map((m) => `[${m.type}] ${m.text}`).join('\n')
+    ).toEqual([])
+  })
+})

--- a/lib/stellar/config.ts
+++ b/lib/stellar/config.ts
@@ -36,10 +36,7 @@ function validateStellarEnv() {
   }
 
   // Warn about missing optional vars in development only (avoid production console noise)
-  if (
-    typeof window !== 'undefined' &&
-    process.env.NODE_ENV !== 'production'
-  ) {
+  if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
     if (!env.NEXT_PUBLIC_TIPPING_CONTRACT_ID) {
       console.warn(
         '[Stellar Config] NEXT_PUBLIC_TIPPING_CONTRACT_ID is not set. Tipping will not work.'

--- a/lib/stellar/config.ts
+++ b/lib/stellar/config.ts
@@ -35,8 +35,11 @@ function validateStellarEnv() {
     }
   }
 
-  // Warn about missing optional vars that affect functionality
-  if (typeof window !== 'undefined') {
+  // Warn about missing optional vars in development only (avoid production console noise)
+  if (
+    typeof window !== 'undefined' &&
+    process.env.NODE_ENV !== 'production'
+  ) {
     if (!env.NEXT_PUBLIC_TIPPING_CONTRACT_ID) {
       console.warn(
         '[Stellar Config] NEXT_PUBLIC_TIPPING_CONTRACT_ID is not set. Tipping will not work.'

--- a/lib/stellar/wallet-kit-loader.test.ts
+++ b/lib/stellar/wallet-kit-loader.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@ngneat/elf', () => ({
+  enableElfProdMode: vi.fn(),
+}))
+
+vi.mock('@creit.tech/stellar-wallets-kit', () => ({
+  StellarWalletsKit: class StellarWalletsKit {},
+  allowAllModules: vi.fn(),
+  WalletNetwork: { TESTNET: 'TESTNET' },
+}))
+
+describe('loadWalletKit', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+    const { enableElfProdMode } = await import('@ngneat/elf')
+    vi.mocked(enableElfProdMode).mockClear()
+  })
+
+  it('calls enableElfProdMode before importing wallet kit in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const { enableElfProdMode } = await import('@ngneat/elf')
+    const { loadWalletKit } = await import('@/lib/stellar/wallet-kit-loader')
+
+    await loadWalletKit()
+
+    expect(enableElfProdMode).toHaveBeenCalledOnce()
+  })
+
+  it('does not call enableElfProdMode outside production', async () => {
+    vi.stubEnv('NODE_ENV', 'test')
+    const { enableElfProdMode } = await import('@ngneat/elf')
+    const { loadWalletKit } = await import('@/lib/stellar/wallet-kit-loader')
+
+    await loadWalletKit()
+
+    expect(enableElfProdMode).not.toHaveBeenCalled()
+  })
+})

--- a/lib/stellar/wallet-kit-loader.ts
+++ b/lib/stellar/wallet-kit-loader.ts
@@ -3,15 +3,21 @@ type WalletKitModule = typeof import('@creit.tech/stellar-wallets-kit')
 let walletKitModule: WalletKitModule | null = null
 let walletKitLoadPromise: Promise<WalletKitModule> | null = null
 
+async function ensureElfProductionMode(): Promise<void> {
+  if (process.env.NODE_ENV !== 'production') return
+  const { enableElfProdMode } = await import('@ngneat/elf')
+  enableElfProdMode()
+}
+
 export async function loadWalletKit(): Promise<WalletKitModule> {
   if (walletKitModule) return walletKitModule
   if (!walletKitLoadPromise) {
-    walletKitLoadPromise = import('@creit.tech/stellar-wallets-kit').then(
-      (mod) => {
-        walletKitModule = mod
-        return mod
-      }
-    )
+    walletKitLoadPromise = (async () => {
+      await ensureElfProductionMode()
+      const mod = await import('@creit.tech/stellar-wallets-kit')
+      walletKitModule = mod
+      return mod
+    })()
   }
   return walletKitLoadPromise
 }

--- a/lib/stubs/elf-devtools.ts
+++ b/lib/stubs/elf-devtools.ts
@@ -1,0 +1,4 @@
+/** Production stub: wallet kit pulls @ngneat/elf-devtools but must not ship devtools in the client bundle. */
+export function devTools(): void {
+  // no-op
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,11 @@ const withBundleAnalyzer = bundleAnalyzer({
 })
 
 const nextConfig: NextConfig = {
+  turbopack: {
+    resolveAlias: {
+      '@ngneat/elf-devtools': './lib/stubs/elf-devtools.ts',
+    },
+  },
   images: {
     ...(process.env.NODE_ENV === 'development' && {
       dangerouslyAllowLocalIP: true,

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:once": "vitest run",
+    "test:e2e:eng-224": "playwright test e2e/eng-224-console.spec.ts",
+    "eng-224:console-baseline": "node scripts/eng-224-console-baseline.mjs",
     "test:debug": "vitest --inspect-brk --no-file-parallelism",
     "test:coverage": "vitest run --coverage --coverage.reporter=text"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:3100'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'list',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/scripts/eng-224-console-baseline.mjs
+++ b/scripts/eng-224-console-baseline.mjs
@@ -54,7 +54,11 @@ async function main() {
   const href = await articleLink.getAttribute('href').catch(() => null)
   await articlesProbe.close()
 
-  if (href && href.startsWith('/') && href.split('/').filter(Boolean).length >= 2) {
+  if (
+    href &&
+    href.startsWith('/') &&
+    href.split('/').filter(Boolean).length >= 2
+  ) {
     articlePath = href
   }
 
@@ -101,7 +105,10 @@ async function main() {
 
   const anyDev = summary.some((s) => s.devMatches.length > 0)
   md += anyDev
-    ? `**Development-related console messages found** on ${summary.filter((s) => s.devMatches.length > 0).map((s) => s.name).join(', ')}.\n\n`
+    ? `**Development-related console messages found** on ${summary
+        .filter((s) => s.devMatches.length > 0)
+        .map((s) => s.name)
+        .join(', ')}.\n\n`
     : `**No messages matching "development" / "dev mode" / "development build"** in automated capture. Check manually in DevTools — filter Console by \`development\`.\n\n`
 
   for (const s of summary) {
@@ -151,11 +158,20 @@ async function main() {
   )
   writeFileSync(desktopPath, md, 'utf8')
   console.log(`Wrote ${desktopPath}`)
-  console.log(JSON.stringify({ anyDev, pages: summary.map((s) => ({
-    name: s.name,
-    devMatches: s.devMatches.length,
-    warnings: s.warnings.length,
-  })) }, null, 2))
+  console.log(
+    JSON.stringify(
+      {
+        anyDev,
+        pages: summary.map((s) => ({
+          name: s.name,
+          devMatches: s.devMatches.length,
+          warnings: s.warnings.length,
+        })),
+      },
+      null,
+      2
+    )
+  )
 }
 
 main().catch((err) => {

--- a/scripts/eng-224-console-baseline.mjs
+++ b/scripts/eng-224-console-baseline.mjs
@@ -1,0 +1,164 @@
+import { chromium } from '@playwright/test'
+import { writeFileSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+
+const BASE = process.env.BASE_URL || 'http://localhost:3100'
+const PAGES = [
+  { name: 'home', path: '/' },
+  { name: 'articles', path: '/articles' },
+  { name: 'guide', path: '/guide' },
+]
+
+function formatEntry(entry) {
+  return `[${entry.type}] ${entry.text}`
+}
+
+async function main() {
+  const browser = await chromium.launch()
+  const context = await browser.newContext()
+  const results = []
+  let articlePath = null
+
+  for (const pageDef of PAGES) {
+    const page = await context.newPage()
+    const entries = []
+    page.on('console', (msg) => {
+      entries.push({
+        type: msg.type(),
+        text: msg.text(),
+      })
+    })
+
+    await page.goto(`${BASE}${pageDef.path}`, {
+      waitUntil: 'networkidle',
+      timeout: 60_000,
+    })
+    await page.waitForTimeout(2000)
+
+    results.push({
+      name: pageDef.name,
+      path: pageDef.path,
+      url: page.url(),
+      entries,
+    })
+    await page.close()
+  }
+
+  const articlesProbe = await context.newPage()
+  await articlesProbe.goto(`${BASE}/articles`, {
+    waitUntil: 'networkidle',
+    timeout: 60_000,
+  })
+  const articleLink = articlesProbe.locator('main a[href^="/"]').nth(1)
+  const href = await articleLink.getAttribute('href').catch(() => null)
+  await articlesProbe.close()
+
+  if (href && href.startsWith('/') && href.split('/').filter(Boolean).length >= 2) {
+    articlePath = href
+  }
+
+  if (articlePath) {
+    const page = await context.newPage()
+    const entries = []
+    page.on('console', (msg) => {
+      entries.push({ type: msg.type(), text: msg.text() })
+    })
+    await page.goto(`${BASE}${articlePath}`, {
+      waitUntil: 'networkidle',
+      timeout: 60_000,
+    })
+    await page.waitForTimeout(2000)
+    results.push({
+      name: 'article_detail',
+      path: articlePath,
+      url: page.url(),
+      entries,
+    })
+    await page.close()
+  }
+
+  await browser.close()
+
+  const devPattern = /development|dev mode|devtools|development build/i
+  const summary = results.map((r) => {
+    const devMatches = r.entries.filter((e) => devPattern.test(e.text))
+    const warnings = r.entries.filter((e) => e.type === 'warning')
+    const errors = r.entries.filter((e) => e.type === 'error')
+    return { ...r, devMatches, warnings, errors }
+  })
+
+  const branch = process.env.GIT_BRANCH || 'unknown'
+  const date = new Date().toISOString()
+
+  const label = process.env.ENG224_BASELINE_LABEL || 'BEFORE'
+  let md = `# ENG-224 Console Baseline (${label})\n\n`
+  md += `- **Captured:** ${date}\n`
+  md += `- **Branch:** ${branch}\n`
+  md += `- **Build:** production (\`bun run build\` + \`bun run start\`)\n`
+  md += `- **Base URL:** ${BASE}\n\n`
+  md += `## Summary\n\n`
+
+  const anyDev = summary.some((s) => s.devMatches.length > 0)
+  md += anyDev
+    ? `**Development-related console messages found** on ${summary.filter((s) => s.devMatches.length > 0).map((s) => s.name).join(', ')}.\n\n`
+    : `**No messages matching "development" / "dev mode" / "development build"** in automated capture. Check manually in DevTools — filter Console by \`development\`.\n\n`
+
+  for (const s of summary) {
+    md += `### ${s.name} (\`${s.path}\`)\n\n`
+    md += `- URL: ${s.url}\n`
+    md += `- Total console messages: ${s.entries.length}\n`
+    md += `- Warnings: ${s.warnings.length}\n`
+    md += `- Errors: ${s.errors.length}\n`
+    md += `- Development-pattern matches: ${s.devMatches.length}\n\n`
+
+    if (s.devMatches.length > 0) {
+      md += `**Matches (ENG-224 target):**\n\n`
+      for (const m of s.devMatches) {
+        md += `- ${formatEntry(m)}\n`
+      }
+      md += `\n`
+    }
+
+    if (s.warnings.length > 0 && s.warnings.length <= 15) {
+      md += `**All warnings:**\n\n`
+      for (const w of s.warnings) {
+        md += `- ${formatEntry(w)}\n`
+      }
+      md += `\n`
+    } else if (s.warnings.length > 15) {
+      md += `**First 10 warnings:**\n\n`
+      for (const w of s.warnings.slice(0, 10)) {
+        md += `- ${formatEntry(w)}\n`
+      }
+      md += `\n_(+ ${s.warnings.length - 10} more warnings)_\n\n`
+    }
+  }
+
+  md += `## Manual check (recommended)\n\n`
+  md += `1. Run \`bun run build && PORT=3100 bun run start\`\n`
+  md += `2. Open each page in Chrome → DevTools → Console\n`
+  md += `3. Filter: \`development\`\n`
+  md += `4. Copy exact warning text into "After" doc for comparison\n\n`
+  md += `## After fix\n\n`
+  md += `Re-run the same steps and save as \`ENG-224-console-baseline-AFTER.md\` on Desktop.\n`
+  md += `Pass = development-mode warning gone on: home, articles, guide, article detail.\n`
+
+  const desktopPath = join(
+    homedir(),
+    'Desktop',
+    `ENG-224-console-baseline-${label}.md`
+  )
+  writeFileSync(desktopPath, md, 'utf8')
+  console.log(`Wrote ${desktopPath}`)
+  console.log(JSON.stringify({ anyDev, pages: summary.map((s) => ({
+    name: s.name,
+    devMatches: s.devMatches.length,
+    warnings: s.warnings.length,
+  })) }, null, 2))
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

- Stub `@ngneat/elf-devtools` in production via Turbopack `resolveAlias` so Stellar wallet kit does not ship devtools in the client bundle
- Call `enableElfProdMode()` before loading `@creit.tech/stellar-wallets-kit` in production
- Gate Stellar config browser `console.warn` calls so missing env warnings only appear outside production (invalid env still throws in production)
- Add Playwright regression (`e2e/eng-224-console.spec.ts`) asserting no development-pattern console messages on home, articles, guide, and article detail
- Add `scripts/eng-224-console-baseline.mjs` and npm scripts for manual before/after console capture

