### PR TITLE
fix(a11y): separate highlight attribution from article prose (ENG-221)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -87,8 +87,8 @@ mark[data-color='#E8BAFF'] {
   --highlight-color: #e8baff;
 } /* Purple */
 
-/* Highlight with note indicator */
-mark[data-note]::after {
+/* Highlight with note indicator (uses ::before so ::after is free for name tooltip) */
+mark[data-note]::before {
   content: '💬';
   position: absolute;
   top: -8px;
@@ -106,7 +106,7 @@ mark[data-note]::after {
   transition: opacity 0.2s ease;
 }
 
-mark[data-note]:hover::after {
+mark[data-note]:hover::before {
   opacity: 1;
 }
 

--- a/app/highlights.css
+++ b/app/highlights.css
@@ -93,9 +93,9 @@ mark[data-highlight-id]:active {
   transition: all 0.05s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-/* Tooltip on Hover */
+/* Tooltip on Hover (visual only via CSS custom property) */
 mark[data-highlight-id]::after {
-  content: attr(data-user-name);
+  content: var(--highlight-user-name, none);
   position: absolute;
   bottom: calc(100% + 8px);
   left: 50%;
@@ -120,6 +120,48 @@ mark[data-highlight-id]:hover::after {
   opacity: 1;
   transform: translateX(-50%) translateY(0);
   transition-delay: 0s;
+}
+
+/* Focusable highlight control (metadata announced on focus only) */
+.highlight-attribution-control {
+  display: inline-block;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  vertical-align: baseline;
+  background: transparent;
+  cursor: pointer;
+}
+
+.highlight-attribution-control:focus {
+  outline: none;
+}
+
+.highlight-attribution-control:focus-visible {
+  width: auto;
+  height: auto;
+  clip: auto;
+  overflow: visible;
+  padding: 2px 6px;
+  margin-left: 2px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.2;
+  color: white;
+  background: rgba(17, 24, 39, 0.95);
+  box-shadow: 0 0 0 2px var(--ring, #3b82f6);
+}
+
+mark[data-highlight-id]:has(+ .highlight-attribution-control:focus-visible) {
+  box-shadow:
+    0 0 0 2px rgba(var(--highlight-color-rgb), 0.35),
+    0 3px 10px rgba(var(--highlight-color-rgb), 0.25);
 }
 
 /* Entrance Animations */

--- a/components/editor/extensions/HighlightExtension.test.ts
+++ b/components/editor/extensions/HighlightExtension.test.ts
@@ -1,0 +1,91 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it, vi } from 'vitest'
+import {
+  buildHighlightAriaLabel,
+  buildHighlightMarkStyle,
+  createHighlightControlButton,
+  cssStringValue,
+  parseHighlightUserNameFromElement,
+} from './HighlightExtension'
+
+describe('HighlightExtension helpers', () => {
+  it('cssStringValue escapes quotes and backslashes', () => {
+    expect(cssStringValue('Jane "Doc" Doe')).toBe('"Jane \\"Doc\\" Doe"')
+    expect(cssStringValue('path\\to')).toBe('"path\\\\to"')
+  })
+
+  it('buildHighlightMarkStyle includes user name CSS var without data attribute', () => {
+    const style = buildHighlightMarkStyle({
+      color: '#F59E0B',
+      userName: 'Jane Doe',
+    })
+    expect(style).toContain('--highlight-color: #F59E0B')
+    expect(style).toContain('--highlight-user-name: "Jane Doe"')
+    expect(style).not.toContain('data-user-name')
+  })
+
+  it('parseHighlightUserNameFromElement reads CSS var and legacy attribute', () => {
+    const fromStyle = document.createElement('mark')
+    fromStyle.setAttribute(
+      'style',
+      '--highlight-user-name: "Alice Smith"; --highlight-color: #F59E0B;'
+    )
+    expect(parseHighlightUserNameFromElement(fromStyle)).toBe('Alice Smith')
+
+    const legacy = document.createElement('mark')
+    legacy.setAttribute('data-user-name', 'Bob')
+    expect(parseHighlightUserNameFromElement(legacy)).toBe('Bob')
+  })
+
+  it('buildHighlightAriaLabel includes creator and note', () => {
+    expect(buildHighlightAriaLabel({ userName: 'Jane' })).toBe(
+      'Highlight by Jane'
+    )
+    expect(
+      buildHighlightAriaLabel({
+        userName: 'Jane',
+        note: 'Great point',
+      })
+    ).toBe('Highlight by Jane. Note: Great point')
+    expect(buildHighlightAriaLabel({})).toBe('Highlight by Anonymous')
+  })
+
+  it('createHighlightControlButton exposes metadata only on the control', () => {
+    const onHighlightClick = vi.fn()
+    const button = createHighlightControlButton(
+      {
+        id: 'hl-1',
+        color: '#F59E0B',
+        userId: 'user-1',
+        userName: 'Jane Doe',
+        createdAt: 0,
+      },
+      onHighlightClick
+    )
+
+    expect(button.getAttribute('aria-label')).toBe('Highlight by Jane Doe')
+    expect(button.className).toBe('highlight-attribution-control')
+
+    button.click()
+    expect(onHighlightClick).toHaveBeenCalledTimes(1)
+
+    button.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+    )
+    expect(onHighlightClick).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('HighlightExtension mark HTML', () => {
+  it('does not render data-user-name or title on marks', () => {
+    expect(buildHighlightMarkStyle({ userName: 'Jane Doe' })).toContain(
+      '--highlight-user-name: "Jane Doe"'
+    )
+    expect(buildHighlightMarkStyle({ userName: 'Jane Doe' })).not.toContain(
+      'data-user-name'
+    )
+
+    const noteOnly = { 'data-note': 'A note' } as const
+    expect(noteOnly).not.toHaveProperty('title')
+  })
+})

--- a/components/editor/extensions/HighlightExtension.ts
+++ b/components/editor/extensions/HighlightExtension.ts
@@ -29,6 +29,90 @@ declare module '@tiptap/core' {
   }
 }
 
+/** Escape a string for use as a CSS custom property value. */
+export function cssStringValue(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+}
+
+/** Parse --highlight-user-name from inline style (or legacy data attribute). */
+export function parseHighlightUserNameFromElement(element: HTMLElement): string | null {
+  const legacy = element.getAttribute('data-user-name')
+  if (legacy) return legacy
+
+  const style = element.getAttribute('style') ?? ''
+  const quoted = style.match(/--highlight-user-name:\s*"((?:[^"\\]|\\.)*)"/)
+  if (quoted?.[1]) {
+    return quoted[1].replace(/\\"/g, '"').replace(/\\\\/g, '\\')
+  }
+  const unquoted = style.match(/--highlight-user-name:\s*([^;]+)/)
+  if (unquoted?.[1]) {
+    return unquoted[1].trim()
+  }
+  return null
+}
+
+/** Build inline style for highlight marks (visual only, not screen-reader metadata). */
+export function buildHighlightMarkStyle(attributes: {
+  color?: string | null
+  userName?: string | null
+}): string | undefined {
+  const parts: string[] = []
+  if (attributes.color) {
+    parts.push(`--highlight-color: ${attributes.color}`)
+    parts.push(`--highlight-color-rgb: ${getColorRgb(attributes.color)}`)
+    parts.push('--highlight-opacity: 0.4')
+  }
+  if (attributes.userName) {
+    parts.push(`--highlight-user-name: ${cssStringValue(attributes.userName)}`)
+  }
+  return parts.length > 0 ? `${parts.join('; ')};` : undefined
+}
+
+/** Accessible name for the focusable highlight control (not the mark). */
+export function buildHighlightAriaLabel(attrs: {
+  userName?: string | null
+  note?: string | null
+}): string {
+  const creator = attrs.userName || 'Anonymous'
+  let label = `Highlight by ${creator}`
+  if (attrs.note) {
+    label += `. Note: ${attrs.note}`
+  }
+  return label
+}
+
+export function createHighlightControlButton(
+  attrs: HighlightAttributes,
+  onHighlightClick?: (
+    highlight: HighlightAttributes,
+    event: MouseEvent
+  ) => void
+): HTMLButtonElement {
+  const button = document.createElement('button')
+  button.type = 'button'
+  button.className = 'highlight-attribution-control'
+  button.setAttribute('aria-label', buildHighlightAriaLabel(attrs))
+
+  if (!onHighlightClick) {
+    return button
+  }
+
+  const activate = (event: Event) => {
+    event.preventDefault()
+    event.stopPropagation()
+    onHighlightClick(attrs, event as MouseEvent)
+  }
+
+  button.addEventListener('click', activate)
+  button.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      activate(event)
+    }
+  })
+
+  return button
+}
+
 // Helper function to convert hex color to RGB values
 const getColorRgb = (hexColor: string): string => {
   const colorMap: Record<string, string> = {
@@ -72,6 +156,7 @@ class HighlightOverlapManager {
     this.highlights.clear()
   }
 }
+
 const HighlightExtension = Mark.create<HighlightOptions>({
   name: 'highlight',
 
@@ -107,14 +192,19 @@ const HighlightExtension = Mark.create<HighlightOptions>({
         parseHTML: (element) =>
           element.getAttribute('data-color') || element.style.backgroundColor,
         renderHTML: (attributes) => {
-          if (!attributes.color) {
+          if (!attributes.color && !attributes.userName) {
             return {}
           }
-          return {
-            'data-color': attributes.color,
-            'data-color-rgb': getColorRgb(attributes.color),
-            style: `--highlight-color: ${attributes.color}; --highlight-color-rgb: ${getColorRgb(attributes.color)}; --highlight-opacity: 0.4;`,
+          const style = buildHighlightMarkStyle(attributes)
+          const result: Record<string, string> = {}
+          if (attributes.color) {
+            result['data-color'] = attributes.color
+            result['data-color-rgb'] = getColorRgb(attributes.color)
           }
+          if (style) {
+            result.style = style
+          }
+          return result
         },
       },
       userId: {
@@ -131,15 +221,10 @@ const HighlightExtension = Mark.create<HighlightOptions>({
       },
       userName: {
         default: null,
-        parseHTML: (element) => element.getAttribute('data-user-name'),
-        renderHTML: (attributes) => {
-          if (!attributes.userName) {
-            return {}
-          }
-          return {
-            'data-user-name': attributes.userName,
-          }
-        },
+        // Kept in ProseMirror attrs for widgets; not exposed as data-user-name on mark.
+        parseHTML: (element) =>
+          parseHighlightUserNameFromElement(element as HTMLElement),
+        renderHTML: () => ({}),
       },
       note: {
         default: null,
@@ -150,7 +235,6 @@ const HighlightExtension = Mark.create<HighlightOptions>({
           }
           return {
             'data-note': attributes.note,
-            title: attributes.note, // Show note on hover
           }
         },
       },
@@ -223,6 +307,11 @@ const HighlightExtension = Mark.create<HighlightOptions>({
               return false
             }
 
+            const target = event.target as HTMLElement
+            if (target.closest('.highlight-attribution-control')) {
+              return false
+            }
+
             const { schema, doc } = view.state
             const range = doc.resolve(pos)
             const marks = range.marks()
@@ -263,6 +352,11 @@ const HighlightExtension = Mark.create<HighlightOptions>({
             // Handle touch events for mobile devices
             touchend: (view, event) => {
               if (!onHighlightClick) {
+                return false
+              }
+
+              const target = event.target as HTMLElement
+              if (target.closest('.highlight-attribution-control')) {
                 return false
               }
 
@@ -327,23 +421,36 @@ const HighlightExtension = Mark.create<HighlightOptions>({
             const { doc, schema } = state
             const decorations: Decoration[] = []
             const overlapManager = new HighlightOverlapManager()
+            const highlightRanges = new Map<
+              string,
+              { to: number; attrs: HighlightAttributes }
+            >()
 
-            // First pass: collect all highlights
+            // First pass: collect all highlights and merge ranges per id
             doc.descendants((node, pos) => {
               if (node.isText && node.marks.length) {
                 node.marks.forEach((mark) => {
                   if (mark.type === schema.marks.highlight && mark.attrs.id) {
-                    overlapManager.addHighlight(
-                      mark.attrs.id,
-                      pos,
-                      pos + node.nodeSize
-                    )
+                    const id = mark.attrs.id as string
+                    const from = pos
+                    const to = pos + node.nodeSize
+                    overlapManager.addHighlight(id, from, to)
+
+                    const existing = highlightRanges.get(id)
+                    if (existing) {
+                      existing.to = Math.max(existing.to, to)
+                    } else {
+                      highlightRanges.set(id, {
+                        to,
+                        attrs: mark.attrs as HighlightAttributes,
+                      })
+                    }
                   }
                 })
               }
             })
 
-            // Second pass: create decorations with overlap counts
+            // Second pass: inline overlap styling per text node
             doc.descendants((node, pos) => {
               if (node.isText && node.marks.length) {
                 node.marks.forEach((mark) => {
@@ -369,6 +476,22 @@ const HighlightExtension = Mark.create<HighlightOptions>({
                   }
                 })
               }
+            })
+
+            // One focusable control per highlight at the end of its range
+            highlightRanges.forEach(({ to, attrs }) => {
+              if (!attrs.id) return
+              decorations.push(
+                Decoration.widget(
+                  to,
+                  () =>
+                    createHighlightControlButton(attrs, onHighlightClick),
+                  {
+                    side: 1,
+                    key: `highlight-control-${attrs.id}`,
+                  }
+                )
+              )
             })
 
             return DecorationSet.create(doc, decorations)

--- a/components/editor/extensions/HighlightExtension.ts
+++ b/components/editor/extensions/HighlightExtension.ts
@@ -35,7 +35,9 @@ export function cssStringValue(value: string): string {
 }
 
 /** Parse --highlight-user-name from inline style (or legacy data attribute). */
-export function parseHighlightUserNameFromElement(element: HTMLElement): string | null {
+export function parseHighlightUserNameFromElement(
+  element: HTMLElement
+): string | null {
   const legacy = element.getAttribute('data-user-name')
   if (legacy) return legacy
 
@@ -83,10 +85,7 @@ export function buildHighlightAriaLabel(attrs: {
 
 export function createHighlightControlButton(
   attrs: HighlightAttributes,
-  onHighlightClick?: (
-    highlight: HighlightAttributes,
-    event: MouseEvent
-  ) => void
+  onHighlightClick?: (highlight: HighlightAttributes, event: MouseEvent) => void
 ): HTMLButtonElement {
   const button = document.createElement('button')
   button.type = 'button'
@@ -484,8 +483,7 @@ const HighlightExtension = Mark.create<HighlightOptions>({
               decorations.push(
                 Decoration.widget(
                   to,
-                  () =>
-                    createHighlightControlButton(attrs, onHighlightClick),
+                  () => createHighlightControlButton(attrs, onHighlightClick),
                   {
                     side: 1,
                     key: `highlight-control-${attrs.id}`,


### PR DESCRIPTION
## Summary

Fixes ENG-221 by separating highlight creator attribution from article body text so screen reader users hear only the writer's prose during linear reading, while sighted users still see who highlighted a passage on hover.

- Remove `data-user-name` and `title` from `<mark>` elements; keep creator metadata in ProseMirror attrs only
- Show visual name tooltips via `--highlight-user-name` CSS custom property (not accessible DOM text)
- Add a focusable `.highlight-attribution-control` button per highlight with `aria-label` (e.g. "Highlight by Jane Doe")
- Move note indicator from `::after` to `::before` so it no longer conflicts with the name tooltip

## Problem

Highlight creator names lived on the same `<mark>` node as article text (`data-user-name`, `title` on notes, CSS `attr(data-user-name)` tooltip). Screen readers could surface that metadata while reading the article, making attribution sound like part of the writer's content.

## Solution

| Concern | Approach |
|--------|----------|
| Linear reading | `<mark>` has no accessible name; only article words are in the mark |
| Creator metadata | Announced only when the separate highlight control is focused |
| Visual attribution | Hover tooltip unchanged via CSS variable on the mark |
| Notes | `data-note` kept for styling; `title` removed from mark |

## Changes

- `components/editor/extensions/HighlightExtension.ts` — decouple DOM metadata, widget buttons, keyboard activation
- `app/highlights.css` — CSS var tooltip, focusable control styles
- `app/globals.css` — note badge uses `::before` instead of `::after`
- `components/editor/extensions/HighlightExtension.test.ts` — unit tests for helpers and aria-label behavior

<img width="1221" height="719" alt="1" src="https://github.com/user-attachments/assets/c0ae0c30-38c3-4098-a361-53e2c3279ffe" />
