### PR TITLE
fix(highlights): clamp highlight detail panel to viewport (ENG-184)

### DIFF
--- a/components/articles/HighlightableArticle.tsx
+++ b/components/articles/HighlightableArticle.tsx
@@ -22,6 +22,7 @@ import { AnimatePresence } from 'motion/react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { toast } from 'sonner'
 import { EDITOR_PROSE_CLASS } from '@/lib/constants'
+import { handleArticleHighlightOverlayPointerDown } from '@/lib/highlights/articleOverlayPointerDismiss'
 import { getRangeBoundingBox } from '@/lib/highlights/utils'
 import type { TocHeading } from '@/lib/tiptap/headings'
 import { useEnsureHeadingIds } from '@/components/articles/useEnsureHeadingIds'
@@ -242,12 +243,14 @@ export function HighlightableArticle({
     if (!container || editable || !showHighlights) return
 
     const handlePointerDown = (e: MouseEvent | TouchEvent) => {
-      const target = e.target as HTMLElement | null
-      // Ignore events from an open popover/dialog so their buttons still click.
-      if (target?.closest('[role="dialog"]')) return
-      isDraggingRef.current = true
-      setSelectedText(null)
-      setPopoverPosition(null)
+      handleArticleHighlightOverlayPointerDown(e.target, {
+        closeCreatePopover: () => {
+          isDraggingRef.current = true
+          setSelectedText(null)
+          setPopoverPosition(null)
+        },
+        closeDetailsPanel: () => setHighlightTooltip(null),
+      })
     }
 
     const handlePointerUp = () => {
@@ -344,20 +347,6 @@ export function HighlightableArticle({
     setHighlightTooltip(null)
     editor?.commands.focus()
   }, [editor])
-
-  useEffect(() => {
-    if (highlightTooltip === null) return
-
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape') return
-      e.preventDefault()
-      e.stopPropagation()
-      handleTooltipClose()
-    }
-
-    document.addEventListener('keydown', onKeyDown, true)
-    return () => document.removeEventListener('keydown', onKeyDown, true)
-  }, [highlightTooltip, handleTooltipClose])
 
   return (
     <div

--- a/components/highlights/HighlightDetailsPanel.test.tsx
+++ b/components/highlights/HighlightDetailsPanel.test.tsx
@@ -1,0 +1,107 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('convex/react', () => ({
+  useMutation: () => vi.fn(),
+}))
+
+vi.mock('@/hooks/convex', () => ({
+  useHighlightTipsByHighlight: () => [],
+}))
+
+vi.mock('@/components/highlights/HighlightTipButton', () => ({
+  HighlightTipButton: () => null,
+}))
+
+vi.mock('motion/react', () => ({
+  motion: {
+    div: ({
+      children,
+      ...props
+    }: React.ComponentProps<'div'> & {
+      initial?: unknown
+      animate?: unknown
+      exit?: unknown
+      transition?: unknown
+    }) => <div {...props}>{children}</div>,
+  },
+}))
+
+import { HighlightDetailsPanel } from '@/components/highlights/HighlightDetailsPanel'
+import type { Id } from '@/types/convex'
+
+const baseHighlight = {
+  _id: 'highlight1' as Id<'highlights'>,
+  text: 'Sample highlighted passage for testing the panel.',
+  startOffset: 0,
+  endOffset: 10,
+  startContainerPath: '0',
+  endContainerPath: '0',
+  highlightId: 'hl-1',
+  color: '#F59E0B',
+  isPublic: true,
+  userId: 'user1' as Id<'users'>,
+  userName: 'Test User',
+  createdAt: Date.now(),
+}
+
+describe('HighlightDetailsPanel', () => {
+  it('calls onClose when Escape is pressed', () => {
+    const onClose = vi.fn()
+    render(
+      <HighlightDetailsPanel
+        highlight={baseHighlight}
+        position={{ top: 100, left: 200 }}
+        onClose={onClose}
+      />
+    )
+
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('removes the Escape listener on unmount', () => {
+    const onClose = vi.fn()
+    const { unmount } = render(
+      <HighlightDetailsPanel
+        highlight={baseHighlight}
+        position={{ top: 100, left: 200 }}
+        onClose={onClose}
+      />
+    )
+
+    unmount()
+
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('renders a labeled close button for keyboard dismiss', () => {
+    render(
+      <HighlightDetailsPanel
+        highlight={baseHighlight}
+        position={{ top: 100, left: 200 }}
+        onClose={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Close highlight details' })
+    ).toBeInTheDocument()
+  })
+})

--- a/components/highlights/HighlightDetailsPanel.tsx
+++ b/components/highlights/HighlightDetailsPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useRef, useEffect } from 'react'
 import { useMutation } from 'convex/react'
 import { api } from '@/convex/_generated/api'
 import { useHighlightTipsByHighlight } from '@/hooks/convex'
@@ -23,6 +23,7 @@ import { formatTipAmount } from '@/lib/stellar/highlight-utils'
 import { UserAvatar } from '@/components/ui/user-avatar'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
+import { useClampedFixedPosition } from '@/hooks/useClampedFixedPosition'
 
 interface HighlightDetailsPanelProps {
   highlight: {
@@ -64,6 +65,23 @@ export function HighlightDetailsPanel({
   const [isEditing, setIsEditing] = useState(false)
   const [editedNote, setEditedNote] = useState(highlight.note || '')
   const [isDeleting, setIsDeleting] = useState(false)
+  const panelRef = useRef<HTMLDivElement>(null)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+  const clampedPosition = useClampedFixedPosition(position, panelRef, {
+    fallbackWidth: 448,
+    fallbackHeight: 400,
+  })
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      e.preventDefault()
+      e.stopPropagation()
+      onClose()
+    }
+    document.addEventListener('keydown', onKeyDown, true)
+    return () => document.removeEventListener('keydown', onKeyDown, true)
+  }, [onClose])
 
   // Check if current user owns this highlight
   const isOwner = currentUserId && currentUserId === highlight.userId
@@ -130,22 +148,29 @@ export function HighlightDetailsPanel({
 
   return (
     <motion.div
+      ref={panelRef}
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 10 }}
       transition={{ duration: 0.2 }}
-      className="fixed z-50 bg-popover text-popover-foreground rounded-xl shadow-2xl border border-border max-w-md w-full outline-none"
+      className="fixed z-50 bg-popover text-popover-foreground rounded-xl shadow-2xl border border-border w-full max-w-[min(28rem,calc(100vw-24px))] outline-none"
       style={{
-        top: position.top,
-        left: position.left,
-        transform: 'translateX(-50%)',
+        top: clampedPosition.top,
+        left: clampedPosition.left,
       }}
       role="dialog"
       aria-modal="true"
       aria-label="Highlight details"
       tabIndex={-1}
     >
-      <FocusScope trapped loop>
+      <FocusScope
+        trapped
+        loop
+        onMountAutoFocus={(e) => {
+          e.preventDefault()
+          closeButtonRef.current?.focus()
+        }}
+      >
         {/* Header */}
         <div className="flex items-start justify-between p-4 border-b border-border">
           <div className="flex-1">
@@ -163,7 +188,10 @@ export function HighlightDetailsPanel({
             </div>
           </div>
           <button
+            ref={closeButtonRef}
+            type="button"
             onClick={onClose}
+            aria-label="Close highlight details"
             className="text-muted-foreground hover:text-foreground transition-colors"
           >
             <X className="w-5 h-5" />

--- a/components/highlights/HighlightPopover.tsx
+++ b/components/highlights/HighlightPopover.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { useMemo, useRef, useState, useEffect } from 'react'
+import { useRef, useState, useEffect } from 'react'
 import { FocusScope } from '@radix-ui/react-focus-scope'
 import { Highlighter, MessageSquare, Lock, Globe } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { HighlightTipButton } from './HighlightTipButton'
 import { Id } from '@/convex/_generated/dataModel'
+import { useClampedFixedPosition } from '@/hooks/useClampedFixedPosition'
 
 interface HighlightPopoverProps {
   position: { top: number; left: number }
@@ -80,29 +81,7 @@ export function HighlightPopover({
   const [isPublic, setIsPublic] = useState(true)
   const [showNoteInput, setShowNoteInput] = useState(false)
   const popoverRef = useRef<HTMLDivElement>(null)
-
-  const clampedPosition = useMemo(() => {
-    const clamp = (v: number, min: number, max: number) =>
-      Math.min(max, Math.max(min, v))
-
-    const margin = 12
-    const rect = popoverRef.current?.getBoundingClientRect()
-    const width = rect?.width ?? 320
-    const height = rect?.height ?? 260
-
-    // `position` is the anchor point for the popover's top-center.
-    const desiredLeft = position.left - width / 2
-    const minLeft = margin
-    const maxLeft = window.innerWidth - margin - width
-    const left = clamp(desiredLeft, minLeft, Math.max(minLeft, maxLeft))
-
-    const desiredTop = position.top
-    const minTop = margin
-    const maxTop = window.innerHeight - margin - height
-    const top = clamp(desiredTop, minTop, Math.max(minTop, maxTop))
-
-    return { top, left }
-  }, [position.left, position.top])
+  const clampedPosition = useClampedFixedPosition(position, popoverRef)
 
   const handleSaveHighlight = () => {
     onCreateHighlight(selectedColor, note || undefined, isPublic)

--- a/hooks/useClampedFixedPosition.ts
+++ b/hooks/useClampedFixedPosition.ts
@@ -1,0 +1,73 @@
+'use client'
+
+import { useLayoutEffect, useState, type RefObject } from 'react'
+import {
+  clampFixedPanelPosition,
+  type PanelAnchor,
+} from '@/lib/ui/clampFixedPanelPosition'
+
+const DEFAULT_FALLBACK_WIDTH = 320
+const DEFAULT_FALLBACK_HEIGHT = 260
+
+export function useClampedFixedPosition(
+  anchor: PanelAnchor,
+  panelRef: RefObject<HTMLElement | null>,
+  options?: {
+    margin?: number
+    fallbackWidth?: number
+    fallbackHeight?: number
+  }
+): { top: number; left: number } {
+  const margin = options?.margin ?? 12
+  const fallbackWidth = options?.fallbackWidth ?? DEFAULT_FALLBACK_WIDTH
+  const fallbackHeight = options?.fallbackHeight ?? DEFAULT_FALLBACK_HEIGHT
+  const anchorTop = anchor.top
+  const anchorLeft = anchor.left
+
+  const [position, setPosition] = useState(() =>
+    clampFixedPanelPosition(
+      { top: anchorTop, left: anchorLeft },
+      { width: fallbackWidth, height: fallbackHeight },
+      {
+        width: typeof window !== 'undefined' ? window.innerWidth : 0,
+        height: typeof window !== 'undefined' ? window.innerHeight : 0,
+      },
+      margin
+    )
+  )
+
+  useLayoutEffect(() => {
+    const recalc = () => {
+      const rect = panelRef.current?.getBoundingClientRect()
+      const width = rect?.width ?? fallbackWidth
+      const height = rect?.height ?? fallbackHeight
+
+      setPosition(
+        clampFixedPanelPosition(
+          { top: anchorTop, left: anchorLeft },
+          { width, height },
+          { width: window.innerWidth, height: window.innerHeight },
+          margin
+        )
+      )
+    }
+
+    recalc()
+
+    window.addEventListener('resize', recalc)
+
+    const element = panelRef.current
+    let resizeObserver: ResizeObserver | undefined
+    if (element && typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(recalc)
+      resizeObserver.observe(element)
+    }
+
+    return () => {
+      window.removeEventListener('resize', recalc)
+      resizeObserver?.disconnect()
+    }
+  }, [anchorTop, anchorLeft, panelRef, margin, fallbackWidth, fallbackHeight])
+
+  return position
+}

--- a/lib/highlights/articleOverlayPointerDismiss.test.ts
+++ b/lib/highlights/articleOverlayPointerDismiss.test.ts
@@ -1,0 +1,39 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it, vi } from 'vitest'
+import { handleArticleHighlightOverlayPointerDown } from '@/lib/highlights/articleOverlayPointerDismiss'
+
+describe('handleArticleHighlightOverlayPointerDown', () => {
+  it('dismisses overlays when pressing on article text', () => {
+    document.body.innerHTML = `
+      <p id="article-text">plain article text</p>
+      <div role="dialog" id="panel"><button id="close">Close</button></div>
+    `
+    const closeCreatePopover = vi.fn()
+    const closeDetailsPanel = vi.fn()
+
+    handleArticleHighlightOverlayPointerDown(
+      document.getElementById('article-text'),
+      { closeCreatePopover, closeDetailsPanel }
+    )
+
+    expect(closeCreatePopover).toHaveBeenCalledTimes(1)
+    expect(closeDetailsPanel).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not dismiss when pressing inside an open dialog', () => {
+    document.body.innerHTML = `
+      <p id="article-text">plain article text</p>
+      <div role="dialog" id="panel"><button id="close">Close</button></div>
+    `
+    const closeCreatePopover = vi.fn()
+    const closeDetailsPanel = vi.fn()
+
+    handleArticleHighlightOverlayPointerDown(
+      document.getElementById('close'),
+      { closeCreatePopover, closeDetailsPanel }
+    )
+
+    expect(closeCreatePopover).not.toHaveBeenCalled()
+    expect(closeDetailsPanel).not.toHaveBeenCalled()
+  })
+})

--- a/lib/highlights/articleOverlayPointerDismiss.test.ts
+++ b/lib/highlights/articleOverlayPointerDismiss.test.ts
@@ -28,10 +28,10 @@ describe('handleArticleHighlightOverlayPointerDown', () => {
     const closeCreatePopover = vi.fn()
     const closeDetailsPanel = vi.fn()
 
-    handleArticleHighlightOverlayPointerDown(
-      document.getElementById('close'),
-      { closeCreatePopover, closeDetailsPanel }
-    )
+    handleArticleHighlightOverlayPointerDown(document.getElementById('close'), {
+      closeCreatePopover,
+      closeDetailsPanel,
+    })
 
     expect(closeCreatePopover).not.toHaveBeenCalled()
     expect(closeDetailsPanel).not.toHaveBeenCalled()

--- a/lib/highlights/articleOverlayPointerDismiss.ts
+++ b/lib/highlights/articleOverlayPointerDismiss.ts
@@ -1,0 +1,17 @@
+export type ArticleOverlayDismissActions = {
+  closeCreatePopover: () => void
+  closeDetailsPanel: () => void
+}
+
+/**
+ * Dismisses highlight overlays when the user presses on the article surface.
+ * Ignores presses inside an open dialog (create popover or details panel).
+ */
+export function handleArticleHighlightOverlayPointerDown(
+  target: EventTarget | null,
+  actions: ArticleOverlayDismissActions
+): void {
+  if ((target as HTMLElement | null)?.closest('[role="dialog"]')) return
+  actions.closeCreatePopover()
+  actions.closeDetailsPanel()
+}

--- a/lib/ui/clampFixedPanelPosition.test.ts
+++ b/lib/ui/clampFixedPanelPosition.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { clampFixedPanelPosition } from './clampFixedPanelPosition'
+
+const viewport = { width: 400, height: 800 }
+const panel = { width: 200, height: 300 }
+const margin = 12
+
+describe('clampFixedPanelPosition', () => {
+  it('centers horizontally on anchor when there is room', () => {
+    const result = clampFixedPanelPosition(
+      { top: 100, left: 200 },
+      panel,
+      viewport,
+      margin
+    )
+    expect(result.left).toBe(100)
+    expect(result.top).toBe(100)
+  })
+
+  it('clamps left edge when anchor is near the left', () => {
+    const result = clampFixedPanelPosition(
+      { top: 100, left: 20 },
+      panel,
+      viewport,
+      margin
+    )
+    expect(result.left).toBe(margin)
+  })
+
+  it('clamps right edge when anchor is near the right', () => {
+    const result = clampFixedPanelPosition(
+      { top: 100, left: 390 },
+      panel,
+      viewport,
+      margin
+    )
+    expect(result.left).toBe(viewport.width - margin - panel.width)
+  })
+
+  it('clamps top when anchor is above the viewport margin', () => {
+    const result = clampFixedPanelPosition(
+      { top: 0, left: 200 },
+      panel,
+      viewport,
+      margin
+    )
+    expect(result.top).toBe(margin)
+  })
+
+  it('clamps bottom when anchor is below the viewport margin', () => {
+    const result = clampFixedPanelPosition(
+      { top: 700, left: 200 },
+      panel,
+      viewport,
+      margin
+    )
+    expect(result.top).toBe(viewport.height - margin - panel.height)
+  })
+
+  it('keeps panel as far in-bounds as possible on narrow viewports', () => {
+    const narrow = { width: 320, height: 600 }
+    const smallPanel = { width: 280, height: 260 }
+    const result = clampFixedPanelPosition(
+      { top: 50, left: 300 },
+      smallPanel,
+      narrow,
+      margin
+    )
+    expect(result.left).toBe(narrow.width - margin - smallPanel.width)
+    expect(result.top).toBe(50)
+  })
+})

--- a/lib/ui/clampFixedPanelPosition.ts
+++ b/lib/ui/clampFixedPanelPosition.ts
@@ -1,0 +1,44 @@
+export interface PanelAnchor {
+  top: number
+  left: number
+}
+
+export interface PanelSize {
+  width: number
+  height: number
+}
+
+export interface ClampedPanelPosition {
+  top: number
+  left: number
+}
+
+const DEFAULT_MARGIN = 12
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+/**
+ * Computes top-left coordinates for a fixed panel anchored at top-center
+ * of the selection, keeping the full panel inside the viewport.
+ */
+export function clampFixedPanelPosition(
+  anchor: PanelAnchor,
+  size: PanelSize,
+  viewport: { width: number; height: number },
+  margin = DEFAULT_MARGIN
+): ClampedPanelPosition {
+  const { width, height } = size
+  const desiredLeft = anchor.left - width / 2
+  const minLeft = margin
+  const maxLeft = viewport.width - margin - width
+  const left = clamp(desiredLeft, minLeft, Math.max(minLeft, maxLeft))
+
+  const desiredTop = anchor.top
+  const minTop = margin
+  const maxTop = viewport.height - margin - height
+  const top = clamp(desiredTop, minTop, Math.max(minTop, maxTop))
+
+  return { top, left }
+}


### PR DESCRIPTION
## Summary

Fixes ENG-184: the highlight detail panel (opened when clicking an existing highlight) could render partially off-screen near page edges or on small viewports, making content and the dismiss control unreachable.

- Add shared viewport clamping (`clampFixedPanelPosition` + `useClampedFixedPosition`) with layout measurement, window resize, and `ResizeObserver` for content height changes
- Apply clamping to `HighlightDetailsPanel` (remove `translateX(-50%)`, add responsive max-width)
- Refactor `HighlightPopover` to use the same hook for consistent behavior
- Improve accessibility: labeled close button, focus on open, Escape handled in the panel
- Remove duplicate Escape listener from `HighlightableArticle`
<img width="588" height="673" alt="mob_" src="https://github.com/user-attachments/assets/323f505b-3a1e-40a4-b164-f802629304d1" />

