### PR TITLE
feat(ui): site footer, legal pages, error shells, dark mode, and lazy-loading (ENG-147)

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { LegalLinks } from '@/components/legal/LegalLinks'
 
 /**
  * Auth Layout
@@ -55,13 +56,10 @@ export default function AuthLayout({
           <div className="mt-8 text-center text-sm text-muted-foreground">
             <p>
               By continuing, you agree to Quilltip&apos;s{' '}
-              <Link href="/terms" className="text-primary hover:underline">
-                Terms of Service
-              </Link>{' '}
-              and{' '}
-              <Link href="/privacy" className="text-primary hover:underline">
-                Privacy Policy
-              </Link>
+              <LegalLinks
+                conjunction="and"
+                linkClassName="text-primary hover:underline"
+              />
             </p>
           </div>
         </div>

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { LegalLinks } from '@/components/legal/LegalLinks'
+import { AUTH_FOOTER_LINKS } from '@/lib/copy/footer-links'
 
 /**
  * Auth Layout
@@ -53,13 +54,30 @@ export default function AuthLayout({
           </div>
 
           {/* Footer Links */}
-          <div className="mt-8 text-center text-sm text-muted-foreground">
+          <div className="mt-8 space-y-3 text-center text-sm text-muted-foreground">
             <p>
               By continuing, you agree to Quilltip&apos;s{' '}
               <LegalLinks
                 conjunction="and"
                 linkClassName="text-primary hover:underline"
               />
+            </p>
+            <p>
+              {AUTH_FOOTER_LINKS.map((link, index) => (
+                <span key={link.href}>
+                  {index > 0 ? (
+                    <span className="mx-1.5 text-muted-foreground" aria-hidden>
+                      |
+                    </span>
+                  ) : null}
+                  <Link
+                    href={link.href}
+                    className="text-primary hover:underline underline-offset-4"
+                  >
+                    {link.label}
+                  </Link>
+                </span>
+              ))}
             </p>
           </div>
         </div>

--- a/app/[username]/[slug]/page.tsx
+++ b/app/[username]/[slug]/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import nextDynamic from 'next/dynamic'
 import { notFound } from 'next/navigation'
 import { use, useState, useMemo } from 'react'
 import {
@@ -11,8 +12,26 @@ import ArticleDisplay from '@/components/articles/ArticleDisplay'
 import { ArticlePageLoadingSkeleton } from '@/components/articles/ArticlePageLoadingSkeleton'
 import AppNavigation from '@/components/layout/AppNavigation'
 import { TipStats } from '@/components/tipping/TipStats'
-import { TipButton } from '@/components/tipping/TipButton'
-import { NFTIntegration } from '@/components/nft/NFTIntegration'
+import {
+  TipButtonSkeleton,
+  NftSidebarSkeleton,
+} from '@/components/articles/ArticleEngagementSkeleton'
+
+const TipButton = nextDynamic(
+  () =>
+    import('@/components/tipping/TipButton').then((mod) => ({
+      default: mod.TipButton,
+    })),
+  { ssr: false, loading: () => <TipButtonSkeleton /> }
+)
+
+const NFTIntegration = nextDynamic(
+  () =>
+    import('@/components/nft/NFTIntegration').then((mod) => ({
+      default: mod.NFTIntegration,
+    })),
+  { ssr: false, loading: () => <NftSidebarSkeleton /> }
+)
 import {
   DollarSign,
   Trophy,

--- a/app/[username]/[slug]/page.tsx
+++ b/app/[username]/[slug]/page.tsx
@@ -11,6 +11,7 @@ import {
 import ArticleDisplay from '@/components/articles/ArticleDisplay'
 import { ArticlePageLoadingSkeleton } from '@/components/articles/ArticlePageLoadingSkeleton'
 import AppNavigation from '@/components/layout/AppNavigation'
+import { SiteFooter } from '@/components/layout/SiteFooter'
 import { TipStats } from '@/components/tipping/TipStats'
 import {
   TipButtonSkeleton,
@@ -129,10 +130,10 @@ export default function ArticlePage({ params }: ArticlePageProps) {
   }
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="flex min-h-screen flex-col bg-background">
       <AppNavigation />
       <ReadingProgressBar />
-      <main className="pt-20">
+      <main className="flex-1 pt-20 w-full">
         <div className="max-w-7xl mx-auto px-4 py-8">
           <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
             {/* Main Article Content */}
@@ -291,6 +292,7 @@ export default function ArticlePage({ params }: ArticlePageProps) {
           </div>
         </div>
       </main>
+      <SiteFooter variant="default" />
     </div>
   )
 }

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -6,6 +6,7 @@ import { use, useState, useEffect } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { useAuth } from '@/components/providers/AuthContext'
 import AppNavigation from '@/components/layout/AppNavigation'
+import { SiteFooter } from '@/components/layout/SiteFooter'
 import ProfileHeader from '@/components/profile/ProfileHeader'
 import { ProfileArticlesTabContent } from '@/components/profile/ProfileArticlesTabContent'
 import { ProfileNftsTabContent } from '@/components/profile/ProfileNftsTabContent'
@@ -122,10 +123,10 @@ export default function ProfilePage({ params }: ProfilePageProps) {
   ]
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="flex min-h-screen flex-col bg-background">
       <AppNavigation />
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12">
+      <main className="flex-1 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12 w-full">
         {/* Profile Header */}
         <div className="mb-8">
           <ProfileHeader user={userWithStats} isOwnProfile={isOwnProfile} />
@@ -267,6 +268,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
           )}
         </div>
       </main>
+      <SiteFooter variant="default" />
     </div>
   )
 }

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { usePathname, useSearchParams, useRouter } from 'next/navigation'
 import AppNavigation from '@/components/layout/AppNavigation'
+import { SiteFooter } from '@/components/layout/SiteFooter'
 import SearchInput from '@/components/articles/SearchInput'
 import { ArticlesBrowseContent } from '@/components/articles/ArticlesBrowseContent'
 import {
@@ -75,10 +76,10 @@ export default function ArticlesPage() {
   }
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="flex min-h-screen flex-col bg-background">
       <AppNavigation />
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12">
+      <main className="flex-1 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12 w-full">
         {/* Page Header */}
         <div className="mb-8">
           <h1 className="text-4xl font-bold text-foreground mb-2">
@@ -178,6 +179,7 @@ export default function ArticlesPage() {
           onArticleNavigate={saveBrowseScrollPosition}
         />
       </main>
+      <SiteFooter variant="default" />
     </div>
   )
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from 'next'
+import { InfoPageLayout } from '@/components/layout/InfoPageLayout'
+import {
+  contactChannels,
+  contactIntro,
+  contactNotes,
+} from '@/lib/copy/contact-page'
+
+export const metadata: Metadata = {
+  title: 'Contact | Quilltip',
+  description:
+    'Contact Quilltip for legal, privacy, and security questions about the Stellar testnet platform.',
+}
+
+export default function ContactPage() {
+  return (
+    <InfoPageLayout title="Contact" description={contactIntro}>
+      <div className="space-y-10 text-foreground">
+        {contactChannels.map((channel) => (
+          <section key={channel.id} id={channel.id}>
+            <h2 className="text-lg font-semibold text-foreground mb-3">
+              {channel.title}
+            </h2>
+            <p className="text-sm leading-relaxed text-muted-foreground mb-3">
+              {channel.description}
+            </p>
+            <a
+              href={`mailto:${channel.email}`}
+              className="text-sm text-primary hover:underline underline-offset-4"
+            >
+              {channel.email}
+            </a>
+          </section>
+        ))}
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-3">
+            Important notes
+          </h2>
+          <div className="space-y-3 text-sm leading-relaxed text-muted-foreground">
+            {contactNotes.map((note, index) => (
+              <p key={`note-${index}`}>{note}</p>
+            ))}
+          </div>
+        </section>
+      </div>
+    </InfoPageLayout>
+  )
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useEffect } from 'react'
 
 import { ErrorPageIllustration } from '@/components/error/ErrorPageIllustration'
+import { FailurePageShell } from '@/components/error/FailurePageShell'
 import { Button } from '@/components/ui/button'
 
 export default function Error({
@@ -22,24 +23,28 @@ export default function Error({
   }, [error])
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-brand-cream px-4 py-8">
-      <div className="mx-auto w-full max-w-md rounded-2xl border border-quill-200 bg-white/90 p-8 text-center shadow-sm backdrop-blur-sm">
-        <ErrorPageIllustration className="mb-6" />
-        <h1 className="font-display text-2xl font-semibold text-brand-blue">
+    <FailurePageShell
+      illustration={<ErrorPageIllustration className="mb-6" />}
+      heading={
+        <h1 className="font-display text-2xl font-semibold text-foreground">
           Something went wrong
         </h1>
-        <p className="mt-3 text-sm text-quill-600">
-          This page ran into a problem. Try again, or go back to the home page.
-        </p>
-        <div className="mt-8 flex w-full flex-col gap-3 sm:flex-row sm:justify-center">
-          <Button type="button" onClick={reset} className="w-full sm:w-auto">
+      }
+      description="This page ran into a problem. Try again, or go back to the home page."
+      actions={
+        <>
+          <Button
+            type="button"
+            onClick={reset}
+            className="w-full sm:w-auto"
+          >
             Try again
           </Button>
           <Button variant="outline" asChild className="w-full sm:w-auto">
             <Link href="/">Go Home</Link>
           </Button>
-        </div>
-      </div>
-    </div>
+        </>
+      }
+    />
   )
 }

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -33,11 +33,7 @@ export default function Error({
       description="This page ran into a problem. Try again, or go back to the home page."
       actions={
         <>
-          <Button
-            type="button"
-            onClick={reset}
-            className="w-full sm:w-auto"
-          >
+          <Button type="button" onClick={reset} className="w-full sm:w-auto">
             Try again
           </Button>
           <Button variant="outline" asChild className="w-full sm:w-auto">

--- a/app/guide/page.tsx
+++ b/app/guide/page.tsx
@@ -4,16 +4,18 @@ import { useAuth } from '@/components/providers/AuthContext'
 import Navigation from '@/components/landing/Navigation'
 import AppNavigation from '@/components/layout/AppNavigation'
 import { WalletGuide } from '@/components/guide/WalletGuide'
+import { SiteFooter } from '@/components/layout/SiteFooter'
 
 export default function GuidePage() {
   const { isAuthenticated } = useAuth()
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="flex min-h-screen flex-col bg-background">
       {isAuthenticated ? <AppNavigation /> : <Navigation />}
-      <div className="pt-24 pb-16 px-4">
+      <div className="flex-1 pt-24 pb-16 px-4">
         <WalletGuide />
       </div>
+      <SiteFooter variant="default" />
     </div>
   )
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,10 +1,11 @@
 import Link from 'next/link'
 
+import { FailurePageShell } from '@/components/error/FailurePageShell'
 import { Button } from '@/components/ui/button'
 
 function NotFoundIllustration() {
   return (
-    <div className="mx-auto w-full max-w-[220px]">
+    <div className="mx-auto mb-6 w-full max-w-[220px]">
       <svg
         viewBox="0 0 200 168"
         className="h-auto w-full"
@@ -17,12 +18,12 @@ function NotFoundIllustration() {
           width="116"
           height="92"
           rx="8"
-          className="fill-brand-cream stroke-brand-blue"
+          className="fill-card stroke-border"
           strokeWidth="2"
         />
         <path
           d="M132 28h36v36l-36-36z"
-          className="fill-brand-accent/20 stroke-brand-blue"
+          className="fill-brand-accent/20 stroke-border"
           strokeWidth="1.5"
           strokeLinejoin="round"
         />
@@ -31,7 +32,7 @@ function NotFoundIllustration() {
           y1="52"
           x2="118"
           y2="52"
-          className="stroke-quill-300"
+          className="stroke-muted-foreground/60"
           strokeWidth="3"
           strokeLinecap="round"
         />
@@ -40,7 +41,7 @@ function NotFoundIllustration() {
           y1="68"
           x2="104"
           y2="68"
-          className="stroke-quill-300"
+          className="stroke-muted-foreground/60"
           strokeWidth="3"
           strokeLinecap="round"
         />
@@ -49,7 +50,7 @@ function NotFoundIllustration() {
           y1="84"
           x2="110"
           y2="84"
-          className="stroke-quill-300"
+          className="stroke-muted-foreground/60"
           strokeWidth="3"
           strokeLinecap="round"
         />
@@ -61,11 +62,11 @@ function NotFoundIllustration() {
         />
         <path
           d="M142 80l-10 26 8 4 10-24c4-10 3-22-4-30"
-          className="fill-brand-blue/15 stroke-brand-blue"
+          className="fill-primary/15 stroke-primary"
           strokeWidth="1.75"
           strokeLinejoin="round"
         />
-        <circle cx="139" cy="74" r="2" className="fill-brand-blue" />
+        <circle cx="139" cy="74" r="2" className="fill-primary" />
       </svg>
     </div>
   )
@@ -73,36 +74,33 @@ function NotFoundIllustration() {
 
 export default function NotFound() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center px-6 py-12">
-      <div className="mx-auto flex w-full max-w-md flex-col items-center gap-6 text-center">
-        <NotFoundIllustration />
-        <div className="space-y-2">
-          <h1 className="font-display text-5xl font-medium tracking-[-0.01em] text-brand-blue sm:text-6xl">
+    <FailurePageShell
+      illustration={<NotFoundIllustration />}
+      heading={
+        <>
+          <h1 className="font-display text-5xl font-medium tracking-[-0.01em] text-foreground sm:text-6xl">
             404
           </h1>
           <h2 className="font-display text-2xl font-medium text-foreground">
             Page not found
           </h2>
-          <p className="font-sans text-quill-700">
-            Sorry, we couldn&apos;t find the page you&apos;re looking for.
-          </p>
-        </div>
-        <div className="flex w-full flex-col items-center gap-4 sm:w-auto">
-          <Button
-            asChild
-            size="lg"
-            className="bg-brand-blue text-white shadow hover:bg-brand-accent focus-visible:ring-brand-blue"
-          >
+        </>
+      }
+      description="Sorry, we couldn't find the page you're looking for."
+      actionsClassName="flex flex-col items-center gap-4 sm:flex-col"
+      actions={
+        <>
+          <Button asChild size="lg" className="w-full sm:w-auto">
             <Link href="/">Go Home</Link>
           </Button>
           <Link
             href="/articles"
-            className="text-sm text-brand-blue underline-offset-4 transition-colors hover:text-brand-accent hover:underline"
+            className="text-sm font-medium text-primary underline-offset-4 transition-colors hover:underline"
           >
             Browse articles
           </Link>
-        </div>
-      </div>
-    </div>
+        </>
+      }
+    />
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,15 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { useAuth } from '@/components/providers/AuthContext'
 import Navigation from '@/components/landing/Navigation'
 import AppNavigation from '@/components/layout/AppNavigation'
 import HeroSection from '@/components/landing/HeroSection'
-import FeaturesSection from '@/components/landing/FeaturesSection'
-import HowItWorksSection from '@/components/landing/HowItWorksSection'
-import FAQSection from '@/components/landing/FAQSection'
-import TrustSection from '@/components/landing/TrustSection'
-import Footer from '@/components/landing/Footer'
+
+const LandingBelowFold = dynamic(
+  () => import('@/components/landing/LandingBelowFold'),
+  { ssr: false }
+)
 import { useLandingHashScroll } from '@/components/landing/useLandingHashScroll'
 import { OnboardingDialog } from '@/components/onboarding/OnboardingDialog'
 import { HomeRecentArticlesSection } from '@/components/articles/HomeRecentArticlesSection'
@@ -24,11 +25,7 @@ function PublicLandingPage() {
     <div className="min-h-screen bg-gradient-to-b from-background via-muted/30 to-background">
       <Navigation />
       <HeroSection />
-      <FeaturesSection />
-      <HowItWorksSection />
-      <TrustSection />
-      <FAQSection />
-      <Footer />
+      <LandingBelowFold />
     </div>
   )
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import { LegalPageLayout } from '@/components/legal/LegalPageLayout'
+import { privacyLastUpdated, privacySections } from '@/lib/copy/legal-privacy'
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy | Quilltip',
+  description:
+    'Privacy Policy for Quilltip, describing how we collect, use, and protect your information.',
+}
+
+export default function PrivacyPage() {
+  return (
+    <LegalPageLayout
+      title="Privacy Policy"
+      lastUpdated={privacyLastUpdated}
+      sections={privacySections}
+      alternatePolicy={{
+        href: '/terms',
+        label: 'Terms of Service',
+      }}
+    />
+  )
+}

--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -1,0 +1,66 @@
+import type { Metadata } from 'next'
+import { InfoPageLayout } from '@/components/layout/InfoPageLayout'
+import {
+  statusBanner,
+  statusIntro,
+  statusNotes,
+  statusServices,
+} from '@/lib/copy/status-page'
+
+export const metadata: Metadata = {
+  title: 'Platform Status | Quilltip',
+  description:
+    'Quilltip platform status on Stellar testnet. Beta launch scope and service availability.',
+}
+
+export default function StatusPage() {
+  return (
+    <InfoPageLayout title="Platform Status" description={statusIntro}>
+      <div className="space-y-10 text-foreground">
+        <div
+          role="status"
+          className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm leading-relaxed text-amber-950 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-100"
+        >
+          {statusBanner}
+        </div>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-4">
+            Services
+          </h2>
+          <ul className="divide-y divide-border rounded-lg border border-border">
+            {statusServices.map((service) => (
+              <li
+                key={service.id}
+                className="flex flex-col gap-1 px-4 py-4 sm:flex-row sm:items-start sm:justify-between"
+              >
+                <div>
+                  <p className="text-sm font-medium text-foreground">
+                    {service.name}
+                  </p>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {service.detail}
+                  </p>
+                </div>
+                <span className="shrink-0 text-sm font-medium text-green-700 dark:text-green-400">
+                  {service.status}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-3">
+            Launch scope
+          </h2>
+          <div className="space-y-3 text-sm leading-relaxed text-muted-foreground">
+            {statusNotes.map((note, index) => (
+              <p key={`status-note-${index}`}>{note}</p>
+            ))}
+          </div>
+        </section>
+      </div>
+    </InfoPageLayout>
+  )
+}

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { InfoPageLayout } from '@/components/layout/InfoPageLayout'
+import {
+  supportIntro,
+  supportResourceLinks,
+  supportSections,
+} from '@/lib/copy/support-page'
+
+export const metadata: Metadata = {
+  title: 'Help & Support | Quilltip',
+  description:
+    'Get help using Quilltip on Stellar testnet. Wallet setup, practice tipping, and support channels.',
+}
+
+export default function SupportPage() {
+  return (
+    <InfoPageLayout title="Help & Support" description={supportIntro}>
+      <div className="space-y-10 text-foreground">
+        {supportSections.map((section) => (
+          <section key={section.id} id={section.id}>
+            <h2 className="text-lg font-semibold text-foreground mb-3">
+              {section.title}
+            </h2>
+            <div className="space-y-3 text-sm leading-relaxed text-muted-foreground">
+              {section.paragraphs.map((paragraph, index) => (
+                <p key={`${section.id}-${index}`}>{paragraph}</p>
+              ))}
+            </div>
+          </section>
+        ))}
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-3">
+            Quick links
+          </h2>
+          <ul className="space-y-2 text-sm">
+            {supportResourceLinks.map((link) => (
+              <li key={link.href}>
+                <Link
+                  href={link.href}
+                  className="text-primary hover:underline underline-offset-4"
+                >
+                  {link.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </InfoPageLayout>
+  )
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import { LegalPageLayout } from '@/components/legal/LegalPageLayout'
+import { termsLastUpdated, termsSections } from '@/lib/copy/legal-terms'
+
+export const metadata: Metadata = {
+  title: 'Terms of Service | Quilltip',
+  description:
+    'Terms of Service for Quilltip, the decentralized publishing platform for writers and readers on Stellar testnet.',
+}
+
+export default function TermsPage() {
+  return (
+    <LegalPageLayout
+      title="Terms of Service"
+      lastUpdated={termsLastUpdated}
+      sections={termsSections}
+      alternatePolicy={{
+        href: '/privacy',
+        label: 'Privacy Policy',
+      }}
+    />
+  )
+}

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
         "@tiptap/extension-text-align": "^3.20.0",
         "@tiptap/extension-underline": "^3.20.0",
         "@tiptap/extension-youtube": "^3.20.0",
+        "@tiptap/html": "^3.20.0",
         "@tiptap/pm": "^3.20.0",
         "@tiptap/react": "^3.20.0",
         "@tiptap/starter-kit": "^3.20.0",
@@ -1100,6 +1101,8 @@
 
     "@tiptap/extensions": ["@tiptap/extensions@3.20.0", "", { "peerDependencies": { "@tiptap/core": "^3.20.0", "@tiptap/pm": "^3.20.0" } }, "sha512-HIsXX942w3nbxEQBlMAAR/aa6qiMBEP7CsSMxaxmTIVAmW35p6yUASw6GdV1u0o3lCZjXq2OSRMTskzIqi5uLg=="],
 
+    "@tiptap/html": ["@tiptap/html@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5", "happy-dom": "^20.8.9" } }, "sha512-lFJbuL3mFHvqe9BaFbEd43cb/lHKAoM0O69opFJLlIYn3dre6kt64Qr7UOXQ3dp6mRU0ptVUwBV3R1eG9EPpUQ=="],
+
     "@tiptap/pm": ["@tiptap/pm@3.20.0", "", { "dependencies": { "prosemirror-changeset": "^2.3.0", "prosemirror-collab": "^1.3.1", "prosemirror-commands": "^1.6.2", "prosemirror-dropcursor": "^1.8.1", "prosemirror-gapcursor": "^1.3.2", "prosemirror-history": "^1.4.1", "prosemirror-inputrules": "^1.4.0", "prosemirror-keymap": "^1.2.2", "prosemirror-markdown": "^1.13.1", "prosemirror-menu": "^1.2.4", "prosemirror-model": "^1.24.1", "prosemirror-schema-basic": "^1.2.3", "prosemirror-schema-list": "^1.5.0", "prosemirror-state": "^1.4.3", "prosemirror-tables": "^1.6.4", "prosemirror-trailing-node": "^3.0.0", "prosemirror-transform": "^1.10.2", "prosemirror-view": "^1.38.1" } }, "sha512-jn+2KnQZn+b+VXr8EFOJKsnjVNaA4diAEr6FOazupMt8W8ro1hfpYtZ25JL87Kao/WbMze55sd8M8BDXLUKu1A=="],
 
     "@tiptap/react": ["@tiptap/react@3.20.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "fast-equals": "^5.3.3", "use-sync-external-store": "^1.4.0" }, "optionalDependencies": { "@tiptap/extension-bubble-menu": "^3.20.0", "@tiptap/extension-floating-menu": "^3.20.0" }, "peerDependencies": { "@tiptap/core": "^3.20.0", "@tiptap/pm": "^3.20.0", "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-jFLNzkmn18zqefJwPje0PPd9VhZ7Oy28YHiSvSc7YpBnQIbuN/HIxZ2lrOsKyEHta0WjRZjfU5X1pGxlbcGwOA=="],
@@ -1212,7 +1215,9 @@
 
     "@types/web": ["@types/web@0.0.197", "", {}, "sha512-V4sOroWDADFx9dLodWpKm298NOJ1VJ6zoDVgaP+WBb/utWxqQ6gnMzd9lvVDAr/F3ibiKaxH9i45eS0gQPSTaQ=="],
 
-    "@types/ws": ["@types/ws@7.4.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww=="],
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.56.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.56.1", "@typescript-eslint/type-utils": "8.56.1", "@typescript-eslint/utils": "8.56.1", "@typescript-eslint/visitor-keys": "8.56.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.56.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A=="],
 
@@ -1927,6 +1932,8 @@
     "gzip-size": ["gzip-size@6.0.0", "", { "dependencies": { "duplexer": "^0.1.2" } }, "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q=="],
 
     "h3": ["h3@1.15.5", "", { "dependencies": { "cookie-es": "^1.2.2", "crossws": "^0.3.5", "defu": "^6.1.4", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg=="],
+
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -3564,6 +3571,12 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "happy-dom/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "happy-dom/whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
+    "happy-dom/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
     "hash-base/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "http-errors/depd": ["depd@1.1.2", "", {}, "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="],
@@ -3573,6 +3586,8 @@
     "is-bun-module/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "jayson/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
+
+    "jayson/@types/ws": ["@types/ws@7.4.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww=="],
 
     "jayson/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
@@ -3623,8 +3638,6 @@
     "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "rpc-websockets/@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "secp256k1/node-addon-api": ["node-addon-api@5.1.0", "", {}, "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="],
 
@@ -4145,6 +4158,8 @@
     "hash-base/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "hash-base/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "jayson/@types/ws/@types/node": ["@types/node@25.3.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw=="],
 
     "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 

--- a/components/articles/ArticleBodySkeleton.tsx
+++ b/components/articles/ArticleBodySkeleton.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+export function ArticleBodySkeleton() {
+  return (
+    <div className="space-y-4 py-2" aria-hidden>
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-5/6" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-4/5" />
+    </div>
+  )
+}

--- a/components/articles/ArticleDisplay.tsx
+++ b/components/articles/ArticleDisplay.tsx
@@ -1,12 +1,22 @@
 'use client'
 
-import { type JSONContent } from '@tiptap/react'
+import dynamic from 'next/dynamic'
+import { type JSONContent } from '@tiptap/core'
 import { useEffect, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import Image from 'next/image'
 import { UserAvatar } from '@/components/ui/user-avatar'
 import ShareButtons from './ShareButtons'
-import { HighlightableArticle } from '@/components/articles/HighlightableArticle'
+import { ArticleReadOnlyBody } from '@/components/articles/ArticleReadOnlyBody'
+import { ArticleBodySkeleton } from '@/components/articles/ArticleBodySkeleton'
+
+const HighlightableArticle = dynamic(
+  () =>
+    import('@/components/articles/HighlightableArticle').then((mod) => ({
+      default: mod.HighlightableArticle,
+    })),
+  { ssr: false, loading: () => <ArticleBodySkeleton /> }
+)
 import { useAuth } from '@/components/providers/AuthContext'
 import type { Id } from '@/types/convex'
 import type { ArticleForDisplay } from '@/types/index'
@@ -112,13 +122,20 @@ export default function ArticleDisplay({
       </header>
 
       <div className="article-content">
-        <HighlightableArticle
-          articleId={article.id as Id<'articles'>}
-          content={article.content ?? EMPTY_DOC}
-          editable={false}
-          showHighlights={effectiveShowHighlights}
-          tocHeadings={tocHeadings}
-        />
+        {effectiveShowHighlights ? (
+          <HighlightableArticle
+            articleId={article.id as Id<'articles'>}
+            content={article.content ?? EMPTY_DOC}
+            editable={false}
+            showHighlights={effectiveShowHighlights}
+            tocHeadings={tocHeadings}
+          />
+        ) : (
+          <ArticleReadOnlyBody
+            content={article.content ?? EMPTY_DOC}
+            tocHeadings={tocHeadings}
+          />
+        )}
       </div>
 
       {currentUrl && (

--- a/components/articles/ArticleEngagementSkeleton.tsx
+++ b/components/articles/ArticleEngagementSkeleton.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+export function TipButtonSkeleton() {
+  return (
+    <div className="space-y-3">
+      <Skeleton className="h-10 w-full" />
+      <Skeleton className="h-4 w-3/4" />
+    </div>
+  )
+}
+
+export function NftSidebarSkeleton() {
+  return (
+    <div className="space-y-3">
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-5/6" />
+      <Skeleton className="h-10 w-full" />
+    </div>
+  )
+}

--- a/components/articles/ArticleReadOnlyBody.tsx
+++ b/components/articles/ArticleReadOnlyBody.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useMemo } from 'react'
+import { generateHTML } from '@tiptap/html'
+import type { JSONContent } from '@tiptap/core'
+import { getReadOnlyExtensions } from '@/lib/tiptap/readExtensions'
+import { EDITOR_PROSE_CLASS } from '@/lib/constants'
+import { cn } from '@/lib/utils'
+import { useEnsureHeadingIds } from '@/components/articles/useEnsureHeadingIds'
+import type { TocHeading } from '@/lib/tiptap/headings'
+
+interface ArticleReadOnlyBodyProps {
+  content: JSONContent
+  tocHeadings?: TocHeading[]
+  className?: string
+}
+
+export function ArticleReadOnlyBody({
+  content,
+  tocHeadings = [],
+  className,
+}: ArticleReadOnlyBodyProps) {
+  const extensions = useMemo(() => getReadOnlyExtensions(), [])
+
+  const html = useMemo(
+    () => generateHTML(content, extensions),
+    [content, extensions]
+  )
+
+  useEnsureHeadingIds(tocHeadings, { rootSelector: '.article-content' })
+
+  return (
+    <div
+      className={cn(
+        EDITOR_PROSE_CLASS,
+        'prose-stone highlightable-article',
+        className
+      )}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+}

--- a/components/articles/ShareButtons.tsx
+++ b/components/articles/ShareButtons.tsx
@@ -128,7 +128,7 @@ export default function ShareButtons({
     <div className={`${className}`}>
       {/* Error message */}
       {error && (
-        <div className="mb-2 text-sm text-red-600 bg-red-50 border border-red-200 rounded px-3 py-1">
+        <div className="mb-2 text-sm text-red-600 dark:text-red-300 bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-900/50 rounded px-3 py-1">
           {error}
         </div>
       )}

--- a/components/error/ErrorBoundary.tsx
+++ b/components/error/ErrorBoundary.tsx
@@ -45,11 +45,11 @@ export class ErrorBoundary extends Component<Props, State> {
       }
       return (
         fallback || (
-          <div className="p-4 border border-red-200 bg-red-50 rounded-lg">
-            <p className="text-red-800">Something went wrong.</p>
+          <div className="p-4 border border-destructive/30 bg-destructive/10 rounded-lg">
+            <p className="text-destructive">Something went wrong.</p>
             <button
               onClick={this.reset}
-              className="mt-2 text-sm text-red-600 underline"
+              className="mt-2 text-sm text-destructive underline"
             >
               Try again
             </button>

--- a/components/error/ErrorPageIllustration.tsx
+++ b/components/error/ErrorPageIllustration.tsx
@@ -21,18 +21,18 @@ export function ErrorPageIllustration({
         width="88"
         height="112"
         rx="6"
-        className="fill-white stroke-quill-200"
+        className="fill-card stroke-border"
         strokeWidth="2"
       />
       <path
         d="M44 48h56M44 64h48M44 80h52M44 96h40"
-        className="stroke-quill-300"
+        className="stroke-muted-foreground/60"
         strokeWidth="2"
         strokeLinecap="round"
       />
       <path
         d="M44 112h28"
-        className="stroke-quill-200"
+        className="stroke-muted-foreground/40"
         strokeWidth="2"
         strokeLinecap="round"
       />
@@ -44,13 +44,13 @@ export function ErrorPageIllustration({
       />
       <path
         d="M88 102l-6 14 8-4 6-14-8 4Z"
-        className="fill-brand-blue stroke-brand-blue"
+        className="fill-primary/15 stroke-primary"
         strokeWidth="1.5"
         strokeLinejoin="round"
       />
       <path
         d="M96 94c-2 4-6 10-10 14"
-        className="stroke-brand-blue"
+        className="stroke-primary"
         strokeWidth="2"
         strokeLinecap="round"
       />

--- a/components/error/FailurePageShell.tsx
+++ b/components/error/FailurePageShell.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react'
+
+import { cn } from '@/lib/utils'
+
+type FailurePageShellProps = {
+  illustration?: ReactNode
+  heading: ReactNode
+  description?: ReactNode
+  actions: ReactNode
+  actionsClassName?: string
+  className?: string
+}
+
+export function FailurePageShell({
+  illustration,
+  heading,
+  description,
+  actions,
+  actionsClassName,
+  className,
+}: FailurePageShellProps) {
+  return (
+    <div
+      className={cn(
+        'flex min-h-screen flex-col items-center justify-center bg-background px-4 py-8 sm:px-6 sm:py-12',
+        className
+      )}
+    >
+      <div className="mx-auto w-full max-w-md rounded-[var(--card-radius)] border border-border bg-card p-6 text-center shadow-[var(--card-shadow)] sm:p-8">
+        {illustration}
+        <div className="space-y-2">{heading}</div>
+        {description ? (
+          <div className="mt-3 text-sm text-muted-foreground">{description}</div>
+        ) : null}
+        <div
+          className={cn(
+            'mt-8 flex w-full flex-col items-center gap-3 sm:flex-row sm:justify-center',
+            actionsClassName
+          )}
+        >
+          {actions}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/error/FailurePageShell.tsx
+++ b/components/error/FailurePageShell.tsx
@@ -30,7 +30,9 @@ export function FailurePageShell({
         {illustration}
         <div className="space-y-2">{heading}</div>
         {description ? (
-          <div className="mt-3 text-sm text-muted-foreground">{description}</div>
+          <div className="mt-3 text-sm text-muted-foreground">
+            {description}
+          </div>
         ) : null}
         <div
           className={cn(

--- a/components/highlights/HighlightDetailsPanel.tsx
+++ b/components/highlights/HighlightDetailsPanel.tsx
@@ -298,7 +298,7 @@ export function HighlightDetailsPanel({
                 <>
                   <button
                     onClick={() => setIsEditing(true)}
-                    className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-blue-50 text-blue-700 rounded-lg hover:bg-blue-100 transition-colors text-sm font-medium"
+                    className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-300 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-950/50 transition-colors text-sm font-medium"
                   >
                     <Edit className="w-4 h-4" />
                     <span>Edit Note</span>
@@ -310,7 +310,7 @@ export function HighlightDetailsPanel({
                       'w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg transition-colors text-sm font-medium',
                       isDeleting
                         ? 'bg-muted text-muted-foreground cursor-not-allowed'
-                        : 'bg-red-50 text-red-700 hover:bg-red-100'
+                        : 'bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-300 hover:bg-red-100 dark:hover:bg-red-950/50'
                     )}
                   >
                     {isDeleting ? (

--- a/components/highlights/HighlightNotes.tsx
+++ b/components/highlights/HighlightNotes.tsx
@@ -109,7 +109,7 @@ export function HighlightNotes({
             if (!tipData?.count) return null
             return (
               <div className="mb-2">
-                <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-yellow-100 text-yellow-800 text-xs rounded-full">
+                <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-yellow-100 dark:bg-yellow-950/50 text-yellow-800 dark:text-yellow-200 text-xs rounded-full">
                   <Coins className="w-3 h-3" />
                   {tipData.count} tip{tipData.count > 1 ? 's' : ''}
                   {' · '}${tipData.totalUsd.toFixed(2)}

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -451,7 +451,7 @@ export function HighlightTipButton({
           </div>
 
           {isConnected && publicKey && (
-            <div className="text-xs text-green-600 text-center mt-4">
+            <div className="text-xs text-green-600 dark:text-green-300 text-center mt-4">
               <p className="flex items-center justify-center gap-1">
                 <Wallet className="w-3 h-3" />
                 Connected: {publicKey.slice(0, 6)}...{publicKey.slice(-6)}

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useConvex, useMutation } from 'convex/react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { useWallet } from '@/components/providers/WalletProvider'
+import { useWalletActivation } from '@/components/providers/WalletActivationContext'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 import { AlertCircle, Coins, Heart, Loader2, Wallet } from 'lucide-react'
@@ -79,6 +80,7 @@ export function HighlightTipButton({
 }: HighlightTipButtonProps) {
   const { isAuthenticated } = useAuth()
   const { isConnected, publicKey, signTransaction, connect } = useWallet()
+  const { activateWallet } = useWalletActivation()
   const router = useRouter()
   const [isOpen, setIsOpen] = useState(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
@@ -102,6 +104,9 @@ export function HighlightTipButton({
 
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
+    if (open) {
+      activateWallet()
+    }
     setIsOpen(open)
     setTipFailure(null)
     if (!open) {

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -34,9 +34,7 @@ export default function Footer() {
 
         <Reveal className="py-8 border-t border-spotlight-border space-y-4">
           <div className="flex justify-center">
-            <LegalLinks
-              linkClassName="text-spotlight-muted hover:text-spotlight-foreground text-[13px]"
-            />
+            <LegalLinks linkClassName="text-spotlight-muted hover:text-spotlight-foreground text-[13px]" />
           </div>
           <div className="flex items-center justify-center gap-2 text-spotlight-muted text-[13px]">
             <span>© {currentYear} Quilltip. Built with</span>

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -1,48 +1,7 @@
 'use client'
 
-import { Heart, PenTool } from 'lucide-react'
-import { Reveal } from '@/components/landing/Reveal'
-import { LegalLinks } from '@/components/legal/LegalLinks'
+import { SiteFooter } from '@/components/layout/SiteFooter'
 
 export default function Footer() {
-  const currentYear = new Date().getFullYear()
-
-  return (
-    <footer className="bg-spotlight text-spotlight-foreground relative overflow-hidden">
-      {/* Background decoration */}
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_30%,color-mix(in_oklab,var(--spotlight-foreground)_6%,transparent),transparent_50%)]" />
-
-      <div className="container mx-auto max-w-7xl px-8 relative z-10">
-        {/* Main Footer Content */}
-        <div className="py-16">
-          {/* Brand Section */}
-          <Reveal className="text-center">
-            <div className="flex items-center gap-3 mb-4 justify-center">
-              <div className="w-9 h-9 bg-card rounded-lg border border-border flex items-center justify-center shadow-sm">
-                <PenTool className="w-5 h-5 text-foreground" />
-              </div>
-              <h3 className="text-2xl font-display font-medium tracking-[-0.01em]">
-                Quilltip
-              </h3>
-            </div>
-            <p className="text-spotlight-muted text-[15px] leading-relaxed max-w-2xl mx-auto">
-              Empowering writers with blockchain-powered micro-tipping on
-              Stellar testnet. Practice with free test XLM today.
-            </p>
-          </Reveal>
-        </div>
-
-        <Reveal className="py-8 border-t border-spotlight-border space-y-4">
-          <div className="flex justify-center">
-            <LegalLinks linkClassName="text-spotlight-muted hover:text-spotlight-foreground text-[13px]" />
-          </div>
-          <div className="flex items-center justify-center gap-2 text-spotlight-muted text-[13px]">
-            <span>© {currentYear} Quilltip. Built with</span>
-            <Heart className="w-4 h-4 text-destructive fill-current animate-pulse" />
-            <span>for writers everywhere</span>
-          </div>
-        </Reveal>
-      </div>
-    </footer>
-  )
+  return <SiteFooter variant="landing" />
 }

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -2,6 +2,7 @@
 
 import { Heart, PenTool } from 'lucide-react'
 import { Reveal } from '@/components/landing/Reveal'
+import { LegalLinks } from '@/components/legal/LegalLinks'
 
 export default function Footer() {
   const currentYear = new Date().getFullYear()
@@ -31,7 +32,12 @@ export default function Footer() {
           </Reveal>
         </div>
 
-        <Reveal className="py-8 border-t border-spotlight-border">
+        <Reveal className="py-8 border-t border-spotlight-border space-y-4">
+          <div className="flex justify-center">
+            <LegalLinks
+              linkClassName="text-spotlight-muted hover:text-spotlight-foreground text-[13px]"
+            />
+          </div>
           <div className="flex items-center justify-center gap-2 text-spotlight-muted text-[13px]">
             <span>© {currentYear} Quilltip. Built with</span>
             <Heart className="w-4 h-4 text-destructive fill-current animate-pulse" />

--- a/components/landing/LandingBelowFold.tsx
+++ b/components/landing/LandingBelowFold.tsx
@@ -1,0 +1,17 @@
+import FeaturesSection from '@/components/landing/FeaturesSection'
+import HowItWorksSection from '@/components/landing/HowItWorksSection'
+import TrustSection from '@/components/landing/TrustSection'
+import FAQSection from '@/components/landing/FAQSection'
+import Footer from '@/components/landing/Footer'
+
+export default function LandingBelowFold() {
+  return (
+    <>
+      <FeaturesSection />
+      <HowItWorksSection />
+      <TrustSection />
+      <FAQSection />
+      <Footer />
+    </>
+  )
+}

--- a/components/landing/useLandingHashScroll.ts
+++ b/components/landing/useLandingHashScroll.ts
@@ -3,25 +3,67 @@
 import { useEffect } from 'react'
 import { scrollToLandingSection } from '@/lib/landing/scroll-to-section'
 
+const SECTION_WAIT_TIMEOUT_MS = 3000
+
+function scrollWhenAvailable(hash: string, timeoutMs = SECTION_WAIT_TIMEOUT_MS) {
+  const normalized = hash.startsWith('#') ? hash : `#${hash}`
+
+  if (document.querySelector(normalized)) {
+    scrollToLandingSection(normalized)
+    return () => {}
+  }
+
+  let settled = false
+  let timeoutId: ReturnType<typeof setTimeout> | null = null
+
+  const observer = new MutationObserver(() => {
+    if (settled) return
+    if (document.querySelector(normalized)) {
+      settled = true
+      observer.disconnect()
+      if (timeoutId !== null) clearTimeout(timeoutId)
+      scrollToLandingSection(normalized)
+    }
+  })
+
+  observer.observe(document.body, { childList: true, subtree: true })
+
+  timeoutId = setTimeout(() => {
+    if (settled) return
+    settled = true
+    observer.disconnect()
+  }, timeoutMs)
+
+  return () => {
+    if (settled) return
+    settled = true
+    observer.disconnect()
+    if (timeoutId !== null) clearTimeout(timeoutId)
+  }
+}
+
 export function useLandingHashScroll() {
   useEffect(() => {
     const hash = window.location.hash
     if (!hash) return
 
-    const frame = requestAnimationFrame(() => {
-      scrollToLandingSection(hash)
-    })
-
-    return () => cancelAnimationFrame(frame)
+    return scrollWhenAvailable(hash)
   }, [])
 
   useEffect(() => {
+    let cancel: (() => void) | null = null
+
     const onHashChange = () => {
       const hash = window.location.hash
-      if (hash) scrollToLandingSection(hash)
+      if (!hash) return
+      cancel?.()
+      cancel = scrollWhenAvailable(hash)
     }
 
     window.addEventListener('hashchange', onHashChange)
-    return () => window.removeEventListener('hashchange', onHashChange)
+    return () => {
+      window.removeEventListener('hashchange', onHashChange)
+      cancel?.()
+    }
   }, [])
 }

--- a/components/landing/useLandingHashScroll.ts
+++ b/components/landing/useLandingHashScroll.ts
@@ -5,7 +5,10 @@ import { scrollToLandingSection } from '@/lib/landing/scroll-to-section'
 
 const SECTION_WAIT_TIMEOUT_MS = 3000
 
-function scrollWhenAvailable(hash: string, timeoutMs = SECTION_WAIT_TIMEOUT_MS) {
+function scrollWhenAvailable(
+  hash: string,
+  timeoutMs = SECTION_WAIT_TIMEOUT_MS
+) {
   const normalized = hash.startsWith('#') ? hash : `#${hash}`
 
   if (document.querySelector(normalized)) {

--- a/components/layout/FooterNav.tsx
+++ b/components/layout/FooterNav.tsx
@@ -1,0 +1,73 @@
+import Link from 'next/link'
+import { cn } from '@/lib/utils'
+import {
+  FOOTER_LINK_CATEGORIES,
+  FOOTER_LINK_GROUP_LABELS,
+  FOOTER_LINKS,
+  type FooterLinkCategory,
+} from '@/lib/copy/footer-links'
+
+type FooterNavProps = {
+  className?: string
+  linkClassName?: string
+  groupLabelClassName?: string
+  variant?: 'landing' | 'default'
+}
+
+function linksForCategory(category: FooterLinkCategory) {
+  return FOOTER_LINKS.filter((link) => link.category === category)
+}
+
+export function FooterNav({
+  className,
+  linkClassName,
+  groupLabelClassName,
+  variant = 'default',
+}: FooterNavProps) {
+  const defaultLinkStyles =
+    variant === 'landing'
+      ? 'text-spotlight-muted hover:text-spotlight-foreground text-[13px]'
+      : 'text-muted-foreground hover:text-foreground text-sm'
+
+  const defaultGroupLabelStyles =
+    variant === 'landing'
+      ? 'text-spotlight-foreground text-xs font-semibold uppercase tracking-wide'
+      : 'text-foreground text-xs font-semibold uppercase tracking-wide'
+
+  const linkStyles = cn(
+    'hover:underline underline-offset-4 transition-colors',
+    linkClassName ?? defaultLinkStyles
+  )
+
+  const groupLabelStyles = cn(
+    'mb-2 block',
+    groupLabelClassName ?? defaultGroupLabelStyles
+  )
+
+  return (
+    <nav
+      aria-label="Footer"
+      className={cn(
+        'grid grid-cols-2 gap-6 sm:grid-cols-4 sm:gap-8',
+        className
+      )}
+    >
+      {FOOTER_LINK_CATEGORIES.map((category) => (
+        <div key={category}>
+          <span className={groupLabelStyles}>
+            {FOOTER_LINK_GROUP_LABELS[category]}
+          </span>
+          <ul className="space-y-2">
+            {linksForCategory(category).map((link) => (
+              <li key={link.href}>
+                <Link href={link.href} className={linkStyles}>
+                  {link.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </nav>
+  )
+}

--- a/components/layout/InfoPageLayout.tsx
+++ b/components/layout/InfoPageLayout.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useAuth } from '@/components/providers/AuthContext'
+import Navigation from '@/components/landing/Navigation'
+import AppNavigation from '@/components/layout/AppNavigation'
+import { SiteFooter } from '@/components/layout/SiteFooter'
+
+type InfoPageLayoutProps = {
+  title: string
+  description?: string
+  children: React.ReactNode
+}
+
+export function InfoPageLayout({
+  title,
+  description,
+  children,
+}: InfoPageLayoutProps) {
+  const { isAuthenticated } = useAuth()
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      {isAuthenticated ? <AppNavigation /> : <Navigation />}
+      <div className="flex-1 pt-24 pb-16 px-4">
+        <div className="mx-auto max-w-3xl">
+          <header className="mb-10 border-b border-border pb-8">
+            <h1 className="font-display text-3xl lg:text-4xl font-medium tracking-[-0.01em] text-foreground">
+              {title}
+            </h1>
+            {description ? (
+              <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                {description}
+              </p>
+            ) : null}
+          </header>
+          {children}
+        </div>
+      </div>
+      <SiteFooter variant="default" />
+    </div>
+  )
+}

--- a/components/layout/SiteFooter.tsx
+++ b/components/layout/SiteFooter.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { Heart, PenTool } from 'lucide-react'
+import { Reveal } from '@/components/landing/Reveal'
+import { FooterNav } from '@/components/layout/FooterNav'
+import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
+import { cn } from '@/lib/utils'
+
+type SiteFooterProps = {
+  variant?: 'landing' | 'default'
+}
+
+export function SiteFooter({ variant = 'default' }: SiteFooterProps) {
+  const currentYear = new Date().getFullYear()
+  const isLanding = variant === 'landing'
+
+  if (isLanding) {
+    return (
+      <footer className="bg-spotlight text-spotlight-foreground relative overflow-hidden">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_30%,color-mix(in_oklab,var(--spotlight-foreground)_6%,transparent),transparent_50%)]" />
+
+        <div className="container mx-auto max-w-7xl px-8 relative z-10">
+          <div className="py-16">
+            <Reveal className="text-center">
+              <div className="flex items-center gap-3 mb-4 justify-center">
+                <div className="w-9 h-9 bg-card rounded-lg border border-border flex items-center justify-center shadow-sm">
+                  <PenTool className="w-5 h-5 text-foreground" />
+                </div>
+                <h3 className="text-2xl font-display font-medium tracking-[-0.01em]">
+                  Quilltip
+                </h3>
+              </div>
+              <p className="text-spotlight-muted text-[15px] leading-relaxed max-w-2xl mx-auto">
+                {TESTNET_PRACTICE_NOTE}
+              </p>
+            </Reveal>
+          </div>
+
+          <Reveal className="py-8 border-t border-spotlight-border space-y-6">
+            <FooterNav variant="landing" className="max-w-3xl mx-auto" />
+            <div className="flex items-center justify-center gap-2 text-spotlight-muted text-[13px]">
+              <span>© {currentYear} Quilltip. Built with</span>
+              <Heart className="w-4 h-4 text-destructive fill-current animate-pulse" />
+              <span>for writers everywhere</span>
+            </div>
+          </Reveal>
+        </div>
+      </footer>
+    )
+  }
+
+  return (
+    <footer className={cn('border-t border-border bg-background mt-auto')}>
+      <div className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-10 space-y-6">
+        <div className="max-w-3xl">
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            {TESTNET_PRACTICE_NOTE}
+          </p>
+        </div>
+        <FooterNav variant="default" className="max-w-3xl" />
+        <p className="text-sm text-muted-foreground">
+          © {currentYear} Quilltip. All rights reserved.
+        </p>
+      </div>
+    </footer>
+  )
+}

--- a/components/legal/LegalLinks.tsx
+++ b/components/legal/LegalLinks.tsx
@@ -1,0 +1,56 @@
+import Link from 'next/link'
+import { cn } from '@/lib/utils'
+
+type LegalLinksProps = {
+  className?: string
+  linkClassName?: string
+  variant?: 'inline' | 'stacked'
+  /** How to separate inline links: pipe (footer) or and (auth copy). */
+  conjunction?: 'pipe' | 'and'
+}
+
+export function LegalLinks({
+  className,
+  linkClassName,
+  variant = 'inline',
+  conjunction = 'pipe',
+}: LegalLinksProps) {
+  const linkStyles = cn(
+    'hover:underline underline-offset-4 transition-colors',
+    linkClassName
+  )
+
+  if (variant === 'stacked') {
+    return (
+      <nav className={cn('flex flex-col gap-2 text-sm', className)}>
+        <Link href="/terms" className={linkStyles}>
+          Terms of Service
+        </Link>
+        <Link href="/privacy" className={linkStyles}>
+          Privacy Policy
+        </Link>
+      </nav>
+    )
+  }
+
+  const separator =
+    conjunction === 'and' ? (
+      <span className="text-muted-foreground"> and </span>
+    ) : (
+      <span className="mx-1.5 text-muted-foreground" aria-hidden>
+        |
+      </span>
+    )
+
+  return (
+    <span className={className}>
+      <Link href="/terms" className={linkStyles}>
+        Terms of Service
+      </Link>
+      {separator}
+      <Link href="/privacy" className={linkStyles}>
+        Privacy Policy
+      </Link>
+    </span>
+  )
+}

--- a/components/legal/LegalPageLayout.tsx
+++ b/components/legal/LegalPageLayout.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '@/components/providers/AuthContext'
 import Navigation from '@/components/landing/Navigation'
 import AppNavigation from '@/components/layout/AppNavigation'
 import { Button } from '@/components/ui/button'
+import { SiteFooter } from '@/components/layout/SiteFooter'
 import type { LegalSection } from '@/lib/copy/legal-shared'
 
 type LegalPageLayoutProps = {
@@ -26,9 +27,9 @@ export function LegalPageLayout({
   const { isAuthenticated } = useAuth()
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="flex min-h-screen flex-col bg-background">
       {isAuthenticated ? <AppNavigation /> : <Navigation />}
-      <div className="pt-24 pb-16 px-4">
+      <div className="flex-1 pt-24 pb-16 px-4">
         <article className="mx-auto max-w-3xl">
           <header className="mb-10 border-b border-border pb-8">
             <p className="text-sm text-muted-foreground mb-2">
@@ -76,6 +77,7 @@ export function LegalPageLayout({
           </footer>
         </article>
       </div>
+      <SiteFooter variant="default" />
     </div>
   )
 }

--- a/components/legal/LegalPageLayout.tsx
+++ b/components/legal/LegalPageLayout.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import Link from 'next/link'
+import { useAuth } from '@/components/providers/AuthContext'
+import Navigation from '@/components/landing/Navigation'
+import AppNavigation from '@/components/layout/AppNavigation'
+import { Button } from '@/components/ui/button'
+import type { LegalSection } from '@/lib/copy/legal-shared'
+
+type LegalPageLayoutProps = {
+  title: string
+  lastUpdated: string
+  sections: LegalSection[]
+  alternatePolicy: {
+    href: '/terms' | '/privacy'
+    label: string
+  }
+}
+
+export function LegalPageLayout({
+  title,
+  lastUpdated,
+  sections,
+  alternatePolicy,
+}: LegalPageLayoutProps) {
+  const { isAuthenticated } = useAuth()
+
+  return (
+    <div className="min-h-screen bg-background">
+      {isAuthenticated ? <AppNavigation /> : <Navigation />}
+      <div className="pt-24 pb-16 px-4">
+        <article className="mx-auto max-w-3xl">
+          <header className="mb-10 border-b border-border pb-8">
+            <p className="text-sm text-muted-foreground mb-2">
+              Last updated: {lastUpdated}
+            </p>
+            <h1 className="font-display text-3xl lg:text-4xl font-medium tracking-[-0.01em] text-foreground">
+              {title}
+            </h1>
+          </header>
+
+          <div className="space-y-10 text-foreground">
+            {sections.map((section) => (
+              <section key={section.id} id={section.id}>
+                <h2 className="text-lg font-semibold text-foreground mb-3">
+                  {section.title}
+                </h2>
+                <div className="space-y-3 text-sm leading-relaxed text-muted-foreground">
+                  {section.paragraphs.map((paragraph, index) => (
+                    <p key={`${section.id}-${index}`}>{paragraph}</p>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+
+          <footer className="mt-12 pt-8 border-t border-border space-y-6">
+            <p className="text-sm text-muted-foreground">
+              See also:{' '}
+              <Link
+                href={alternatePolicy.href}
+                className="text-primary hover:underline underline-offset-4"
+              >
+                {alternatePolicy.label}
+              </Link>
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-3 sm:items-center">
+              <Button asChild className="sm:w-auto w-full">
+                <Link href="/">Back to home</Link>
+              </Button>
+              <Button asChild variant="outline" className="sm:w-auto w-full">
+                <Link href="/articles">Browse articles</Link>
+              </Button>
+            </div>
+          </footer>
+        </article>
+      </div>
+    </div>
+  )
+}

--- a/components/nft/MintButton.tsx
+++ b/components/nft/MintButton.tsx
@@ -287,8 +287,8 @@ export function MintButton({
 
           <div className="space-y-4">
             {!wallet.isConnected && (
-              <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
-                <p className="text-sm text-amber-900">
+              <div className="bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3">
+                <p className="text-sm text-amber-900 dark:text-amber-100">
                   Connect your wallet to mint this article as an NFT.
                 </p>
               </div>
@@ -307,19 +307,19 @@ export function MintButton({
                   </span>
                 </div>
                 {wallet.isConnected && wallet.publicKey ? (
-                  <div className="bg-green-50 border border-green-200 rounded p-2">
+                  <div className="bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800 rounded p-2">
                     <div className="flex items-center justify-between text-xs">
-                      <span className="text-green-900 font-medium">
+                      <span className="text-green-900 dark:text-green-200 font-medium">
                         ✓ Wallet Connected
                       </span>
-                      <span className="font-mono text-green-700">
+                      <span className="font-mono text-green-700 dark:text-green-300">
                         {`${wallet.publicKey.slice(0, 4)}...${wallet.publicKey.slice(-4)}`}
                       </span>
                     </div>
                   </div>
                 ) : (
-                  <div className="bg-amber-50 border border-amber-200 rounded p-2">
-                    <span className="text-xs text-amber-900">
+                  <div className="bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded p-2">
+                    <span className="text-xs text-amber-900 dark:text-amber-100">
                       Wallet not connected
                     </span>
                   </div>

--- a/components/nft/MintButton.tsx
+++ b/components/nft/MintButton.tsx
@@ -15,7 +15,8 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import { useStellarWallet } from '@/hooks/useStellarWallet'
+import { useWallet } from '@/components/providers/WalletProvider'
+import { useWalletActivation } from '@/components/providers/WalletActivationContext'
 import { nftClient } from '@/lib/stellar/nft-client'
 import { stellarClient } from '@/lib/stellar/client'
 import { InstallWalletDialog } from '@/components/stellar/InstallWalletDialog'
@@ -93,7 +94,8 @@ export function MintButton({
   const uploadNftMetadataForMint = useAction(
     api.nftMetadataUpload.uploadNftMetadataForMint
   )
-  const wallet = useStellarWallet()
+  const wallet = useWallet()
+  const { activateWallet } = useWalletActivation()
   const [xlmPrice, setXlmPrice] = useState<number | null>(null)
 
   useEffect(() => {
@@ -250,7 +252,13 @@ export function MintButton({
 
   return (
     <>
-      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+      <Dialog
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          if (open) activateWallet()
+          setDialogOpen(open)
+        }}
+      >
         <DialogTrigger asChild>
           <Button
             disabled={!canMint}

--- a/components/nft/TransferModal.test.tsx
+++ b/components/nft/TransferModal.test.tsx
@@ -52,8 +52,10 @@ describe('TransferModal', () => {
     vi.mocked(toast.error).mockClear()
   })
 
-  it('shows a single success message in the message slot after transfer', async () => {
-    const user = userEvent.setup()
+  it(
+    'shows a single success message in the message slot after transfer',
+    async () => {
+    const user = userEvent.setup({ delay: null })
     mockTransfer.mockResolvedValue('transfer_id')
 
     render(
@@ -84,10 +86,12 @@ describe('TransferModal', () => {
     expect(
       screen.getAllByText('Transfer completed successfully!')
     ).toHaveLength(1)
-  })
+  },
+    10_000
+  )
 
   it('shows a single error message in the message slot on mutation failure', async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup({ delay: null })
     mockTransfer.mockRejectedValue(new Error('Recipient not found'))
 
     render(
@@ -126,7 +130,7 @@ describe('TransferModal', () => {
   })
 
   it('shows progress only in the message slot while the button stays Transfer NFT', async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup({ delay: null })
     let resolveTransfer!: (value: string) => void
     const transferPromise = new Promise<string>((resolve) => {
       resolveTransfer = resolve
@@ -165,7 +169,7 @@ describe('TransferModal', () => {
   })
 
   it('clears the message slot when the modal is closed and reopened', async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup({ delay: null })
 
     render(<ControlledTransferModal />)
 

--- a/components/nft/TransferModal.test.tsx
+++ b/components/nft/TransferModal.test.tsx
@@ -52,9 +52,7 @@ describe('TransferModal', () => {
     vi.mocked(toast.error).mockClear()
   })
 
-  it(
-    'shows a single success message in the message slot after transfer',
-    async () => {
+  it('shows a single success message in the message slot after transfer', async () => {
     const user = userEvent.setup({ delay: null })
     mockTransfer.mockResolvedValue('transfer_id')
 
@@ -86,9 +84,7 @@ describe('TransferModal', () => {
     expect(
       screen.getAllByText('Transfer completed successfully!')
     ).toHaveLength(1)
-  },
-    10_000
-  )
+  }, 10_000)
 
   it('shows a single error message in the message slot on mutation failure', async () => {
     const user = userEvent.setup({ delay: null })

--- a/components/nft/TransferModal.tsx
+++ b/components/nft/TransferModal.tsx
@@ -156,11 +156,11 @@ export function TransferModal({
 
   const messageBannerClass =
     transferMessage.kind === 'success'
-      ? 'bg-green-50 text-green-700'
+      ? 'bg-green-50 text-green-700 dark:bg-green-950/50 dark:text-green-200'
       : transferMessage.kind === 'error'
-        ? 'bg-red-50 text-red-700'
+        ? 'bg-red-50 text-red-700 dark:bg-red-950/50 dark:text-red-200'
         : transferMessage.kind === 'progress'
-          ? 'bg-blue-50 text-blue-700'
+          ? 'bg-blue-50 text-blue-700 dark:bg-blue-950/50 dark:text-blue-200'
           : ''
 
   const messageIcon =

--- a/components/onboarding/OnboardingDialog.tsx
+++ b/components/onboarding/OnboardingDialog.tsx
@@ -31,21 +31,24 @@ const steps = [
     icon: Sparkles,
     title: 'Welcome to Quilltip',
     description: `A platform where readers reward writers directly on Stellar testnet. ${TESTNET_PRACTICE_NOTE}`,
-    color: 'bg-blue-100 text-blue-700',
+    color:
+      'bg-blue-100 text-blue-700 dark:bg-blue-950/50 dark:text-blue-300',
   },
   {
     icon: Wallet,
     title: 'Set Up Your Wallet',
     description:
       'To tip writers on testnet, you need a Stellar wallet (like Freighter) set to Testnet with free test XLM. It takes about 2 minutes. Reading articles is always free — no wallet needed.',
-    color: 'bg-amber-100 text-amber-700',
+    color:
+      'bg-amber-100 text-amber-700 dark:bg-amber-950/50 dark:text-amber-300',
   },
   {
     icon: BookOpen,
     title: 'Start Exploring',
     description:
       'Browse articles from writers, highlight passages you love, and send practice tips starting at $0.01 in testnet XLM. 97.5% goes directly to the author.',
-    color: 'bg-green-100 text-green-700',
+    color:
+      'bg-green-100 text-green-700 dark:bg-green-950/50 dark:text-green-300',
   },
 ]
 
@@ -127,7 +130,7 @@ export function OnboardingDialog() {
             <div
               key={i}
               className={`h-1.5 rounded-full transition-all duration-300 ${
-                i === currentStep ? 'w-8 bg-neutral-900' : 'w-4 bg-neutral-200'
+                i === currentStep ? 'w-8 bg-foreground' : 'w-4 bg-muted'
               }`}
             />
           ))}
@@ -145,10 +148,10 @@ export function OnboardingDialog() {
             <div className={`inline-flex p-4 rounded-2xl ${step.color} mb-4`}>
               <StepIcon className="w-8 h-8" />
             </div>
-            <h3 className="text-xl font-bold text-neutral-900 mb-2">
+            <h3 className="text-xl font-bold text-foreground mb-2">
               {step.title}
             </h3>
-            <p className="text-sm text-neutral-600 leading-relaxed max-w-sm mx-auto">
+            <p className="text-sm text-muted-foreground leading-relaxed max-w-sm mx-auto">
               {step.description}
             </p>
           </motion.div>

--- a/components/onboarding/OnboardingDialog.tsx
+++ b/components/onboarding/OnboardingDialog.tsx
@@ -31,8 +31,7 @@ const steps = [
     icon: Sparkles,
     title: 'Welcome to Quilltip',
     description: `A platform where readers reward writers directly on Stellar testnet. ${TESTNET_PRACTICE_NOTE}`,
-    color:
-      'bg-blue-100 text-blue-700 dark:bg-blue-950/50 dark:text-blue-300',
+    color: 'bg-blue-100 text-blue-700 dark:bg-blue-950/50 dark:text-blue-300',
   },
   {
     icon: Wallet,

--- a/components/providers/Providers.tsx
+++ b/components/providers/Providers.tsx
@@ -1,19 +1,21 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { ConvexAuthProvider } from '@convex-dev/auth/react'
 import { ConvexReactClient } from 'convex/react'
-import { WalletProvider } from './WalletProvider'
 import { Toaster } from '@/components/ui/sonner'
 import { ErrorBoundary } from '@/components/error/ErrorBoundary'
 import { ThemeProvider } from '@/components/theme/ThemeProvider'
+import {
+  WalletActivationProvider,
+  useWalletActivation,
+} from './WalletActivationContext'
 
-/**
- * Global Providers
- *
- * Wraps the application with ConvexAuthProvider for authentication,
- * Convex database access, and Stellar wallet connection.
- * Provides real-time subscriptions and type-safe queries throughout the app.
- */
+const LazyWalletProvider = dynamic(
+  () =>
+    import('./WalletProvider').then((mod) => ({ default: mod.WalletProvider })),
+  { ssr: false }
+)
 
 const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!)
 
@@ -30,16 +32,28 @@ const WalletErrorFallback = (
   </div>
 )
 
+function WalletBoundary({ children }: { children: React.ReactNode }) {
+  const { isWalletActive } = useWalletActivation()
+
+  if (!isWalletActive) {
+    return <>{children}</>
+  }
+
+  return <LazyWalletProvider>{children}</LazyWalletProvider>
+}
+
 export default function Providers({ children }: ProvidersProps) {
   return (
     <ConvexAuthProvider client={convex}>
       <ThemeProvider>
-        <ErrorBoundary fallback={WalletErrorFallback}>
-          <WalletProvider>
-            {children}
-            <Toaster />
-          </WalletProvider>
-        </ErrorBoundary>
+        <WalletActivationProvider>
+          <ErrorBoundary fallback={WalletErrorFallback}>
+            <WalletBoundary>
+              {children}
+              <Toaster />
+            </WalletBoundary>
+          </ErrorBoundary>
+        </WalletActivationProvider>
       </ThemeProvider>
     </ConvexAuthProvider>
   )

--- a/components/providers/WalletActivationContext.tsx
+++ b/components/providers/WalletActivationContext.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  type ReactNode,
+} from 'react'
+
+type WalletActivationContextValue = {
+  isWalletActive: boolean
+  activateWallet: () => void
+}
+
+const WalletActivationContext =
+  createContext<WalletActivationContextValue | undefined>(undefined)
+
+export function WalletActivationProvider({ children }: { children: ReactNode }) {
+  const [isWalletActive, setIsWalletActive] = useState(false)
+  const activateWallet = useCallback(() => setIsWalletActive(true), [])
+
+  return (
+    <WalletActivationContext.Provider
+      value={{ isWalletActive, activateWallet }}
+    >
+      {children}
+    </WalletActivationContext.Provider>
+  )
+}
+
+export function useWalletActivation(): WalletActivationContextValue {
+  const context = useContext(WalletActivationContext)
+  if (context === undefined) {
+    throw new Error(
+      'useWalletActivation must be used within WalletActivationProvider'
+    )
+  }
+  return context
+}

--- a/components/providers/WalletActivationContext.tsx
+++ b/components/providers/WalletActivationContext.tsx
@@ -13,10 +13,15 @@ type WalletActivationContextValue = {
   activateWallet: () => void
 }
 
-const WalletActivationContext =
-  createContext<WalletActivationContextValue | undefined>(undefined)
+const WalletActivationContext = createContext<
+  WalletActivationContextValue | undefined
+>(undefined)
 
-export function WalletActivationProvider({ children }: { children: ReactNode }) {
+export function WalletActivationProvider({
+  children,
+}: {
+  children: ReactNode
+}) {
   const [isWalletActive, setIsWalletActive] = useState(false)
   const activateWallet = useCallback(() => setIsWalletActive(true), [])
 

--- a/components/providers/WalletProvider.tsx
+++ b/components/providers/WalletProvider.tsx
@@ -1,15 +1,43 @@
 'use client'
 
-import { createContext, useContext, ReactNode } from 'react'
+import {
+  createContext,
+  useContext,
+  useEffect,
+  type ReactNode,
+} from 'react'
 import {
   useStellarWallet,
   StellarWalletState,
   StellarWalletActions,
 } from '@/hooks/useStellarWallet'
+import { useWalletActivation } from './WalletActivationContext'
 
 type WalletContextType = StellarWalletState & StellarWalletActions
 
 const WalletContext = createContext<WalletContextType | undefined>(undefined)
+
+const INACTIVE_WALLET_STUB: WalletContextType = {
+  isInstalled: false,
+  isConnected: false,
+  isLoading: false,
+  publicKey: null,
+  network: null,
+  networkPassphrase: null,
+  error: null,
+  selectedWallet: null,
+  connect: async () => false,
+  disconnect: () => {},
+  signTransaction: async () => {
+    throw new Error('Wallet not activated')
+  },
+  refreshConnection: async () => {},
+}
+
+const LOADING_WALLET_STUB: WalletContextType = {
+  ...INACTIVE_WALLET_STUB,
+  isLoading: true,
+}
 
 interface WalletProviderProps {
   children: ReactNode
@@ -23,10 +51,34 @@ export function WalletProvider({ children }: WalletProviderProps) {
   )
 }
 
-export function useWallet(): WalletContextType {
+type UseWalletOptions = {
+  /** Load wallet subsystem when this component mounts (profile, wallet settings). */
+  activateOnMount?: boolean
+}
+
+export function useWallet(options?: UseWalletOptions): WalletContextType {
+  const { isWalletActive, activateWallet } = useWalletActivation()
   const context = useContext(WalletContext)
-  if (context === undefined) {
-    throw new Error('useWallet must be used within a WalletProvider')
+
+  useEffect(() => {
+    if (options?.activateOnMount) {
+      activateWallet()
+    }
+  }, [options?.activateOnMount, activateWallet])
+
+  if (!isWalletActive) {
+    return {
+      ...INACTIVE_WALLET_STUB,
+      connect: async () => {
+        activateWallet()
+        return false
+      },
+    }
   }
+
+  if (context === undefined) {
+    return LOADING_WALLET_STUB
+  }
+
   return context
 }

--- a/components/providers/WalletProvider.tsx
+++ b/components/providers/WalletProvider.tsx
@@ -1,11 +1,6 @@
 'use client'
 
-import {
-  createContext,
-  useContext,
-  useEffect,
-  type ReactNode,
-} from 'react'
+import { createContext, useContext, useEffect, type ReactNode } from 'react'
 import {
   useStellarWallet,
   StellarWalletState,

--- a/components/stellar/WalletConnectButton.tsx
+++ b/components/stellar/WalletConnectButton.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { useWallet } from '@/components/providers/WalletProvider'
+import { useWalletActivation } from '@/components/providers/WalletActivationContext'
 import { Wallet, Loader2, AlertCircle, CheckCircle } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
@@ -32,7 +33,8 @@ export function WalletConnectButton({
     selectedWallet,
     connect,
     disconnect,
-  } = useWallet()
+  } = useWallet({ activateOnMount: true })
+  const { activateWallet } = useWalletActivation()
   const [isConnecting, setIsConnecting] = useState(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
 
@@ -42,6 +44,7 @@ export function WalletConnectButton({
       return
     }
 
+    activateWallet()
     setIsConnecting(true)
     try {
       await connect()

--- a/components/stellar/WalletConnectButton.tsx
+++ b/components/stellar/WalletConnectButton.tsx
@@ -97,7 +97,10 @@ export function WalletConnectButton({
         onClick={handleConnect}
         size={size}
         variant="outline"
-        className={cn('text-red-600 border-red-300', className)}
+        className={cn(
+          'text-destructive border-destructive/50 dark:text-red-300 dark:border-red-800',
+          className
+        )}
       >
         <AlertCircle className="w-4 h-4 mr-2" />
         Wallet Error

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -50,7 +50,7 @@ export function WalletSettings({
   className = '',
 }: WalletSettingsProps) {
   const updateProfile = useMutation(api.users.updateProfile)
-  const { isLoading, connect, disconnect } = useWallet()
+  const { isLoading, connect, disconnect } = useWallet({ activateOnMount: true })
   const [isCopied, setIsCopied] = useState(false)
   const [isConnecting, setIsConnecting] = useState(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -50,7 +50,9 @@ export function WalletSettings({
   className = '',
 }: WalletSettingsProps) {
   const updateProfile = useMutation(api.users.updateProfile)
-  const { isLoading, connect, disconnect } = useWallet({ activateOnMount: true })
+  const { isLoading, connect, disconnect } = useWallet({
+    activateOnMount: true,
+  })
   const [isCopied, setIsCopied] = useState(false)
   const [isConnecting, setIsConnecting] = useState(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -184,9 +184,9 @@ export function WalletSettings({
         </CardHeader>
         <CardContent className="space-y-4">
           {isOwnProfile && (
-            <Alert className="bg-blue-50 border-blue-200">
-              <AlertCircle className="h-4 w-4 text-blue-600" />
-              <AlertDescription className="text-blue-900">
+            <Alert className="border-info/50 bg-info">
+              <AlertCircle className="h-4 w-4 text-info-foreground" />
+              <AlertDescription className="text-info-foreground">
                 <strong>This wallet is for receiving tips.</strong> When readers
                 tip your articles, payments come here. To send tips to other
                 authors, you&apos;ll connect your wallet extension directly on
@@ -230,7 +230,7 @@ export function WalletSettings({
                     Need a wallet?{' '}
                     <Link
                       href="/guide"
-                      className="text-blue-600 hover:underline"
+                      className="text-info-foreground hover:underline"
                     >
                       Follow our setup guide
                     </Link>
@@ -239,11 +239,11 @@ export function WalletSettings({
               ) : (
                 <div className="space-y-4">
                   {/* Connected State */}
-                  <div className="p-4 bg-green-50 border border-green-200 rounded-lg space-y-3">
+                  <div className="p-4 bg-success border border-success/50 rounded-lg space-y-3">
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-2">
                         <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
-                        <span className="text-sm font-medium">
+                        <span className="text-sm font-medium text-success-foreground">
                           Wallet Connected
                         </span>
                       </div>

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -367,9 +367,7 @@ export function WalletSettings({
 
           {isOwnProfile && (
             <div className="pt-4 mt-2 border-t border-border">
-              <LegalLinks
-                linkClassName="text-muted-foreground hover:text-foreground text-xs"
-              />
+              <LegalLinks linkClassName="text-muted-foreground hover:text-foreground text-xs" />
             </div>
           )}
         </CardContent>

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -30,6 +30,7 @@ import { WalletTooltip } from '@/components/guide/WalletTooltip'
 import { toast } from 'sonner'
 import { useWallet } from '@/components/providers/WalletProvider'
 import { InstallWalletDialog } from '@/components/stellar/InstallWalletDialog'
+import { LegalLinks } from '@/components/legal/LegalLinks'
 import {
   NO_WALLET_AVAILABLE_ERROR_CODE,
   ALBEDO_INSECURE_LOCALHOST_ERROR_CODE,
@@ -361,6 +362,14 @@ export function WalletSettings({
                   platform fees.
                 </AlertDescription>
               </Alert>
+            </div>
+          )}
+
+          {isOwnProfile && (
+            <div className="pt-4 mt-2 border-t border-border">
+              <LegalLinks
+                linkClassName="text-muted-foreground hover:text-foreground text-xs"
+              />
             </div>
           )}
         </CardContent>

--- a/components/stellar/WalletStatus.tsx
+++ b/components/stellar/WalletStatus.tsx
@@ -36,7 +36,7 @@ export function WalletStatus({ className }: WalletStatusProps) {
     connect,
     disconnect,
     refreshConnection,
-  } = useWallet()
+  } = useWallet({ activateOnMount: true })
   const [isConnecting, setIsConnecting] = useState(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
 

--- a/components/stellar/WalletStatus.tsx
+++ b/components/stellar/WalletStatus.tsx
@@ -93,14 +93,14 @@ export function WalletStatus({ className }: WalletStatusProps) {
       <Card className={className}>
         <CardContent className="pt-6">
           <div className="flex flex-col items-center space-y-4 text-center">
-            <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
-              <Wallet className="w-6 h-6 text-red-600" />
+            <div className="w-12 h-12 bg-red-100 dark:bg-red-950/50 rounded-full flex items-center justify-center">
+              <Wallet className="w-6 h-6 text-red-600 dark:text-red-300" />
             </div>
             <div>
-              <h3 className="font-semibold text-red-900">
+              <h3 className="font-semibold text-red-900 dark:text-red-200">
                 Wallet Connection Error
               </h3>
-              <p className="text-sm text-red-600">{error}</p>
+              <p className="text-sm text-red-600 dark:text-red-300">{error}</p>
             </div>
             <Button variant="outline" onClick={refreshConnection}>
               <RefreshCw className="w-4 h-4 mr-2" />

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useConvex, useMutation } from 'convex/react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { useWallet } from '@/components/providers/WalletProvider'
+import { useWalletActivation } from '@/components/providers/WalletActivationContext'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 import { AlertCircle, Coins, Heart, Loader2, Wallet } from 'lucide-react'
@@ -65,6 +66,7 @@ export function TipButton({
 }: TipButtonProps) {
   const { isAuthenticated } = useAuth()
   const { isConnected, publicKey, signTransaction, connect } = useWallet()
+  const { activateWallet } = useWalletActivation()
   const router = useRouter()
   const [isOpen, setIsOpen] = useState(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
@@ -89,6 +91,9 @@ export function TipButton({
 
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
+    if (open) {
+      activateWallet()
+    }
     setIsOpen(open)
     setTipFailure(null)
   }

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -290,13 +290,13 @@ export function TipButton({
           )}
 
           {!isConnected && (
-            <div className="p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-900">
+            <div className="p-3 bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-lg text-sm text-amber-900 dark:text-amber-100">
               <p>Connect your Stellar wallet to send tips to {authorName}.</p>
               <p className="mt-1">
                 New to crypto?{' '}
                 <Link
                   href="/guide"
-                  className="focus-ring rounded text-amber-700 underline font-medium hover:text-amber-900"
+                  className="focus-ring rounded text-amber-700 dark:text-amber-300 underline font-medium hover:text-amber-900 dark:hover:text-amber-100"
                 >
                   Follow our setup guide
                 </Link>
@@ -316,7 +316,7 @@ export function TipButton({
                 disabled={isLoading}
                 className={`focus-ring relative flex min-h-12 items-center justify-center px-4 py-3 rounded-lg border-2 transition-all disabled:opacity-50 ${
                   selectedAmount === amount.cents
-                    ? 'border-orange-500 bg-orange-50'
+                    ? 'border-orange-500 bg-orange-50 dark:bg-orange-950/30'
                     : 'border-border hover:border-orange-300'
                 }`}
               >

--- a/convex/reconcileTips.test.ts
+++ b/convex/reconcileTips.test.ts
@@ -590,6 +590,8 @@ function stubMalformedHorizonResponse() {
 async function drainScheduler(t: ReturnType<typeof convexTest>) {
   await new Promise((resolve) => setTimeout(resolve, 50))
   await t.finishAllScheduledFunctions(() => {})
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  await t.finishAllScheduledFunctions(() => {})
 }
 
 describe('recoverStuckPendingHighlightTips', () => {

--- a/e2e/eng-224-console.spec.ts
+++ b/e2e/eng-224-console.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test'
+
+const DEV_CONSOLE_PATTERN = /development|dev mode|devtools|development build/i
+
+const PUBLIC_PAGES = [
+  { name: 'home', path: '/' },
+  { name: 'articles', path: '/articles' },
+  { name: 'guide', path: '/guide' },
+] as const
+
+function collectDevConsoleMessages(
+  entries: { type: string; text: string }[]
+): { type: string; text: string }[] {
+  return entries.filter((e) => DEV_CONSOLE_PATTERN.test(e.text))
+}
+
+async function captureConsoleForPath(
+  page: import('@playwright/test').Page,
+  path: string
+) {
+  const entries: { type: string; text: string }[] = []
+  page.on('console', (msg) => {
+    entries.push({ type: msg.type(), text: msg.text() })
+  })
+  await page.goto(path, { waitUntil: 'networkidle', timeout: 60_000 })
+  await page.waitForTimeout(2000)
+  return entries
+}
+
+test.describe('ENG-224 public pages console', () => {
+  test.setTimeout(120_000)
+
+  for (const pageDef of PUBLIC_PAGES) {
+    test(`${pageDef.name} has no development-mode console messages`, async ({
+      page,
+    }) => {
+      const entries = await captureConsoleForPath(page, pageDef.path)
+      const devMatches = collectDevConsoleMessages(entries)
+      expect(
+        devMatches,
+        devMatches.map((m) => `[${m.type}] ${m.text}`).join('\n')
+      ).toEqual([])
+    })
+  }
+
+  test('article detail has no development-mode console messages', async ({
+    page,
+  }) => {
+    await page.goto('/articles', {
+      waitUntil: 'networkidle',
+      timeout: 60_000,
+    })
+    const articleLink = page
+      .locator('a[href^="/"]')
+      .filter({ has: page.locator('article, [data-article], h2, h3') })
+      .first()
+    const href = await articleLink.getAttribute('href').catch(() => null)
+
+    const fallbackLink = page.locator('main a[href*="/"]').nth(1)
+    const resolvedHref =
+      href &&
+      href.startsWith('/') &&
+      href.split('/').filter(Boolean).length >= 2
+        ? href
+        : await fallbackLink.getAttribute('href').catch(() => null)
+
+    test.skip(
+      !resolvedHref ||
+        !resolvedHref.startsWith('/') ||
+        resolvedHref.split('/').filter(Boolean).length < 2,
+      'No published article link on /articles to test article detail'
+    )
+
+    const entries = await captureConsoleForPath(page, resolvedHref!)
+    const devMatches = collectDevConsoleMessages(entries)
+    expect(
+      devMatches,
+      devMatches.map((m) => `[${m.type}] ${m.text}`).join('\n')
+    ).toEqual([])
+  })
+})

--- a/e2e/home-visual.spec.ts
+++ b/e2e/home-visual.spec.ts
@@ -113,3 +113,28 @@ test.describe('landing nav hash navigation', () => {
     await assertRevealContentVisible(page, '#arweave-storage')
   })
 })
+
+test.describe('home landing footer links', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await expect(
+      page.getByRole('heading', { name: 'Reward the words that move you' })
+    ).toBeVisible()
+  })
+
+  test('footer includes trust and support destinations', async ({ page }) => {
+    const footer = page.getByRole('navigation', { name: 'Footer' })
+    await footer.scrollIntoViewIfNeeded()
+
+    for (const label of [
+      'Terms of Service',
+      'Privacy Policy',
+      'Help & Support',
+      'Wallet Guide',
+      'Contact',
+      'Platform Status',
+    ]) {
+      await expect(footer.getByRole('link', { name: label })).toBeVisible()
+    }
+  })
+})

--- a/hooks/useStellarWallet.ts
+++ b/hooks/useStellarWallet.ts
@@ -30,7 +30,7 @@ export function useStellarWallet(): StellarWalletState & StellarWalletActions {
   const [state, setState] = useState<StellarWalletState>({
     isInstalled: false,
     isConnected: false,
-    isLoading: true,
+    isLoading: false,
     publicKey: null,
     network: null,
     networkPassphrase: null,
@@ -188,9 +188,9 @@ export function useStellarWallet(): StellarWalletState & StellarWalletActions {
     await checkWalletStatus()
   }, [checkWalletStatus])
 
-  // Initialize wallet check on mount
+  // Run status check when the wallet provider mounts (after activation).
   useEffect(() => {
-    checkWalletStatus()
+    void checkWalletStatus()
   }, [checkWalletStatus])
 
   // NOTE: Removed automatic wallet detail fetching to prevent unwanted popups

--- a/lib/copy/contact-page.ts
+++ b/lib/copy/contact-page.ts
@@ -1,0 +1,41 @@
+import { LEGAL_CONTACT_EMAIL } from '@/lib/copy/legal-shared'
+import {
+  MAINNET_COMING_NOTE,
+  TESTNET_PRACTICE_NOTE,
+} from '@/lib/copy/network-status'
+
+export const SECURITY_CONTACT_EMAIL = 'security@quilltip.me'
+
+export type ContactChannel = {
+  id: string
+  title: string
+  email: string
+  description: string
+}
+
+export const contactIntro =
+  'Reach the Quilltip team for legal, privacy, security, and general questions about the testnet product.'
+
+export const contactChannels: ContactChannel[] = [
+  {
+    id: 'legal',
+    title: 'Legal and privacy',
+    email: LEGAL_CONTACT_EMAIL,
+    description:
+      'Questions about our Terms of Service, Privacy Policy, data requests, or account-related legal matters.',
+  },
+  {
+    id: 'security',
+    title: 'Security reports',
+    email: SECURITY_CONTACT_EMAIL,
+    description:
+      'Report vulnerabilities privately. Do not open public GitHub issues for security concerns.',
+  },
+]
+
+export const contactNotes = [
+  TESTNET_PRACTICE_NOTE,
+  MAINNET_COMING_NOTE,
+  'Quilltip does not process real-money payments today. Billing, refund, or chargeback requests do not apply to testnet practice funds.',
+  'We aim to respond to general inquiries within a few business days. Security reports receive acknowledgment within 48 hours per our security policy.',
+]

--- a/lib/copy/footer-links.test.ts
+++ b/lib/copy/footer-links.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import {
+  AUTH_FOOTER_LINKS,
+  FOOTER_LINKS,
+  FOOTER_LINK_CATEGORIES,
+  FOOTER_LINK_GROUP_LABELS,
+  INTERNAL_FOOTER_ROUTES,
+} from '@/lib/copy/footer-links'
+
+describe('footer-links', () => {
+  it('includes legal, support, contact, and status categories', () => {
+    expect(FOOTER_LINK_CATEGORIES).toEqual([
+      'legal',
+      'support',
+      'contact',
+      'status',
+    ])
+
+    for (const category of FOOTER_LINK_CATEGORIES) {
+      expect(FOOTER_LINK_GROUP_LABELS[category]).toBeTruthy()
+      expect(FOOTER_LINKS.some((link) => link.category === category)).toBe(
+        true
+      )
+    }
+  })
+
+  it('uses only known internal routes for footer destinations', () => {
+    for (const link of FOOTER_LINKS) {
+      expect(link.href.startsWith('/')).toBe(true)
+      expect(INTERNAL_FOOTER_ROUTES).toContain(
+        link.href as (typeof INTERNAL_FOOTER_ROUTES)[number]
+      )
+    }
+  })
+
+  it('excludes legal links from auth footer compact row', () => {
+    expect(AUTH_FOOTER_LINKS.every((link) => link.category !== 'legal')).toBe(
+      true
+    )
+    expect(AUTH_FOOTER_LINKS.map((link) => link.label)).toEqual([
+      'Help & Support',
+      'Wallet Guide',
+      'Contact',
+      'Platform Status',
+    ])
+  })
+})

--- a/lib/copy/footer-links.test.ts
+++ b/lib/copy/footer-links.test.ts
@@ -18,9 +18,7 @@ describe('footer-links', () => {
 
     for (const category of FOOTER_LINK_CATEGORIES) {
       expect(FOOTER_LINK_GROUP_LABELS[category]).toBeTruthy()
-      expect(FOOTER_LINKS.some((link) => link.category === category)).toBe(
-        true
-      )
+      expect(FOOTER_LINKS.some((link) => link.category === category)).toBe(true)
     }
   })
 

--- a/lib/copy/footer-links.ts
+++ b/lib/copy/footer-links.ts
@@ -1,0 +1,43 @@
+export type FooterLinkCategory = 'legal' | 'support' | 'contact' | 'status'
+
+export type FooterLink = {
+  label: string
+  href: string
+  category: FooterLinkCategory
+}
+
+export const FOOTER_LINKS: FooterLink[] = [
+  { label: 'Terms of Service', href: '/terms', category: 'legal' },
+  { label: 'Privacy Policy', href: '/privacy', category: 'legal' },
+  { label: 'Help & Support', href: '/support', category: 'support' },
+  { label: 'Wallet Guide', href: '/guide', category: 'support' },
+  { label: 'Contact', href: '/contact', category: 'contact' },
+  { label: 'Platform Status', href: '/status', category: 'status' },
+]
+
+export const FOOTER_LINK_GROUP_LABELS: Record<FooterLinkCategory, string> = {
+  legal: 'Legal',
+  support: 'Support',
+  contact: 'Contact',
+  status: 'Status',
+}
+
+export const FOOTER_LINK_CATEGORIES: FooterLinkCategory[] = [
+  'legal',
+  'support',
+  'contact',
+  'status',
+]
+
+export const AUTH_FOOTER_LINKS = FOOTER_LINKS.filter(
+  (link) => link.category !== 'legal'
+)
+
+export const INTERNAL_FOOTER_ROUTES = [
+  '/terms',
+  '/privacy',
+  '/guide',
+  '/support',
+  '/contact',
+  '/status',
+] as const

--- a/lib/copy/legal-privacy.ts
+++ b/lib/copy/legal-privacy.ts
@@ -79,7 +79,7 @@ export const privacySections: LegalSection[] = [
   },
   {
     id: 'children',
-    title: '9. Children\'s privacy',
+    title: "9. Children's privacy",
     paragraphs: [
       'The Service is not directed to children under 13. We do not knowingly collect personal information from children under 13. If you believe we have done so, contact us and we will take appropriate steps to delete it.',
     ],

--- a/lib/copy/legal-privacy.ts
+++ b/lib/copy/legal-privacy.ts
@@ -88,7 +88,7 @@ export const privacySections: LegalSection[] = [
     id: 'international',
     title: '10. International users',
     paragraphs: [
-      'If you access the Service from outside the United States, you understand that information may be processed in the United States or other countries where our providers operate, which may have different data protection rules than your jurisdiction.',
+      'If you access the Service from outside India, you understand that information may be processed in India or other countries where our providers operate, which may have different data protection rules than your jurisdiction.',
     ],
   },
   {

--- a/lib/copy/legal-privacy.ts
+++ b/lib/copy/legal-privacy.ts
@@ -1,0 +1,108 @@
+import {
+  LEGAL_CONTACT_EMAIL,
+  LEGAL_LAST_UPDATED,
+  type LegalSection,
+} from '@/lib/copy/legal-shared'
+import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
+
+export const privacyLastUpdated = LEGAL_LAST_UPDATED
+
+export const privacySections: LegalSection[] = [
+  {
+    id: 'introduction',
+    title: '1. Introduction',
+    paragraphs: [
+      'This Privacy Policy explains how Quilltip ("Quilltip," "we," "us," or "our") collects, uses, and shares information when you use our website, applications, and related services (collectively, the "Service").',
+      'By using the Service, you agree to the practices described here. Please also read our Terms of Service.',
+    ],
+  },
+  {
+    id: 'information-we-collect',
+    title: '2. Information we collect',
+    paragraphs: [
+      'Account information: When you register, we collect information such as your email address, username, password (stored in hashed form through our authentication provider), and optional display name.',
+      'Profile information: You may provide a bio, avatar, and Stellar wallet address associated with your profile for receiving tips or connecting a wallet.',
+      'Content and activity: We store articles, drafts, highlights, tips, and related metadata you create or interact with on the Service.',
+      'Wallet and blockchain data: When you connect a wallet or send tips, we process public blockchain addresses and transaction-related data needed to display balances, history, and withdrawals. On-chain transactions are public by nature.',
+      TESTNET_PRACTICE_NOTE,
+      'Technical data: We automatically collect information such as device type, browser, IP address, and usage logs to secure and operate the Service.',
+    ],
+  },
+  {
+    id: 'how-we-use',
+    title: '3. How we use information',
+    paragraphs: [
+      'We use collected information to provide and improve the Service, authenticate users, publish and display content, process tips and withdrawals on testnet, prevent abuse, respond to support requests, and comply with legal obligations.',
+      'We may use aggregated or de-identified data for analytics and product improvement.',
+    ],
+  },
+  {
+    id: 'sharing',
+    title: '4. How we share information',
+    paragraphs: [
+      'Service providers: We use infrastructure providers (including hosting, database, and authentication services such as Convex) to operate the Service. They process data on our behalf under contractual safeguards.',
+      'Blockchain networks: Tips, withdrawals, and NFT activity are recorded on the Stellar network and may be visible to anyone via public explorers.',
+      'Decentralized storage: When enabled, article content may be stored on networks such as Arweave, where data may be permanent and publicly accessible.',
+      'Analytics: We use Vercel Analytics to understand how the Service is used. Analytics data is generally aggregated and does not include article body text.',
+      'Legal requirements: We may disclose information if required by law, court order, or to protect the rights, safety, and security of Quilltip, our users, or others.',
+    ],
+  },
+  {
+    id: 'cookies',
+    title: '5. Cookies and session data',
+    paragraphs: [
+      'We use cookies and similar technologies to keep you signed in, remember preferences, and secure the Service. You can control cookies through your browser settings, but disabling them may limit functionality.',
+    ],
+  },
+  {
+    id: 'retention',
+    title: '6. Data retention',
+    paragraphs: [
+      'We retain account and content data for as long as your account is active or as needed to provide the Service. We may retain certain records after account closure where required for legal, security, or backup purposes.',
+      'Blockchain and decentralized storage data may persist indefinitely outside our control even after we delete copies from our systems.',
+    ],
+  },
+  {
+    id: 'your-rights',
+    title: '7. Your choices and rights',
+    paragraphs: [
+      'You may update profile information from your account settings. You may request account deletion or data access by contacting us at the email below, subject to legal and operational limitations (including data already on public blockchains).',
+      'Depending on where you live, you may have additional rights under applicable privacy laws (such as access, correction, or deletion). We will respond to valid requests in accordance with those laws.',
+    ],
+  },
+  {
+    id: 'security',
+    title: '8. Security',
+    paragraphs: [
+      'We implement reasonable technical and organizational measures to protect information. No method of transmission or storage is completely secure; use strong passwords and protect your wallet keys.',
+    ],
+  },
+  {
+    id: 'children',
+    title: '9. Children\'s privacy',
+    paragraphs: [
+      'The Service is not directed to children under 13. We do not knowingly collect personal information from children under 13. If you believe we have done so, contact us and we will take appropriate steps to delete it.',
+    ],
+  },
+  {
+    id: 'international',
+    title: '10. International users',
+    paragraphs: [
+      'If you access the Service from outside the United States, you understand that information may be processed in the United States or other countries where our providers operate, which may have different data protection rules than your jurisdiction.',
+    ],
+  },
+  {
+    id: 'changes',
+    title: '11. Changes to this Policy',
+    paragraphs: [
+      'We may update this Privacy Policy from time to time. We will post the revised policy on this page and update the "Last updated" date. Material changes may also be communicated through the Service where appropriate.',
+    ],
+  },
+  {
+    id: 'contact',
+    title: '12. Contact',
+    paragraphs: [
+      `Privacy questions or requests may be sent to ${LEGAL_CONTACT_EMAIL}.`,
+    ],
+  },
+]

--- a/lib/copy/legal-shared.ts
+++ b/lib/copy/legal-shared.ts
@@ -1,0 +1,9 @@
+export const LEGAL_CONTACT_EMAIL = 'legal@quilltip.com'
+
+export const LEGAL_LAST_UPDATED = 'May 19, 2026'
+
+export type LegalSection = {
+  id: string
+  title: string
+  paragraphs: string[]
+}

--- a/lib/copy/legal-shared.ts
+++ b/lib/copy/legal-shared.ts
@@ -1,4 +1,4 @@
-export const LEGAL_CONTACT_EMAIL = 'legal@quilltip.com'
+export const LEGAL_CONTACT_EMAIL = 'legal@quilltip.me'
 
 export const LEGAL_LAST_UPDATED = 'May 19, 2026'
 

--- a/lib/copy/legal-terms.ts
+++ b/lib/copy/legal-terms.ts
@@ -42,7 +42,7 @@ export const termsSections: LegalSection[] = [
     title: '4. Your content',
     paragraphs: [
       'You retain ownership of content you publish on Quilltip, subject to the licenses you grant us to operate the Service (for example, to display, store, and distribute your articles to readers).',
-      'You represent that you have the rights to publish your content and that it does not infringe others\' intellectual property, privacy, or other rights.',
+      "You represent that you have the rights to publish your content and that it does not infringe others' intellectual property, privacy, or other rights.",
       'You grant Quilltip a non-exclusive, worldwide license to host, reproduce, display, and promote your content solely to provide and improve the Service.',
     ],
   },
@@ -61,7 +61,7 @@ export const termsSections: LegalSection[] = [
     title: '6. Permanent storage and NFTs',
     paragraphs: [
       'Quilltip may store or reference article content on decentralized networks such as Arweave so that published work can persist independently of our servers. Once content is stored on a decentralized network, copies may remain accessible even if we remove content from the Quilltip interface.',
-      'Article NFTs on Stellar may serve as proof of ownership or authorship. Minting, transfer, and on-chain metadata are subject to network rules and your wallet provider\'s terms.',
+      "Article NFTs on Stellar may serve as proof of ownership or authorship. Minting, transfer, and on-chain metadata are subject to network rules and your wallet provider's terms.",
     ],
   },
   {

--- a/lib/copy/legal-terms.ts
+++ b/lib/copy/legal-terms.ts
@@ -1,0 +1,107 @@
+import {
+  LEGAL_CONTACT_EMAIL,
+  LEGAL_LAST_UPDATED,
+  type LegalSection,
+} from '@/lib/copy/legal-shared'
+import {
+  MAINNET_COMING_NOTE,
+  TESTNET_PRACTICE_NOTE,
+} from '@/lib/copy/network-status'
+
+export const termsLastUpdated = LEGAL_LAST_UPDATED
+
+export const termsSections: LegalSection[] = [
+  {
+    id: 'acceptance',
+    title: '1. Acceptance of these Terms',
+    paragraphs: [
+      'These Terms of Service ("Terms") govern your access to and use of Quilltip ("Quilltip," "we," "us," or "our"), including our website, applications, and related services (collectively, the "Service").',
+      'By creating an account, signing in, publishing content, connecting a wallet, or otherwise using the Service, you agree to these Terms and to our Privacy Policy. If you do not agree, do not use the Service.',
+    ],
+  },
+  {
+    id: 'service-description',
+    title: '2. The Service',
+    paragraphs: [
+      'Quilltip is a publishing platform where writers share articles and readers may send voluntary tips. The Service is designed to help writers receive direct support from readers using blockchain-based payments.',
+      TESTNET_PRACTICE_NOTE,
+      MAINNET_COMING_NOTE,
+    ],
+  },
+  {
+    id: 'accounts',
+    title: '3. Accounts and eligibility',
+    paragraphs: [
+      'You must provide accurate registration information and keep your account credentials secure. You are responsible for all activity under your account.',
+      'You must be at least 13 years old to use the Service. If you are under 18, you may use the Service only with permission from a parent or legal guardian who accepts these Terms on your behalf.',
+      'We may suspend or terminate accounts that violate these Terms, applicable law, or our community standards.',
+    ],
+  },
+  {
+    id: 'user-content',
+    title: '4. Your content',
+    paragraphs: [
+      'You retain ownership of content you publish on Quilltip, subject to the licenses you grant us to operate the Service (for example, to display, store, and distribute your articles to readers).',
+      'You represent that you have the rights to publish your content and that it does not infringe others\' intellectual property, privacy, or other rights.',
+      'You grant Quilltip a non-exclusive, worldwide license to host, reproduce, display, and promote your content solely to provide and improve the Service.',
+    ],
+  },
+  {
+    id: 'tipping',
+    title: '5. Tips, fees, and payments',
+    paragraphs: [
+      'Tips on Quilltip are voluntary. Readers choose whether and how much to tip. Writers receive 97.5% of each tip; Quilltip retains 2.5% to support platform operations.',
+      'While the Service operates on Stellar testnet, tips use test XLM only and have no real-world monetary value. You should not treat testnet balances as cash or savings.',
+      'Blockchain transactions are processed on the Stellar network. Network fees, confirmation times, and wallet compatibility are outside our direct control. You are responsible for verifying wallet addresses before sending tips or withdrawals.',
+      'We do not guarantee uninterrupted tipping, withdrawal, or wallet connectivity. Smart contract and network behavior may change as we iterate on the product.',
+    ],
+  },
+  {
+    id: 'storage-nfts',
+    title: '6. Permanent storage and NFTs',
+    paragraphs: [
+      'Quilltip may store or reference article content on decentralized networks such as Arweave so that published work can persist independently of our servers. Once content is stored on a decentralized network, copies may remain accessible even if we remove content from the Quilltip interface.',
+      'Article NFTs on Stellar may serve as proof of ownership or authorship. Minting, transfer, and on-chain metadata are subject to network rules and your wallet provider\'s terms.',
+    ],
+  },
+  {
+    id: 'conduct',
+    title: '7. Acceptable use and moderation',
+    paragraphs: [
+      'You may not use the Service for illegal activity, harassment, fraud, malware distribution, spam, or impersonation. You may not attempt to disrupt, scrape, or reverse engineer the Service without permission.',
+      'We may remove or restrict content that violates law, these Terms, or community guidelines. As described in our product documentation, we may remove violating material from the Quilltip interface while decentralized copies may still exist elsewhere.',
+    ],
+  },
+  {
+    id: 'disclaimers',
+    title: '8. Disclaimers',
+    paragraphs: [
+      'THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.',
+      'We do not warrant that the Service will be error-free, secure, or available at all times. Blockchain and third-party wallet services may fail, delay, or change without notice.',
+      'Nothing in these Terms constitutes financial, legal, or investment advice.',
+    ],
+  },
+  {
+    id: 'liability',
+    title: '9. Limitation of liability',
+    paragraphs: [
+      'To the fullest extent permitted by law, Quilltip and its operators will not be liable for indirect, incidental, special, consequential, or punitive damages, or for loss of profits, data, goodwill, or digital assets, arising from your use of the Service.',
+      'Our total liability for any claim relating to the Service is limited to the greater of (a) amounts you paid to Quilltip in the twelve months before the claim or (b) fifty U.S. dollars (USD $50).',
+      'Some jurisdictions do not allow certain limitations; in those cases, our liability is limited to the maximum extent permitted by law.',
+    ],
+  },
+  {
+    id: 'changes',
+    title: '10. Changes to these Terms',
+    paragraphs: [
+      'We may update these Terms from time to time. When we make material changes, we will post the updated Terms on this page and update the "Last updated" date. Continued use of the Service after changes become effective constitutes acceptance of the revised Terms.',
+    ],
+  },
+  {
+    id: 'contact',
+    title: '11. Contact',
+    paragraphs: [
+      `Questions about these Terms may be sent to ${LEGAL_CONTACT_EMAIL}.`,
+    ],
+  },
+]

--- a/lib/copy/status-page.ts
+++ b/lib/copy/status-page.ts
@@ -1,0 +1,49 @@
+import {
+  MAINNET_COMING_NOTE,
+  TESTNET_PRACTICE_NOTE,
+} from '@/lib/copy/network-status'
+
+export type StatusService = {
+  id: string
+  name: string
+  status: string
+  detail: string
+}
+
+export const statusIntro =
+  'Current platform scope for Quilltip. This page describes our testnet launch status—not a live uptime dashboard for mainnet production payments.'
+
+export const statusBanner = TESTNET_PRACTICE_NOTE
+
+export const statusServices: StatusService[] = [
+  {
+    id: 'website',
+    name: 'Quilltip website',
+    status: 'Operational',
+    detail: 'Beta on Vercel. Reading, publishing, and account features are available.',
+  },
+  {
+    id: 'backend',
+    name: 'Convex backend',
+    status: 'Operational',
+    detail: 'Real-time articles, tips, and user data on Convex Cloud.',
+  },
+  {
+    id: 'stellar',
+    name: 'Stellar testnet tipping',
+    status: 'Operational on testnet',
+    detail:
+      'Tips and withdrawals use test XLM only. Not connected to mainnet or real funds.',
+  },
+  {
+    id: 'arweave',
+    name: 'Arweave storage',
+    status: 'Operational',
+    detail: 'Published articles may be stored permanently on Arweave.',
+  },
+]
+
+export const statusNotes = [
+  MAINNET_COMING_NOTE,
+  'Stage: Beta. Network: Stellar Testnet. Tips have no real-world monetary value.',
+]

--- a/lib/copy/status-page.ts
+++ b/lib/copy/status-page.ts
@@ -20,7 +20,8 @@ export const statusServices: StatusService[] = [
     id: 'website',
     name: 'Quilltip website',
     status: 'Operational',
-    detail: 'Beta on Vercel. Reading, publishing, and account features are available.',
+    detail:
+      'Beta on Vercel. Reading, publishing, and account features are available.',
   },
   {
     id: 'backend',

--- a/lib/copy/support-page.ts
+++ b/lib/copy/support-page.ts
@@ -1,0 +1,56 @@
+import {
+  MAINNET_COMING_NOTE,
+  TESTNET_PRACTICE_NOTE,
+} from '@/lib/copy/network-status'
+
+export const SUPPORT_GITHUB_URL =
+  'https://github.com/pragya-shar/quilltip/issues'
+
+export type InfoSection = {
+  id: string
+  title: string
+  paragraphs: string[]
+}
+
+export const supportIntro =
+  'Help for using Quilltip on Stellar testnet. Tips use free test XLM for practice—not real money.'
+
+export const supportSections: InfoSection[] = [
+  {
+    id: 'scope',
+    title: 'What we support today',
+    paragraphs: [
+      TESTNET_PRACTICE_NOTE,
+      MAINNET_COMING_NOTE,
+      'On testnet, writers keep 97.5% of each practice tip and Quilltip retains 2.5% to cover platform operations. Testnet balances have no real-world monetary value.',
+    ],
+  },
+  {
+    id: 'wallet',
+    title: 'Wallet and tipping help',
+    paragraphs: [
+      'If you are new to Stellar wallets or testnet XLM, start with our step-by-step wallet guide. It covers connecting Freighter, xBull, Albedo, or hot wallet, funding with test XLM, and sending your first practice tip.',
+    ],
+  },
+  {
+    id: 'bugs',
+    title: 'Bug reports and feature requests',
+    paragraphs: [
+      'For technical issues, broken flows, or product feedback, open a GitHub issue. Include what you tried, what you expected, and any error messages or transaction IDs if relevant.',
+    ],
+  },
+  {
+    id: 'other',
+    title: 'Other questions',
+    paragraphs: [
+      'For legal, privacy, or account-related questions, use the contact page. Do not post security vulnerabilities in public issues—email security@quilltip.me instead.',
+    ],
+  },
+]
+
+export const supportResourceLinks = [
+  { label: 'Wallet Guide', href: '/guide' },
+  { label: 'FAQ on homepage', href: '/#faq' },
+  { label: 'GitHub Issues', href: SUPPORT_GITHUB_URL },
+  { label: 'Contact', href: '/contact' },
+]

--- a/lib/stellar/__tests__/nft-client.test.ts
+++ b/lib/stellar/__tests__/nft-client.test.ts
@@ -20,7 +20,9 @@ describe('NFTClient.buildMintTransaction', () => {
     vi.restoreAllMocks()
   })
 
-  it('produces a Soroban transaction with no memo', async () => {
+  it(
+    'produces a Soroban transaction with no memo',
+    async () => {
     const StellarSdk = await import('@stellar/stellar-sdk')
     const { NFTClient } = await import('@/lib/stellar/nft-client')
 
@@ -52,7 +54,9 @@ describe('NFTClient.buildMintTransaction', () => {
     ) as InstanceType<typeof StellarSdk.Transaction>
 
     expect(decoded.memo.type).toBe('none')
-  })
+  },
+    15_000
+  )
 })
 
 describe('NFTClient.submitMintTransaction', () => {

--- a/lib/stellar/__tests__/nft-client.test.ts
+++ b/lib/stellar/__tests__/nft-client.test.ts
@@ -20,9 +20,7 @@ describe('NFTClient.buildMintTransaction', () => {
     vi.restoreAllMocks()
   })
 
-  it(
-    'produces a Soroban transaction with no memo',
-    async () => {
+  it('produces a Soroban transaction with no memo', async () => {
     const StellarSdk = await import('@stellar/stellar-sdk')
     const { NFTClient } = await import('@/lib/stellar/nft-client')
 
@@ -54,9 +52,7 @@ describe('NFTClient.buildMintTransaction', () => {
     ) as InstanceType<typeof StellarSdk.Transaction>
 
     expect(decoded.memo.type).toBe('none')
-  },
-    15_000
-  )
+  }, 15_000)
 })
 
 describe('NFTClient.submitMintTransaction', () => {

--- a/lib/stellar/config.ts
+++ b/lib/stellar/config.ts
@@ -36,10 +36,7 @@ function validateStellarEnv() {
   }
 
   // Warn about missing optional vars in development only (avoid production console noise)
-  if (
-    typeof window !== 'undefined' &&
-    process.env.NODE_ENV !== 'production'
-  ) {
+  if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
     if (!env.NEXT_PUBLIC_TIPPING_CONTRACT_ID) {
       console.warn(
         '[Stellar Config] NEXT_PUBLIC_TIPPING_CONTRACT_ID is not set. Tipping will not work.'

--- a/lib/stellar/config.ts
+++ b/lib/stellar/config.ts
@@ -35,8 +35,11 @@ function validateStellarEnv() {
     }
   }
 
-  // Warn about missing optional vars that affect functionality
-  if (typeof window !== 'undefined') {
+  // Warn about missing optional vars in development only (avoid production console noise)
+  if (
+    typeof window !== 'undefined' &&
+    process.env.NODE_ENV !== 'production'
+  ) {
     if (!env.NEXT_PUBLIC_TIPPING_CONTRACT_ID) {
       console.warn(
         '[Stellar Config] NEXT_PUBLIC_TIPPING_CONTRACT_ID is not set. Tipping will not work.'

--- a/lib/stellar/wallet-adapter.ts
+++ b/lib/stellar/wallet-adapter.ts
@@ -12,20 +12,25 @@
  * - Better error messages for all wallet types
  */
 
-import {
-  StellarWalletsKit,
-  WalletNetwork,
-  allowAllModules,
+import type {
   ISupportedWallet,
+  WalletNetwork as WalletNetworkValue,
+} from '@creit.tech/stellar-wallets-kit'
+import { toast } from 'sonner'
+import { hasInstalledWalletForKitModal as supportedWalletsAllowKitModal } from '@/lib/stellar/wallet-availability'
+import { loadWalletKit } from '@/lib/stellar/wallet-kit-loader'
+import {
   FREIGHTER_ID,
   XBULL_ID,
   ALBEDO_ID,
   RABET_ID,
   HANA_ID,
   HOTWALLET_ID,
-} from '@creit.tech/stellar-wallets-kit'
-import { toast } from 'sonner'
-import { hasInstalledWalletForKitModal as supportedWalletsAllowKitModal } from '@/lib/stellar/wallet-availability'
+} from '@/lib/stellar/wallet-ids'
+
+type StellarWalletsKit = InstanceType<
+  Awaited<ReturnType<typeof loadWalletKit>>['StellarWalletsKit']
+>
 
 // Wallet type definitions
 export type WalletType =
@@ -200,8 +205,12 @@ class StellarWalletAdapter {
   /**
    * Create or recreate the wallet kit instance
    */
-  private createKit(network?: WalletNetwork): StellarWalletsKit {
-    const targetNetwork = network || this.getNetworkFromEnv()
+  private async createKit(
+    network?: WalletNetworkValue
+  ): Promise<StellarWalletsKit> {
+    const { StellarWalletsKit, allowAllModules, WalletNetwork } =
+      await loadWalletKit()
+    const targetNetwork = network ?? this.getNetworkFromEnv(WalletNetwork)
     const savedWalletId = this.getStoredWalletId()
 
     return new StellarWalletsKit({
@@ -214,7 +223,9 @@ class StellarWalletAdapter {
   /**
    * Get network from environment variable
    */
-  private getNetworkFromEnv(): WalletNetwork {
+  private getNetworkFromEnv(
+    WalletNetwork: Awaited<ReturnType<typeof loadWalletKit>>['WalletNetwork']
+  ): WalletNetworkValue {
     const envNetwork = process.env.NEXT_PUBLIC_STELLAR_NETWORK
     return envNetwork === 'PUBLIC'
       ? WalletNetwork.PUBLIC
@@ -250,13 +261,13 @@ class StellarWalletAdapter {
   /**
    * Ensure kit is initialized (client-side only)
    */
-  private ensureKit(): StellarWalletsKit {
+  private async ensureKit(): Promise<StellarWalletsKit> {
     if (typeof window === 'undefined') {
       throw new Error('Wallet adapter can only be used in the browser')
     }
 
     if (!this.kit) {
-      this.kit = this.createKit()
+      this.kit = await this.createKit()
     }
 
     return this.kit
@@ -264,7 +275,7 @@ class StellarWalletAdapter {
 
   private async hasInstalledWalletForKitModal(): Promise<boolean> {
     await this.initialize()
-    const kit = this.ensureKit()
+    const kit = await this.ensureKit()
     const supported = (await kit.getSupportedWallets()) as ISupportedWallet[]
     return supportedWalletsAllowKitModal(supported)
   }
@@ -277,7 +288,7 @@ class StellarWalletAdapter {
     if (this.isInitialized) return
 
     // Ensure kit exists
-    this.ensureKit()
+    await this.ensureKit()
 
     // Only restore the wallet ID from storage, don't trigger connection
     const storedWalletId = this.getStoredWalletId()
@@ -301,7 +312,7 @@ class StellarWalletAdapter {
    */
   async connect(): Promise<ConnectionResult> {
     await this.initialize()
-    const kit = this.ensureKit()
+    const kit = await this.ensureKit()
 
     const hasWallet = await this.hasInstalledWalletForKitModal()
     if (!hasWallet) {
@@ -408,7 +419,7 @@ class StellarWalletAdapter {
     walletId: string,
     maxRetries = 3
   ): Promise<void> {
-    const kit = this.ensureKit()
+    const kit = await this.ensureKit()
     const walletInfo = this.getWalletInfo(walletId)
 
     // For wallets requiring eager connection (xBull, Hot, Hana), reduce retries to avoid multiple popups
@@ -478,7 +489,7 @@ class StellarWalletAdapter {
    */
   async connectToWallet(walletId: string): Promise<ConnectionResult> {
     await this.initialize()
-    const kit = this.ensureKit()
+    const kit = await this.ensureKit()
 
     // Check cache first
     const cached = this.connectionCache.get(walletId)
@@ -596,7 +607,7 @@ class StellarWalletAdapter {
    */
   async getPublicKey(): Promise<string> {
     await this.initialize()
-    const kit = this.ensureKit()
+    const kit = await this.ensureKit()
 
     // Check cache first
     if (this.selectedWalletId) {
@@ -628,7 +639,7 @@ class StellarWalletAdapter {
    */
   async getNetwork(): Promise<{ network: string; networkPassphrase: string }> {
     await this.initialize()
-    const kit = this.ensureKit()
+    const kit = await this.ensureKit()
 
     // Check cache first
     if (this.selectedWalletId) {
@@ -687,7 +698,7 @@ class StellarWalletAdapter {
     networkPassphrase: string
   ): Promise<string> {
     await this.initialize()
-    const kit = this.ensureKit()
+    const kit = await this.ensureKit()
 
     if (!this.selectedWalletId) {
       throw new Error('No wallet connected')
@@ -751,12 +762,12 @@ class StellarWalletAdapter {
 
     let lastAddress: string | null = null
     let isActive = true
-    const kit = this.ensureKit()
 
     const poll = async () => {
       if (!isActive) return
 
       try {
+        const kit = await this.ensureKit()
         const { address } = await kit.getAddress()
         if (address !== lastAddress) {
           lastAddress = address
@@ -796,12 +807,12 @@ class StellarWalletAdapter {
 
     let lastNetwork: string | null = null
     let isActive = true
-    const kit = this.ensureKit()
 
     const poll = async () => {
       if (!isActive) return
 
       try {
+        const kit = await this.ensureKit()
         const network = await kit.getNetwork()
         if (network.network !== lastNetwork) {
           lastNetwork = network.network
@@ -830,7 +841,7 @@ class StellarWalletAdapter {
    */
   async refresh(): Promise<void> {
     await this.initialize()
-    const kit = this.ensureKit()
+    const kit = await this.ensureKit()
 
     if (this.selectedWalletId) {
       try {
@@ -847,7 +858,7 @@ class StellarWalletAdapter {
 // Export singleton instance
 export const walletAdapter = new StellarWalletAdapter()
 
-// Export wallet IDs for direct reference
+// Re-export wallet IDs for direct reference
 export {
   FREIGHTER_ID,
   XBULL_ID,
@@ -855,5 +866,4 @@ export {
   RABET_ID,
   HANA_ID,
   HOTWALLET_ID,
-  WalletNetwork,
-}
+} from '@/lib/stellar/wallet-ids'

--- a/lib/stellar/wallet-ids.ts
+++ b/lib/stellar/wallet-ids.ts
@@ -1,0 +1,7 @@
+/** Wallet product IDs from @creit.tech/stellar-wallets-kit (stable string constants). */
+export const FREIGHTER_ID = 'freighter'
+export const XBULL_ID = 'xbull'
+export const ALBEDO_ID = 'albedo'
+export const RABET_ID = 'rabet'
+export const HANA_ID = 'hana'
+export const HOTWALLET_ID = 'hot-wallet'

--- a/lib/stellar/wallet-kit-loader.test.ts
+++ b/lib/stellar/wallet-kit-loader.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@ngneat/elf', () => ({
+  enableElfProdMode: vi.fn(),
+}))
+
+vi.mock('@creit.tech/stellar-wallets-kit', () => ({
+  StellarWalletsKit: class StellarWalletsKit {},
+  allowAllModules: vi.fn(),
+  WalletNetwork: { TESTNET: 'TESTNET' },
+}))
+
+describe('loadWalletKit', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+    const { enableElfProdMode } = await import('@ngneat/elf')
+    vi.mocked(enableElfProdMode).mockClear()
+  })
+
+  it('calls enableElfProdMode before importing wallet kit in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const { enableElfProdMode } = await import('@ngneat/elf')
+    const { loadWalletKit } = await import('@/lib/stellar/wallet-kit-loader')
+
+    await loadWalletKit()
+
+    expect(enableElfProdMode).toHaveBeenCalledOnce()
+  })
+
+  it('does not call enableElfProdMode outside production', async () => {
+    vi.stubEnv('NODE_ENV', 'test')
+    const { enableElfProdMode } = await import('@ngneat/elf')
+    const { loadWalletKit } = await import('@/lib/stellar/wallet-kit-loader')
+
+    await loadWalletKit()
+
+    expect(enableElfProdMode).not.toHaveBeenCalled()
+  })
+})

--- a/lib/stellar/wallet-kit-loader.ts
+++ b/lib/stellar/wallet-kit-loader.ts
@@ -1,0 +1,17 @@
+type WalletKitModule = typeof import('@creit.tech/stellar-wallets-kit')
+
+let walletKitModule: WalletKitModule | null = null
+let walletKitLoadPromise: Promise<WalletKitModule> | null = null
+
+export async function loadWalletKit(): Promise<WalletKitModule> {
+  if (walletKitModule) return walletKitModule
+  if (!walletKitLoadPromise) {
+    walletKitLoadPromise = import('@creit.tech/stellar-wallets-kit').then(
+      (mod) => {
+        walletKitModule = mod
+        return mod
+      }
+    )
+  }
+  return walletKitLoadPromise
+}

--- a/lib/stellar/wallet-kit-loader.ts
+++ b/lib/stellar/wallet-kit-loader.ts
@@ -3,15 +3,21 @@ type WalletKitModule = typeof import('@creit.tech/stellar-wallets-kit')
 let walletKitModule: WalletKitModule | null = null
 let walletKitLoadPromise: Promise<WalletKitModule> | null = null
 
+async function ensureElfProductionMode(): Promise<void> {
+  if (process.env.NODE_ENV !== 'production') return
+  const { enableElfProdMode } = await import('@ngneat/elf')
+  enableElfProdMode()
+}
+
 export async function loadWalletKit(): Promise<WalletKitModule> {
   if (walletKitModule) return walletKitModule
   if (!walletKitLoadPromise) {
-    walletKitLoadPromise = import('@creit.tech/stellar-wallets-kit').then(
-      (mod) => {
-        walletKitModule = mod
-        return mod
-      }
-    )
+    walletKitLoadPromise = (async () => {
+      await ensureElfProductionMode()
+      const mod = await import('@creit.tech/stellar-wallets-kit')
+      walletKitModule = mod
+      return mod
+    })()
   }
   return walletKitLoadPromise
 }

--- a/lib/stubs/elf-devtools.ts
+++ b/lib/stubs/elf-devtools.ts
@@ -1,0 +1,4 @@
+/** Production stub: wallet kit pulls @ngneat/elf-devtools but must not ship devtools in the client bundle. */
+export function devTools(): void {
+  // no-op
+}

--- a/lib/tiptap/readExtensions.ts
+++ b/lib/tiptap/readExtensions.ts
@@ -1,0 +1,47 @@
+import { Node, mergeAttributes } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import Underline from '@tiptap/extension-underline'
+import Link from '@tiptap/extension-link'
+import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
+import { lowlight } from '@/lib/lowlight'
+
+/** Read-only image node matching editor `resizableImage` output (no React node view). */
+const ReadOnlyResizableImage = Node.create({
+  name: 'resizableImage',
+  group: 'block',
+  draggable: false,
+  addAttributes() {
+    return {
+      src: { default: null },
+      alt: { default: null },
+      title: { default: null },
+      width: { default: null },
+      height: { default: null },
+    }
+  },
+  parseHTML() {
+    return [{ tag: 'img[src]:not([src^="data:"])' }]
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['img', mergeAttributes(HTMLAttributes)]
+  },
+})
+
+export function getReadOnlyExtensions() {
+  return [
+    StarterKit.configure({
+      codeBlock: false,
+      link: false,
+      underline: false,
+    }),
+    Underline,
+    Link.configure({
+      openOnClick: true,
+      HTMLAttributes: { rel: 'noopener noreferrer', target: '_blank' },
+    }),
+    CodeBlockLowlight.configure({
+      lowlight,
+    }),
+    ReadOnlyResizableImage,
+  ]
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,11 @@ const withBundleAnalyzer = bundleAnalyzer({
 })
 
 const nextConfig: NextConfig = {
+  turbopack: {
+    resolveAlias: {
+      '@ngneat/elf-devtools': './lib/stubs/elf-devtools.ts',
+    },
+  },
   images: {
     ...(process.env.NODE_ENV === 'development' && {
       dangerouslyAllowLocalIP: true,

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:once": "vitest run",
+    "test:e2e:eng-224": "playwright test e2e/eng-224-console.spec.ts",
+    "eng-224:console-baseline": "node scripts/eng-224-console-baseline.mjs",
     "test:debug": "vitest --inspect-brk --no-file-parallelism",
     "test:coverage": "vitest run --coverage --coverage.reporter=text"
   },

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@tiptap/extension-text-align": "^3.20.0",
     "@tiptap/extension-underline": "^3.20.0",
     "@tiptap/extension-youtube": "^3.20.0",
+    "@tiptap/html": "^3.20.0",
     "@tiptap/pm": "^3.20.0",
     "@tiptap/react": "^3.20.0",
     "@tiptap/starter-kit": "^3.20.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:3100'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'list',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/scripts/eng-224-console-baseline.mjs
+++ b/scripts/eng-224-console-baseline.mjs
@@ -54,7 +54,11 @@ async function main() {
   const href = await articleLink.getAttribute('href').catch(() => null)
   await articlesProbe.close()
 
-  if (href && href.startsWith('/') && href.split('/').filter(Boolean).length >= 2) {
+  if (
+    href &&
+    href.startsWith('/') &&
+    href.split('/').filter(Boolean).length >= 2
+  ) {
     articlePath = href
   }
 
@@ -101,7 +105,10 @@ async function main() {
 
   const anyDev = summary.some((s) => s.devMatches.length > 0)
   md += anyDev
-    ? `**Development-related console messages found** on ${summary.filter((s) => s.devMatches.length > 0).map((s) => s.name).join(', ')}.\n\n`
+    ? `**Development-related console messages found** on ${summary
+        .filter((s) => s.devMatches.length > 0)
+        .map((s) => s.name)
+        .join(', ')}.\n\n`
     : `**No messages matching "development" / "dev mode" / "development build"** in automated capture. Check manually in DevTools — filter Console by \`development\`.\n\n`
 
   for (const s of summary) {
@@ -151,11 +158,20 @@ async function main() {
   )
   writeFileSync(desktopPath, md, 'utf8')
   console.log(`Wrote ${desktopPath}`)
-  console.log(JSON.stringify({ anyDev, pages: summary.map((s) => ({
-    name: s.name,
-    devMatches: s.devMatches.length,
-    warnings: s.warnings.length,
-  })) }, null, 2))
+  console.log(
+    JSON.stringify(
+      {
+        anyDev,
+        pages: summary.map((s) => ({
+          name: s.name,
+          devMatches: s.devMatches.length,
+          warnings: s.warnings.length,
+        })),
+      },
+      null,
+      2
+    )
+  )
 }
 
 main().catch((err) => {

--- a/scripts/eng-224-console-baseline.mjs
+++ b/scripts/eng-224-console-baseline.mjs
@@ -1,0 +1,164 @@
+import { chromium } from '@playwright/test'
+import { writeFileSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+
+const BASE = process.env.BASE_URL || 'http://localhost:3100'
+const PAGES = [
+  { name: 'home', path: '/' },
+  { name: 'articles', path: '/articles' },
+  { name: 'guide', path: '/guide' },
+]
+
+function formatEntry(entry) {
+  return `[${entry.type}] ${entry.text}`
+}
+
+async function main() {
+  const browser = await chromium.launch()
+  const context = await browser.newContext()
+  const results = []
+  let articlePath = null
+
+  for (const pageDef of PAGES) {
+    const page = await context.newPage()
+    const entries = []
+    page.on('console', (msg) => {
+      entries.push({
+        type: msg.type(),
+        text: msg.text(),
+      })
+    })
+
+    await page.goto(`${BASE}${pageDef.path}`, {
+      waitUntil: 'networkidle',
+      timeout: 60_000,
+    })
+    await page.waitForTimeout(2000)
+
+    results.push({
+      name: pageDef.name,
+      path: pageDef.path,
+      url: page.url(),
+      entries,
+    })
+    await page.close()
+  }
+
+  const articlesProbe = await context.newPage()
+  await articlesProbe.goto(`${BASE}/articles`, {
+    waitUntil: 'networkidle',
+    timeout: 60_000,
+  })
+  const articleLink = articlesProbe.locator('main a[href^="/"]').nth(1)
+  const href = await articleLink.getAttribute('href').catch(() => null)
+  await articlesProbe.close()
+
+  if (href && href.startsWith('/') && href.split('/').filter(Boolean).length >= 2) {
+    articlePath = href
+  }
+
+  if (articlePath) {
+    const page = await context.newPage()
+    const entries = []
+    page.on('console', (msg) => {
+      entries.push({ type: msg.type(), text: msg.text() })
+    })
+    await page.goto(`${BASE}${articlePath}`, {
+      waitUntil: 'networkidle',
+      timeout: 60_000,
+    })
+    await page.waitForTimeout(2000)
+    results.push({
+      name: 'article_detail',
+      path: articlePath,
+      url: page.url(),
+      entries,
+    })
+    await page.close()
+  }
+
+  await browser.close()
+
+  const devPattern = /development|dev mode|devtools|development build/i
+  const summary = results.map((r) => {
+    const devMatches = r.entries.filter((e) => devPattern.test(e.text))
+    const warnings = r.entries.filter((e) => e.type === 'warning')
+    const errors = r.entries.filter((e) => e.type === 'error')
+    return { ...r, devMatches, warnings, errors }
+  })
+
+  const branch = process.env.GIT_BRANCH || 'unknown'
+  const date = new Date().toISOString()
+
+  const label = process.env.ENG224_BASELINE_LABEL || 'BEFORE'
+  let md = `# ENG-224 Console Baseline (${label})\n\n`
+  md += `- **Captured:** ${date}\n`
+  md += `- **Branch:** ${branch}\n`
+  md += `- **Build:** production (\`bun run build\` + \`bun run start\`)\n`
+  md += `- **Base URL:** ${BASE}\n\n`
+  md += `## Summary\n\n`
+
+  const anyDev = summary.some((s) => s.devMatches.length > 0)
+  md += anyDev
+    ? `**Development-related console messages found** on ${summary.filter((s) => s.devMatches.length > 0).map((s) => s.name).join(', ')}.\n\n`
+    : `**No messages matching "development" / "dev mode" / "development build"** in automated capture. Check manually in DevTools — filter Console by \`development\`.\n\n`
+
+  for (const s of summary) {
+    md += `### ${s.name} (\`${s.path}\`)\n\n`
+    md += `- URL: ${s.url}\n`
+    md += `- Total console messages: ${s.entries.length}\n`
+    md += `- Warnings: ${s.warnings.length}\n`
+    md += `- Errors: ${s.errors.length}\n`
+    md += `- Development-pattern matches: ${s.devMatches.length}\n\n`
+
+    if (s.devMatches.length > 0) {
+      md += `**Matches (ENG-224 target):**\n\n`
+      for (const m of s.devMatches) {
+        md += `- ${formatEntry(m)}\n`
+      }
+      md += `\n`
+    }
+
+    if (s.warnings.length > 0 && s.warnings.length <= 15) {
+      md += `**All warnings:**\n\n`
+      for (const w of s.warnings) {
+        md += `- ${formatEntry(w)}\n`
+      }
+      md += `\n`
+    } else if (s.warnings.length > 15) {
+      md += `**First 10 warnings:**\n\n`
+      for (const w of s.warnings.slice(0, 10)) {
+        md += `- ${formatEntry(w)}\n`
+      }
+      md += `\n_(+ ${s.warnings.length - 10} more warnings)_\n\n`
+    }
+  }
+
+  md += `## Manual check (recommended)\n\n`
+  md += `1. Run \`bun run build && PORT=3100 bun run start\`\n`
+  md += `2. Open each page in Chrome → DevTools → Console\n`
+  md += `3. Filter: \`development\`\n`
+  md += `4. Copy exact warning text into "After" doc for comparison\n\n`
+  md += `## After fix\n\n`
+  md += `Re-run the same steps and save as \`ENG-224-console-baseline-AFTER.md\` on Desktop.\n`
+  md += `Pass = development-mode warning gone on: home, articles, guide, article detail.\n`
+
+  const desktopPath = join(
+    homedir(),
+    'Desktop',
+    `ENG-224-console-baseline-${label}.md`
+  )
+  writeFileSync(desktopPath, md, 'utf8')
+  console.log(`Wrote ${desktopPath}`)
+  console.log(JSON.stringify({ anyDev, pages: summary.map((s) => ({
+    name: s.name,
+    devMatches: s.devMatches.length,
+    warnings: s.warnings.length,
+  })) }, null, 2))
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
           include: ['convex/**/*.test.ts'],
           exclude: ['node_modules', 'convex/_generated'],
           environment: 'edge-runtime',
+          // Scheduled-function tests share fake DB state; run files one at a time.
+          fileParallelism: false,
         },
       },
       {


### PR DESCRIPTION
## Summary

Improves trust, navigation, compliance, failure UX, dark mode consistency, and initial load performance across the app.

## What changed

### Trust and landing performance
- Lazy-loads below-the-fold landing content (`LandingBelowFold`) so hero and nav render first; includes Features, How It Works, **Trust and permanence** (`TrustSection`), FAQ, and landing footer.
- Splits article reading into lighter chunks with `ArticleReadOnlyBody`, `ArticleBodySkeleton`, and `ArticleEngagementSkeleton` for clearer loading states on article pages.

### Site footer and info pages
- Adds shared `SiteFooter` and grouped `FooterNav` (Legal, Support, Contact, Status) wired through centralized copy in `lib/copy/footer-links.ts`.
- Rolls footer out across app surfaces (articles, profiles, guide, auth layout, etc.) with landing vs default variants.
- Adds info routes: `/terms`, `/privacy`, `/support`, `/contact`, `/status` using `InfoPageLayout` / `LegalPageLayout` and copy modules under `lib/copy/`.

### Legal links
- Adds reusable `LegalLinks` (inline and stacked variants) on Privacy/Terms pages and in footers.
- Full Terms of Service and Privacy Policy content lives in `lib/copy/legal-terms.ts` and `lib/copy/legal-privacy.ts`.

### Error and 404 UX
- Introduces `FailurePageShell` as the shared layout for `app/error.tsx` and `app/not-found.tsx`.
- Aligns illustrations and actions (Try again, Go Home, Browse articles) with semantic tokens and card styling.

### Dark mode
- Updates wallet, tipping, NFT, highlights, onboarding, and share UI to use semantic color tokens (`background`, `foreground`, `muted-foreground`, `card`, etc.) for consistent dark mode contrast.

### Wallet and bundle performance
- Defers Stellar wallet kit load via `wallet-kit-loader.ts` and `WalletActivationContext` so the kit loads only after the user engages wallet UI.
- Dynamic-imports heavy client modules (landing below-fold, tipping, NFT mint, article engagement) to reduce first-load JavaScript.

### Regression guardrails (ENG-224)
- Playwright spec `e2e/eng-224-console.spec.ts` and baseline script `scripts/eng-224-console-baseline.mjs` to catch dev-only console noise on public routes.
- Extends `e2e/home-visual.spec.ts` for landing visual checks.

