### PR TITLE
feat: show sign-in prompt when signed-out users try to highlight (ENG-183)

### DIFF
--- a/components/articles/ArticleDisplay.tsx
+++ b/components/articles/ArticleDisplay.tsx
@@ -7,7 +7,6 @@ import Image from 'next/image'
 import { UserAvatar } from '@/components/ui/user-avatar'
 import ShareButtons from './ShareButtons'
 import { HighlightableArticle } from '@/components/articles/HighlightableArticle'
-import { useAuth } from '@/components/providers/AuthContext'
 import type { Id } from '@/types/convex'
 import type { ArticleForDisplay } from '@/types/index'
 import { TagFilterLink } from '@/components/articles/TagFilterLink'
@@ -30,13 +29,10 @@ export default function ArticleDisplay({
   tocHeadings = [],
 }: ArticleDisplayProps) {
   const [currentUrl, setCurrentUrl] = useState('')
-  const { isAuthenticated } = useAuth()
 
   useEffect(() => {
     setCurrentUrl(window.location.href)
   }, [])
-
-  const effectiveShowHighlights = showHighlights && isAuthenticated
 
   const publishedDate = article.publishedAt
     ? formatDistanceToNow(new Date(article.publishedAt), { addSuffix: true })
@@ -116,7 +112,7 @@ export default function ArticleDisplay({
           articleId={article.id as Id<'articles'>}
           content={article.content ?? EMPTY_DOC}
           editable={false}
-          showHighlights={effectiveShowHighlights}
+          showHighlights={showHighlights}
           tocHeadings={tocHeadings}
         />
       </div>

--- a/components/articles/HighlightableArticle.tsx
+++ b/components/articles/HighlightableArticle.tsx
@@ -16,6 +16,7 @@ import { api } from '@/convex/_generated/api'
 import { useArticleById, useArticleHighlightsQuery } from '@/hooks/convex'
 import type { Id } from '@/types/convex'
 import { HighlightPopover } from '@/components/highlights/HighlightPopover'
+import { HighlightSignInPrompt } from '@/components/highlights/HighlightSignInPrompt'
 import { HighlightDetailsPanel } from '@/components/highlights/HighlightDetailsPanel'
 import { cn } from '@/lib/utils'
 import { AnimatePresence } from 'motion/react'
@@ -87,6 +88,13 @@ export function HighlightableArticle({
     highlight: HighlightData
     position: { top: number; left: number }
   } | null>(null)
+  const [signInPromptPosition, setSignInPromptPosition] = useState<{
+    top: number
+    left: number
+  } | null>(null)
+  const [signInPreviewText, setSignInPreviewText] = useState<string | null>(
+    null
+  )
   const editorRef = useRef<HTMLDivElement>(null)
   const isApplyingHighlightsRef = useRef(false)
   // During a drag, onSelectionUpdate fires on every move; if we mount the
@@ -94,12 +102,14 @@ export function HighlightableArticle({
   // the article body and the native selection collapses. Defer popover to pointerup.
   const isDraggingRef = useRef(false)
 
-  const { user } = useAuth()
+  const { user, isAuthenticated } = useAuth()
+  const highlightsActive = showHighlights && isAuthenticated
+  const signInPromptActive = showHighlights && !isAuthenticated
 
   useEnsureHeadingIds(tocHeadings, { rootSelector: '.highlightable-article' })
   const article = useArticleById(articleId)
 
-  const highlights = useArticleHighlightsQuery(articleId, showHighlights)
+  const highlights = useArticleHighlightsQuery(articleId, highlightsActive)
 
   const highlightsRef = useRef(highlights)
   useEffect(() => {
@@ -127,7 +137,7 @@ export function HighlightableArticle({
         }),
         ResizableImage,
         ...(editable ? [EditorKeymap] : []),
-        ...(showHighlights
+        ...(highlightsActive
           ? [
               HighlightExtension.configure({
                 multicolor: true,
@@ -198,24 +208,45 @@ export function HighlightableArticle({
           const domSelection = window.getSelection()
           if (domSelection && domSelection.rangeCount > 0) {
             const range = domSelection.getRangeAt(0)
-            const rect = range.getBoundingClientRect()
-            const containerRect = editorRef.current?.getBoundingClientRect()
 
-            setSelectedText({ text, from, to })
-            if (containerRect) {
-              setPopoverPosition({
-                top: rect.top - containerRect.top - 60,
-                left: rect.left - containerRect.left + rect.width / 2,
-              })
+            if (signInPromptActive) {
+              const anchor = getRangeTopCenterAnchor(range)
+              if (anchor) {
+                setSignInPreviewText(text)
+                setSignInPromptPosition(anchor)
+              }
+              setSelectedText(null)
+              setPopoverPosition(null)
+            } else if (highlightsActive) {
+              const rect = range.getBoundingClientRect()
+              const containerRect = editorRef.current?.getBoundingClientRect()
+
+              setSelectedText({ text, from, to })
+              if (containerRect) {
+                setPopoverPosition({
+                  top: rect.top - containerRect.top - 60,
+                  left: rect.left - containerRect.left + rect.width / 2,
+                })
+              }
+              setSignInPreviewText(null)
+              setSignInPromptPosition(null)
             }
           }
         } else {
           setSelectedText(null)
           setPopoverPosition(null)
+          setSignInPreviewText(null)
+          setSignInPromptPosition(null)
         }
       },
     },
-    [showHighlights, editable, articleId]
+    [
+      showHighlights,
+      highlightsActive,
+      signInPromptActive,
+      editable,
+      articleId,
+    ]
   )
 
   useEffect(() => {
@@ -223,10 +254,20 @@ export function HighlightableArticle({
       setSelectedText(null)
       setPopoverPosition(null)
       setHighlightTooltip(null)
+      setSignInPreviewText(null)
+      setSignInPromptPosition(null)
     }
   }, [showHighlights])
+
   useEffect(() => {
-    if (!editor || !highlights || !showHighlights) return
+    if (isAuthenticated) {
+      setSignInPreviewText(null)
+      setSignInPromptPosition(null)
+    }
+  }, [isAuthenticated])
+
+  useEffect(() => {
+    if (!editor || !highlights || !highlightsActive) return
 
     // Suppress popover during programmatic highlight application
     isApplyingHighlightsRef.current = true
@@ -235,9 +276,9 @@ export function HighlightableArticle({
     requestAnimationFrame(() => {
       isApplyingHighlightsRef.current = false
     })
-  }, [editor, highlights, showHighlights])
+  }, [editor, highlights, highlightsActive])
 
-  // Show the highlight popover only after the user releases a drag-select.
+  // Show overlay only after the user releases a drag-select.
   useEffect(() => {
     const container = editorRef.current
     if (!container || editable || !showHighlights) return
@@ -248,8 +289,14 @@ export function HighlightableArticle({
           isDraggingRef.current = true
           setSelectedText(null)
           setPopoverPosition(null)
+          setSignInPreviewText(null)
+          setSignInPromptPosition(null)
         },
         closeDetailsPanel: () => setHighlightTooltip(null),
+        closeSignInPrompt: () => {
+          setSignInPreviewText(null)
+          setSignInPromptPosition(null)
+        },
       })
     }
 
@@ -267,13 +314,18 @@ export function HighlightableArticle({
         const range = domSelection.getRangeAt(0)
         const anchor = getRangeTopCenterAnchor(range)
         if (!anchor) return
-        setSelectedText({ text, from, to })
-        setPopoverPosition({
-          // Viewport coordinates (HighlightPopover is `position: fixed`).
-          // Anchor at top-center of the selection bounding box.
-          top: anchor.top,
-          left: anchor.left,
-        })
+
+        if (signInPromptActive) {
+          setSignInPreviewText(text)
+          setSignInPromptPosition(anchor)
+          setSelectedText(null)
+          setPopoverPosition(null)
+        } else if (highlightsActive) {
+          setSelectedText({ text, from, to })
+          setPopoverPosition(anchor)
+          setSignInPreviewText(null)
+          setSignInPromptPosition(null)
+        }
       })
     }
 
@@ -290,7 +342,7 @@ export function HighlightableArticle({
       document.removeEventListener('mouseup', handlePointerUp)
       document.removeEventListener('touchend', handlePointerUp)
     }
-  }, [editor, editable, showHighlights])
+  }, [editor, editable, showHighlights, highlightsActive, signInPromptActive])
 
   const handleCreateHighlight = useCallback(
     async (color: string, note?: string, isPublic: boolean = true) => {
@@ -348,6 +400,19 @@ export function HighlightableArticle({
     editor?.commands.focus()
   }, [editor])
 
+  const handleSignInPromptClose = useCallback(() => {
+    if (editor) {
+      const { from, to } = editor.state.selection
+      if (from !== to) {
+        editor.chain().setTextSelection(from).run()
+      }
+    }
+    setSignInPreviewText(null)
+    setSignInPromptPosition(null)
+    window.getSelection()?.removeAllRanges()
+    editor?.commands.focus()
+  }, [editor])
+
   return (
     <div
       className={cn('highlightable-article relative', className)}
@@ -356,7 +421,10 @@ export function HighlightableArticle({
       <EditorContent editor={editor} />
 
       <AnimatePresence>
-        {popoverPosition && selectedText && article && (
+        {highlightsActive &&
+          popoverPosition &&
+          selectedText &&
+          article && (
           <HighlightPopover
             position={popoverPosition}
             onCreateHighlight={handleCreateHighlight}
@@ -368,6 +436,16 @@ export function HighlightableArticle({
             authorStellarAddress={article.author?.stellarAddress}
             startOffset={selectedText.from}
             endOffset={selectedText.to}
+          />
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {signInPromptActive && signInPromptPosition && signInPreviewText && (
+          <HighlightSignInPrompt
+            position={signInPromptPosition}
+            selectedText={signInPreviewText}
+            onClose={handleSignInPromptClose}
           />
         )}
       </AnimatePresence>

--- a/components/articles/HighlightableArticle.tsx
+++ b/components/articles/HighlightableArticle.tsx
@@ -240,13 +240,7 @@ export function HighlightableArticle({
         }
       },
     },
-    [
-      showHighlights,
-      highlightsActive,
-      signInPromptActive,
-      editable,
-      articleId,
-    ]
+    [showHighlights, highlightsActive, signInPromptActive, editable, articleId]
   )
 
   useEffect(() => {
@@ -421,10 +415,7 @@ export function HighlightableArticle({
       <EditorContent editor={editor} />
 
       <AnimatePresence>
-        {highlightsActive &&
-          popoverPosition &&
-          selectedText &&
-          article && (
+        {highlightsActive && popoverPosition && selectedText && article && (
           <HighlightPopover
             position={popoverPosition}
             onCreateHighlight={handleCreateHighlight}

--- a/components/highlights/HighlightSignInPrompt.test.tsx
+++ b/components/highlights/HighlightSignInPrompt.test.tsx
@@ -1,0 +1,99 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { HighlightSignInPrompt } from '@/components/highlights/HighlightSignInPrompt'
+
+describe('HighlightSignInPrompt', () => {
+  it('calls onClose when Escape is pressed', () => {
+    const onClose = vi.fn()
+    render(
+      <HighlightSignInPrompt
+        position={{ top: 0, left: 0 }}
+        selectedText="Enough text for the preview area"
+        onClose={onClose}
+      />
+    )
+
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('removes the Escape listener on unmount', () => {
+    const onClose = vi.fn()
+    const { unmount } = render(
+      <HighlightSignInPrompt
+        position={{ top: 0, left: 0 }}
+        selectedText="Enough text for the preview area"
+        onClose={onClose}
+      />
+    )
+
+    unmount()
+
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('calls onClose when Not now is clicked', () => {
+    const onClose = vi.fn()
+    render(
+      <HighlightSignInPrompt
+        position={{ top: 0, left: 0 }}
+        selectedText="Enough text for the preview area"
+        onClose={onClose}
+      />
+    )
+
+    screen.getByRole('button', { name: 'Not now' }).click()
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('links Sign in to /login and register to /register', () => {
+    render(
+      <HighlightSignInPrompt
+        position={{ top: 0, left: 0 }}
+        selectedText="Enough text for the preview area"
+        onClose={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('link', { name: 'Sign in' })).toHaveAttribute(
+      'href',
+      '/login'
+    )
+    expect(
+      screen.getByRole('link', { name: 'Create a free account' })
+    ).toHaveAttribute('href', '/register')
+  })
+
+  it('exposes dialog semantics for assistive tech', () => {
+    render(
+      <HighlightSignInPrompt
+        position={{ top: 0, left: 0 }}
+        selectedText="Enough text for the preview area"
+        onClose={vi.fn()}
+      />
+    )
+
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(dialog).toHaveAttribute('aria-labelledby')
+    expect(dialog).toHaveAttribute('aria-describedby')
+  })
+})

--- a/components/highlights/HighlightSignInPrompt.tsx
+++ b/components/highlights/HighlightSignInPrompt.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { useEffect, useId, useRef } from 'react'
+import Link from 'next/link'
+import { FocusScope } from '@radix-ui/react-focus-scope'
+import { Highlighter } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useClampedFixedPosition } from '@/hooks/useClampedFixedPosition'
+
+interface HighlightSignInPromptProps {
+  position: { top: number; left: number }
+  selectedText: string
+  onClose: () => void
+}
+
+export function HighlightSignInPrompt({
+  position,
+  selectedText,
+  onClose,
+}: HighlightSignInPromptProps) {
+  const titleId = useId()
+  const descriptionId = useId()
+  const promptRef = useRef<HTMLDivElement>(null)
+  const clampedPosition = useClampedFixedPosition(position, promptRef, {
+    fallbackWidth: 320,
+    fallbackHeight: 220,
+  })
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      e.preventDefault()
+      e.stopPropagation()
+      onClose()
+    }
+    document.addEventListener('keydown', onKeyDown, true)
+    return () => document.removeEventListener('keydown', onKeyDown, true)
+  }, [onClose])
+
+  useEffect(() => {
+    promptRef.current?.focus()
+  }, [])
+
+  const preview =
+    selectedText.length > 150
+      ? `${selectedText.slice(0, 150)}...`
+      : selectedText
+
+  return (
+    <FocusScope trapped loop>
+      <div
+        ref={promptRef}
+        className="highlight-popover fixed z-50 w-[320px] max-w-[calc(100vw-24px)] rounded-2xl border border-border bg-background p-4 shadow-lg outline-none"
+        style={{
+          top: clampedPosition.top,
+          left: clampedPosition.left,
+        }}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
+      >
+        <div className="mb-3 flex items-start gap-2">
+          <Highlighter
+            className="mt-0.5 h-5 w-5 shrink-0 text-brand-blue"
+            aria-hidden
+          />
+          <div>
+            <h2 id={titleId} className="text-sm font-semibold text-foreground">
+              Sign in to save highlights
+            </h2>
+            <p
+              id={descriptionId}
+              className="mt-1 text-sm text-muted-foreground"
+            >
+              Save passages you care about with personal highlights and notes.
+              They stay on your account and show up in the article sidebar.
+            </p>
+          </div>
+        </div>
+
+        <div className="highlight-text-preview mb-4 text-sm">
+          &ldquo;{preview}&rdquo;
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Button asChild className="w-full">
+            <Link href="/login">Sign in</Link>
+          </Button>
+          <p className="text-center text-xs text-muted-foreground">
+            New here?{' '}
+            <Link
+              href="/register"
+              className="font-medium text-brand-blue hover:text-brand-accent transition-colors"
+            >
+              Create a free account
+            </Link>
+          </p>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-full py-1 text-center text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Not now
+          </button>
+        </div>
+      </div>
+    </FocusScope>
+  )
+}

--- a/lib/highlights/articleOverlayPointerDismiss.test.ts
+++ b/lib/highlights/articleOverlayPointerDismiss.test.ts
@@ -20,6 +20,22 @@ describe('handleArticleHighlightOverlayPointerDown', () => {
     expect(closeDetailsPanel).toHaveBeenCalledTimes(1)
   })
 
+  it('calls closeSignInPrompt when provided', () => {
+    document.body.innerHTML = `<p id="article-text">plain article text</p>`
+    const closeSignInPrompt = vi.fn()
+
+    handleArticleHighlightOverlayPointerDown(
+      document.getElementById('article-text'),
+      {
+        closeCreatePopover: vi.fn(),
+        closeDetailsPanel: vi.fn(),
+        closeSignInPrompt,
+      }
+    )
+
+    expect(closeSignInPrompt).toHaveBeenCalledTimes(1)
+  })
+
   it('does not dismiss when pressing inside an open dialog', () => {
     document.body.innerHTML = `
       <p id="article-text">plain article text</p>

--- a/lib/highlights/articleOverlayPointerDismiss.ts
+++ b/lib/highlights/articleOverlayPointerDismiss.ts
@@ -1,6 +1,7 @@
 export type ArticleOverlayDismissActions = {
   closeCreatePopover: () => void
   closeDetailsPanel: () => void
+  closeSignInPrompt?: () => void
 }
 
 /**
@@ -14,4 +15,5 @@ export function handleArticleHighlightOverlayPointerDown(
   if ((target as HTMLElement | null)?.closest('[role="dialog"]')) return
   actions.closeCreatePopover()
   actions.closeDetailsPanel()
+  actions.closeSignInPrompt?.()
 }


### PR DESCRIPTION
## Summary

Signed-out readers could select article text but got no feedback that saving highlights requires sign-in. This adds an accessible, dismissible prompt with a value explanation and sign-in CTA when they select 3+ characters. Signed-in highlight behavior is unchanged.

## Changes

- Remove auth gate on `showHighlights` in `ArticleDisplay`; handle auth in `HighlightableArticle`
- Split signed-out (`HighlightSignInPrompt`) vs signed-in (`HighlightPopover`) selection flows
- Add `HighlightSignInPrompt` with sign-in/register links, Escape, Not now, and outside-click dismiss
- Extend overlay pointer dismiss to close the sign-in prompt

<img width="1225" height="722" alt="1" src="https://github.com/user-attachments/assets/b50af674-22f8-4701-8ad6-775cbf579e63" />
