### PR TITLE
feat(footer): add trust and support links on public pages (ENG-215)

### DIFF
--- a/components/landing/useLandingHashScroll.ts
+++ b/components/landing/useLandingHashScroll.ts
@@ -3,25 +3,67 @@
 import { useEffect } from 'react'
 import { scrollToLandingSection } from '@/lib/landing/scroll-to-section'
 
+const SECTION_WAIT_TIMEOUT_MS = 3000
+
+function scrollWhenAvailable(hash: string, timeoutMs = SECTION_WAIT_TIMEOUT_MS) {
+  const normalized = hash.startsWith('#') ? hash : `#${hash}`
+
+  if (document.querySelector(normalized)) {
+    scrollToLandingSection(normalized)
+    return () => {}
+  }
+
+  let settled = false
+  let timeoutId: ReturnType<typeof setTimeout> | null = null
+
+  const observer = new MutationObserver(() => {
+    if (settled) return
+    if (document.querySelector(normalized)) {
+      settled = true
+      observer.disconnect()
+      if (timeoutId !== null) clearTimeout(timeoutId)
+      scrollToLandingSection(normalized)
+    }
+  })
+
+  observer.observe(document.body, { childList: true, subtree: true })
+
+  timeoutId = setTimeout(() => {
+    if (settled) return
+    settled = true
+    observer.disconnect()
+  }, timeoutMs)
+
+  return () => {
+    if (settled) return
+    settled = true
+    observer.disconnect()
+    if (timeoutId !== null) clearTimeout(timeoutId)
+  }
+}
+
 export function useLandingHashScroll() {
   useEffect(() => {
     const hash = window.location.hash
     if (!hash) return
 
-    const frame = requestAnimationFrame(() => {
-      scrollToLandingSection(hash)
-    })
-
-    return () => cancelAnimationFrame(frame)
+    return scrollWhenAvailable(hash)
   }, [])
 
   useEffect(() => {
+    let cancel: (() => void) | null = null
+
     const onHashChange = () => {
       const hash = window.location.hash
-      if (hash) scrollToLandingSection(hash)
+      if (!hash) return
+      cancel?.()
+      cancel = scrollWhenAvailable(hash)
     }
 
     window.addEventListener('hashchange', onHashChange)
-    return () => window.removeEventListener('hashchange', onHashChange)
+    return () => {
+      window.removeEventListener('hashchange', onHashChange)
+      cancel?.()
+    }
   }, [])
 }

--- a/components/landing/useLandingHashScroll.ts
+++ b/components/landing/useLandingHashScroll.ts
@@ -5,7 +5,10 @@ import { scrollToLandingSection } from '@/lib/landing/scroll-to-section'
 
 const SECTION_WAIT_TIMEOUT_MS = 3000
 
-function scrollWhenAvailable(hash: string, timeoutMs = SECTION_WAIT_TIMEOUT_MS) {
+function scrollWhenAvailable(
+  hash: string,
+  timeoutMs = SECTION_WAIT_TIMEOUT_MS
+) {
   const normalized = hash.startsWith('#') ? hash : `#${hash}`
 
   if (document.querySelector(normalized)) {

--- a/lib/copy/legal-privacy.ts
+++ b/lib/copy/legal-privacy.ts
@@ -88,7 +88,7 @@ export const privacySections: LegalSection[] = [
     id: 'international',
     title: '10. International users',
     paragraphs: [
-      'If you access the Service from outside the United States, you understand that information may be processed in the United States or other countries where our providers operate, which may have different data protection rules than your jurisdiction.',
+      'If you access the Service from outside India, you understand that information may be processed in India or other countries where our providers operate, which may have different data protection rules than your jurisdiction.',
     ],
   },
   {

--- a/lib/copy/legal-shared.ts
+++ b/lib/copy/legal-shared.ts
@@ -1,4 +1,4 @@
-export const LEGAL_CONTACT_EMAIL = 'legal@quilltip.com'
+export const LEGAL_CONTACT_EMAIL = 'legal@quilltip.me'
 
 export const LEGAL_LAST_UPDATED = 'May 19, 2026'
 


### PR DESCRIPTION
## Summary

Adds launch-ready trust and support destinations to the public footer and fixes preview feedback for homepage section deep links and legal copy. This branch builds on ENG-147 (footer, legal pages, dark mode, and related public UX).



## Changes

### Footer and trust destinations (ENG-215)
- Introduce `SiteFooter` / `FooterNav` on public pages with grouped links: Legal, Support, Contact, Status
- Footer destinations: Terms of Service, Privacy Policy, Help & Support, Wallet Guide, Contact, Platform Status
- Centralize link config in `lib/copy/footer-links.ts` with tests
- Add or wire pages: `/terms`, `/privacy`, `/support`, `/contact`, `/status`
- Trust copy aligned with Stellar testnet / practice-funds scope (not production money movement)

### Preview fixes (post-review)
- **Homepage section links:** Fix cold-load deep links (`/#features`, `/#security`, `/#arweave-storage`, `/#faq`) by waiting for dynamically loaded below-fold sections before scrolling (`useLandingHashScroll` + `MutationObserver`)
- **Terms:** Section 11 Contact email updated to `legal@quilltip.me` via `LEGAL_CONTACT_EMAIL`
- **Privacy:** Section 10 International users — processing location updated from United States to India

### Included from ENG-147 (stacked base)
- Legal pages (Terms, Privacy), `FailurePageShell`, dark mode improvements, landing performance (`dynamic` imports), and related public navigation UX
<img width="1222" height="675" alt="1" src="https://github.com/user-attachments/assets/4da26345-30dd-43ce-8e97-95edb0ab5d86" />

<img width="1224" height="716" alt="2" src="https://github.com/user-attachments/assets/3b125a60-d476-4667-a629-be1d2c60a8ff" />
