### PR TITLE
fix(editor): improve image URL field accessibility (ENG-197)

### DIFF
--- a/components/editor/EditorToolbar.tsx
+++ b/components/editor/EditorToolbar.tsx
@@ -787,7 +787,7 @@ export function EditorToolbar({
 
       {showImageDialog && (
         <ImageUploadDialog
-          isOpen
+          isOpen={showImageDialog}
           onClose={() => setShowImageDialog(false)}
           onImageSelect={handleImageSelect}
           triggerRef={imageDialogTriggerRef}

--- a/components/editor/ImageUploadDialog.tsx
+++ b/components/editor/ImageUploadDialog.tsx
@@ -6,6 +6,8 @@ import {
   uploadFile,
   compressImage,
   validateImageUploadFile,
+  isValidImageSourceUrl,
+  IMAGE_UPLOAD_FORMAT_HINT,
 } from '@/lib/upload'
 import { useConvex } from 'convex/react'
 import {
@@ -15,6 +17,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { cn } from '@/lib/utils'
+
+const IMAGE_URL_INPUT_ID = 'image-url-input'
+const IMAGE_URL_REQUIREMENTS_ID = 'image-url-requirements'
+const IMAGE_URL_ERROR_ID = 'image-url-error'
+const FILE_UPLOAD_ERROR_ID = 'file-upload-error'
 
 interface ImageUploadDialogProps {
   onImageSelect: (url: string) => void
@@ -38,27 +49,85 @@ export function ImageUploadDialog({
   const [isUploading, setIsUploading] = useState(false)
   const [uploadProgress, setUploadProgress] = useState(0)
   const [dragActive, setDragActive] = useState(false)
-  const [error, setError] = useState('')
+  const [fileError, setFileError] = useState('')
+  const [urlError, setUrlError] = useState('')
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const convex = useConvex()
   const urlInputRef = useRef<HTMLInputElement>(null)
+  const [open, setOpen] = useState(isOpen)
+  const isUploadingRef = useRef(isUploading)
+  const handleCloseRef = useRef<() => void>(() => {})
+
+  isUploadingRef.current = isUploading
 
   useEffect(() => {
-    if (!isOpen || uploadMethod !== 'url') return
+    if (isOpen) setOpen(true)
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!open || uploadMethod !== 'url') return
     urlInputRef.current?.focus()
-  }, [isOpen, uploadMethod])
+  }, [open, uploadMethod])
+
+  const handleUploadMethodChange = (value: string) => {
+    setUploadMethod(value as 'file' | 'url')
+    setFileError('')
+    setUrlError('')
+  }
+
+  const resetState = () => {
+    setImageUrl('')
+    setIsUploading(false)
+    setUploadProgress(0)
+    setFileError('')
+    setUrlError('')
+    setUploadMethod('file')
+  }
+
+  const handleClose = () => {
+    setOpen(false)
+    onClose()
+    resetState()
+  }
+
+  handleCloseRef.current = handleClose
+
+  // Radix only delivers Escape to the top dismissable layer; a higher invisible
+  // layer (e.g. another dialog portal) can block it while outside click still works.
+  useEffect(() => {
+    if (!open) return
+
+    const onDocumentKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || isUploadingRef.current) return
+      event.preventDefault()
+      event.stopImmediatePropagation()
+      handleCloseRef.current()
+    }
+
+    document.addEventListener('keydown', onDocumentKeyDown, { capture: true })
+    return () =>
+      document.removeEventListener('keydown', onDocumentKeyDown, { capture: true })
+  }, [open])
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen) {
+      setOpen(true)
+      return
+    }
+    handleClose()
+  }
 
   if (!isOpen) {
     return null
   }
 
   const handleFileSelect = async (file: File) => {
-    setError('')
+    setFileError('')
 
     const validation = validateImageUploadFile(file)
     if (!validation.ok) {
-      setError(validation.error)
+      setFileError(validation.error)
       return
     }
 
@@ -79,13 +148,12 @@ export function ImageUploadDialog({
 
       if (result.success && result.url) {
         onImageSelect(result.url)
-        onClose()
-        resetState()
+        handleClose()
       } else {
-        setError(result.error || 'Upload failed')
+        setFileError(result.error || 'Upload failed')
       }
     } catch (error) {
-      setError('Upload failed. Please try again.')
+      setFileError('Upload failed. Please try again.')
       console.error('Upload error:', error)
     } finally {
       setIsUploading(false)
@@ -95,7 +163,7 @@ export function ImageUploadDialog({
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (file) {
-      handleFileSelect(file)
+      void handleFileSelect(file)
     }
   }
 
@@ -115,7 +183,7 @@ export function ImageUploadDialog({
 
     const file = e.dataTransfer.files?.[0]
     if (!file) {
-      setError('Please drop an image file')
+      setFileError('Please drop an image file')
       return
     }
 
@@ -123,15 +191,23 @@ export function ImageUploadDialog({
   }
 
   const handleUrlSubmit = async () => {
-    if (!imageUrl.trim()) return
+    const trimmed = imageUrl.trim()
+    if (!trimmed) {
+      setUrlError('Enter an image URL')
+      return
+    }
+    if (!isValidImageSourceUrl(trimmed)) {
+      setUrlError('URL must start with http:// or https://')
+      return
+    }
 
-    setError('')
+    setUrlError('')
     setIsUploading(true)
     setUploadProgress(0)
 
     try {
       setUploadProgress(20)
-      const response = await fetch(imageUrl)
+      const response = await fetch(trimmed)
 
       if (!response.ok) {
         throw new Error('Failed to fetch image from URL')
@@ -163,22 +239,21 @@ export function ImageUploadDialog({
 
       if (result.success && result.url) {
         onImageSelect(result.url)
-        onClose()
-        resetState()
+        handleClose()
       } else {
-        setError(result.error || 'Upload failed')
+        setUrlError(result.error || 'Upload failed')
       }
     } catch (error) {
       if (error instanceof Error) {
         if (error.message.includes('Failed to fetch')) {
-          setError(
+          setUrlError(
             'Unable to fetch image from URL. The image may be protected by CORS policy.'
           )
         } else {
-          setError(error.message)
+          setUrlError(error.message)
         }
       } else {
-        setError('Failed to process image from URL')
+        setUrlError('Failed to process image from URL')
       }
       console.error('URL image upload error:', error)
     } finally {
@@ -186,25 +261,12 @@ export function ImageUploadDialog({
     }
   }
 
-  const resetState = () => {
-    setImageUrl('')
-    setIsUploading(false)
-    setUploadProgress(0)
-    setError('')
-    setUploadMethod('file')
-  }
-
-  const handleClose = () => {
-    onClose()
-    resetState()
-  }
-
-  const handleOpenChange = (open: boolean) => {
-    if (!open) handleClose()
-  }
+  const urlDescribedBy = urlError
+    ? `${IMAGE_URL_REQUIREMENTS_ID} ${IMAGE_URL_ERROR_ID}`
+    : IMAGE_URL_REQUIREMENTS_ID
 
   return (
-    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         className="sm:max-w-md p-0 gap-0 overflow-hidden"
         onCloseAutoFocus={(e) => {
@@ -220,55 +282,49 @@ export function ImageUploadDialog({
           if (isUploading) e.preventDefault()
         }}
       >
-        <DialogHeader className="p-4 border-b border-border space-y-0 text-left pr-12">
+        <DialogHeader className="p-4 border-b border-border space-y-1 text-left pr-12">
           <DialogTitle>{title}</DialogTitle>
-          <DialogDescription className="sr-only">
+          <DialogDescription>
             Upload a file or paste an image URL to insert into your article.
           </DialogDescription>
         </DialogHeader>
 
         <div className="p-4">
-          <div className="flex gap-2 mb-4">
-            <button
-              type="button"
-              onClick={() => setUploadMethod('file')}
-              className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-colors ${
-                uploadMethod === 'file'
-                  ? 'bg-primary/15 text-primary border border-border'
-                  : 'bg-muted text-foreground hover:bg-muted/80'
-              }`}
+          <Tabs
+            value={uploadMethod}
+            onValueChange={handleUploadMethodChange}
+            className="w-full"
+          >
+            <TabsList
+              className="grid w-full grid-cols-2 mb-4 h-auto p-1"
+              aria-label="Image upload method"
             >
-              <Upload className="w-4 h-4 inline mr-2" />
-              Upload File
-            </button>
-            <button
-              type="button"
-              onClick={() => setUploadMethod('url')}
-              className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-colors ${
-                uploadMethod === 'url'
-                  ? 'bg-primary/15 text-primary border border-border'
-                  : 'bg-muted text-foreground hover:bg-muted/80'
-              }`}
-            >
-              <Link2 className="w-4 h-4 inline mr-2" />
-              URL
-            </button>
-          </div>
+              <TabsTrigger value="file" className="gap-2 py-2">
+                <Upload className="w-4 h-4" />
+                Upload File
+              </TabsTrigger>
+              <TabsTrigger value="url" className="gap-2 py-2">
+                <Link2 className="w-4 h-4" />
+                URL
+              </TabsTrigger>
+            </TabsList>
 
-          {uploadMethod === 'file' && (
-            <div>
+            <TabsContent value="file" className="mt-0">
               <div
-                className={`border-2 border-dashed rounded-lg p-6 text-center transition-colors ${
+                className={cn(
+                  'border-2 border-dashed rounded-lg p-6 text-center transition-colors',
                   dragActive
                     ? 'border-primary bg-primary/15'
-                    : 'border-border hover:border-muted-foreground/40'
-                }`}
+                    : 'border-border hover:border-muted-foreground/40',
+                  fileError && 'border-destructive'
+                )}
                 onDragOver={handleDragOver}
                 onDragLeave={handleDragLeave}
                 onDrop={handleDrop}
+                aria-describedby={fileError ? FILE_UPLOAD_ERROR_ID : undefined}
               >
-                {isUploading ? (
-                  <div className="space-y-3">
+                {isUploading && uploadMethod === 'file' ? (
+                  <div className="space-y-3" role="status" aria-live="polite">
                     <div className="w-12 h-12 bg-primary/15 rounded-full flex items-center justify-center mx-auto">
                       <Upload className="w-6 h-6 text-primary animate-pulse" />
                     </div>
@@ -306,12 +362,22 @@ export function ImageUploadDialog({
                         </button>
                       </p>
                       <p className="text-xs text-muted-foreground mt-1">
-                        PNG, JPG, GIF, WEBP up to 10MB
+                        {IMAGE_UPLOAD_FORMAT_HINT}
                       </p>
                     </div>
                   </div>
                 )}
               </div>
+
+              {fileError ? (
+                <p
+                  id={FILE_UPLOAD_ERROR_ID}
+                  role="alert"
+                  className="text-xs text-destructive mt-2"
+                >
+                  {fileError}
+                </p>
+              ) : null}
 
               <input
                 ref={fileInputRef}
@@ -320,13 +386,11 @@ export function ImageUploadDialog({
                 onChange={handleFileChange}
                 className="hidden"
               />
-            </div>
-          )}
+            </TabsContent>
 
-          {uploadMethod === 'url' && (
-            <div className="space-y-3">
+            <TabsContent value="url" className="mt-0">
               {isUploading ? (
-                <div className="space-y-3">
+                <div className="space-y-3" role="status" aria-live="polite">
                   <div className="w-12 h-12 bg-primary/15 rounded-full flex items-center justify-center mx-auto">
                     <Upload className="w-6 h-6 text-primary animate-pulse" />
                   </div>
@@ -348,24 +412,53 @@ export function ImageUploadDialog({
                   </div>
                 </div>
               ) : (
-                <>
-                  <input
-                    ref={urlInputRef}
-                    type="url"
-                    placeholder="https://example.com/image.jpg"
-                    value={imageUrl}
-                    onChange={(e) => setImageUrl(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' && !isUploading) {
-                        void handleUrlSubmit()
-                      }
-                    }}
-                    className="w-full px-3 py-2 border border-input bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
-                  />
+                <div className="space-y-3">
+                  <div className="space-y-2">
+                    <Label htmlFor={IMAGE_URL_INPUT_ID}>Image URL</Label>
+                    <Input
+                      ref={urlInputRef}
+                      id={IMAGE_URL_INPUT_ID}
+                      type="url"
+                      placeholder="https://example.com/image.jpg"
+                      value={imageUrl}
+                      onChange={(e) => {
+                        setImageUrl(e.target.value)
+                        if (urlError) setUrlError('')
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && !isUploading) {
+                          void handleUrlSubmit()
+                        }
+                      }}
+                      aria-invalid={!!urlError}
+                      aria-describedby={urlDescribedBy}
+                      aria-busy={isUploading}
+                      className={cn(
+                        urlError &&
+                          'border-destructive focus-visible:ring-destructive'
+                      )}
+                    />
+                    <p
+                      id={IMAGE_URL_REQUIREMENTS_ID}
+                      className="text-xs text-muted-foreground"
+                    >
+                      Must be http:// or https://. Image will be downloaded;
+                      supported types: {IMAGE_UPLOAD_FORMAT_HINT}.
+                    </p>
+                    {urlError ? (
+                      <p
+                        id={IMAGE_URL_ERROR_ID}
+                        role="alert"
+                        className="text-xs text-destructive"
+                      >
+                        {urlError}
+                      </p>
+                    ) : null}
+                  </div>
                   <button
                     type="button"
                     onClick={() => void handleUrlSubmit()}
-                    disabled={!imageUrl.trim() || isUploading}
+                    disabled={isUploading}
                     className="w-full bg-primary text-primary-foreground py-2 px-4 rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     Upload Image
@@ -373,16 +466,10 @@ export function ImageUploadDialog({
                   <p className="text-xs text-muted-foreground text-center">
                     External images will be downloaded and stored in Convex
                   </p>
-                </>
+                </div>
               )}
-            </div>
-          )}
-
-          {error && (
-            <div className="mt-3 rounded-lg border border-destructive/25 bg-destructive/10 p-3">
-              <p className="text-sm text-destructive">{error}</p>
-            </div>
-          )}
+            </TabsContent>
+          </Tabs>
         </div>
       </DialogContent>
     </Dialog>

--- a/components/editor/ImageUploadDialog.tsx
+++ b/components/editor/ImageUploadDialog.tsx
@@ -107,7 +107,9 @@ export function ImageUploadDialog({
 
     document.addEventListener('keydown', onDocumentKeyDown, { capture: true })
     return () =>
-      document.removeEventListener('keydown', onDocumentKeyDown, { capture: true })
+      document.removeEventListener('keydown', onDocumentKeyDown, {
+        capture: true,
+      })
   }, [open])
 
   const handleOpenChange = (nextOpen: boolean) => {

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -1144,7 +1144,7 @@ export function WriteEditorWorkspace() {
 
       {showCoverImageDialog && (
         <ImageUploadDialog
-          isOpen
+          isOpen={showCoverImageDialog}
           title="Add Cover Image"
           triggerRef={coverImage ? coverChangeButtonRef : undefined}
           onImageSelect={(url) => {

--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -15,6 +15,18 @@ export const ALLOWED_IMAGE_MIME_TYPES = new Set([
   'image/webp',
 ])
 
+export const IMAGE_UPLOAD_FORMAT_HINT =
+  'PNG, JPG, GIF, or WEBP up to 10MB'
+
+export function isValidImageSourceUrl(value: string): boolean {
+  try {
+    const u = new URL(value.trim())
+    return u.protocol === 'http:' || u.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
 export type ImageUploadValidationResult =
   | { ok: true }
   | { ok: false; error: string }

--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -15,8 +15,7 @@ export const ALLOWED_IMAGE_MIME_TYPES = new Set([
   'image/webp',
 ])
 
-export const IMAGE_UPLOAD_FORMAT_HINT =
-  'PNG, JPG, GIF, or WEBP up to 10MB'
+export const IMAGE_UPLOAD_FORMAT_HINT = 'PNG, JPG, GIF, or WEBP up to 10MB'
 
 export function isValidImageSourceUrl(value: string): boolean {
   try {


### PR DESCRIPTION
## Summary

Fixes ENG-197 by making the image URL upload field in `ImageUploadDialog` understandable without placeholder text and usable with keyboard and screen readers.

- Add a visible **Image URL** label, requirements hint, and visible dialog description on the URL tab
- Show validation errors inline next to the URL field (empty URL, invalid protocol, type/size, CORS/fetch failures)
- Scope file upload errors to the file drop zone instead of a shared bottom error block
- Replace custom upload-method buttons with Radix `Tabs` for proper tablist/tab/tabpanel semantics and arrow-key navigation
- Add shared helpers in `lib/upload.ts`: `IMAGE_UPLOAD_FORMAT_HINT` and `isValidImageSourceUrl`

## Changes

- `components/editor/ImageUploadDialog.tsx` — label/input, split `urlError`/`fileError`, ARIA (`aria-invalid`, `aria-describedby`, `role="alert"`), accessible tabs, upload status for assistive tech
- `lib/upload.ts` — shared format hint string and HTTP(S) URL validation helper
<img width="1222" height="673" alt="1" src="https://github.com/user-attachments/assets/97e49eb1-ca22-45d4-b8e8-2a641e3bac26" />

<img width="1220" height="719" alt="2" src="https://github.com/user-attachments/assets/be8a5acd-0ba1-4162-88b3-8930ed5b6a37" />
<img width="1223" height="721" alt="3" src="https://github.com/user-attachments/assets/322b5c13-0557-4783-bc49-1cd831ae1f6e" />
<img width="1217" height="716" alt="4" src="https://github.com/user-attachments/assets/c501d4db-8a9e-4872-8b82-18d1bf6c58fb" />
