### PR TITLE
feat(a11y): add keyboard file-picker fallbacks for drag-and-drop uploads (ENG-198)

### DIFF
--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -8,7 +8,7 @@ import Placeholder from '@tiptap/extension-placeholder'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import Youtube from '@tiptap/extension-youtube'
 import { lowlight } from '@/lib/lowlight'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { ResizableImage } from './extensions/ResizableImage'
 import { EditorKeymap } from './extensions/EditorKeymap'
 import {
@@ -17,9 +17,20 @@ import {
   validateImageUploadFile,
   isAbortError,
 } from '@/lib/upload'
-import { EDITOR_PROSE_CLASS } from '@/lib/constants'
+import { EDITOR_PROSE_CLASS, UPLOAD_CONTROL_FOCUS_RING } from '@/lib/constants'
 import { useConvex } from 'convex/react'
 import { toast } from 'sonner'
+import { cn } from '@/lib/utils'
+
+const BODY_FILE_INPUT_ID = 'editor-body-image-file-input'
+const BODY_UPLOAD_ERROR_ID = 'editor-body-upload-error'
+const BODY_UPLOAD_STATUS_ID = 'editor-body-upload-status'
+
+type UploadAnnouncement = { type: 'status' | 'error'; text: string }
+
+function shouldAnnounceProgress(last: number, next: number): boolean {
+  return next === 0 || next >= 100 || next - last >= 25
+}
 
 interface EditorProps {
   content?: string
@@ -39,7 +50,11 @@ export function Editor({
   const [isDragging, setIsDragging] = useState(false)
   const [isUploading, setIsUploading] = useState(false)
   const [uploadProgress, setUploadProgress] = useState(0)
+  const [uploadAnnouncement, setUploadAnnouncement] =
+    useState<UploadAnnouncement | null>(null)
   const uploadAbortRef = useRef<AbortController | null>(null)
+  const bodyFileInputRef = useRef<HTMLInputElement>(null)
+  const lastAnnouncedProgressRef = useRef(-1)
 
   const convex = useConvex()
 
@@ -126,6 +141,87 @@ export function Editor({
     }
   }, [editable, editor])
 
+  const uploadImageFromFile = useCallback(
+    async (file: File) => {
+      if (!editor || !editable) return
+
+      setUploadAnnouncement(null)
+      lastAnnouncedProgressRef.current = -1
+
+      const validation = validateImageUploadFile(file)
+      if (!validation.ok) {
+        setUploadAnnouncement({ type: 'error', text: validation.error })
+        toast.error(validation.error)
+        return
+      }
+
+      uploadAbortRef.current?.abort()
+      const controller = new AbortController()
+      uploadAbortRef.current = controller
+
+      setIsUploading(true)
+      setUploadProgress(0)
+      setUploadAnnouncement({ type: 'status', text: 'Uploading image' })
+
+      try {
+        const compressedFile = await compressImage(
+          file,
+          1200,
+          0.8,
+          controller.signal
+        )
+        const result = await uploadFile(
+          compressedFile,
+          convex,
+          'article_image',
+          undefined,
+          (progress) => {
+            const pct = progress.percentage
+            setUploadProgress(pct)
+            if (
+              shouldAnnounceProgress(lastAnnouncedProgressRef.current, pct)
+            ) {
+              lastAnnouncedProgressRef.current = pct
+              setUploadAnnouncement({
+                type: 'status',
+                text: `Uploading image, ${pct}% complete`,
+              })
+            }
+          },
+          controller.signal
+        )
+
+        if (result.success && result.url) {
+          editor.chain().focus().setResizableImage({ src: result.url }).run()
+          setUploadAnnouncement({
+            type: 'status',
+            text: 'Image added to article',
+          })
+        } else if (result.error) {
+          setUploadAnnouncement({ type: 'error', text: result.error })
+          toast.error(result.error)
+        }
+      } catch (error) {
+        if (isAbortError(error)) {
+          return
+        }
+        console.error('Error uploading dropped image:', error)
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Upload failed. Please try again.'
+        setUploadAnnouncement({ type: 'error', text: message })
+        toast.error(message)
+      } finally {
+        if (uploadAbortRef.current === controller) {
+          uploadAbortRef.current = null
+        }
+        setIsUploading(false)
+      }
+    },
+    [convex, editor, editable]
+  )
+
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
@@ -135,7 +231,6 @@ export function Editor({
   const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    // Only set dragging to false if we're leaving the editor container
     if (!e.currentTarget.contains(e.relatedTarget as Node)) {
       setIsDragging(false)
     }
@@ -152,107 +247,129 @@ export function Editor({
     const imageFiles = files.filter((file) => file.type.startsWith('image/'))
 
     if (imageFiles.length === 0) {
-      return // No image files dropped
+      return
     }
 
     const file = imageFiles[0]
     if (!file) return
 
-    const validation = validateImageUploadFile(file)
-    if (!validation.ok) {
-      toast.error(validation.error)
-      return
-    }
+    await uploadImageFromFile(file)
+  }
 
-    uploadAbortRef.current?.abort()
-    const controller = new AbortController()
-    uploadAbortRef.current = controller
-
-    setIsUploading(true)
-    setUploadProgress(0)
-
-    try {
-      const compressedFile = await compressImage(
-        file,
-        1200,
-        0.8,
-        controller.signal
-      )
-      const result = await uploadFile(
-        compressedFile,
-        convex,
-        'article_image',
-        undefined,
-        (progress) => {
-          setUploadProgress(progress.percentage)
-        },
-        controller.signal
-      )
-
-      if (result.success && result.url) {
-        editor.chain().focus().setResizableImage({ src: result.url }).run()
-      } else if (result.error) {
-        toast.error(result.error)
-      }
-    } catch (error) {
-      if (isAbortError(error)) {
-        return
-      }
-      console.error('Error uploading dropped image:', error)
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : 'Upload failed. Please try again.'
-      )
-    } finally {
-      if (uploadAbortRef.current === controller) {
-        uploadAbortRef.current = null
-      }
-      setIsUploading(false)
+  const handleBodyFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    e.target.value = ''
+    if (file) {
+      void uploadImageFromFile(file)
     }
   }
 
   return (
-    <div
-      className={`editor-wrapper bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border relative ${className} ${
-        isDragging ? 'border-primary bg-primary/10' : ''
-      } ${isUploading ? 'pointer-events-none' : ''}`}
-      onDragOver={handleDragOver}
-      onDragLeave={handleDragLeave}
-      onDrop={handleDrop}
-    >
-      {isDragging && (
-        <div className="absolute inset-0 bg-primary/15 flex items-center justify-center z-10 rounded-lg border-2 border-dashed border-primary">
-          <div className="text-center">
-            <div className="text-primary text-lg font-medium mb-2">
-              Drop image here
+    <div className={cn('space-y-2', className)}>
+      <div
+        className={cn(
+          'editor-wrapper bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border relative',
+          isDragging ? 'border-primary bg-primary/10' : '',
+          isUploading ? 'pointer-events-none' : ''
+        )}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        aria-describedby={
+          [
+            uploadAnnouncement?.type === 'error' ? BODY_UPLOAD_ERROR_ID : null,
+            uploadAnnouncement?.type === 'status' ? BODY_UPLOAD_STATUS_ID : null,
+          ]
+            .filter(Boolean)
+            .join(' ') || undefined
+        }
+      >
+        {isDragging && (
+          <div className="absolute inset-0 bg-primary/15 flex items-center justify-center z-10 rounded-lg border-2 border-dashed border-primary">
+            <div className="text-center">
+              <div className="text-primary text-lg font-medium mb-2">
+                Drop image here to add it
+              </div>
+              <div className="text-primary/80 text-sm">
+                or choose a file below
+              </div>
             </div>
-            <div className="text-primary/80 text-sm">Release to upload</div>
           </div>
-        </div>
-      )}
+        )}
 
-      {isUploading && (
-        <div className="absolute inset-0 bg-card bg-opacity-90 flex items-center justify-center z-10 rounded-lg">
-          <div className="text-center">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-2"></div>
-            <div className="text-muted-foreground text-sm">
-              Optimizing and uploading image...
-            </div>
-            <div className="mt-2 w-48 bg-muted rounded-full h-2 mx-auto">
+        {isUploading && (
+          <div
+            className="absolute inset-0 bg-card bg-opacity-90 flex items-center justify-center z-10 rounded-lg"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            <div className="text-center">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-2"></div>
+              <div className="text-muted-foreground text-sm">
+                Optimizing and uploading image...
+              </div>
               <div
-                className="bg-primary h-2 rounded-full transition-all duration-300"
-                style={{ width: `${uploadProgress}%` }}
-              ></div>
-            </div>
-            <div className="text-muted-foreground text-xs mt-1">
-              {uploadProgress}%
+                className="mt-2 w-48 bg-muted rounded-full h-2 mx-auto"
+                role="progressbar"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={uploadProgress}
+                aria-label="Image upload progress"
+              >
+                <div
+                  className="bg-primary h-2 rounded-full transition-all duration-300"
+                  style={{ width: `${uploadProgress}%` }}
+                ></div>
+              </div>
+              <div className="text-muted-foreground text-xs mt-1">
+                {uploadProgress}%
+              </div>
+              {uploadAnnouncement?.type === 'status' ? (
+                <p className="sr-only">{uploadAnnouncement.text}</p>
+              ) : null}
             </div>
           </div>
-        </div>
-      )}
+        )}
 
-      <EditorContent editor={editor} className="editor-content" />
+        <EditorContent editor={editor} className="editor-content" />
+      </div>
+      <label
+        className={cn(
+          'inline-flex cursor-pointer text-sm font-medium text-primary underline-offset-4 hover:text-primary/80 hover:underline',
+          UPLOAD_CONTROL_FOCUS_RING
+        )}
+      >
+        <input
+          ref={bodyFileInputRef}
+          id={BODY_FILE_INPUT_ID}
+          type="file"
+          accept="image/png,image/jpeg,image/gif,image/webp"
+          className="sr-only"
+          onChange={handleBodyFileChange}
+        />
+        Choose image file
+      </label>
+      {uploadAnnouncement && !isUploading ? (
+        <p
+          id={
+            uploadAnnouncement.type === 'error'
+              ? BODY_UPLOAD_ERROR_ID
+              : BODY_UPLOAD_STATUS_ID
+          }
+          role={uploadAnnouncement.type === 'error' ? 'alert' : 'status'}
+          aria-live={uploadAnnouncement.type === 'error' ? 'assertive' : 'polite'}
+          aria-atomic="true"
+          className={cn(
+            'text-xs',
+            uploadAnnouncement.type === 'error'
+              ? 'text-destructive'
+              : 'sr-only'
+          )}
+        >
+          {uploadAnnouncement.text}
+        </p>
+      ) : null}
     </div>
   )
 }

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -178,9 +178,7 @@ export function Editor({
           (progress) => {
             const pct = progress.percentage
             setUploadProgress(pct)
-            if (
-              shouldAnnounceProgress(lastAnnouncedProgressRef.current, pct)
-            ) {
+            if (shouldAnnounceProgress(lastAnnouncedProgressRef.current, pct)) {
               lastAnnouncedProgressRef.current = pct
               setUploadAnnouncement({
                 type: 'status',
@@ -278,7 +276,9 @@ export function Editor({
         aria-describedby={
           [
             uploadAnnouncement?.type === 'error' ? BODY_UPLOAD_ERROR_ID : null,
-            uploadAnnouncement?.type === 'status' ? BODY_UPLOAD_STATUS_ID : null,
+            uploadAnnouncement?.type === 'status'
+              ? BODY_UPLOAD_STATUS_ID
+              : null,
           ]
             .filter(Boolean)
             .join(' ') || undefined
@@ -358,13 +358,13 @@ export function Editor({
               : BODY_UPLOAD_STATUS_ID
           }
           role={uploadAnnouncement.type === 'error' ? 'alert' : 'status'}
-          aria-live={uploadAnnouncement.type === 'error' ? 'assertive' : 'polite'}
+          aria-live={
+            uploadAnnouncement.type === 'error' ? 'assertive' : 'polite'
+          }
           aria-atomic="true"
           className={cn(
             'text-xs',
-            uploadAnnouncement.type === 'error'
-              ? 'text-destructive'
-              : 'sr-only'
+            uploadAnnouncement.type === 'error' ? 'text-destructive' : 'sr-only'
           )}
         >
           {uploadAnnouncement.text}

--- a/components/editor/ImageUploadDialog.test.tsx
+++ b/components/editor/ImageUploadDialog.test.tsx
@@ -1,0 +1,59 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ImageUploadDialog } from '@/components/editor/ImageUploadDialog'
+import { UPLOAD_CONTROL_FOCUS_RING } from '@/lib/constants'
+
+vi.mock('convex/react', () => ({
+  useConvex: () => ({}),
+}))
+
+describe('ImageUploadDialog accessibility', () => {
+  it('renders choose file control with focus ring utilities', () => {
+    render(
+      <ImageUploadDialog
+        isOpen
+        onClose={vi.fn()}
+        onImageSelect={vi.fn()}
+      />
+    )
+
+    const chooseFileLabel = screen.getByText('Choose file').closest('label')
+    expect(chooseFileLabel).not.toBeNull()
+    for (const cls of UPLOAD_CONTROL_FOCUS_RING.split(' ')) {
+      expect(chooseFileLabel!.className).toContain(cls)
+    }
+  })
+
+  it('mentions choosing a file in drag-and-drop instructions', () => {
+    render(
+      <ImageUploadDialog
+        isOpen
+        onClose={vi.fn()}
+        onImageSelect={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.getByText(
+        'Drag and drop an image here, or choose a file to upload.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('nests sr-only file input inside the choose file label', () => {
+    render(
+      <ImageUploadDialog
+        isOpen
+        onClose={vi.fn()}
+        onImageSelect={vi.fn()}
+      />
+    )
+
+    const chooseFileLabel = screen.getByText('Choose file').closest('label')
+    const input = chooseFileLabel?.querySelector('#image-file-input')
+    expect(input).not.toBeNull()
+    expect(input).toHaveAttribute('type', 'file')
+    expect(input?.className).toContain('sr-only')
+  })
+})

--- a/components/editor/ImageUploadDialog.test.tsx
+++ b/components/editor/ImageUploadDialog.test.tsx
@@ -11,11 +11,7 @@ vi.mock('convex/react', () => ({
 describe('ImageUploadDialog accessibility', () => {
   it('renders choose file control with focus ring utilities', () => {
     render(
-      <ImageUploadDialog
-        isOpen
-        onClose={vi.fn()}
-        onImageSelect={vi.fn()}
-      />
+      <ImageUploadDialog isOpen onClose={vi.fn()} onImageSelect={vi.fn()} />
     )
 
     const chooseFileLabel = screen.getByText('Choose file').closest('label')
@@ -27,11 +23,7 @@ describe('ImageUploadDialog accessibility', () => {
 
   it('mentions choosing a file in drag-and-drop instructions', () => {
     render(
-      <ImageUploadDialog
-        isOpen
-        onClose={vi.fn()}
-        onImageSelect={vi.fn()}
-      />
+      <ImageUploadDialog isOpen onClose={vi.fn()} onImageSelect={vi.fn()} />
     )
 
     expect(
@@ -43,11 +35,7 @@ describe('ImageUploadDialog accessibility', () => {
 
   it('nests sr-only file input inside the choose file label', () => {
     render(
-      <ImageUploadDialog
-        isOpen
-        onClose={vi.fn()}
-        onImageSelect={vi.fn()}
-      />
+      <ImageUploadDialog isOpen onClose={vi.fn()} onImageSelect={vi.fn()} />
     )
 
     const chooseFileLabel = screen.getByText('Choose file').closest('label')

--- a/components/editor/ImageUploadDialog.tsx
+++ b/components/editor/ImageUploadDialog.tsx
@@ -272,12 +272,13 @@ export function ImageUploadDialog({
     ? `${IMAGE_URL_REQUIREMENTS_ID} ${IMAGE_URL_ERROR_ID}`
     : IMAGE_URL_REQUIREMENTS_ID
 
-  const fileDropDescribedBy = [
-    fileError ? FILE_UPLOAD_ERROR_ID : null,
-    isUploading && uploadMethod === 'file' ? FILE_UPLOAD_STATUS_ID : null,
-  ]
-    .filter(Boolean)
-    .join(' ') || undefined
+  const fileDropDescribedBy =
+    [
+      fileError ? FILE_UPLOAD_ERROR_ID : null,
+      isUploading && uploadMethod === 'file' ? FILE_UPLOAD_STATUS_ID : null,
+    ]
+      .filter(Boolean)
+      .join(' ') || undefined
 
   const fileProgressStatusText =
     isUploading && uploadMethod === 'file'

--- a/components/editor/ImageUploadDialog.tsx
+++ b/components/editor/ImageUploadDialog.tsx
@@ -9,6 +9,7 @@ import {
   isValidImageSourceUrl,
   IMAGE_UPLOAD_FORMAT_HINT,
 } from '@/lib/upload'
+import { UPLOAD_CONTROL_FOCUS_RING } from '@/lib/constants'
 import { useConvex } from 'convex/react'
 import {
   Dialog,
@@ -22,10 +23,13 @@ import { Label } from '@/components/ui/label'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { cn } from '@/lib/utils'
 
+const IMAGE_FILE_INPUT_ID = 'image-file-input'
 const IMAGE_URL_INPUT_ID = 'image-url-input'
 const IMAGE_URL_REQUIREMENTS_ID = 'image-url-requirements'
 const IMAGE_URL_ERROR_ID = 'image-url-error'
 const FILE_UPLOAD_ERROR_ID = 'file-upload-error'
+const FILE_UPLOAD_STATUS_ID = 'file-upload-status'
+const URL_UPLOAD_STATUS_ID = 'url-upload-status'
 
 interface ImageUploadDialogProps {
   onImageSelect: (url: string) => void
@@ -164,6 +168,7 @@ export function ImageUploadDialog({
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
+    e.target.value = ''
     if (file) {
       void handleFileSelect(file)
     }
@@ -267,6 +272,22 @@ export function ImageUploadDialog({
     ? `${IMAGE_URL_REQUIREMENTS_ID} ${IMAGE_URL_ERROR_ID}`
     : IMAGE_URL_REQUIREMENTS_ID
 
+  const fileDropDescribedBy = [
+    fileError ? FILE_UPLOAD_ERROR_ID : null,
+    isUploading && uploadMethod === 'file' ? FILE_UPLOAD_STATUS_ID : null,
+  ]
+    .filter(Boolean)
+    .join(' ') || undefined
+
+  const fileProgressStatusText =
+    isUploading && uploadMethod === 'file'
+      ? `Uploading image, ${uploadProgress}% complete`
+      : ''
+
+  const urlProgressStatusText = isUploading
+    ? `Processing image from URL, ${uploadProgress}% complete`
+    : ''
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
@@ -323,10 +344,16 @@ export function ImageUploadDialog({
                 onDragOver={handleDragOver}
                 onDragLeave={handleDragLeave}
                 onDrop={handleDrop}
-                aria-describedby={fileError ? FILE_UPLOAD_ERROR_ID : undefined}
+                aria-describedby={fileDropDescribedBy}
               >
                 {isUploading && uploadMethod === 'file' ? (
-                  <div className="space-y-3" role="status" aria-live="polite">
+                  <div
+                    className="space-y-3"
+                    role="status"
+                    aria-live="polite"
+                    aria-atomic="true"
+                    id={FILE_UPLOAD_STATUS_ID}
+                  >
                     <div className="w-12 h-12 bg-primary/15 rounded-full flex items-center justify-center mx-auto">
                       <Upload className="w-6 h-6 text-primary animate-pulse" />
                     </div>
@@ -335,7 +362,14 @@ export function ImageUploadDialog({
                         Optimizing and uploading...
                       </p>
                       <div className="mt-2">
-                        <div className="bg-muted rounded-full h-2">
+                        <div
+                          className="bg-muted rounded-full h-2"
+                          role="progressbar"
+                          aria-valuemin={0}
+                          aria-valuemax={100}
+                          aria-valuenow={uploadProgress}
+                          aria-label="Upload progress"
+                        >
                           <div
                             className="bg-primary h-2 rounded-full transition-all duration-300"
                             style={{ width: `${uploadProgress}%` }}
@@ -345,6 +379,7 @@ export function ImageUploadDialog({
                           {uploadProgress}%
                         </p>
                       </div>
+                      <p className="sr-only">{fileProgressStatusText}</p>
                     </div>
                   </div>
                 ) : (
@@ -354,18 +389,27 @@ export function ImageUploadDialog({
                     </div>
                     <div>
                       <p className="text-sm font-medium text-foreground">
-                        Drag and drop an image, or{' '}
-                        <button
-                          type="button"
-                          onClick={() => fileInputRef.current?.click()}
-                          className="text-primary hover:text-primary/80"
-                        >
-                          browse
-                        </button>
+                        Drag and drop an image here, or choose a file to upload.
                       </p>
                       <p className="text-xs text-muted-foreground mt-1">
                         {IMAGE_UPLOAD_FORMAT_HINT}
                       </p>
+                      <Label
+                        className={cn(
+                          'mt-3 inline-flex cursor-pointer rounded-md text-sm font-medium text-primary underline-offset-4 hover:text-primary/80 hover:underline',
+                          UPLOAD_CONTROL_FOCUS_RING
+                        )}
+                      >
+                        <input
+                          ref={fileInputRef}
+                          id={IMAGE_FILE_INPUT_ID}
+                          type="file"
+                          accept={IMAGE_ACCEPT}
+                          onChange={handleFileChange}
+                          className="sr-only"
+                        />
+                        Choose file
+                      </Label>
                     </div>
                   </div>
                 )}
@@ -380,19 +424,17 @@ export function ImageUploadDialog({
                   {fileError}
                 </p>
               ) : null}
-
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept={IMAGE_ACCEPT}
-                onChange={handleFileChange}
-                className="hidden"
-              />
             </TabsContent>
 
             <TabsContent value="url" className="mt-0">
               {isUploading ? (
-                <div className="space-y-3" role="status" aria-live="polite">
+                <div
+                  className="space-y-3"
+                  role="status"
+                  aria-live="polite"
+                  aria-atomic="true"
+                  id={URL_UPLOAD_STATUS_ID}
+                >
                   <div className="w-12 h-12 bg-primary/15 rounded-full flex items-center justify-center mx-auto">
                     <Upload className="w-6 h-6 text-primary animate-pulse" />
                   </div>
@@ -401,7 +443,14 @@ export function ImageUploadDialog({
                       Processing image from URL...
                     </p>
                     <div className="mt-2">
-                      <div className="bg-muted rounded-full h-2">
+                      <div
+                        className="bg-muted rounded-full h-2"
+                        role="progressbar"
+                        aria-valuemin={0}
+                        aria-valuemax={100}
+                        aria-valuenow={uploadProgress}
+                        aria-label="URL upload progress"
+                      >
                         <div
                           className="bg-primary h-2 rounded-full transition-all duration-300"
                           style={{ width: `${uploadProgress}%` }}
@@ -411,6 +460,7 @@ export function ImageUploadDialog({
                         {uploadProgress}%
                       </p>
                     </div>
+                    <p className="sr-only">{urlProgressStatusText}</p>
                   </div>
                 </div>
               ) : (
@@ -461,7 +511,10 @@ export function ImageUploadDialog({
                     type="button"
                     onClick={() => void handleUrlSubmit()}
                     disabled={isUploading}
-                    className="w-full bg-primary text-primary-foreground py-2 px-4 rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
+                    className={cn(
+                      'w-full bg-primary text-primary-foreground py-2 px-4 rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed',
+                      UPLOAD_CONTROL_FOCUS_RING
+                    )}
                   >
                     Upload Image
                   </button>

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -24,7 +24,7 @@ import { useArticleById } from '@/hooks/convex'
 import type { Id } from '@/types/convex'
 import { toast } from 'sonner'
 import Image from 'next/image'
-import { EDITOR_PROSE_CLASS } from '@/lib/constants'
+import { EDITOR_PROSE_CLASS, UPLOAD_CONTROL_FOCUS_RING } from '@/lib/constants'
 import { mutationWithTimeout } from '@/lib/convexMutationWithTimeout'
 import {
   Collapsible,
@@ -64,8 +64,18 @@ import { getWriteUrlWithDraftId } from '@/lib/writeDraftUrl'
 const PUBLISH_EXCERPT_PREVIEW_MAX = 280
 const EXCERPT_MAX_CHARS = 500
 
-const coverControlFocusRing =
-  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+const COVER_FILE_INPUT_ID = 'cover-image-file-input'
+const BODY_FILE_INPUT_ID = 'body-image-file-input'
+const COVER_UPLOAD_ERROR_ID = 'cover-upload-error'
+const COVER_UPLOAD_STATUS_ID = 'cover-upload-status'
+const BODY_UPLOAD_ERROR_ID = 'body-upload-error'
+const BODY_UPLOAD_STATUS_ID = 'body-upload-status'
+
+type UploadAnnouncement = { type: 'status' | 'error'; text: string }
+
+function shouldAnnounceProgress(last: number, next: number): boolean {
+  return next === 0 || next >= 100 || next - last >= 25
+}
 
 const EMPTY_DOC: JSONContent = { type: 'doc', content: [] }
 
@@ -110,6 +120,10 @@ export function WriteEditorWorkspace() {
   const [bodyImageDragging, setBodyImageDragging] = useState(false)
   const [bodyImageUploading, setBodyImageUploading] = useState(false)
   const [bodyImageUploadProgress, setBodyImageUploadProgress] = useState(0)
+  const [coverUploadAnnouncement, setCoverUploadAnnouncement] =
+    useState<UploadAnnouncement | null>(null)
+  const [bodyUploadAnnouncement, setBodyUploadAnnouncement] =
+    useState<UploadAnnouncement | null>(null)
   const [isPublishing, setIsPublishing] = useState(false)
   const [articleId, setArticleId] = useState<string | undefined>()
   const [editorContent, setEditorContent] = useState<JSONContent | null>(null)
@@ -123,6 +137,10 @@ export function WriteEditorWorkspace() {
   const excerptTextareaRef = useRef<HTMLTextAreaElement>(null)
   const tagsInputRef = useRef<HTMLInputElement>(null)
   const coverChangeButtonRef = useRef<HTMLButtonElement>(null)
+  const coverFileInputRef = useRef<HTMLInputElement>(null)
+  const bodyFileInputRef = useRef<HTMLInputElement>(null)
+  const coverLastAnnouncedProgressRef = useRef(-1)
+  const bodyLastAnnouncedProgressRef = useRef(-1)
   const [publishStatus, setPublishStatus] = useState<{
     published: boolean
     publishedAt: Date | null
@@ -624,17 +642,14 @@ export function WriteEditorWorkspace() {
     }
   }, [])
 
-  const handleCoverPlaceholderDrop = useCallback(
-    async (e: React.DragEvent) => {
-      e.preventDefault()
-      e.stopPropagation()
-      setCoverDropActive(false)
-
-      const file = e.dataTransfer.files?.[0]
-      if (!file) return
+  const uploadCoverFromFile = useCallback(
+    async (file: File) => {
+      setCoverUploadAnnouncement(null)
+      coverLastAnnouncedProgressRef.current = -1
 
       const validation = validateImageUploadFile(file)
       if (!validation.ok) {
+        setCoverUploadAnnouncement({ type: 'error', text: validation.error })
         toast.error(validation.error)
         return
       }
@@ -644,6 +659,11 @@ export function WriteEditorWorkspace() {
       coverUploadAbortRef.current = controller
 
       setCoverDropUploading(true)
+      setCoverUploadAnnouncement({
+        type: 'status',
+        text: 'Uploading cover image',
+      })
+
       try {
         const compressedFile = await compressImage(
           file,
@@ -656,25 +676,46 @@ export function WriteEditorWorkspace() {
           convex,
           'article_image',
           undefined,
-          undefined,
+          (progress) => {
+            const pct = progress.percentage
+            if (
+              shouldAnnounceProgress(
+                coverLastAnnouncedProgressRef.current,
+                pct
+              )
+            ) {
+              coverLastAnnouncedProgressRef.current = pct
+              setCoverUploadAnnouncement({
+                type: 'status',
+                text: `Uploading cover image, ${pct}% complete`,
+              })
+            }
+          },
           controller.signal
         )
         if (result.success && result.url) {
           setCoverImage(result.url)
           setHasUnsavedChanges(true)
+          setCoverUploadAnnouncement({
+            type: 'status',
+            text: 'Cover image uploaded',
+          })
         } else {
-          toast.error(result.error || 'Upload failed')
+          const message = result.error || 'Upload failed'
+          setCoverUploadAnnouncement({ type: 'error', text: message })
+          toast.error(message)
         }
       } catch (err) {
         if (isAbortError(err)) {
           return
         }
-        console.error('Cover drop upload error:', err)
-        toast.error(
+        console.error('Cover upload error:', err)
+        const message =
           err instanceof Error
             ? err.message
             : 'Upload failed. Please try again.'
-        )
+        setCoverUploadAnnouncement({ type: 'error', text: message })
+        toast.error(message)
       } finally {
         if (coverUploadAbortRef.current === controller) {
           coverUploadAbortRef.current = null
@@ -684,6 +725,35 @@ export function WriteEditorWorkspace() {
     },
     [convex]
   )
+
+  const handleCoverPlaceholderDrop = useCallback(
+    async (e: React.DragEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      setCoverDropActive(false)
+
+      const file = e.dataTransfer.files?.[0]
+      if (!file) return
+
+      await uploadCoverFromFile(file)
+    },
+    [uploadCoverFromFile]
+  )
+
+  const handleCoverFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0]
+      e.target.value = ''
+      if (file) {
+        void uploadCoverFromFile(file)
+      }
+    },
+    [uploadCoverFromFile]
+  )
+
+  const openCoverFilePicker = useCallback(() => {
+    coverFileInputRef.current?.click()
+  }, [])
 
   const handleBodyEditorDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault()
@@ -698,6 +768,94 @@ export function WriteEditorWorkspace() {
       setBodyImageDragging(false)
     }
   }, [])
+
+  const uploadBodyImageFromFile = useCallback(
+    async (file: File) => {
+      if (!editor) return
+
+      setBodyUploadAnnouncement(null)
+      bodyLastAnnouncedProgressRef.current = -1
+
+      const validation = validateImageUploadFile(file)
+      if (!validation.ok) {
+        setBodyUploadAnnouncement({ type: 'error', text: validation.error })
+        toast.error(validation.error)
+        return
+      }
+
+      bodyUploadAbortRef.current?.abort()
+      const controller = new AbortController()
+      bodyUploadAbortRef.current = controller
+
+      setBodyImageUploading(true)
+      setBodyImageUploadProgress(0)
+      setBodyUploadAnnouncement({
+        type: 'status',
+        text: 'Uploading image',
+      })
+
+      try {
+        const compressedFile = await compressImage(
+          file,
+          1200,
+          0.8,
+          controller.signal
+        )
+        const result = await uploadFile(
+          compressedFile,
+          convex,
+          'article_image',
+          undefined,
+          (progress) => {
+            const pct = progress.percentage
+            setBodyImageUploadProgress(pct)
+            if (
+              shouldAnnounceProgress(
+                bodyLastAnnouncedProgressRef.current,
+                pct
+              )
+            ) {
+              bodyLastAnnouncedProgressRef.current = pct
+              setBodyUploadAnnouncement({
+                type: 'status',
+                text: `Uploading image, ${pct}% complete`,
+              })
+            }
+          },
+          controller.signal
+        )
+
+        if (result.success && result.url) {
+          editor.chain().focus().setResizableImage({ src: result.url }).run()
+          setBodyUploadAnnouncement({
+            type: 'status',
+            text: 'Image added to article',
+          })
+        } else {
+          const message = result.error || 'Upload failed'
+          setBodyUploadAnnouncement({ type: 'error', text: message })
+          toast.error(message)
+        }
+      } catch (err) {
+        if (isAbortError(err)) {
+          return
+        }
+        console.error('Error uploading image:', err)
+        const message =
+          err instanceof Error
+            ? err.message
+            : 'Upload failed. Please try again.'
+        setBodyUploadAnnouncement({ type: 'error', text: message })
+        toast.error(message)
+      } finally {
+        if (bodyUploadAbortRef.current === controller) {
+          bodyUploadAbortRef.current = null
+        }
+        setBodyImageUploading(false)
+      }
+    },
+    [convex, editor]
+  )
 
   const handleBodyEditorDrop = useCallback(
     async (e: React.DragEvent) => {
@@ -714,60 +872,20 @@ export function WriteEditorWorkspace() {
       const file = imageFiles[0]
       if (!file) return
 
-      const validation = validateImageUploadFile(file)
-      if (!validation.ok) {
-        toast.error(validation.error)
-        return
-      }
+      await uploadBodyImageFromFile(file)
+    },
+    [editor, uploadBodyImageFromFile]
+  )
 
-      bodyUploadAbortRef.current?.abort()
-      const controller = new AbortController()
-      bodyUploadAbortRef.current = controller
-
-      setBodyImageUploading(true)
-      setBodyImageUploadProgress(0)
-
-      try {
-        const compressedFile = await compressImage(
-          file,
-          1200,
-          0.8,
-          controller.signal
-        )
-        const result = await uploadFile(
-          compressedFile,
-          convex,
-          'article_image',
-          undefined,
-          (progress) => {
-            setBodyImageUploadProgress(progress.percentage)
-          },
-          controller.signal
-        )
-
-        if (result.success && result.url) {
-          editor.chain().focus().setResizableImage({ src: result.url }).run()
-        } else {
-          toast.error(result.error || 'Upload failed')
-        }
-      } catch (err) {
-        if (isAbortError(err)) {
-          return
-        }
-        console.error('Error uploading dropped image:', err)
-        toast.error(
-          err instanceof Error
-            ? err.message
-            : 'Upload failed. Please try again.'
-        )
-      } finally {
-        if (bodyUploadAbortRef.current === controller) {
-          bodyUploadAbortRef.current = null
-        }
-        setBodyImageUploading(false)
+  const handleBodyFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0]
+      e.target.value = ''
+      if (file) {
+        void uploadBodyImageFromFile(file)
       }
     },
-    [convex, editor]
+    [uploadBodyImageFromFile]
   )
 
   const confirmLeaveNavigation = useCallback(() => {
@@ -909,7 +1027,7 @@ export function WriteEditorWorkspace() {
                     aria-label="Change cover image"
                     className={cn(
                       'rounded-lg border border-border bg-card px-4 py-2 text-sm font-medium text-foreground shadow hover:bg-muted',
-                      coverControlFocusRing
+                      UPLOAD_CONTROL_FOCUS_RING
                     )}
                   >
                     Change
@@ -923,7 +1041,7 @@ export function WriteEditorWorkspace() {
                     aria-label="Remove cover image"
                     className={cn(
                       'rounded-lg border border-border bg-card px-4 py-2 text-sm font-medium text-destructive shadow hover:bg-destructive/10',
-                      coverControlFocusRing
+                      UPLOAD_CONTROL_FOCUS_RING
                     )}
                   >
                     Remove
@@ -931,48 +1049,119 @@ export function WriteEditorWorkspace() {
                 </div>
               </div>
             ) : (
-              <div
-                role="button"
-                tabIndex={0}
-                aria-label="Add cover image"
-                onClick={() => setShowCoverImageDialog(true)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault()
-                    setShowCoverImageDialog(true)
+              <div className="space-y-2">
+                <div
+                  role="button"
+                  tabIndex={0}
+                  aria-label="Add cover image. Drag an image here, or choose a file."
+                  aria-describedby={
+                    [
+                      coverUploadAnnouncement?.type === 'error'
+                        ? COVER_UPLOAD_ERROR_ID
+                        : null,
+                      coverUploadAnnouncement?.type === 'status'
+                        ? COVER_UPLOAD_STATUS_ID
+                        : null,
+                    ]
+                      .filter(Boolean)
+                      .join(' ') || undefined
                   }
-                }}
-                onDragOver={handleCoverPlaceholderDragOver}
-                onDragLeave={handleCoverPlaceholderDragLeave}
-                onDrop={handleCoverPlaceholderDrop}
-                className={cn(
-                  'group flex h-28 w-full cursor-pointer items-center justify-center gap-2 rounded-xl border-2 border-dashed border-border text-muted-foreground transition-colors hover:border-primary hover:text-primary',
-                  coverDropActive &&
-                    'border-primary bg-primary/15 text-primary',
-                  coverDropUploading && 'pointer-events-none opacity-70'
-                )}
-              >
-                <svg
-                  className="h-5 w-5 shrink-0"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden
+                  onClick={openCoverFilePicker}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      openCoverFilePicker()
+                    }
+                  }}
+                  onDragOver={handleCoverPlaceholderDragOver}
+                  onDragLeave={handleCoverPlaceholderDragLeave}
+                  onDrop={handleCoverPlaceholderDrop}
+                  className={cn(
+                    'group flex h-28 w-full cursor-pointer items-center justify-center gap-2 rounded-xl border-2 border-dashed border-border text-muted-foreground transition-colors hover:border-primary hover:text-primary',
+                    UPLOAD_CONTROL_FOCUS_RING,
+                    coverDropActive &&
+                      'border-primary bg-primary/15 text-primary',
+                    coverDropUploading && 'pointer-events-none opacity-70'
+                  )}
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={1.5}
-                    d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-                  />
-                </svg>
-                <span className="text-sm font-medium">
-                  {coverDropUploading
-                    ? 'Uploading…'
-                    : coverDropActive
-                      ? 'Drop image to set cover'
-                      : 'Add cover image'}
-                </span>
+                  <svg
+                    className="h-5 w-5 shrink-0"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={1.5}
+                      d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                    />
+                  </svg>
+                  <span className="text-sm font-medium">
+                    {coverDropUploading
+                      ? 'Uploading…'
+                      : coverDropActive
+                        ? 'Drop image to set cover'
+                        : 'Drag an image here, or choose a file'}
+                  </span>
+                </div>
+                <div className="flex flex-wrap items-center gap-3">
+                  <label
+                    className={cn(
+                      'inline-flex cursor-pointer text-sm font-medium text-primary underline-offset-4 hover:text-primary/80 hover:underline',
+                      UPLOAD_CONTROL_FOCUS_RING
+                    )}
+                  >
+                    <input
+                      ref={coverFileInputRef}
+                      id={COVER_FILE_INPUT_ID}
+                      type="file"
+                      accept="image/png,image/jpeg,image/gif,image/webp"
+                      className="sr-only"
+                      onChange={handleCoverFileChange}
+                    />
+                    Choose file
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => setShowCoverImageDialog(true)}
+                    className={cn(
+                      'text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline',
+                      UPLOAD_CONTROL_FOCUS_RING
+                    )}
+                  >
+                    Paste image URL
+                  </button>
+                </div>
+                {coverUploadAnnouncement ? (
+                  <p
+                    id={
+                      coverUploadAnnouncement.type === 'error'
+                        ? COVER_UPLOAD_ERROR_ID
+                        : COVER_UPLOAD_STATUS_ID
+                    }
+                    role={
+                      coverUploadAnnouncement.type === 'error'
+                        ? 'alert'
+                        : 'status'
+                    }
+                    aria-live={
+                      coverUploadAnnouncement.type === 'error'
+                        ? 'assertive'
+                        : 'polite'
+                    }
+                    aria-atomic="true"
+                    className={cn(
+                      'text-xs',
+                      coverUploadAnnouncement.type === 'error'
+                        ? 'text-destructive'
+                        : 'sr-only'
+                    )}
+                  >
+                    {coverUploadAnnouncement.text}
+                  </p>
+                ) : null}
               </div>
             )}
           </div>
@@ -1069,53 +1258,128 @@ export function WriteEditorWorkspace() {
           </div>
 
           {editor && (
-            <div
-              className={cn(
-                'relative min-h-[400px] rounded-[var(--card-radius)] border border-transparent transition-colors',
-                bodyImageDragging && 'border-primary bg-primary/10',
-                bodyImageUploading && 'pointer-events-none'
-              )}
-              onDragOver={handleBodyEditorDragOver}
-              onDragLeave={handleBodyEditorDragLeave}
-              onDrop={handleBodyEditorDrop}
-            >
-              <EditorContent
-                editor={editor}
-                className="editor-content min-h-[400px]"
-              />
+            <div className="space-y-2">
+              <div
+                className={cn(
+                  'relative min-h-[400px] rounded-[var(--card-radius)] border border-transparent transition-colors',
+                  bodyImageDragging && 'border-primary bg-primary/10',
+                  bodyImageUploading && 'pointer-events-none'
+                )}
+                onDragOver={handleBodyEditorDragOver}
+                onDragLeave={handleBodyEditorDragLeave}
+                onDrop={handleBodyEditorDrop}
+                aria-describedby={
+                  [
+                    bodyUploadAnnouncement?.type === 'error'
+                      ? BODY_UPLOAD_ERROR_ID
+                      : null,
+                    bodyUploadAnnouncement?.type === 'status'
+                      ? BODY_UPLOAD_STATUS_ID
+                      : null,
+                  ]
+                    .filter(Boolean)
+                    .join(' ') || undefined
+                }
+              >
+                <EditorContent
+                  editor={editor}
+                  className="editor-content min-h-[400px]"
+                />
 
-              {bodyImageDragging && (
-                <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center rounded-[var(--card-radius)] border-2 border-dashed border-primary bg-primary/15">
-                  <div className="text-center">
-                    <div className="mb-2 text-lg font-medium text-primary">
-                      Drop image here
-                    </div>
-                    <div className="text-sm text-primary/80">
-                      Release to add to article
+                {bodyImageDragging && (
+                  <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center rounded-[var(--card-radius)] border-2 border-dashed border-primary bg-primary/15">
+                    <div className="text-center">
+                      <div className="mb-2 text-lg font-medium text-primary">
+                        Drop image here to add it
+                      </div>
+                      <div className="text-sm text-primary/80">
+                        or choose a file below
+                      </div>
                     </div>
                   </div>
-                </div>
-              )}
+                )}
 
-              {bodyImageUploading && (
-                <div className="absolute inset-0 z-20 flex items-center justify-center rounded-[var(--card-radius)] bg-card/90">
-                  <div className="text-center">
-                    <div className="mx-auto mb-2 h-8 w-8 animate-spin rounded-full border-b-2 border-primary" />
-                    <div className="text-sm text-muted-foreground">
-                      Optimizing and uploading image...
-                    </div>
-                    <div className="mx-auto mt-2 h-2 w-48 rounded-full bg-muted">
+                {bodyImageUploading && (
+                  <div
+                    className="absolute inset-0 z-20 flex items-center justify-center rounded-[var(--card-radius)] bg-card/90"
+                    role="status"
+                    aria-live="polite"
+                    aria-atomic="true"
+                  >
+                    <div className="text-center">
+                      <div className="mx-auto mb-2 h-8 w-8 animate-spin rounded-full border-b-2 border-primary" />
+                      <div className="text-sm text-muted-foreground">
+                        Optimizing and uploading image...
+                      </div>
                       <div
-                        className="h-2 rounded-full bg-primary transition-all duration-300"
-                        style={{ width: `${bodyImageUploadProgress}%` }}
-                      />
-                    </div>
-                    <div className="mt-1 text-xs text-muted-foreground">
-                      {bodyImageUploadProgress}%
+                        className="mx-auto mt-2 h-2 w-48 rounded-full bg-muted"
+                        role="progressbar"
+                        aria-valuemin={0}
+                        aria-valuemax={100}
+                        aria-valuenow={bodyImageUploadProgress}
+                        aria-label="Image upload progress"
+                      >
+                        <div
+                          className="h-2 rounded-full bg-primary transition-all duration-300"
+                          style={{ width: `${bodyImageUploadProgress}%` }}
+                        />
+                      </div>
+                      <div className="mt-1 text-xs text-muted-foreground">
+                        {bodyImageUploadProgress}%
+                      </div>
+                      {bodyUploadAnnouncement?.type === 'status' ? (
+                        <p className="sr-only">{bodyUploadAnnouncement.text}</p>
+                      ) : null}
                     </div>
                   </div>
-                </div>
-              )}
+                )}
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <label
+                  className={cn(
+                    'inline-flex cursor-pointer text-sm font-medium text-primary underline-offset-4 hover:text-primary/80 hover:underline',
+                    UPLOAD_CONTROL_FOCUS_RING
+                  )}
+                >
+                  <input
+                    ref={bodyFileInputRef}
+                    id={BODY_FILE_INPUT_ID}
+                    type="file"
+                    accept="image/png,image/jpeg,image/gif,image/webp"
+                    className="sr-only"
+                    onChange={handleBodyFileChange}
+                  />
+                  Choose image file
+                </label>
+                <p className="text-xs text-muted-foreground">
+                  You can also insert an image from the toolbar.
+                </p>
+              </div>
+              {bodyUploadAnnouncement &&
+              !bodyImageUploading &&
+              bodyUploadAnnouncement.type === 'error' ? (
+                <p
+                  id={BODY_UPLOAD_ERROR_ID}
+                  role="alert"
+                  aria-live="assertive"
+                  aria-atomic="true"
+                  className="text-xs text-destructive"
+                >
+                  {bodyUploadAnnouncement.text}
+                </p>
+              ) : bodyUploadAnnouncement &&
+                !bodyImageUploading &&
+                bodyUploadAnnouncement.type === 'status' ? (
+                <p
+                  id={BODY_UPLOAD_STATUS_ID}
+                  role="status"
+                  aria-live="polite"
+                  aria-atomic="true"
+                  className="sr-only"
+                >
+                  {bodyUploadAnnouncement.text}
+                </p>
+              ) : null}
             </div>
           )}
 

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -679,10 +679,7 @@ export function WriteEditorWorkspace() {
           (progress) => {
             const pct = progress.percentage
             if (
-              shouldAnnounceProgress(
-                coverLastAnnouncedProgressRef.current,
-                pct
-              )
+              shouldAnnounceProgress(coverLastAnnouncedProgressRef.current, pct)
             ) {
               coverLastAnnouncedProgressRef.current = pct
               setCoverUploadAnnouncement({
@@ -810,10 +807,7 @@ export function WriteEditorWorkspace() {
             const pct = progress.percentage
             setBodyImageUploadProgress(pct)
             if (
-              shouldAnnounceProgress(
-                bodyLastAnnouncedProgressRef.current,
-                pct
-              )
+              shouldAnnounceProgress(bodyLastAnnouncedProgressRef.current, pct)
             ) {
               bodyLastAnnouncedProgressRef.current = pct
               setBodyUploadAnnouncement({

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -23,3 +23,7 @@ export const TIP_PRESETS_HIGHLIGHT = [
 // Editor content styling (prose class for Tiptap)
 export const EDITOR_PROSE_CLASS =
   'prose prose-lg max-w-none focus:outline-none dark:prose-invert'
+
+/** Visible focus ring for upload controls (file pickers, drop zones, file labels). */
+export const UPLOAD_CONTROL_FOCUS_RING =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background'


### PR DESCRIPTION
## Summary

Every drag-and-drop image upload surface now has a visible, keyboard-accessible file-picker fallback, updated instructions that mention the non-drag path, consistent focus rings, and screen-reader-friendly progress and error announcements.


## Changes

### Image upload dialog (`ImageUploadDialog.tsx`)
- Replaced inline "browse" link with a labeled **Choose file** control (`sr-only` input + `htmlFor` label)
- Updated copy: "Drag and drop an image here, or choose a file to upload."
- Progress: `aria-live`, `aria-atomic`, `role="progressbar"`, sr-only status text
- URL tab upload button uses shared focus ring

### Write editor (`WriteEditorWorkspace.tsx`)
- **Cover:** click/Enter/Space opens file picker; **Choose file** label; **Paste image URL** for URL uploads; `aria-live` for upload progress and errors
- **Body:** **Choose image file** under editor; drag overlay mentions choosing a file; toolbar hint; throttled progress announcements (every 25%)

### Legacy editor (`Editor.tsx`)
- Same body-editor accessibility patterns for parity (not used in app routes)

<img width="1223" height="716" alt="1" src="https://github.com/user-attachments/assets/5db0e5cc-3d4d-4284-bc3a-86e1381f9ffa" />


