### PR TITLE
fix(a11y): trap focus in mobile nav menu and restore on close (ENG-175)

### DIFF
--- a/components/landing/Navigation.test.tsx
+++ b/components/landing/Navigation.test.tsx
@@ -39,4 +39,32 @@ describe('Navigation mobile menu', () => {
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
+
+  it('closes the mobile sheet when opened with Enter and closed with Escape', async () => {
+    const user = userEvent.setup()
+    render(<Navigation />)
+
+    const trigger = screen.getByRole('button', { name: 'Toggle menu' })
+    trigger.focus()
+    await user.keyboard('{Enter}')
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it('returns focus to the menu trigger when closed with Escape', async () => {
+    const user = userEvent.setup()
+    render(<Navigation />)
+
+    const trigger = screen.getByRole('button', { name: 'Toggle menu' })
+
+    await user.click(trigger)
+    await user.keyboard('{Escape}')
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
 })

--- a/components/landing/Navigation.tsx
+++ b/components/landing/Navigation.tsx
@@ -207,13 +207,13 @@ export default function Navigation() {
   }, [])
 
   useEffect(() => {
-    if (!openDropdown) return
+    if (!openDropdown || isOpen) return
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setOpenDropdown(null)
     }
     document.addEventListener('keydown', handleEscape)
     return () => document.removeEventListener('keydown', handleEscape)
-  }, [openDropdown])
+  }, [openDropdown, isOpen])
 
   const handleSmoothScroll = (
     e: React.MouseEvent<HTMLAnchorElement>,

--- a/components/layout/AppNavigation.test.tsx
+++ b/components/layout/AppNavigation.test.tsx
@@ -57,4 +57,53 @@ describe('AppNavigation mobile menu', () => {
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
+
+  it('closes the dialog when opened with Enter and closed with Escape', async () => {
+    const user = userEvent.setup()
+    render(<AppNavigation />)
+
+    const trigger = screen.getByRole('button', { name: 'Toggle menu' })
+    trigger.focus()
+    await user.keyboard('{Enter}')
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it('keeps focus inside the dialog when tabbing', async () => {
+    const user = userEvent.setup()
+    render(
+      <>
+        <button type="button">Behind</button>
+        <AppNavigation />
+      </>
+    )
+
+    const behind = screen.getByRole('button', { name: 'Behind' })
+
+    await user.click(screen.getByRole('button', { name: 'Toggle menu' }))
+    const dialog = screen.getByRole('dialog')
+
+    for (let i = 0; i < 12; i++) {
+      await user.tab()
+      expect(behind).not.toHaveFocus()
+      expect(dialog.contains(document.activeElement)).toBe(true)
+    }
+  })
+
+  it('returns focus to the menu trigger when closed with Escape', async () => {
+    const user = userEvent.setup()
+    render(<AppNavigation />)
+
+    const trigger = screen.getByRole('button', { name: 'Toggle menu' })
+
+    await user.click(trigger)
+    await user.keyboard('{Escape}')
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
 })

--- a/components/ui/sheet.test.tsx
+++ b/components/ui/sheet.test.tsx
@@ -13,11 +13,7 @@ function TestSheet() {
     <>
       <button type="button">Behind</button>
       <Sheet open={open} onOpenChange={setOpen}>
-        <button
-          ref={triggerRef}
-          type="button"
-          onClick={() => setOpen(true)}
-        >
+        <button ref={triggerRef} type="button" onClick={() => setOpen(true)}>
           Open menu
         </button>
         <SheetContent

--- a/components/ui/sheet.test.tsx
+++ b/components/ui/sheet.test.tsx
@@ -1,28 +1,37 @@
 /** @vitest-environment jsdom */
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, beforeEach } from 'vitest'
-import {
-  Sheet,
-  SheetContent,
-  SheetTitle,
-  SheetTrigger,
-} from '@/components/ui/sheet'
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 
 function TestSheet() {
   const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
 
   return (
-    <Sheet open={open} onOpenChange={setOpen}>
-      <SheetTrigger asChild>
-        <button type="button">Open menu</button>
-      </SheetTrigger>
-      <SheetContent>
-        <SheetTitle className="sr-only">Menu</SheetTitle>
-        <p>Menu content</p>
-      </SheetContent>
-    </Sheet>
+    <>
+      <button type="button">Behind</button>
+      <Sheet open={open} onOpenChange={setOpen}>
+        <button
+          ref={triggerRef}
+          type="button"
+          onClick={() => setOpen(true)}
+        >
+          Open menu
+        </button>
+        <SheetContent
+          onCloseAutoFocus={(e) => {
+            e.preventDefault()
+            triggerRef.current?.focus()
+          }}
+        >
+          <SheetTitle className="sr-only">Menu</SheetTitle>
+          <button type="button">Inside action</button>
+          <p>Menu content</p>
+        </SheetContent>
+      </Sheet>
+    </>
   )
 }
 
@@ -41,5 +50,34 @@ describe('Sheet', () => {
     await user.keyboard('{Escape}')
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('keeps focus inside the dialog when tabbing', async () => {
+    const user = userEvent.setup()
+    render(<TestSheet />)
+
+    const behind = screen.getByRole('button', { name: 'Behind' })
+
+    await user.click(screen.getByRole('button', { name: 'Open menu' }))
+    const dialog = screen.getByRole('dialog')
+
+    for (let i = 0; i < 12; i++) {
+      await user.tab()
+      expect(behind).not.toHaveFocus()
+      expect(dialog.contains(document.activeElement)).toBe(true)
+    }
+  })
+
+  it('returns focus to the trigger when closed with Escape', async () => {
+    const user = userEvent.setup()
+    render(<TestSheet />)
+
+    const trigger = screen.getByRole('button', { name: 'Open menu' })
+
+    await user.click(trigger)
+    await user.keyboard('{Escape}')
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
   })
 })

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -50,7 +50,8 @@ const sheetVariants = cva(
 )
 
 interface SheetContentProps
-  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+  extends
+    React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {}
 
 const SheetContent = React.forwardRef<

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -7,25 +7,7 @@ import { X } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 
-const SheetCloseContext = React.createContext<(() => void) | null>(null)
-
-const Sheet = ({
-  onOpenChange,
-  ...props
-}: React.ComponentPropsWithoutRef<typeof SheetPrimitive.Root>) => {
-  const onOpenChangeRef = React.useRef(onOpenChange)
-  onOpenChangeRef.current = onOpenChange
-
-  const close = React.useCallback(() => {
-    onOpenChangeRef.current?.(false)
-  }, [])
-
-  return (
-    <SheetCloseContext.Provider value={onOpenChange ? close : null}>
-      <SheetPrimitive.Root onOpenChange={onOpenChange} {...props} />
-    </SheetCloseContext.Provider>
-  )
-}
+const Sheet = SheetPrimitive.Root
 
 const SheetTrigger = SheetPrimitive.Trigger
 
@@ -39,7 +21,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-[100] bg-black/80 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0',
       className
     )}
     {...props}
@@ -49,7 +31,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out',
+  'fixed z-[100] gap-4 bg-background p-6 shadow-lg duration-300 data-[state=open]:animate-in data-[state=closed]:animate-out',
   {
     variants: {
       side: {
@@ -68,66 +50,28 @@ const sheetVariants = cva(
 )
 
 interface SheetContentProps
-  extends
-    React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {}
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = 'right', className, children, onEscapeKeyDown, ...props }, ref) => {
-  const closeSheet = React.useContext(SheetCloseContext)
-  const contentRef = React.useRef<HTMLDivElement>(null)
-
-  const setContentRef = React.useCallback(
-    (node: HTMLDivElement | null) => {
-      contentRef.current = node
-      if (typeof ref === 'function') {
-        ref(node)
-      } else if (ref) {
-        ref.current = node
-      }
-    },
-    [ref]
-  )
-
-  React.useEffect(() => {
-    if (!closeSheet) return
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return
-      const content = contentRef.current
-      if (!content || content.getAttribute('data-state') !== 'open') return
-      closeSheet()
-    }
-
-    window.addEventListener('keydown', handleKeyDown, true)
-    return () => window.removeEventListener('keydown', handleKeyDown, true)
-  }, [closeSheet])
-
-  return (
-    <SheetPortal>
-      <SheetOverlay />
-      <SheetPrimitive.Content
-        ref={setContentRef}
-        className={cn(sheetVariants({ side }), className)}
-        onEscapeKeyDown={(event) => {
-          onEscapeKeyDown?.(event)
-          if (!event.defaultPrevented && closeSheet) {
-            closeSheet()
-          }
-        }}
-        {...props}
-      >
-        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </SheetPrimitive.Close>
-        {children}
-      </SheetPrimitive.Content>
-    </SheetPortal>
-  )
-})
+>(({ side = 'right', className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+      {children}
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
 SheetContent.displayName = SheetPrimitive.Content.displayName
 
 const SheetHeader = ({


### PR DESCRIPTION
## Summary

Fixes keyboard accessibility for the mobile navigation menu (ENG-175). When the menu is open, focus stays inside the panel, Escape closes it, focus returns to the hamburger button on dismiss, and background content is not reachable.

## Changes

### Sheet primitive (`components/ui/sheet.tsx`)
- Set overlay and content to `z-[100]` so the menu stacks above the fixed nav (`z-50`)
- Rely on Radix Dialog modal behavior for focus trapping and `aria-hidden` on background content
- Remove redundant window-level Escape handler so close/focus flows go through Radix

### Mobile navigation
- **`components/layout/AppNavigation.tsx`** — app shell mobile menu
- **`components/landing/Navigation.tsx`** — landing page mobile menu
- Replace `SheetTrigger` with a ref-backed hamburger button and `onCloseAutoFocus` to return focus to the trigger on close (Escape, overlay, close button, nav links)




