### PR TITLE
fix(a11y): expose FAQ accordion state and keyboard behavior (ENG-193)

### DIFF
--- a/components/landing/FAQSection.test.tsx
+++ b/components/landing/FAQSection.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import type { HTMLAttributes, ReactNode } from 'react'
+import type { HTMLAttributes } from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
@@ -7,7 +7,9 @@ import FAQSection from '@/components/landing/FAQSection'
 
 vi.mock('motion/react', () => ({
   motion: {
-    h2: (props: HTMLAttributes<HTMLHeadingElement>) => <h2 {...props} />,
+    h2: ({ children, ...props }: HTMLAttributes<HTMLHeadingElement>) => (
+      <h2 {...props}>{children}</h2>
+    ),
     div: (props: HTMLAttributes<HTMLDivElement>) => <div {...props} />,
   },
   useInView: () => true,

--- a/components/landing/FAQSection.test.tsx
+++ b/components/landing/FAQSection.test.tsx
@@ -16,8 +16,7 @@ vi.mock('motion/react', () => ({
 }))
 
 describe('FAQSection accordion accessibility', () => {
-  const firstQuestion =
-    'What is Quilltip and what problem does it solve?'
+  const firstQuestion = 'What is Quilltip and what problem does it solve?'
   const secondQuestion = 'Do I need cryptocurrency to read articles?'
 
   function getTrigger(name: string) {

--- a/components/landing/FAQSection.test.tsx
+++ b/components/landing/FAQSection.test.tsx
@@ -1,0 +1,76 @@
+/** @vitest-environment jsdom */
+import type { HTMLAttributes, ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import FAQSection from '@/components/landing/FAQSection'
+
+vi.mock('motion/react', () => ({
+  motion: {
+    h2: (props: HTMLAttributes<HTMLHeadingElement>) => <h2 {...props} />,
+    div: (props: HTMLAttributes<HTMLDivElement>) => <div {...props} />,
+  },
+  useInView: () => true,
+}))
+
+describe('FAQSection accordion accessibility', () => {
+  const firstQuestion =
+    'What is Quilltip and what problem does it solve?'
+  const secondQuestion = 'Do I need cryptocurrency to read articles?'
+
+  function getTrigger(name: string) {
+    return screen.getByRole('button', { name })
+  }
+
+  it('exposes expanded state on the default open item', () => {
+    render(<FAQSection />)
+
+    const first = getTrigger(firstQuestion)
+    expect(first).toHaveAttribute('aria-expanded', 'true')
+    expect(first).toHaveAttribute('aria-controls')
+
+    const controlsId = first.getAttribute('aria-controls')
+    expect(controlsId).toBeTruthy()
+    const panel = document.getElementById(controlsId!)
+    expect(panel).toBeInTheDocument()
+    expect(panel).toHaveAttribute('aria-labelledby', first.id)
+  })
+
+  it('collapses the previous item when another is opened', async () => {
+    const user = userEvent.setup()
+    render(<FAQSection />)
+
+    const first = getTrigger(firstQuestion)
+    const second = getTrigger(secondQuestion)
+
+    expect(second).toHaveAttribute('aria-expanded', 'false')
+
+    await user.click(second)
+
+    expect(first).toHaveAttribute('aria-expanded', 'false')
+    expect(second).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('moves focus to the next question with ArrowDown', async () => {
+    const user = userEvent.setup()
+    render(<FAQSection />)
+
+    const first = getTrigger(firstQuestion)
+    const second = getTrigger(secondQuestion)
+
+    first.focus()
+    await user.keyboard('{ArrowDown}')
+
+    expect(second).toHaveFocus()
+  })
+
+  it('labels the FAQ section for assistive tech', () => {
+    render(<FAQSection />)
+
+    const section = document.getElementById('faq')
+    expect(section).toHaveAttribute('aria-labelledby', 'faq-heading')
+    expect(document.getElementById('faq-heading')).toHaveTextContent(
+      'Frequently Asked Questions'
+    )
+  })
+})

--- a/components/landing/FAQSection.tsx
+++ b/components/landing/FAQSection.tsx
@@ -47,8 +47,7 @@ const faqs = [
       "Reading articles: completely free, no wallet needed. Tipping writers: pay only the Stellar network fee (0.05 XLM, less than $0.01) plus your chosen tip amount. Publishing articles: free, no hosting fees or subscriptions. Minting article NFTs: requires reaching a tip threshold (currently 10 XLM in total tips received), then pay minimal Stellar network fee for minting (approximately 0.05 XLM). Editing published articles: free, unlimited edits. When you update an article that's been minted as an NFT, the blockchain preserves the original version while displaying your latest edits to readers.",
   },
   {
-    question:
-      'What barriers prevent mainstream users from adopting Quilltip?',
+    question: 'What barriers prevent mainstream users from adopting Quilltip?',
     answer:
       "Currently requires a Stellar wallet to tip or publish, which can intimidate non-crypto users. We're addressing this by: (1) Supporting four popular wallets through Stellar Wallet Kit for maximum compatibility, (2) Providing wallet setup guides and testnet XLM for new users, (3) Making all articles readable without any wallet, (4) Planning USDC support so users can tip with stablecoins instead of volatile XLM. Future roadmap includes social login options and custodial wallet integration.",
   },

--- a/components/landing/FAQSection.tsx
+++ b/components/landing/FAQSection.tsx
@@ -1,76 +1,84 @@
 'use client'
 
-import { useState } from 'react'
-import { ChevronDown } from 'lucide-react'
-import { motion, AnimatePresence, useInView } from 'motion/react'
 import { useRef } from 'react'
+import { ChevronDown } from 'lucide-react'
+import { motion, useInView } from 'motion/react'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion'
+import { cn } from '@/lib/utils'
+
+const faqTriggerFocusClass =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+
+const faqs = [
+  {
+    question: 'What is Quilltip and what problem does it solve?',
+    answer:
+      'Quilltip lets writers earn money directly from readers without ads, subscriptions, or gatekeepers taking large cuts. Anyone can publish articles for free, readers tip writers instantly with cryptocurrency, and writers keep 97.5% of every tip. All payments happen through Stellar blockchain smart contracts in 3-5 seconds with no intermediaries. Writers own their content permanently through NFTs (digital certificates of ownership), and readers never pay to access articles - tipping is always voluntary.',
+  },
+  {
+    question: 'Do I need cryptocurrency to read articles?',
+    answer:
+      'No. Reading articles on Quilltip is completely free — no wallet, no account, no crypto needed. You only need a Stellar wallet if you want to tip writers for content you love. Setting up a wallet takes about 2 minutes, and we have a step-by-step guide to help you.',
+  },
+  {
+    question: 'How does the tipping mechanism work?',
+    answer:
+      "Readers connect a Stellar wallet (Freighter, xBull, Albedo, or hot wallet), browse articles, and click \"Tip\" to send XLM directly to the writer's wallet. The transaction completes in 3-5 seconds through Soroban smart contracts. Writers receive funds instantly in their wallet - no withdrawal process or waiting period. Minimum tip is 0.026 XLM (approximately $0.01 USD) to ensure transaction fees don't exceed the tip value. There's no maximum limit.",
+  },
+  {
+    question: "What's Quilltip's business model and revenue split?",
+    answer:
+      'Writers keep 97.5% of all tips. Quilltip takes 2.5% to cover infrastructure costs (hosting, Arweave storage fees, platform development). There are no subscription fees, hosting costs, or hidden charges for writers or readers.',
+  },
+  {
+    question:
+      'Is Quilltip live on mainnet or testnet? When can I use it with real money?',
+    answer:
+      "We're live on testnet for now and working towards our mainnet launch soon. You can test all features with free testnet XLM — no real money needed.",
+  },
+  {
+    question: 'What does it cost to use Quilltip as a writer or reader?',
+    answer:
+      "Reading articles: completely free, no wallet needed. Tipping writers: pay only the Stellar network fee (0.05 XLM, less than $0.01) plus your chosen tip amount. Publishing articles: free, no hosting fees or subscriptions. Minting article NFTs: requires reaching a tip threshold (currently 10 XLM in total tips received), then pay minimal Stellar network fee for minting (approximately 0.05 XLM). Editing published articles: free, unlimited edits. When you update an article that's been minted as an NFT, the blockchain preserves the original version while displaying your latest edits to readers.",
+  },
+  {
+    question:
+      'What barriers prevent mainstream users from adopting Quilltip?',
+    answer:
+      "Currently requires a Stellar wallet to tip or publish, which can intimidate non-crypto users. We're addressing this by: (1) Supporting four popular wallets through Stellar Wallet Kit for maximum compatibility, (2) Providing wallet setup guides and testnet XLM for new users, (3) Making all articles readable without any wallet, (4) Planning USDC support so users can tip with stablecoins instead of volatile XLM. Future roadmap includes social login options and custodial wallet integration.",
+  },
+  {
+    question:
+      'How does Quilltip ensure my content survives long-term, even if the platform shuts down?',
+    answer:
+      'Two-layer permanence: (1) Arweave integration stores articles on decentralized, permanent storage that exists independently of Quilltip, with no recurring storage fees. (2) Article NFTs minted on Stellar blockchain create immutable proof of ownership and authorship. If Quilltip disappears, content persists on Arweave and ownership rights exist on Stellar.',
+  },
+  {
+    question:
+      'How does Quilltip handle content moderation while remaining decentralized?',
+    answer:
+      'Quilltip removes illegal content and violations of community guidelines from the platform interface. However, once Arweave integration launches, articles are stored on a decentralized network beyond our control, meaning censorship-resistant copies may persist. This balances platform safety with writer freedom: we curate the Quilltip experience while writers retain true ownership. Think of it like a library removing a book from shelves while the book itself still exists elsewhere.',
+  },
+] as const
 
 export default function FAQSection() {
   const ref = useRef(null)
   const isInView = useInView(ref, { once: true, margin: '-100px' })
-  const [openIndex, setOpenIndex] = useState<number | null>(0)
-
-  const faqs = [
-    {
-      question: 'What is Quilltip and what problem does it solve?',
-      answer:
-        'Quilltip lets writers earn money directly from readers without ads, subscriptions, or gatekeepers taking large cuts. Anyone can publish articles for free, readers tip writers instantly with cryptocurrency, and writers keep 97.5% of every tip. All payments happen through Stellar blockchain smart contracts in 3-5 seconds with no intermediaries. Writers own their content permanently through NFTs (digital certificates of ownership), and readers never pay to access articles - tipping is always voluntary.',
-    },
-    {
-      question: 'Do I need cryptocurrency to read articles?',
-      answer:
-        'No. Reading articles on Quilltip is completely free — no wallet, no account, no crypto needed. You only need a Stellar wallet if you want to tip writers for content you love. Setting up a wallet takes about 2 minutes, and we have a step-by-step guide to help you.',
-    },
-    {
-      question: 'How does the tipping mechanism work?',
-      answer:
-        "Readers connect a Stellar wallet (Freighter, xBull, Albedo, or hot wallet), browse articles, and click \"Tip\" to send XLM directly to the writer's wallet. The transaction completes in 3-5 seconds through Soroban smart contracts. Writers receive funds instantly in their wallet - no withdrawal process or waiting period. Minimum tip is 0.026 XLM (approximately $0.01 USD) to ensure transaction fees don't exceed the tip value. There's no maximum limit.",
-    },
-    {
-      question: "What's Quilltip's business model and revenue split?",
-      answer:
-        'Writers keep 97.5% of all tips. Quilltip takes 2.5% to cover infrastructure costs (hosting, Arweave storage fees, platform development). There are no subscription fees, hosting costs, or hidden charges for writers or readers.',
-    },
-    {
-      question:
-        'Is Quilltip live on mainnet or testnet? When can I use it with real money?',
-      answer:
-        "We're live on testnet for now and working towards our mainnet launch soon. You can test all features with free testnet XLM — no real money needed.",
-    },
-    {
-      question: 'What does it cost to use Quilltip as a writer or reader?',
-      answer:
-        "Reading articles: completely free, no wallet needed. Tipping writers: pay only the Stellar network fee (0.05 XLM, less than $0.01) plus your chosen tip amount. Publishing articles: free, no hosting fees or subscriptions. Minting article NFTs: requires reaching a tip threshold (currently 10 XLM in total tips received), then pay minimal Stellar network fee for minting (approximately 0.05 XLM). Editing published articles: free, unlimited edits. When you update an article that's been minted as an NFT, the blockchain preserves the original version while displaying your latest edits to readers.",
-    },
-    {
-      question:
-        'What barriers prevent mainstream users from adopting Quilltip?',
-      answer:
-        "Currently requires a Stellar wallet to tip or publish, which can intimidate non-crypto users. We're addressing this by: (1) Supporting four popular wallets through Stellar Wallet Kit for maximum compatibility, (2) Providing wallet setup guides and testnet XLM for new users, (3) Making all articles readable without any wallet, (4) Planning USDC support so users can tip with stablecoins instead of volatile XLM. Future roadmap includes social login options and custodial wallet integration.",
-    },
-    {
-      question:
-        'How does Quilltip ensure my content survives long-term, even if the platform shuts down?',
-      answer:
-        'Two-layer permanence: (1) Arweave integration stores articles on decentralized, permanent storage that exists independently of Quilltip, with no recurring storage fees. (2) Article NFTs minted on Stellar blockchain create immutable proof of ownership and authorship. If Quilltip disappears, content persists on Arweave and ownership rights exist on Stellar.',
-    },
-    {
-      question:
-        'How does Quilltip handle content moderation while remaining decentralized?',
-      answer:
-        'Quilltip removes illegal content and violations of community guidelines from the platform interface. However, once Arweave integration launches, articles are stored on a decentralized network beyond our control, meaning censorship-resistant copies may persist. This balances platform safety with writer freedom: we curate the Quilltip experience while writers retain true ownership. Think of it like a library removing a book from shelves while the book itself still exists elsewhere.',
-    },
-  ]
-
-  const toggleFAQ = (index: number) => {
-    setOpenIndex(openIndex === index ? null : index)
-  }
 
   return (
-    <section id="faq" className="py-32 px-8 bg-background">
+    <section
+      id="faq"
+      aria-labelledby="faq-heading"
+      className="py-32 px-8 bg-background"
+    >
       <div className="container mx-auto max-w-6xl" ref={ref}>
-        {/* Section Header */}
         <motion.h2
+          id="faq-heading"
           className="font-display text-4xl lg:text-5xl font-medium tracking-[-0.01em] mb-16 leading-[1.2] text-foreground"
           initial={{ opacity: 0, y: 30 }}
           animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 30 }}
@@ -79,51 +87,50 @@ export default function FAQSection() {
           Frequently Asked Questions
         </motion.h2>
 
-        {/* FAQ Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-16 gap-y-6">
+        <Accordion
+          type="single"
+          collapsible
+          defaultValue="faq-0"
+          className="grid grid-cols-1 md:grid-cols-2 gap-x-16 gap-y-6"
+        >
           {faqs.map((faq, index) => (
             <motion.div
-              key={index}
+              key={faq.question}
               initial={{ opacity: 0, y: 20 }}
               animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
               transition={{ duration: 0.5, delay: index * 0.08 }}
             >
-              <button
-                onClick={() => toggleFAQ(index)}
-                className="w-full flex items-start gap-4 text-left py-2"
-              >
-                <div
-                  className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5 transition-colors duration-200 ${
-                    openIndex === index
-                      ? 'bg-brand/15 text-brand'
-                      : 'bg-muted text-foreground border border-border'
-                  }`}
+              <AccordionItem value={`faq-${index}`} className="border-none">
+                <AccordionTrigger
+                  showChevron={false}
+                  className={cn(
+                    'group w-full flex items-start gap-4 py-2 hover:no-underline',
+                    faqTriggerFocusClass
+                  )}
                 >
-                  <ChevronDown className="w-4 h-4" />
-                </div>
-                <h3 className="font-semibold text-foreground text-[15px] leading-relaxed pt-1">
-                  {faq.question}
-                </h3>
-              </button>
-
-              <AnimatePresence>
-                {openIndex === index && (
-                  <motion.div
-                    initial={{ height: 0, opacity: 0 }}
-                    animate={{ height: 'auto', opacity: 1 }}
-                    exit={{ height: 0, opacity: 0 }}
-                    transition={{ duration: 0.3 }}
-                    className="overflow-hidden"
+                  <div
+                    className={cn(
+                      'w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5 transition-colors duration-200',
+                      'bg-muted text-foreground border border-border',
+                      'group-data-[state=open]:bg-brand/15 group-data-[state=open]:text-brand group-data-[state=open]:border-transparent'
+                    )}
                   >
-                    <div className="ml-12 pb-4 text-[14px] text-muted-foreground leading-relaxed">
-                      {faq.answer}
-                    </div>
-                  </motion.div>
-                )}
-              </AnimatePresence>
+                    <ChevronDown
+                      className="w-4 h-4 transition-transform duration-200 group-data-[state=open]:rotate-180"
+                      aria-hidden="true"
+                    />
+                  </div>
+                  <span className="font-semibold text-foreground text-[15px] leading-relaxed pt-1 text-left">
+                    {faq.question}
+                  </span>
+                </AccordionTrigger>
+                <AccordionContent className="ml-12 text-[14px] text-muted-foreground leading-relaxed">
+                  {faq.answer}
+                </AccordionContent>
+              </AccordionItem>
             </motion.div>
           ))}
-        </div>
+        </Accordion>
       </div>
     </section>
   )

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -20,21 +20,30 @@ const AccordionItem = React.forwardRef<
 ))
 AccordionItem.displayName = 'AccordionItem'
 
+type AccordionTriggerProps = React.ComponentPropsWithoutRef<
+  typeof AccordionPrimitive.Trigger
+> & {
+  showChevron?: boolean
+}
+
 const AccordionTrigger = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
+  AccordionTriggerProps
+>(({ className, children, showChevron = true, ...props }, ref) => (
   <AccordionPrimitive.Header className="flex">
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        'flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline text-left [&[data-state=open]>svg]:rotate-180',
+        'flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline text-left',
+        showChevron && '[&[data-state=open]>svg]:rotate-180',
         className
       )}
       {...props}
     >
       {children}
-      <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200" />
+      {showChevron ? (
+        <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200" />
+      ) : null}
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
 ))


### PR DESCRIPTION
## Summary

Fixes FAQ accordion accessibility on the landing page. FAQ items now use the Radix/shadcn accordion so assistive tech gets expanded/collapsed state, a proper question-to-answer relationship, and standard accordion keyboard navigation.



## Changes

- Refactor `FAQSection` from custom `useState` + Framer `AnimatePresence` to Radix `Accordion` (`type="single"`, `collapsible`, first item open by default)
- Expose `aria-expanded`, `aria-controls`, and panel `aria-labelledby` via Radix (no hand-rolled ARIA)
- Label the FAQ section with `id="faq-heading"` and `aria-labelledby` on `<section id="faq">`
- Use a single accordion root on the 2-column grid so Arrow Up/Down, Home, and End work across all 9 questions
- Add `focus-visible` ring styles on FAQ triggers
- Mark decorative chevron `aria-hidden`; rotate on open via `data-state`
- Add optional `showChevron` prop to `AccordionTrigger` so FAQ keeps its left-circle icon layout
- Add `FAQSection.test.tsx` regression tests for expanded state, controls relationship, ArrowDown focus, and section labelings

<img width="1221" height="718" alt="1" src="https://github.com/user-attachments/assets/5c7f8ff4-bd93-4f06-bbbb-1258123b465f" />
<img width="1220" height="717" alt="2" src="https://github.com/user-attachments/assets/b2ac528e-5e0b-4dd0-8c4e-d2307e222175" />

