### PR TITLE
feat: preserve tip context through login (ENG-182)

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,17 +1,17 @@
-import Link from 'next/link'
+import { Suspense } from 'react'
 import LoginForm from '@/components/auth/LoginForm'
+import { AuthReturnLinks } from '@/components/auth/AuthReturnLinks'
 
 /**
  * Login Page
  *
  * Provides user login functionality with email and password.
- * Integrates with NextAuth for authentication.
+ * Integrates with Convex Auth for authentication.
  */
 
 export default function LoginPage() {
   return (
     <div className="space-y-6">
-      {/* Page Header */}
       <div className="text-center">
         <h2 className="text-2xl font-bold text-foreground">
           Sign in to your account
@@ -21,21 +21,11 @@ export default function LoginPage() {
         </p>
       </div>
 
-      {/* Login Form */}
-      <LoginForm />
+      <Suspense fallback={null}>
+        <LoginForm />
+      </Suspense>
 
-      {/* Registration Link */}
-      <div className="text-center">
-        <p className="text-sm text-muted-foreground">
-          Don&apos;t have an account?{' '}
-          <Link
-            href="/register"
-            className="font-medium text-brand-blue hover:text-brand-accent transition-colors"
-          >
-            Sign up for free
-          </Link>
-        </p>
-      </div>
+      <AuthReturnLinks variant="login" />
     </div>
   )
 }

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,5 +1,6 @@
-import Link from 'next/link'
+import { Suspense } from 'react'
 import RegisterForm from '@/components/auth/RegisterForm'
+import { AuthReturnLinks } from '@/components/auth/AuthReturnLinks'
 
 /**
  * Registration Page
@@ -11,7 +12,6 @@ import RegisterForm from '@/components/auth/RegisterForm'
 export default function RegisterPage() {
   return (
     <div className="space-y-6">
-      {/* Page Header */}
       <div className="text-center">
         <h2 className="text-2xl font-bold text-foreground">
           Create your account
@@ -21,21 +21,11 @@ export default function RegisterPage() {
         </p>
       </div>
 
-      {/* Registration Form */}
-      <RegisterForm />
+      <Suspense fallback={null}>
+        <RegisterForm />
+      </Suspense>
 
-      {/* Login Link */}
-      <div className="text-center">
-        <p className="text-sm text-muted-foreground">
-          Already have an account?{' '}
-          <Link
-            href="/login"
-            className="font-medium text-brand-blue hover:text-brand-accent transition-colors"
-          >
-            Sign in here
-          </Link>
-        </p>
-      </div>
+      <AuthReturnLinks variant="register" />
     </div>
   )
 }

--- a/app/[username]/[slug]/page.tsx
+++ b/app/[username]/[slug]/page.tsx
@@ -13,6 +13,7 @@ import { ArticlePageLoadingSkeleton } from '@/components/articles/ArticlePageLoa
 import AppNavigation from '@/components/layout/AppNavigation'
 import { SiteFooter } from '@/components/layout/SiteFooter'
 import { TipStats } from '@/components/tipping/TipStats'
+import { PendingTipResume } from '@/components/tipping/PendingTipResume'
 import {
   TipButtonSkeleton,
   NftSidebarSkeleton,
@@ -163,6 +164,14 @@ export default function ArticlePage({ params }: ArticlePageProps) {
                     </h3>
                     <TipButton
                       articleId={article._id}
+                      authorName={
+                        article.author.name || article.author.username
+                      }
+                      authorStellarAddress={article.author.stellarAddress}
+                    />
+                    <PendingTipResume
+                      articleId={article._id}
+                      articleSlug={article.slug}
                       authorName={
                         article.author.name || article.author.username
                       }

--- a/components/articles/ArticleDisplay.tsx
+++ b/components/articles/ArticleDisplay.tsx
@@ -17,7 +17,6 @@ const HighlightableArticle = dynamic(
     })),
   { ssr: false, loading: () => <ArticleBodySkeleton /> }
 )
-import { useAuth } from '@/components/providers/AuthContext'
 import type { Id } from '@/types/convex'
 import type { ArticleForDisplay } from '@/types/index'
 import { TagFilterLink } from '@/components/articles/TagFilterLink'
@@ -40,13 +39,11 @@ export default function ArticleDisplay({
   tocHeadings = [],
 }: ArticleDisplayProps) {
   const [currentUrl, setCurrentUrl] = useState('')
-  const { isAuthenticated } = useAuth()
-
   useEffect(() => {
     setCurrentUrl(window.location.href)
   }, [])
 
-  const effectiveShowHighlights = showHighlights && isAuthenticated
+  const effectiveShowHighlights = showHighlights
 
   const publishedDate = article.publishedAt
     ? formatDistanceToNow(new Date(article.publishedAt), { addSuffix: true })

--- a/components/auth/AuthReturnLinks.tsx
+++ b/components/auth/AuthReturnLinks.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { Suspense } from 'react'
+import {
+  buildLoginHref,
+  buildRegisterHref,
+  getSafeReturnPath,
+} from '@/lib/auth/safeReturnPath'
+import { clearPendingTipIntent } from '@/lib/tip/pendingTipIntent'
+
+function AuthReturnLinksInner({
+  variant,
+}: {
+  variant: 'login' | 'register'
+}) {
+  const searchParams = useSearchParams()
+  const returnTo = getSafeReturnPath(searchParams.get('returnTo'))
+
+  const handleCancel = () => {
+    clearPendingTipIntent()
+  }
+
+  if (variant === 'login') {
+    return (
+      <div className="space-y-4">
+        <div className="text-center">
+          <p className="text-sm text-muted-foreground">
+            Don&apos;t have an account?{' '}
+            <Link
+              href={buildRegisterHref(returnTo)}
+              className="font-medium text-brand-blue hover:text-brand-accent transition-colors"
+            >
+              Sign up for free
+            </Link>
+          </p>
+        </div>
+        <div className="text-center">
+          <Link
+            href={returnTo}
+            onClick={handleCancel}
+            className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Cancel
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="text-center">
+        <p className="text-sm text-muted-foreground">
+          Already have an account?{' '}
+          <Link
+            href={buildLoginHref(returnTo)}
+            className="font-medium text-brand-blue hover:text-brand-accent transition-colors"
+          >
+            Sign in here
+          </Link>
+        </p>
+      </div>
+      <div className="text-center">
+        <Link
+          href={returnTo}
+          onClick={handleCancel}
+          className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Cancel
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+export function AuthReturnLinks({
+  variant,
+}: {
+  variant: 'login' | 'register'
+}) {
+  return (
+    <Suspense fallback={null}>
+      <AuthReturnLinksInner variant={variant} />
+    </Suspense>
+  )
+}

--- a/components/auth/AuthReturnLinks.tsx
+++ b/components/auth/AuthReturnLinks.tsx
@@ -10,11 +10,7 @@ import {
 } from '@/lib/auth/safeReturnPath'
 import { clearPendingTipIntent } from '@/lib/tip/pendingTipIntent'
 
-function AuthReturnLinksInner({
-  variant,
-}: {
-  variant: 'login' | 'register'
-}) {
+function AuthReturnLinksInner({ variant }: { variant: 'login' | 'register' }) {
   const searchParams = useSearchParams()
   const returnTo = getSafeReturnPath(searchParams.get('returnTo'))
 

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useAuthActions } from '@convex-dev/auth/react'
 import { useRouter } from 'next/navigation'
+import { useAuthReturnPath } from '@/components/auth/useAuthReturnPath'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { loginSchema, type LoginFormData } from '@/lib/validations/auth'
@@ -26,6 +27,7 @@ export default function LoginForm() {
   const [error, setError] = useState<string | null>(null)
 
   const router = useRouter()
+  const returnPath = useAuthReturnPath()
   const { signIn } = useAuthActions()
 
   const {
@@ -49,7 +51,7 @@ export default function LoginForm() {
 
       // If we reach here, sign-in was successful
       // Use replace to prevent back button returning to login
-      router.replace('/')
+      router.replace(returnPath)
     } catch (error) {
       console.error('Login error:', error)
       setError('Invalid email or password. Please try again.')

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { useAuthReturnPath } from '@/components/auth/useAuthReturnPath'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { mapRegisterSignInError } from '@/lib/auth/map-register-error'
@@ -29,6 +30,7 @@ export default function RegisterForm() {
   const [success, setSuccess] = useState(false)
 
   const router = useRouter()
+  const returnPath = useAuthReturnPath()
   const { signIn } = useAuth()
 
   const {
@@ -54,7 +56,7 @@ export default function RegisterForm() {
 
       setSuccess(true)
       // Use replace to prevent back button returning to register
-      router.replace('/')
+      router.replace(returnPath)
     } catch (error) {
       setError(mapRegisterSignInError(error))
       setIsLoading(false)

--- a/components/auth/useAuthReturnPath.ts
+++ b/components/auth/useAuthReturnPath.ts
@@ -1,0 +1,9 @@
+'use client'
+
+import { useSearchParams } from 'next/navigation'
+import { getSafeReturnPath } from '@/lib/auth/safeReturnPath'
+
+export function useAuthReturnPath(): string {
+  const searchParams = useSearchParams()
+  return getSafeReturnPath(searchParams.get('returnTo'))
+}

--- a/components/highlights/HighlightPopover.test.tsx
+++ b/components/highlights/HighlightPopover.test.tsx
@@ -6,6 +6,10 @@ vi.mock('@/components/highlights/HighlightTipButton', () => ({
   HighlightTipButton: () => null,
 }))
 
+vi.mock('@/components/providers/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: true, isLoading: false, user: null }),
+}))
+
 import { HighlightPopover } from '@/components/highlights/HighlightPopover'
 
 describe('HighlightPopover', () => {

--- a/components/highlights/HighlightPopover.tsx
+++ b/components/highlights/HighlightPopover.tsx
@@ -6,6 +6,7 @@ import { Highlighter, MessageSquare, Lock, Globe } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { HighlightTipButton } from './HighlightTipButton'
 import { Id } from '@/convex/_generated/dataModel'
+import { useAuth } from '@/components/providers/AuthContext'
 
 interface HighlightPopoverProps {
   position: { top: number; left: number }
@@ -73,6 +74,7 @@ export function HighlightPopover({
   startOffset,
   endOffset,
 }: HighlightPopoverProps) {
+  const { isAuthenticated } = useAuth()
   const [selectedColor, setSelectedColor] = useState(
     PREMIUM_HIGHLIGHT_COLORS[0]?.value || '#F59E0B'
   )
@@ -145,7 +147,8 @@ export function HighlightPopover({
           {selectedText.length > 150 ? '...' : ''}&rdquo;
         </div>
 
-        {/* Color Picker */}
+        {isAuthenticated && (
+          <>
         <div className="mb-4">
           <div className="text-xs font-medium text-muted-foreground mb-2">
             Choose Highlight Color
@@ -220,30 +223,35 @@ export function HighlightPopover({
             />
           </div>
         )}
+          </>
+        )}
 
-        {/* Action Buttons Section */}
         <div className="pt-3 border-t border-border">
           <div className="text-xs font-medium text-muted-foreground mb-3 text-center">
-            Save highlight{' '}
-            {articleId &&
-              articleSlug &&
-              authorStellarAddress &&
-              startOffset !== undefined &&
-              endOffset !== undefined &&
-              'or tip the author'}
+            {isAuthenticated
+              ? `Save highlight${
+                  articleId &&
+                  articleSlug &&
+                  authorStellarAddress &&
+                  startOffset !== undefined &&
+                  endOffset !== undefined
+                    ? ' or tip the author'
+                    : ''
+                }`
+              : 'Tip the author for this selection'}
           </div>
 
           <div className="flex gap-2 mb-3">
-            {/* Save Highlight Button */}
-            <button
-              onClick={handleSaveHighlight}
-              className="highlight-action-button flex-1 bg-gradient-to-r from-blue-500 to-blue-600 text-white hover:from-blue-600 hover:to-blue-700 flex items-center justify-center"
-            >
-              <Highlighter className="w-4 h-4 mr-2" />
-              <span>Save</span>
-            </button>
+            {isAuthenticated && (
+              <button
+                onClick={handleSaveHighlight}
+                className="highlight-action-button flex-1 bg-gradient-to-r from-blue-500 to-blue-600 text-white hover:from-blue-600 hover:to-blue-700 flex items-center justify-center"
+              >
+                <Highlighter className="w-4 h-4 mr-2" />
+                <span>Save</span>
+              </button>
+            )}
 
-            {/* Tip Highlight Button - Show if article data is available */}
             {articleId &&
               articleSlug &&
               authorStellarAddress &&
@@ -258,15 +266,18 @@ export function HighlightPopover({
                   startOffset={startOffset}
                   endOffset={endOffset}
                   className="flex-1"
-                  onSuccess={() => {
-                    // Create highlight with selected settings, then close
-                    onCreateHighlight(
-                      selectedColor,
-                      note || undefined,
-                      isPublic
-                    )
-                    onClose()
-                  }}
+                  onSuccess={
+                    isAuthenticated
+                      ? () => {
+                          onCreateHighlight(
+                            selectedColor,
+                            note || undefined,
+                            isPublic
+                          )
+                          onClose()
+                        }
+                      : undefined
+                  }
                 />
               )}
           </div>

--- a/components/highlights/HighlightPopover.tsx
+++ b/components/highlights/HighlightPopover.tsx
@@ -149,80 +149,82 @@ export function HighlightPopover({
 
         {isAuthenticated && (
           <>
-        <div className="mb-4">
-          <div className="text-xs font-medium text-muted-foreground mb-2">
-            Choose Highlight Color
-          </div>
-          <div className="color-picker-container">
-            {PREMIUM_HIGHLIGHT_COLORS.map((color) => (
+            <div className="mb-4">
+              <div className="text-xs font-medium text-muted-foreground mb-2">
+                Choose Highlight Color
+              </div>
+              <div className="color-picker-container">
+                {PREMIUM_HIGHLIGHT_COLORS.map((color) => (
+                  <button
+                    key={color.value}
+                    onClick={() => handleColorSelect(color.value)}
+                    className={cn(
+                      'color-picker-button',
+                      selectedColor === color.value && 'selected'
+                    )}
+                    style={{
+                      background: `linear-gradient(135deg, ${color.value}, ${color.value}dd)`,
+                    }}
+                    aria-label={`Select ${color.name} highlight`}
+                  >
+                    <div className="color-tooltip">
+                      <div className="font-medium">{color.name}</div>
+                      <div className="text-xs opacity-80">
+                        {color.description}
+                      </div>
+                      <div className="color-tooltip-arrow" />
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Actions */}
+            <div className="flex items-center gap-2 mb-3">
               <button
-                key={color.value}
-                onClick={() => handleColorSelect(color.value)}
+                onClick={() => setShowNoteInput(!showNoteInput)}
                 className={cn(
-                  'color-picker-button',
-                  selectedColor === color.value && 'selected'
+                  'highlight-action-button flex items-center gap-2',
+                  'bg-muted hover:bg-muted/80 text-foreground',
+                  showNoteInput && 'bg-muted/90'
                 )}
-                style={{
-                  background: `linear-gradient(135deg, ${color.value}, ${color.value}dd)`,
-                }}
-                aria-label={`Select ${color.name} highlight`}
               >
-                <div className="color-tooltip">
-                  <div className="font-medium">{color.name}</div>
-                  <div className="text-xs opacity-80">{color.description}</div>
-                  <div className="color-tooltip-arrow" />
-                </div>
+                <MessageSquare className="w-4 h-4" />
+                <span>Add Note</span>
               </button>
-            ))}
-          </div>
-        </div>
 
-        {/* Actions */}
-        <div className="flex items-center gap-2 mb-3">
-          <button
-            onClick={() => setShowNoteInput(!showNoteInput)}
-            className={cn(
-              'highlight-action-button flex items-center gap-2',
-              'bg-muted hover:bg-muted/80 text-foreground',
-              showNoteInput && 'bg-muted/90'
+              <button
+                onClick={() => setIsPublic(!isPublic)}
+                className="privacy-toggle"
+              >
+                {isPublic ? (
+                  <>
+                    <Globe className="w-4 h-4 text-green-800 dark:text-green-300" />
+                    <span className="text-sm text-foreground">Public</span>
+                  </>
+                ) : (
+                  <>
+                    <Lock className="w-4 h-4 text-muted-foreground" />
+                    <span className="text-sm text-foreground">Private</span>
+                  </>
+                )}
+              </button>
+            </div>
+
+            {/* Note Input */}
+            {showNoteInput && (
+              <div className="mb-3">
+                <textarea
+                  value={note}
+                  onChange={(e) => setNote(e.target.value)}
+                  placeholder="Add a note to your highlight..."
+                  className="w-full px-3 py-2 text-sm border border-input bg-background text-foreground rounded-lg focus:ring-2 focus:ring-ring focus:border-transparent resize-none"
+                  rows={3}
+                  // eslint-disable-next-line jsx-a11y/no-autofocus
+                  autoFocus
+                />
+              </div>
             )}
-          >
-            <MessageSquare className="w-4 h-4" />
-            <span>Add Note</span>
-          </button>
-
-          <button
-            onClick={() => setIsPublic(!isPublic)}
-            className="privacy-toggle"
-          >
-            {isPublic ? (
-              <>
-                <Globe className="w-4 h-4 text-green-800 dark:text-green-300" />
-                <span className="text-sm text-foreground">Public</span>
-              </>
-            ) : (
-              <>
-                <Lock className="w-4 h-4 text-muted-foreground" />
-                <span className="text-sm text-foreground">Private</span>
-              </>
-            )}
-          </button>
-        </div>
-
-        {/* Note Input */}
-        {showNoteInput && (
-          <div className="mb-3">
-            <textarea
-              value={note}
-              onChange={(e) => setNote(e.target.value)}
-              placeholder="Add a note to your highlight..."
-              className="w-full px-3 py-2 text-sm border border-input bg-background text-foreground rounded-lg focus:ring-2 focus:ring-ring focus:border-transparent resize-none"
-              rows={3}
-              // eslint-disable-next-line jsx-a11y/no-autofocus
-              autoFocus
-            />
-          </div>
-        )}
           </>
         )}
 

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -126,12 +126,7 @@ export function HighlightTipButton({
     )
     activateWallet()
     setIsOpen(true)
-  }, [
-    resumeOpen,
-    resumeAmountCents,
-    resumeCustomAmount,
-    activateWallet,
-  ])
+  }, [resumeOpen, resumeAmountCents, resumeCustomAmount, activateWallet])
 
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useConvex, useMutation } from 'convex/react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { useWallet } from '@/components/providers/WalletProvider'
 import { useWalletActivation } from '@/components/providers/WalletActivationContext'
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 import { AlertCircle, Coins, Heart, Loader2, Wallet } from 'lucide-react'
 import { api } from '@/convex/_generated/api'
@@ -50,6 +50,9 @@ import {
   type TipFailureMessage,
 } from '@/lib/stellar/tip-error-messages'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { redirectToLoginForTip } from '@/lib/tip/redirectToLoginForTip'
+import { applyPendingAmountFields } from '@/lib/tip/applyPendingTipFormState'
+import { clearPendingTipIntent } from '@/lib/tip/pendingTipIntent'
 
 interface HighlightTipButtonProps {
   articleId: Id<'articles'>
@@ -63,6 +66,9 @@ interface HighlightTipButtonProps {
   endContainerPath?: string
   className?: string
   onSuccess?: () => void
+  resumeOpen?: boolean
+  resumeAmountCents?: number
+  resumeCustomAmount?: string
 }
 
 export function HighlightTipButton({
@@ -77,12 +83,17 @@ export function HighlightTipButton({
   endContainerPath,
   className = '',
   onSuccess,
+  resumeOpen = false,
+  resumeAmountCents,
+  resumeCustomAmount,
 }: HighlightTipButtonProps) {
   const { isAuthenticated } = useAuth()
   const { isConnected, publicKey, signTransaction, connect } = useWallet()
   const { activateWallet } = useWalletActivation()
   const router = useRouter()
-  const [isOpen, setIsOpen] = useState(false)
+  const pathname = usePathname()
+  const [isOpen, setIsOpen] = useState(resumeOpen)
+  const resumedRef = useRef(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
   const [selectedAmount, setSelectedAmount] = useState<number | null>(null)
   const [customAmount, setCustomAmount] = useState('')
@@ -102,6 +113,26 @@ export function HighlightTipButton({
     })
   }, [])
 
+  useEffect(() => {
+    if (!resumeOpen || resumedRef.current) return
+    resumedRef.current = true
+    applyPendingAmountFields(
+      {
+        amountCents: resumeAmountCents,
+        customAmount: resumeCustomAmount,
+      },
+      setSelectedAmount,
+      setCustomAmount
+    )
+    activateWallet()
+    setIsOpen(true)
+  }, [
+    resumeOpen,
+    resumeAmountCents,
+    resumeCustomAmount,
+    activateWallet,
+  ])
+
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
     if (open) {
@@ -116,9 +147,32 @@ export function HighlightTipButton({
   }
 
   const handleTip = async () => {
+    const amountCents = selectedAmount || parseFloat(customAmount) * 100
+
+    if (!amountCents || amountCents < TIP_MIN_CENTS) {
+      toast.error('Please select or enter a valid amount')
+      return
+    }
+
+    if (amountCents > TIP_MAX_CENTS) {
+      toast.error(`Maximum tip amount is $${TIP_MAX_USD.toFixed(2)}`)
+      return
+    }
+
     if (!isAuthenticated) {
       toast.error('Please sign in to send tips')
-      router.push('/login')
+      redirectToLoginForTip(router, pathname, {
+        kind: 'highlight',
+        articleId: articleId,
+        articleSlug,
+        highlightText,
+        startOffset,
+        endOffset,
+        ...(startContainerPath ? { startContainerPath } : {}),
+        ...(endContainerPath ? { endContainerPath } : {}),
+        ...(selectedAmount != null ? { amountCents: selectedAmount } : {}),
+        ...(customAmount ? { customAmount } : {}),
+      })
       return
     }
 
@@ -129,18 +183,6 @@ export function HighlightTipButton({
 
     if (!authorStellarAddress) {
       toast.error('Author has not set up their Stellar wallet yet')
-      return
-    }
-
-    const amountCents = selectedAmount || parseFloat(customAmount) * 100
-
-    if (!amountCents || amountCents < TIP_MIN_CENTS) {
-      toast.error('Please select or enter a valid amount')
-      return
-    }
-
-    if (amountCents > TIP_MAX_CENTS) {
-      toast.error(`Maximum tip amount is $${TIP_MAX_USD.toFixed(2)}`)
       return
     }
 
@@ -212,6 +254,7 @@ export function HighlightTipButton({
         authorShare: transactionData.authorReceived,
       })
 
+      clearPendingTipIntent()
       setTipFailure(null)
       setIsOpen(false)
       setSelectedAmount(null)

--- a/components/tipping/PendingTipResume.tsx
+++ b/components/tipping/PendingTipResume.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useAuth } from '@/components/providers/AuthContext'
+import { HighlightTipButton } from '@/components/highlights/HighlightTipButton'
+import {
+  clearPendingTipIntent,
+  matchesHighlightPendingIntent,
+  readPendingTipIntent,
+  type HighlightPendingTipIntent,
+} from '@/lib/tip/pendingTipIntent'
+import type { Id } from '@/convex/_generated/dataModel'
+
+interface PendingTipResumeProps {
+  articleId: Id<'articles'>
+  articleSlug: string
+  authorName: string
+  authorStellarAddress?: string | null
+}
+
+export function PendingTipResume({
+  articleId,
+  articleSlug,
+  authorName,
+  authorStellarAddress,
+}: PendingTipResumeProps) {
+  const { isAuthenticated } = useAuth()
+  const resumedRef = useRef(false)
+  const [intent, setIntent] = useState<HighlightPendingTipIntent | null>(null)
+
+  useEffect(() => {
+    if (!isAuthenticated || resumedRef.current) return
+    const pending = readPendingTipIntent()
+    if (!matchesHighlightPendingIntent(pending, articleId)) return
+    resumedRef.current = true
+    clearPendingTipIntent()
+    setIntent(pending)
+  }, [isAuthenticated, articleId])
+
+  if (!intent) return null
+
+  return (
+    <div className="sr-only" aria-hidden>
+      <HighlightTipButton
+        articleId={articleId}
+        articleSlug={articleSlug}
+        authorName={authorName}
+        authorStellarAddress={authorStellarAddress}
+        highlightText={intent.highlightText}
+        startOffset={intent.startOffset}
+        endOffset={intent.endOffset}
+        startContainerPath={intent.startContainerPath}
+        endContainerPath={intent.endContainerPath}
+        resumeOpen
+        resumeAmountCents={intent.amountCents}
+        resumeCustomAmount={intent.customAmount}
+      />
+    </div>
+  )
+}

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useConvex, useMutation } from 'convex/react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { useWallet } from '@/components/providers/WalletProvider'
 import { useWalletActivation } from '@/components/providers/WalletActivationContext'
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 import { AlertCircle, Coins, Heart, Loader2, Wallet } from 'lucide-react'
 import { WalletTooltip } from '@/components/guide/WalletTooltip'
@@ -50,6 +50,13 @@ import {
   type TipFailureMessage,
 } from '@/lib/stellar/tip-error-messages'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { redirectToLoginForTip } from '@/lib/tip/redirectToLoginForTip'
+import { applyPendingAmountFields } from '@/lib/tip/applyPendingTipFormState'
+import {
+  clearPendingTipIntent,
+  matchesArticlePendingIntent,
+  readPendingTipIntent,
+} from '@/lib/tip/pendingTipIntent'
 
 interface TipButtonProps {
   articleId: Id<'articles'>
@@ -68,6 +75,7 @@ export function TipButton({
   const { isConnected, publicKey, signTransaction, connect } = useWallet()
   const { activateWallet } = useWalletActivation()
   const router = useRouter()
+  const pathname = usePathname()
   const [isOpen, setIsOpen] = useState(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
   const [selectedAmount, setSelectedAmount] = useState<number | null>(null)
@@ -76,6 +84,7 @@ export function TipButton({
   const [tipFlowStep, setTipFlowStep] = useState<TipFlowStep | null>(null)
   const [tipFailure, setTipFailure] = useState<TipFailureMessage | null>(null)
   const [tipMessage, setTipMessage] = useState('')
+  const resumedRef = useRef(false)
 
   const convex = useConvex()
   const sendTip = useMutation(api.tips.sendTip)
@@ -89,6 +98,18 @@ export function TipButton({
     })
   }, [])
 
+  useEffect(() => {
+    if (!isAuthenticated || resumedRef.current) return
+    const pending = readPendingTipIntent()
+    if (!matchesArticlePendingIntent(pending, articleId)) return
+    resumedRef.current = true
+    applyPendingAmountFields(pending, setSelectedAmount, setCustomAmount)
+    if (pending.message) setTipMessage(pending.message)
+    clearPendingTipIntent()
+    activateWallet()
+    setIsOpen(true)
+  }, [isAuthenticated, articleId, activateWallet])
+
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
     if (open) {
@@ -99,17 +120,6 @@ export function TipButton({
   }
 
   const handleTip = async () => {
-    if (!isAuthenticated) {
-      toast.error('Please sign in to send tips')
-      router.push('/login')
-      return
-    }
-
-    if (!isConnected || !publicKey) {
-      toast.error('Please connect your Stellar wallet to send tips')
-      return
-    }
-
     const amountCents = selectedAmount || parseFloat(customAmount) * 100
 
     if (!amountCents || amountCents < TIP_MIN_CENTS) {
@@ -122,15 +132,32 @@ export function TipButton({
       return
     }
 
+    if (tipMessage.length > 500) {
+      toast.error('Message must be 500 characters or less')
+      return
+    }
+
+    if (!isAuthenticated) {
+      toast.error('Please sign in to send tips')
+      redirectToLoginForTip(router, pathname, {
+        kind: 'article',
+        articleId: articleId,
+        ...(selectedAmount != null ? { amountCents: selectedAmount } : {}),
+        ...(customAmount ? { customAmount } : {}),
+        ...(tipMessage.trim() ? { message: tipMessage.trim() } : {}),
+      })
+      return
+    }
+
+    if (!isConnected || !publicKey) {
+      toast.error('Please connect your Stellar wallet to send tips')
+      return
+    }
+
     if (!authorStellarAddress) {
       toast.error(
         'Author has not set up their Stellar wallet for receiving tips'
       )
-      return
-    }
-
-    if (tipMessage.length > 500) {
-      toast.error('Message must be 500 characters or less')
       return
     }
 
@@ -188,6 +215,7 @@ export function TipButton({
         authorShare: transactionData.authorReceived,
       })
 
+      clearPendingTipIntent()
       setTipFailure(null)
       setIsOpen(false)
       setSelectedAmount(null)

--- a/lib/auth/safeReturnPath.test.ts
+++ b/lib/auth/safeReturnPath.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildLoginHref,
+  buildRegisterHref,
+  getSafeReturnPath,
+} from './safeReturnPath'
+
+describe('getSafeReturnPath', () => {
+  it('returns fallback for null, undefined, and empty', () => {
+    expect(getSafeReturnPath(null)).toBe('/')
+    expect(getSafeReturnPath(undefined)).toBe('/')
+    expect(getSafeReturnPath('')).toBe('/')
+    expect(getSafeReturnPath('   ')).toBe('/')
+  })
+
+  it('accepts valid relative paths', () => {
+    expect(getSafeReturnPath('/alice/my-article')).toBe('/alice/my-article')
+    expect(getSafeReturnPath('/articles?page=2')).toBe('/articles?page=2')
+  })
+
+  it('rejects protocol-relative and absolute URLs', () => {
+    expect(getSafeReturnPath('//evil.com')).toBe('/')
+    expect(getSafeReturnPath('https://evil.com')).toBe('/')
+    expect(getSafeReturnPath('http://evil.com/path')).toBe('/')
+  })
+
+  it('rejects paths without leading slash', () => {
+    expect(getSafeReturnPath('alice/article')).toBe('/')
+  })
+
+  it('rejects javascript and data URLs', () => {
+    expect(getSafeReturnPath('javascript:alert(1)')).toBe('/')
+    expect(getSafeReturnPath('/x?next=data:text/html,bad')).toBe(
+      '/x?next=data:text/html,bad'
+    )
+    expect(getSafeReturnPath('data:text/html,bad')).toBe('/')
+  })
+
+  it('rejects paths with backslashes', () => {
+    expect(getSafeReturnPath('/path\\evil')).toBe('/')
+  })
+
+  it('uses custom fallback', () => {
+    expect(getSafeReturnPath(null, '/articles')).toBe('/articles')
+  })
+})
+
+describe('buildLoginHref / buildRegisterHref', () => {
+  it('encodes safe return path in login URL', () => {
+    expect(buildLoginHref('/user/slug')).toBe(
+      '/login?returnTo=%2Fuser%2Fslug'
+    )
+  })
+
+  it('falls back for unsafe paths', () => {
+    expect(buildLoginHref('https://evil.com')).toBe('/login?returnTo=%2F')
+  })
+
+  it('encodes safe return path in register URL', () => {
+    expect(buildRegisterHref('/user/slug')).toBe(
+      '/register?returnTo=%2Fuser%2Fslug'
+    )
+  })
+})

--- a/lib/auth/safeReturnPath.test.ts
+++ b/lib/auth/safeReturnPath.test.ts
@@ -47,9 +47,7 @@ describe('getSafeReturnPath', () => {
 
 describe('buildLoginHref / buildRegisterHref', () => {
   it('encodes safe return path in login URL', () => {
-    expect(buildLoginHref('/user/slug')).toBe(
-      '/login?returnTo=%2Fuser%2Fslug'
-    )
+    expect(buildLoginHref('/user/slug')).toBe('/login?returnTo=%2Fuser%2Fslug')
   })
 
   it('falls back for unsafe paths', () => {

--- a/lib/auth/safeReturnPath.ts
+++ b/lib/auth/safeReturnPath.ts
@@ -1,0 +1,52 @@
+/**
+ * Validates a post-auth return path from query params.
+ * Only same-origin relative paths are allowed (open-redirect protection).
+ */
+export function getSafeReturnPath(
+  returnTo: string | null | undefined,
+  fallback = '/'
+): string {
+  if (!returnTo || typeof returnTo !== 'string') {
+    return fallback
+  }
+
+  const trimmed = returnTo.trim()
+  if (trimmed.length === 0) {
+    return fallback
+  }
+
+  if (!trimmed.startsWith('/')) {
+    return fallback
+  }
+
+  if (trimmed.startsWith('//')) {
+    return fallback
+  }
+
+  const lower = trimmed.toLowerCase()
+  if (
+    lower.startsWith('http:') ||
+    lower.startsWith('https:') ||
+    lower.startsWith('javascript:') ||
+    lower.startsWith('data:') ||
+    lower.startsWith('vbscript:')
+  ) {
+    return fallback
+  }
+
+  if (trimmed.includes('\\')) {
+    return fallback
+  }
+
+  return trimmed
+}
+
+export function buildLoginHref(returnPath: string): string {
+  const safe = getSafeReturnPath(returnPath)
+  return `/login?returnTo=${encodeURIComponent(safe)}`
+}
+
+export function buildRegisterHref(returnPath: string): string {
+  const safe = getSafeReturnPath(returnPath)
+  return `/register?returnTo=${encodeURIComponent(safe)}`
+}

--- a/lib/tip/applyPendingTipFormState.test.ts
+++ b/lib/tip/applyPendingTipFormState.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyPendingAmountFields } from './applyPendingTipFormState'
+
+describe('applyPendingAmountFields', () => {
+  it('sets preset amount and clears custom amount', () => {
+    const setSelectedAmount = vi.fn()
+    const setCustomAmount = vi.fn()
+    applyPendingAmountFields(
+      { amountCents: 100 },
+      setSelectedAmount,
+      setCustomAmount
+    )
+    expect(setSelectedAmount).toHaveBeenCalledWith(100)
+    expect(setCustomAmount).toHaveBeenCalledWith('')
+  })
+
+  it('sets custom amount and clears preset when no amountCents', () => {
+    const setSelectedAmount = vi.fn()
+    const setCustomAmount = vi.fn()
+    applyPendingAmountFields(
+      { customAmount: '2.50' },
+      setSelectedAmount,
+      setCustomAmount
+    )
+    expect(setCustomAmount).toHaveBeenCalledWith('2.50')
+    expect(setSelectedAmount).toHaveBeenCalledWith(null)
+  })
+
+  it('does nothing when no amount fields', () => {
+    const setSelectedAmount = vi.fn()
+    const setCustomAmount = vi.fn()
+    applyPendingAmountFields({}, setSelectedAmount, setCustomAmount)
+    expect(setSelectedAmount).not.toHaveBeenCalled()
+    expect(setCustomAmount).not.toHaveBeenCalled()
+  })
+})

--- a/lib/tip/applyPendingTipFormState.ts
+++ b/lib/tip/applyPendingTipFormState.ts
@@ -1,0 +1,17 @@
+import type { PendingTipIntent } from '@/lib/tip/pendingTipIntent'
+
+type AmountFields = Pick<PendingTipIntent, 'amountCents' | 'customAmount'>
+
+export function applyPendingAmountFields(
+  intent: AmountFields,
+  setSelectedAmount: (value: number | null) => void,
+  setCustomAmount: (value: string) => void
+): void {
+  if (intent.amountCents != null) {
+    setSelectedAmount(intent.amountCents)
+    setCustomAmount('')
+  } else if (intent.customAmount) {
+    setCustomAmount(intent.customAmount)
+    setSelectedAmount(null)
+  }
+}

--- a/lib/tip/pendingTipIntent.test.ts
+++ b/lib/tip/pendingTipIntent.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  PENDING_TIP_INTENT_STORAGE_KEY,
+  clearPendingTipIntent,
+  matchesArticlePendingIntent,
+  matchesHighlightPendingIntent,
+  readPendingTipIntent,
+  writePendingTipIntent,
+} from './pendingTipIntent'
+import type { Id } from '@/convex/_generated/dataModel'
+
+describe('pendingTipIntent storage', () => {
+  const store: Record<string, string> = {}
+
+  beforeEach(() => {
+    vi.stubGlobal('window', {
+      sessionStorage: {
+        getItem: (k: string) => (k in store ? store[k] : null),
+        setItem: (k: string, v: string) => {
+          store[k] = v
+        },
+        removeItem: (k: string) => {
+          delete store[k]
+        },
+        clear: () => {
+          for (const key of Object.keys(store)) delete store[key]
+        },
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    for (const key of Object.keys(store)) delete store[key]
+  })
+
+  it('writes and reads article intent', () => {
+    writePendingTipIntent({
+      kind: 'article',
+      articleId: 'articles:abc',
+      amountCents: 100,
+      message: 'Great read',
+    })
+    expect(readPendingTipIntent()).toEqual({
+      kind: 'article',
+      articleId: 'articles:abc',
+      amountCents: 100,
+      message: 'Great read',
+    })
+    expect(store[PENDING_TIP_INTENT_STORAGE_KEY]).toBeDefined()
+  })
+
+  it('writes and reads highlight intent', () => {
+    writePendingTipIntent({
+      kind: 'highlight',
+      articleId: 'articles:abc',
+      articleSlug: 'my-post',
+      highlightText: 'insightful phrase',
+      startOffset: 10,
+      endOffset: 28,
+      amountCents: 50,
+    })
+    expect(readPendingTipIntent()).toEqual({
+      kind: 'highlight',
+      articleId: 'articles:abc',
+      articleSlug: 'my-post',
+      highlightText: 'insightful phrase',
+      startOffset: 10,
+      endOffset: 28,
+      amountCents: 50,
+    })
+  })
+
+  it('returns null for missing or invalid stored data', () => {
+    expect(readPendingTipIntent()).toBeNull()
+    store[PENDING_TIP_INTENT_STORAGE_KEY] = 'not-json'
+    expect(readPendingTipIntent()).toBeNull()
+    store[PENDING_TIP_INTENT_STORAGE_KEY] = JSON.stringify({ kind: 'unknown' })
+    expect(readPendingTipIntent()).toBeNull()
+  })
+
+  it('clears stored intent', () => {
+    writePendingTipIntent({
+      kind: 'article',
+      articleId: 'articles:abc',
+    })
+    clearPendingTipIntent()
+    expect(readPendingTipIntent()).toBeNull()
+    expect(store[PENDING_TIP_INTENT_STORAGE_KEY]).toBeUndefined()
+  })
+})
+
+describe('matchesArticlePendingIntent / matchesHighlightPendingIntent', () => {
+  const articleId = 'articles:abc' as Id<'articles'>
+
+  it('matches article intent by id', () => {
+    const intent = {
+      kind: 'article' as const,
+      articleId: 'articles:abc',
+    }
+    expect(matchesArticlePendingIntent(intent, articleId)).toBe(true)
+    expect(matchesHighlightPendingIntent(intent, articleId)).toBe(false)
+  })
+
+  it('matches highlight intent by id', () => {
+    const intent = {
+      kind: 'highlight' as const,
+      articleId: 'articles:abc',
+      articleSlug: 'slug',
+      highlightText: 'text',
+      startOffset: 0,
+      endOffset: 4,
+    }
+    expect(matchesHighlightPendingIntent(intent, articleId)).toBe(true)
+    expect(matchesArticlePendingIntent(intent, articleId)).toBe(false)
+  })
+
+  it('returns false for null or mismatched id', () => {
+    expect(matchesArticlePendingIntent(null, articleId)).toBe(false)
+    expect(
+      matchesArticlePendingIntent(
+        { kind: 'article', articleId: 'articles:other' },
+        articleId
+      )
+    ).toBe(false)
+  })
+})

--- a/lib/tip/pendingTipIntent.ts
+++ b/lib/tip/pendingTipIntent.ts
@@ -1,0 +1,87 @@
+import { z } from 'zod'
+import type { Id } from '@/convex/_generated/dataModel'
+
+export const PENDING_TIP_INTENT_STORAGE_KEY = 'quilltip:pendingTipIntent'
+
+const amountFieldsSchema = z.object({
+  amountCents: z.number().int().positive().optional(),
+  customAmount: z.string().optional(),
+})
+
+const articlePendingTipIntentSchema = amountFieldsSchema.extend({
+  kind: z.literal('article'),
+  articleId: z.string(),
+  message: z.string().max(500).optional(),
+})
+
+const highlightPendingTipIntentSchema = amountFieldsSchema.extend({
+  kind: z.literal('highlight'),
+  articleId: z.string(),
+  articleSlug: z.string(),
+  highlightText: z.string(),
+  startOffset: z.number().int().nonnegative(),
+  endOffset: z.number().int().nonnegative(),
+  startContainerPath: z.string().optional(),
+  endContainerPath: z.string().optional(),
+})
+
+export const pendingTipIntentSchema = z.discriminatedUnion('kind', [
+  articlePendingTipIntentSchema,
+  highlightPendingTipIntentSchema,
+])
+
+export type PendingTipIntent = z.infer<typeof pendingTipIntentSchema>
+export type ArticlePendingTipIntent = z.infer<
+  typeof articlePendingTipIntentSchema
+>
+export type HighlightPendingTipIntent = z.infer<
+  typeof highlightPendingTipIntentSchema
+>
+
+export function writePendingTipIntent(intent: PendingTipIntent): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(
+      PENDING_TIP_INTENT_STORAGE_KEY,
+      JSON.stringify(intent)
+    )
+  } catch {
+    // Quota or private mode
+  }
+}
+
+export function readPendingTipIntent(): PendingTipIntent | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.sessionStorage.getItem(PENDING_TIP_INTENT_STORAGE_KEY)
+    if (raw === null) return null
+    const parsed: unknown = JSON.parse(raw)
+    const result = pendingTipIntentSchema.safeParse(parsed)
+    return result.success ? result.data : null
+  } catch {
+    return null
+  }
+}
+
+export function clearPendingTipIntent(): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.removeItem(PENDING_TIP_INTENT_STORAGE_KEY)
+  } catch {
+    // Ignore
+  }
+}
+
+export function matchesArticlePendingIntent(
+  intent: PendingTipIntent | null,
+  articleId: Id<'articles'>
+): intent is ArticlePendingTipIntent {
+  return intent?.kind === 'article' && intent.articleId === articleId
+}
+
+export function matchesHighlightPendingIntent(
+  intent: PendingTipIntent | null,
+  articleId: Id<'articles'>
+): intent is HighlightPendingTipIntent {
+  return intent?.kind === 'highlight' && intent.articleId === articleId
+}

--- a/lib/tip/redirectToLoginForTip.ts
+++ b/lib/tip/redirectToLoginForTip.ts
@@ -1,0 +1,15 @@
+import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
+import { buildLoginHref } from '@/lib/auth/safeReturnPath'
+import {
+  writePendingTipIntent,
+  type PendingTipIntent,
+} from '@/lib/tip/pendingTipIntent'
+
+export function redirectToLoginForTip(
+  router: AppRouterInstance,
+  returnPath: string,
+  intent: PendingTipIntent
+): void {
+  writePendingTipIntent(intent)
+  router.push(buildLoginHref(returnPath))
+}


### PR DESCRIPTION
## Summary

Signed-out readers who start an article or highlight tip are no longer sent to login without context. Tip amount, message, and highlight selection are stored in session storage, login/register redirect back to the original article via a safe `returnTo` query param, and the tip dialog auto-opens after authentication so the reader can finish where they left off. Cancel on the auth pages returns to the article and clears pending tip state.

- Save pending tip intent (`article` or `highlight`) before redirecting to `/login?returnTo=...`
- Honor `returnTo` after login/register with open-redirect protection (`getSafeReturnPath`)
- Resume article tips in `TipButton` and highlight tips via `PendingTipResume`
- Add Cancel on login/register that returns to the article and clears intent
- Allow signed-out text selection and highlight tipping; hide Save highlight until signed in
<img width="1275" height="760" alt="1" src="https://github.com/user-attachments/assets/6fcecf1e-897b-4577-af7c-550b6cafc9c0" />

<img width="1220" height="719" alt="2" src="https://github.com/user-attachments/assets/6fc5dace-639f-4ce8-8c59-b09959ba698f" />

<img width="1225" height="716" alt="3" src="https://github.com/user-attachments/assets/dd8ca2dd-4a4f-44aa-97fa-e214feac1dc8" />
