### PR TITLE
fix(onboarding): make new-user onboarding a true modal (ENG-189)

### DIFF
--- a/components/onboarding/OnboardingDialog.test.tsx
+++ b/components/onboarding/OnboardingDialog.test.tsx
@@ -1,0 +1,124 @@
+/** @vitest-environment jsdom */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import { OnboardingDialog } from '@/components/onboarding/OnboardingDialog'
+
+const mockCompleteOnboarding = vi.hoisted(() => vi.fn())
+const mockPush = vi.hoisted(() => vi.fn())
+
+vi.mock('convex/react', () => ({
+  useMutation: () => mockCompleteOnboarding,
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}))
+
+describe('OnboardingDialog', () => {
+  beforeEach(() => {
+    mockCompleteOnboarding.mockReset()
+    mockPush.mockReset()
+    vi.mocked(toast.error).mockClear()
+    mockCompleteOnboarding.mockResolvedValue(undefined)
+  })
+
+  it('shows step progress on first step', () => {
+    render(<OnboardingDialog />)
+
+    expect(screen.getByText('Step 1 of 3')).toBeInTheDocument()
+    expect(screen.getByRole('group', { name: 'Step 1 of 3' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^Next/i })).toBeInTheDocument()
+  })
+
+  it('advances step progress when Next is clicked', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<OnboardingDialog />)
+
+    await user.click(screen.getByRole('button', { name: /^Next/i }))
+
+    expect(screen.getByText('Step 2 of 3')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Set Up Now/i })
+    ).toBeInTheDocument()
+  })
+
+  it('calls completeOnboarding when Skip is clicked', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<OnboardingDialog />)
+
+    await user.click(screen.getByRole('button', { name: /Skip onboarding/i }))
+
+    await waitFor(() => {
+      expect(mockCompleteOnboarding).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('calls completeOnboarding when close button is clicked', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<OnboardingDialog />)
+
+    await user.click(screen.getByRole('button', { name: /Close onboarding/i }))
+
+    await waitFor(() => {
+      expect(mockCompleteOnboarding).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('shows Get Started on final step and completes onboarding', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<OnboardingDialog />)
+
+    await user.click(screen.getByRole('button', { name: /^Next/i }))
+    await user.click(screen.getByRole('button', { name: /I'll do this later/i }))
+    expect(screen.getByText('Step 3 of 3')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /Get Started/i }))
+
+    await waitFor(() => {
+      expect(mockCompleteOnboarding).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('navigates after completing via shortcut on final step', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<OnboardingDialog />)
+
+    await user.click(screen.getByRole('button', { name: /^Next/i }))
+    await user.click(screen.getByRole('button', { name: /I'll do this later/i }))
+    await user.click(screen.getByRole('button', { name: /^Read$/i }))
+
+    await waitFor(() => {
+      expect(mockCompleteOnboarding).toHaveBeenCalledTimes(1)
+      expect(mockPush).toHaveBeenCalledWith('/articles')
+    })
+  })
+
+  it('shows error toast when completeOnboarding fails', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockCompleteOnboarding.mockRejectedValue(new Error('Network error'))
+    render(<OnboardingDialog />)
+
+    await user.click(screen.getByRole('button', { name: /Skip onboarding/i }))
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Could not save your progress. Please try again.'
+      )
+    })
+    expect(screen.getByRole('button', { name: /Skip onboarding/i })).toBeInTheDocument()
+  })
+
+  it('renders a modal dialog', () => {
+    render(<OnboardingDialog />)
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+})

--- a/components/onboarding/OnboardingDialog.test.tsx
+++ b/components/onboarding/OnboardingDialog.test.tsx
@@ -34,7 +34,9 @@ describe('OnboardingDialog', () => {
     render(<OnboardingDialog />)
 
     expect(screen.getByText('Step 1 of 3')).toBeInTheDocument()
-    expect(screen.getByRole('group', { name: 'Step 1 of 3' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('group', { name: 'Step 1 of 3' })
+    ).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /^Next/i })).toBeInTheDocument()
   })
 
@@ -77,7 +79,9 @@ describe('OnboardingDialog', () => {
     render(<OnboardingDialog />)
 
     await user.click(screen.getByRole('button', { name: /^Next/i }))
-    await user.click(screen.getByRole('button', { name: /I'll do this later/i }))
+    await user.click(
+      screen.getByRole('button', { name: /I'll do this later/i })
+    )
     expect(screen.getByText('Step 3 of 3')).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: /Get Started/i }))
@@ -92,7 +96,9 @@ describe('OnboardingDialog', () => {
     render(<OnboardingDialog />)
 
     await user.click(screen.getByRole('button', { name: /^Next/i }))
-    await user.click(screen.getByRole('button', { name: /I'll do this later/i }))
+    await user.click(
+      screen.getByRole('button', { name: /I'll do this later/i })
+    )
     await user.click(screen.getByRole('button', { name: /^Read$/i }))
 
     await waitFor(() => {
@@ -113,7 +119,9 @@ describe('OnboardingDialog', () => {
         'Could not save your progress. Please try again.'
       )
     })
-    expect(screen.getByRole('button', { name: /Skip onboarding/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Skip onboarding/i })
+    ).toBeInTheDocument()
   })
 
   it('renders a modal dialog', () => {

--- a/components/onboarding/OnboardingDialog.tsx
+++ b/components/onboarding/OnboardingDialog.tsx
@@ -22,6 +22,7 @@ import {
   ArrowRight,
   HelpCircle,
   X,
+  Loader2,
 } from 'lucide-react'
 import Link from 'next/link'
 import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
@@ -76,6 +77,12 @@ export function OnboardingDialog() {
     }
   }
 
+  const handleOpenChange = (next: boolean) => {
+    if (!next && open && !isCompleting) {
+      void handleComplete()
+    }
+  }
+
   const navigateAfterComplete = async (href: string) => {
     const ok = await handleComplete()
     if (ok) {
@@ -94,17 +101,21 @@ export function OnboardingDialog() {
   const step = steps[currentStep]
   if (!step) return null
   const StepIcon = step.icon
+  const stepLabel = `Step ${currentStep + 1} of ${steps.length}`
 
   return (
-    <Dialog modal={false} open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
-        className="sm:max-w-md pointer-events-auto"
-        overlayClassName="pointer-events-none bg-black/40"
+        className="sm:max-w-md"
+        overlayClassName="bg-black/40"
         hideCloseButton
+        onInteractOutside={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => e.preventDefault()}
         onEscapeKeyDown={(e) => {
           e.preventDefault()
-          void handleComplete()
+          if (!isCompleting) void handleComplete()
         }}
+        aria-busy={isCompleting}
       >
         <Button
           type="button"
@@ -124,15 +135,25 @@ export function OnboardingDialog() {
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex justify-center gap-2 mb-2">
-          {steps.map((_, i) => (
-            <div
-              key={i}
-              className={`h-1.5 rounded-full transition-all duration-300 ${
-                i === currentStep ? 'w-8 bg-foreground' : 'w-4 bg-muted'
-              }`}
-            />
-          ))}
+        <div
+          role="group"
+          aria-label={stepLabel}
+          className="flex flex-col items-center gap-2 mb-2"
+        >
+          <p className="text-xs text-muted-foreground font-medium">
+            {stepLabel}
+          </p>
+          <div className="flex justify-center gap-2">
+            {steps.map((_, i) => (
+              <div
+                key={i}
+                aria-current={i === currentStep ? 'step' : undefined}
+                className={`h-1.5 rounded-full transition-all duration-300 ${
+                  i === currentStep ? 'w-8 bg-foreground' : 'w-4 bg-muted'
+                }`}
+              />
+            ))}
+          </div>
         </div>
 
         <AnimatePresence mode="wait">
@@ -172,7 +193,11 @@ export function OnboardingDialog() {
                   variant="default"
                   disabled={isCompleting}
                 >
-                  <HelpCircle className="w-4 h-4 mr-2" />
+                  {isCompleting ? (
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  ) : (
+                    <HelpCircle className="w-4 h-4 mr-2" />
+                  )}
                   Set Up Now
                 </Button>
               </Link>
@@ -249,8 +274,17 @@ export function OnboardingDialog() {
               className="w-full min-h-11"
               disabled={isCompleting}
             >
-              Next
-              <ArrowRight className="w-4 h-4 ml-2" />
+              {isCompleting ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                <>
+                  Next
+                  <ArrowRight className="w-4 h-4 ml-2" />
+                </>
+              )}
             </Button>
           )}
 
@@ -260,7 +294,14 @@ export function OnboardingDialog() {
               className="w-full min-h-11"
               disabled={isCompleting}
             >
-              Get Started
+              {isCompleting ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                'Get Started'
+              )}
             </Button>
           )}
 
@@ -273,7 +314,14 @@ export function OnboardingDialog() {
             disabled={isCompleting}
             aria-label="Skip onboarding"
           >
-            Skip onboarding
+            {isCompleting ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              'Skip onboarding'
+            )}
           </Button>
         </div>
       </DialogContent>


### PR DESCRIPTION
## Summary

Fixes ENG-189 by restoring true modal behavior for the new-user onboarding dialog. The page behind onboarding is no longer interactive while the flow is open, and every dismiss path persists `onboardingCompleted` in Convex.

## Changes

- Remove `modal={false}` and `pointer-events-none` overlay overrides so Radix traps focus and keeps the background inert
- Block outside-click dismiss via `onInteractOutside` / `onPointerDownOutside`
- Route `onOpenChange` through `handleComplete()` so the dialog cannot close without saving progress
- Add visible step progress (`Step X of 3`), `aria-current="step"` on dots, and loading states while completing
- Add `OnboardingDialog.test.tsx` regression tests

