### PR TITLE
fix(auth): preserve returnTo for write, drafts, tipping, and wallet setup

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -23,6 +23,18 @@ interface ProfilePageProps {
 
 type TabType = 'articles' | 'nfts' | 'earnings' | 'stats' | 'wallet'
 
+const PROFILE_TAB_IDS: TabType[] = [
+  'articles',
+  'nfts',
+  'wallet',
+  'earnings',
+  'stats',
+]
+
+function isProfileTab(value: string | null): value is TabType {
+  return value !== null && PROFILE_TAB_IDS.includes(value as TabType)
+}
+
 export default function ProfilePage({ params }: ProfilePageProps) {
   const { username } = use(params)
   const searchParams = useSearchParams()
@@ -42,6 +54,13 @@ export default function ProfilePage({ params }: ProfilePageProps) {
   const nftMintedPage = parsePositivePage(
     searchParams?.get('nftMintedPage') ?? null
   )
+
+  useEffect(() => {
+    const tab = searchParams?.get('tab') ?? null
+    if (isProfileTab(tab)) {
+      setActiveTab(tab)
+    }
+  }, [searchParams])
 
   // Fetch user profile
   const user = useUserByUsername(username)

--- a/app/drafts/page.tsx
+++ b/app/drafts/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useState } from 'react'
 import { useAuth } from '@/components/providers/AuthContext'
+import { useRedirectWhenUnauthenticated } from '@/hooks/useRedirectWhenUnauthenticated'
 import Link from 'next/link'
 import AppNavigation from '@/components/layout/AppNavigation'
 import { useMutation } from 'convex/react'
@@ -34,8 +34,9 @@ import { Loader2, MoreHorizontal, Pencil, Trash2 } from 'lucide-react'
 import { mutationWithTimeout } from '@/lib/convexMutationWithTimeout'
 
 export default function DraftsPage() {
-  const router = useRouter()
   const { isAuthenticated, isLoading } = useAuth()
+
+  useRedirectWhenUnauthenticated(isLoading, isAuthenticated)
 
   const draftsQuery = useUserDrafts()
   const loading = draftsQuery === undefined
@@ -60,11 +61,6 @@ export default function DraftsPage() {
       setIsDeleting(false)
     }
   }
-
-  useEffect(() => {
-    if (isLoading || isAuthenticated) return
-    router.replace('/login')
-  }, [isLoading, isAuthenticated, router])
 
   if (isLoading) {
     return (

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/components/providers/AuthContext'
+import { buildLoginHref } from '@/lib/auth/safeReturnPath'
+import AppNavigation from '@/components/layout/AppNavigation'
+import { Skeleton } from '@/components/ui/skeleton'
+
+const WALLET_RETURN_PATH = '/profile?tab=wallet'
+
+export default function ProfilePage() {
+  const router = useRouter()
+  const { user, isAuthenticated, isLoading } = useAuth()
+
+  useEffect(() => {
+    if (isLoading) return
+    if (isAuthenticated && user?.username) {
+      router.replace(`/${user.username}?tab=wallet`)
+      return
+    }
+    if (!isAuthenticated) {
+      router.replace(buildLoginHref(WALLET_RETURN_PATH))
+    }
+  }, [isAuthenticated, isLoading, router, user?.username])
+
+  return (
+    <div className="min-h-screen bg-background">
+      <AppNavigation />
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12">
+        <Skeleton className="h-9 w-48 mb-8" />
+        <Skeleton className="h-64 w-full max-w-2xl" />
+      </div>
+    </div>
+  )
+}

--- a/app/write/page.tsx
+++ b/app/write/page.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import { useEffect } from 'react'
-import { useRouter } from 'next/navigation'
 import { useAuth } from '@/components/providers/AuthContext'
+import { useRedirectWhenUnauthenticated } from '@/hooks/useRedirectWhenUnauthenticated'
 import AppNavigation from '@/components/layout/AppNavigation'
 import { EditorChromeSkeleton } from '@/components/editor/EditorChromeSkeleton'
 import { ErrorBoundary } from '@/components/error/ErrorBoundary'
@@ -10,13 +9,9 @@ import { EditorWorkspaceErrorFallback } from '@/components/error/SectionErrorFal
 import { WriteEditorWorkspace } from '@/components/editor/WriteEditorWorkspace'
 
 export default function WritePage() {
-  const router = useRouter()
   const { isAuthenticated, isLoading } = useAuth()
 
-  useEffect(() => {
-    if (isLoading || isAuthenticated) return
-    router.replace('/login')
-  }, [isLoading, isAuthenticated, router])
+  useRedirectWhenUnauthenticated(isLoading, isAuthenticated)
 
   if (isLoading) {
     return (

--- a/hooks/useRedirectWhenUnauthenticated.ts
+++ b/hooks/useRedirectWhenUnauthenticated.ts
@@ -2,10 +2,7 @@
 
 import { useEffect } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import {
-  buildLoginHref,
-  getCurrentReturnPath,
-} from '@/lib/auth/safeReturnPath'
+import { buildLoginHref, getCurrentReturnPath } from '@/lib/auth/safeReturnPath'
 
 export function useRedirectWhenUnauthenticated(
   isLoading: boolean,

--- a/hooks/useRedirectWhenUnauthenticated.ts
+++ b/hooks/useRedirectWhenUnauthenticated.ts
@@ -1,18 +1,23 @@
 'use client'
 
 import { useEffect } from 'react'
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import {
+  buildLoginHref,
+  getCurrentReturnPath,
+} from '@/lib/auth/safeReturnPath'
 
 export function useRedirectWhenUnauthenticated(
   isLoading: boolean,
-  isAuthenticated: boolean,
-  loginPath = '/login'
+  isAuthenticated: boolean
 ): void {
   const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
   useEffect(() => {
-    if (isLoading) return
-    if (!isAuthenticated) {
-      router.push(loginPath)
-    }
-  }, [isAuthenticated, isLoading, loginPath, router])
+    if (isLoading || isAuthenticated) return
+    const returnPath = getCurrentReturnPath(pathname, searchParams)
+    router.replace(buildLoginHref(returnPath))
+  }, [isAuthenticated, isLoading, pathname, router, searchParams])
 }

--- a/lib/auth/safeReturnPath.test.ts
+++ b/lib/auth/safeReturnPath.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   buildLoginHref,
   buildRegisterHref,
+  getCurrentReturnPath,
   getSafeReturnPath,
 } from './safeReturnPath'
 
@@ -42,6 +43,30 @@ describe('getSafeReturnPath', () => {
 
   it('uses custom fallback', () => {
     expect(getSafeReturnPath(null, '/articles')).toBe('/articles')
+  })
+})
+
+describe('getCurrentReturnPath', () => {
+  it('returns pathname only when search is empty', () => {
+    expect(getCurrentReturnPath('/write', new URLSearchParams())).toBe('/write')
+  })
+
+  it('combines pathname and query string', () => {
+    expect(
+      getCurrentReturnPath(
+        '/write',
+        new URLSearchParams('id=abc123')
+      )
+    ).toBe('/write?id=abc123')
+  })
+
+  it('preserves multiple query params', () => {
+    expect(
+      getCurrentReturnPath(
+        '/profile',
+        new URLSearchParams('tab=wallet')
+      )
+    ).toBe('/profile?tab=wallet')
   })
 })
 

--- a/lib/auth/safeReturnPath.test.ts
+++ b/lib/auth/safeReturnPath.test.ts
@@ -53,19 +53,13 @@ describe('getCurrentReturnPath', () => {
 
   it('combines pathname and query string', () => {
     expect(
-      getCurrentReturnPath(
-        '/write',
-        new URLSearchParams('id=abc123')
-      )
+      getCurrentReturnPath('/write', new URLSearchParams('id=abc123'))
     ).toBe('/write?id=abc123')
   })
 
   it('preserves multiple query params', () => {
     expect(
-      getCurrentReturnPath(
-        '/profile',
-        new URLSearchParams('tab=wallet')
-      )
+      getCurrentReturnPath('/profile', new URLSearchParams('tab=wallet'))
     ).toBe('/profile?tab=wallet')
   })
 })

--- a/lib/auth/safeReturnPath.ts
+++ b/lib/auth/safeReturnPath.ts
@@ -41,6 +41,14 @@ export function getSafeReturnPath(
   return trimmed
 }
 
+export function getCurrentReturnPath(
+  pathname: string,
+  searchParams: URLSearchParams | { toString(): string }
+): string {
+  const qs = searchParams.toString()
+  return qs ? `${pathname}?${qs}` : pathname
+}
+
 export function buildLoginHref(returnPath: string): string {
   const safe = getSafeReturnPath(returnPath)
   return `/login?returnTo=${encodeURIComponent(safe)}`

--- a/lib/tip/redirectToLoginForTip.ts
+++ b/lib/tip/redirectToLoginForTip.ts
@@ -11,5 +11,5 @@ export function redirectToLoginForTip(
   intent: PendingTipIntent
 ): void {
   writePendingTipIntent(intent)
-  router.push(buildLoginHref(returnPath))
+  router.replace(buildLoginHref(returnPath))
 }


### PR DESCRIPTION
## Summary

Signed-out users who tried to write, open drafts, tip, or set up a wallet were sent to `/login` without a return path, so after sign-in they landed on the home dashboard instead of the flow they started. This wires those entry points through the existing `returnTo` pattern (already used for tipping).

## Changes

- Add `getCurrentReturnPath()` and upgrade `useRedirectWhenUnauthenticated` to redirect to `/login?returnTo=<current path + query>`
- Apply the hook on `/write` and `/drafts` (includes `/write?id=…` for draft editing)
- Use `router.replace` in `redirectToLoginForTip` for consistent back-stack behavior with other protected routes
- Add `/profile` entry route: signed out → login with `returnTo=/profile?tab=wallet`; signed in → `/{username}?tab=wallet`
- Parse `?tab=` on profile pages so deep links (e.g. earnings, wallet) work after login
- Extend `safeReturnPath` unit tests for path + query composition

