### PR TITLE
fix(profile): open earnings tab from homepage shortcut and sync tab to URL

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -3,7 +3,12 @@
 import { notFound } from 'next/navigation'
 import { useUserByUsername, useUserStats } from '@/hooks/convex'
 import { use, useState, useEffect } from 'react'
-import { useSearchParams } from 'next/navigation'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import {
+  buildProfileTabHref,
+  parseProfileTab,
+  type ProfileTabId,
+} from '@/lib/profile/profileTab'
 import { useAuth } from '@/components/providers/AuthContext'
 import AppNavigation from '@/components/layout/AppNavigation'
 import { SiteFooter } from '@/components/layout/SiteFooter'
@@ -21,13 +26,12 @@ interface ProfilePageProps {
   }>
 }
 
-type TabType = 'articles' | 'nfts' | 'earnings' | 'stats' | 'wallet'
-
 export default function ProfilePage({ params }: ProfilePageProps) {
   const { username } = use(params)
+  const pathname = usePathname()
+  const router = useRouter()
   const searchParams = useSearchParams()
   const { user: currentUser } = useAuth()
-  const [activeTab, setActiveTab] = useState<TabType>('articles')
   const [localWalletAddress, setLocalWalletAddress] = useState<
     string | null | undefined
   >()
@@ -58,6 +62,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
 
   // Check if this is the current user's profile
   const isOwnProfile = currentUser?.username === username
+  const activeTab = parseProfileTab(searchParams?.get('tab') ?? null, isOwnProfile)
 
   // Check if user exists
   if (user === null) {
@@ -92,28 +97,28 @@ export default function ProfilePage({ params }: ProfilePageProps) {
   // Tab configuration
   const tabs = [
     {
-      id: 'articles' as TabType,
+      id: 'articles' as ProfileTabId,
       label: 'Articles',
       icon: BookOpen,
       count: userWithStats.articleCount,
     },
     {
-      id: 'nfts' as TabType,
+      id: 'nfts' as ProfileTabId,
       label: 'NFTs',
       icon: Image,
       count: userWithStats.nftsOwned,
     },
-    { id: 'wallet' as TabType, label: 'Wallet', icon: Wallet, count: null },
+    { id: 'wallet' as ProfileTabId, label: 'Wallet', icon: Wallet, count: null },
     ...(isOwnProfile
       ? [
           {
-            id: 'earnings' as TabType,
+            id: 'earnings' as ProfileTabId,
             label: 'Earnings',
             icon: DollarSign,
             count: null,
           },
           {
-            id: 'stats' as TabType,
+            id: 'stats' as ProfileTabId,
             label: 'Stats',
             icon: ChartBar,
             count: null,
@@ -139,7 +144,15 @@ export default function ProfilePage({ params }: ProfilePageProps) {
               <button
                 key={tab.id}
                 data-tab={tab.id}
-                onClick={() => setActiveTab(tab.id)}
+                onClick={() =>
+                  router.push(
+                    buildProfileTabHref(
+                      pathname,
+                      new URLSearchParams(searchParams?.toString() ?? ''),
+                      tab.id
+                    )
+                  )
+                }
                 className={`
                   flex items-center gap-2 py-3 px-1 border-b-2 font-medium text-sm transition-colors
                   ${

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -62,7 +62,10 @@ export default function ProfilePage({ params }: ProfilePageProps) {
 
   // Check if this is the current user's profile
   const isOwnProfile = currentUser?.username === username
-  const activeTab = parseProfileTab(searchParams?.get('tab') ?? null, isOwnProfile)
+  const activeTab = parseProfileTab(
+    searchParams?.get('tab') ?? null,
+    isOwnProfile
+  )
 
   // Check if user exists
   if (user === null) {
@@ -108,7 +111,12 @@ export default function ProfilePage({ params }: ProfilePageProps) {
       icon: Image,
       count: userWithStats.nftsOwned,
     },
-    { id: 'wallet' as ProfileTabId, label: 'Wallet', icon: Wallet, count: null },
+    {
+      id: 'wallet' as ProfileTabId,
+      label: 'Wallet',
+      icon: Wallet,
+      count: null,
+    },
     ...(isOwnProfile
       ? [
           {

--- a/components/dashboard/EarningsStats.test.tsx
+++ b/components/dashboard/EarningsStats.test.tsx
@@ -2,6 +2,10 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { EarningsStats } from '@/components/dashboard/EarningsStats'
+
+vi.mock('@/hooks/useProfileTabNavigation', () => ({
+  useProfileTabNavigation: () => vi.fn(),
+}))
 import type { Doc } from '@/types/convex'
 import type { Id } from '@/types/convex'
 

--- a/components/dashboard/EarningsStats.tsx
+++ b/components/dashboard/EarningsStats.tsx
@@ -5,10 +5,8 @@ import { Coins, Clock, DollarSign, Wallet } from 'lucide-react'
 import type { Doc } from '@/types/convex'
 import { MonthlyEarningsChart } from '@/components/dashboard/monthly-earnings-chart'
 import { TopEarningArticles } from '@/components/dashboard/top-earning-articles'
-import {
-  WalletSetupNotice,
-  navigateToWalletTab,
-} from '@/components/dashboard/wallet-setup-notice'
+import { WalletSetupNotice } from '@/components/dashboard/wallet-setup-notice'
+import { useProfileTabNavigation } from '@/hooks/useProfileTabNavigation'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
 
@@ -27,6 +25,7 @@ export function EarningsStats({
   onOpenWithdrawModal,
   withdrawTriggerRef,
 }: EarningsStatsProps) {
+  const navigateToTab = useProfileTabNavigation()
   const lastWithdrawal = earnings.lastWithdrawalAt
   const belowWithdrawalMinimum = earnings.availableBalanceUsd < minWithdrawalUsd
   const showMinimumWithdrawalHelper =
@@ -69,7 +68,7 @@ export function EarningsStats({
             type="button"
             onClick={() => {
               if (!userProfile?.stellarAddress) {
-                navigateToWalletTab()
+                navigateToTab('wallet')
               } else {
                 onOpenWithdrawModal()
               }

--- a/components/dashboard/wallet-setup-notice.tsx
+++ b/components/dashboard/wallet-setup-notice.tsx
@@ -1,15 +1,11 @@
 'use client'
 
 import { AlertCircle } from 'lucide-react'
-
-export function navigateToWalletTab() {
-  const walletTab = document.querySelector(
-    '[data-tab="wallet"]'
-  ) as HTMLButtonElement | null
-  if (walletTab) walletTab.click()
-}
+import { useProfileTabNavigation } from '@/hooks/useProfileTabNavigation'
 
 export function WalletSetupNotice() {
+  const navigateToTab = useProfileTabNavigation()
+
   return (
     <div className="bg-warning border border-warning/50 rounded-lg p-6">
       <div className="flex items-start gap-3">
@@ -24,7 +20,7 @@ export function WalletSetupNotice() {
           </p>
           <button
             type="button"
-            onClick={navigateToWalletTab}
+            onClick={() => navigateToTab('wallet')}
             className="text-sm font-medium text-warning-foreground hover:text-warning-foreground/80 underline"
           >
             Go to Wallet Settings →

--- a/hooks/useProfileTabNavigation.ts
+++ b/hooks/useProfileTabNavigation.ts
@@ -1,0 +1,23 @@
+'use client'
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import {
+  buildProfileTabHref,
+  type ProfileTabId,
+} from '@/lib/profile/profileTab'
+
+export function useProfileTabNavigation() {
+  const pathname = usePathname()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  return (tab: ProfileTabId) => {
+    router.push(
+      buildProfileTabHref(
+        pathname,
+        new URLSearchParams(searchParams?.toString() ?? ''),
+        tab
+      )
+    )
+  }
+}

--- a/lib/profile/profileTab.test.ts
+++ b/lib/profile/profileTab.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { buildProfileTabHref, parseProfileTab } from './profileTab'
+
+describe('parseProfileTab', () => {
+  it('defaults to articles when tab is missing', () => {
+    expect(parseProfileTab(null, true)).toBe('articles')
+    expect(parseProfileTab(null, false)).toBe('articles')
+  })
+
+  it('accepts public tabs for any profile', () => {
+    expect(parseProfileTab('nfts', false)).toBe('nfts')
+    expect(parseProfileTab('wallet', false)).toBe('wallet')
+  })
+
+  it('accepts earnings and stats only on own profile', () => {
+    expect(parseProfileTab('earnings', true)).toBe('earnings')
+    expect(parseProfileTab('stats', true)).toBe('stats')
+    expect(parseProfileTab('earnings', false)).toBe('articles')
+    expect(parseProfileTab('stats', false)).toBe('articles')
+  })
+
+  it('falls back to articles for invalid tab values', () => {
+    expect(parseProfileTab('invalid', true)).toBe('articles')
+    expect(parseProfileTab('', true)).toBe('articles')
+  })
+})
+
+describe('buildProfileTabHref', () => {
+  it('sets tab param for non-articles tabs', () => {
+    const sp = new URLSearchParams('page=2')
+    expect(buildProfileTabHref('/alice', sp, 'earnings')).toBe(
+      '/alice?page=2&tab=earnings'
+    )
+  })
+
+  it('removes tab param for articles', () => {
+    const sp = new URLSearchParams('tab=wallet&page=2')
+    expect(buildProfileTabHref('/alice', sp, 'articles')).toBe('/alice?page=2')
+  })
+
+  it('returns pathname only when no query remains', () => {
+    const sp = new URLSearchParams('tab=earnings')
+    expect(buildProfileTabHref('/bob', sp, 'articles')).toBe('/bob')
+  })
+
+  it('preserves NFT pagination params', () => {
+    const sp = new URLSearchParams('nftOwnedPage=2&nftMintedPage=3')
+    expect(buildProfileTabHref('/bob', sp, 'wallet')).toBe(
+      '/bob?nftOwnedPage=2&nftMintedPage=3&tab=wallet'
+    )
+  })
+})

--- a/lib/profile/profileTab.ts
+++ b/lib/profile/profileTab.ts
@@ -1,0 +1,36 @@
+export const PROFILE_TAB_IDS = [
+  'articles',
+  'nfts',
+  'wallet',
+  'earnings',
+  'stats',
+] as const
+
+export type ProfileTabId = (typeof PROFILE_TAB_IDS)[number]
+
+const PUBLIC_TABS: ProfileTabId[] = ['articles', 'nfts', 'wallet']
+const OWN_PROFILE_TABS: ProfileTabId[] = ['earnings', 'stats']
+
+export function parseProfileTab(
+  raw: string | null,
+  isOwnProfile: boolean
+): ProfileTabId {
+  if (!raw) return 'articles'
+  if (!PROFILE_TAB_IDS.includes(raw as ProfileTabId)) return 'articles'
+  const tab = raw as ProfileTabId
+  if (PUBLIC_TABS.includes(tab)) return tab
+  if (isOwnProfile && OWN_PROFILE_TABS.includes(tab)) return tab
+  return 'articles'
+}
+
+export function buildProfileTabHref(
+  pathname: string,
+  searchParams: URLSearchParams,
+  tab: ProfileTabId
+): string {
+  const next = new URLSearchParams(searchParams.toString())
+  if (tab === 'articles') next.delete('tab')
+  else next.set('tab', tab)
+  const qs = next.toString()
+  return qs ? `${pathname}?${qs}` : pathname
+}


### PR DESCRIPTION
## What

Wire profile tab state to the `tab` query parameter so the homepage "Your Earnings" shortcut opens the Earnings tab directly, tab clicks update the URL, and refresh/back/forward behave predictably.

## Why

The homepage already linked to `/{username}?tab=earnings`, but the profile page ignored that param and always defaulted to Articles. Writers had to find the Earnings tab manually.



## How

- Add `parseProfileTab` and `buildProfileTabHref` in `lib/profile/profileTab.ts` (preserves `page`, `nftOwnedPage`, `nftMintedPage`; omits `tab` for the default Articles tab)
- Derive active tab from `searchParams` in `app/[username]/page.tsx` instead of local `useState`
- Use `router.push` on tab clicks so each switch updates the URL and history
- Replace DOM tab clicks in wallet setup flows with `useProfileTabNavigation` so "Go to Wallet Settings" / "Set Up Wallet" use real navigation



