### PR TITLE
fix: route generic profile destinations for signed-in and signed-out users (ENG-160)

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,5 +1,5 @@
-import Link from 'next/link'
 import LoginForm from '@/components/auth/LoginForm'
+import { AuthAlternateLink } from '@/components/auth/AuthAlternateLink'
 
 /**
  * Login Page
@@ -26,15 +26,11 @@ export default function LoginPage() {
 
       {/* Registration Link */}
       <div className="text-center">
-        <p className="text-sm text-muted-foreground">
-          Don&apos;t have an account?{' '}
-          <Link
-            href="/register"
-            className="font-medium text-brand-blue hover:text-brand-accent transition-colors"
-          >
-            Sign up for free
-          </Link>
-        </p>
+        <AuthAlternateLink
+          authPath="/register"
+          prompt="Don't have an account?"
+          linkLabel="Sign up for free"
+        />
       </div>
     </div>
   )

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,5 +1,5 @@
-import Link from 'next/link'
 import RegisterForm from '@/components/auth/RegisterForm'
+import { AuthAlternateLink } from '@/components/auth/AuthAlternateLink'
 
 /**
  * Registration Page
@@ -26,15 +26,11 @@ export default function RegisterPage() {
 
       {/* Login Link */}
       <div className="text-center">
-        <p className="text-sm text-muted-foreground">
-          Already have an account?{' '}
-          <Link
-            href="/login"
-            className="font-medium text-brand-blue hover:text-brand-accent transition-colors"
-          >
-            Sign in here
-          </Link>
-        </p>
+        <AuthAlternateLink
+          authPath="/login"
+          prompt="Already have an account?"
+          linkLabel="Sign in here"
+        />
       </div>
     </div>
   )

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,5 @@
+import { GenericProfileRedirect } from '@/components/profile/GenericProfileRedirect'
+
+export default function ProfileRedirectPage() {
+  return <GenericProfileRedirect />
+}

--- a/app/settings/profile/page.tsx
+++ b/app/settings/profile/page.tsx
@@ -1,0 +1,5 @@
+import { GenericProfileRedirect } from '@/components/profile/GenericProfileRedirect'
+
+export default function SettingsProfileRedirectPage() {
+  return <GenericProfileRedirect />
+}

--- a/components/auth/AuthAlternateLink.tsx
+++ b/components/auth/AuthAlternateLink.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { appendNextToAuthPath } from '@/lib/profile/profileDestination'
+
+interface AuthAlternateLinkProps {
+  authPath: '/login' | '/register'
+  prompt: string
+  linkLabel: string
+}
+
+export function AuthAlternateLink({
+  authPath,
+  prompt,
+  linkLabel,
+}: AuthAlternateLinkProps) {
+  const searchParams = useSearchParams()
+  const href = appendNextToAuthPath(authPath, searchParams.get('next'))
+
+  return (
+    <p className="text-sm text-muted-foreground">
+      {prompt}{' '}
+      <Link
+        href={href}
+        className="font-medium text-brand-blue hover:text-brand-accent transition-colors"
+      >
+        {linkLabel}
+      </Link>
+    </p>
+  )
+}

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react'
 import { useAuthActions } from '@convex-dev/auth/react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { parseSafeNextParam } from '@/lib/profile/profileDestination'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { loginSchema, type LoginFormData } from '@/lib/validations/auth'
@@ -26,6 +27,7 @@ export default function LoginForm() {
   const [error, setError] = useState<string | null>(null)
 
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { signIn } = useAuthActions()
 
   const {
@@ -47,9 +49,8 @@ export default function LoginForm() {
         flow: 'signIn',
       })
 
-      // If we reach here, sign-in was successful
-      // Use replace to prevent back button returning to login
-      router.replace('/')
+      const next = parseSafeNextParam(searchParams.get('next'))
+      router.replace(next ?? '/')
     } catch (error) {
       console.error('Login error:', error)
       setError('Invalid email or password. Please try again.')

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { parseSafeNextParam } from '@/lib/profile/profileDestination'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { mapRegisterSignInError } from '@/lib/auth/map-register-error'
@@ -29,6 +30,7 @@ export default function RegisterForm() {
   const [success, setSuccess] = useState(false)
 
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { signIn } = useAuth()
 
   const {
@@ -53,8 +55,8 @@ export default function RegisterForm() {
       })
 
       setSuccess(true)
-      // Use replace to prevent back button returning to register
-      router.replace('/')
+      const next = parseSafeNextParam(searchParams.get('next'))
+      router.replace(next ?? '/')
     } catch (error) {
       setError(mapRegisterSignInError(error))
       setIsLoading(false)

--- a/components/guide/WalletGuide.tsx
+++ b/components/guide/WalletGuide.tsx
@@ -174,7 +174,7 @@ export function WalletGuide() {
             isLast
           >
             <Link
-              href="/profile"
+              href="/profile?tab=wallet"
               className="inline-flex items-center gap-2 px-4 py-2 bg-muted text-foreground text-sm rounded-lg border border-border hover:bg-muted/80 transition-colors"
             >
               Go to Profile Settings

--- a/components/layout/AppNavigation.tsx
+++ b/components/layout/AppNavigation.tsx
@@ -106,9 +106,9 @@ export default function AppNavigation() {
                   <span>Drafts</span>
                 </Link>
                 <Link
-                  href={`/${user?.username || 'profile'}`}
+                  href="/profile"
                   className={desktopLinkClass(
-                    pathname === `/${user?.username}`
+                    pathname === `/${user?.username}` || pathname === '/profile'
                   )}
                 >
                   <User className="w-4 h-4" />
@@ -210,9 +210,10 @@ export default function AppNavigation() {
                       <span>Drafts</span>
                     </Link>
                     <Link
-                      href={`/${user?.username || 'profile'}`}
+                      href="/profile"
                       className={mobileLinkClass(
-                        pathname === `/${user?.username}`
+                        pathname === `/${user?.username}` ||
+                          pathname === '/profile'
                       )}
                       onClick={closeMenu}
                     >

--- a/components/profile/GenericProfileRedirect.tsx
+++ b/components/profile/GenericProfileRedirect.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { useAuth } from '@/components/providers/AuthContext'
+import AppNavigation from '@/components/layout/AppNavigation'
+import { ProfilePageLoadingSkeleton } from '@/components/profile/ProfilePageLoadingSkeleton'
+import {
+  buildLoginRedirectPath,
+  buildPathWithSearch,
+  resolveSignedInProfilePath,
+} from '@/lib/profile/profileDestination'
+
+export function GenericProfileRedirect() {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const { isAuthenticated, isLoading, user } = useAuth()
+
+  useEffect(() => {
+    if (isLoading) return
+
+    const intendedPath = buildPathWithSearch(
+      pathname,
+      new URLSearchParams(searchParams?.toString() ?? '')
+    )
+
+    if (!isAuthenticated) {
+      router.replace(buildLoginRedirectPath(intendedPath))
+      return
+    }
+
+    if (!user?.username) {
+      router.replace('/')
+      return
+    }
+
+    router.replace(
+      resolveSignedInProfilePath(
+        user.username,
+        new URLSearchParams(searchParams?.toString() ?? '')
+      )
+    )
+  }, [
+    isAuthenticated,
+    isLoading,
+    pathname,
+    router,
+    searchParams,
+    user?.username,
+  ])
+
+  return (
+    <div className="min-h-screen bg-background">
+      <AppNavigation />
+      <ProfilePageLoadingSkeleton />
+    </div>
+  )
+}

--- a/lib/profile/profileDestination.test.ts
+++ b/lib/profile/profileDestination.test.ts
@@ -29,10 +29,7 @@ describe('resolveSignedInProfilePath', () => {
 
   it('maps wallet tab to profile URL', () => {
     expect(
-      resolveSignedInProfilePath(
-        'alice',
-        new URLSearchParams('tab=wallet')
-      )
+      resolveSignedInProfilePath('alice', new URLSearchParams('tab=wallet'))
     ).toBe('/alice?tab=wallet')
   })
 
@@ -48,10 +45,7 @@ describe('resolveSignedInProfilePath', () => {
 
   it('ignores invalid tab values', () => {
     expect(
-      resolveSignedInProfilePath(
-        'alice',
-        new URLSearchParams('tab=invalid')
-      )
+      resolveSignedInProfilePath('alice', new URLSearchParams('tab=invalid'))
     ).toBe('/alice')
   })
 })

--- a/lib/profile/profileDestination.test.ts
+++ b/lib/profile/profileDestination.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import {
+  appendNextToAuthPath,
+  buildGenericProfilePath,
+  buildLoginRedirectPath,
+  buildPathWithSearch,
+  parseSafeNextParam,
+  resolveSignedInProfilePath,
+} from './profileDestination'
+
+describe('buildGenericProfilePath', () => {
+  it('returns /profile without tab', () => {
+    expect(buildGenericProfilePath()).toBe('/profile')
+    expect(buildGenericProfilePath('articles')).toBe('/profile')
+  })
+
+  it('includes tab query for non-articles tabs', () => {
+    expect(buildGenericProfilePath('wallet')).toBe('/profile?tab=wallet')
+    expect(buildGenericProfilePath('earnings')).toBe('/profile?tab=earnings')
+  })
+})
+
+describe('resolveSignedInProfilePath', () => {
+  it('returns username path without tab by default', () => {
+    expect(resolveSignedInProfilePath('alice', new URLSearchParams())).toBe(
+      '/alice'
+    )
+  })
+
+  it('maps wallet tab to profile URL', () => {
+    expect(
+      resolveSignedInProfilePath(
+        'alice',
+        new URLSearchParams('tab=wallet')
+      )
+    ).toBe('/alice?tab=wallet')
+  })
+
+  it('preserves other query params', () => {
+    const result = resolveSignedInProfilePath(
+      'alice',
+      new URLSearchParams('tab=wallet&page=2')
+    )
+    expect(result).toContain('/alice')
+    expect(result).toContain('tab=wallet')
+    expect(result).toContain('page=2')
+  })
+
+  it('ignores invalid tab values', () => {
+    expect(
+      resolveSignedInProfilePath(
+        'alice',
+        new URLSearchParams('tab=invalid')
+      )
+    ).toBe('/alice')
+  })
+})
+
+describe('buildLoginRedirectPath', () => {
+  it('encodes intended path in next param', () => {
+    expect(buildLoginRedirectPath('/profile?tab=wallet')).toBe(
+      '/login?next=%2Fprofile%3Ftab%3Dwallet'
+    )
+  })
+})
+
+describe('parseSafeNextParam', () => {
+  it('accepts same-site relative paths', () => {
+    expect(parseSafeNextParam('/profile')).toBe('/profile')
+    expect(parseSafeNextParam('/profile?tab=wallet')).toBe(
+      '/profile?tab=wallet'
+    )
+  })
+
+  it('rejects open redirects and external URLs', () => {
+    expect(parseSafeNextParam(null)).toBeNull()
+    expect(parseSafeNextParam('')).toBeNull()
+    expect(parseSafeNextParam('//evil.com')).toBeNull()
+    expect(parseSafeNextParam('https://evil.com')).toBeNull()
+    expect(parseSafeNextParam('profile')).toBeNull()
+  })
+})
+
+describe('buildPathWithSearch', () => {
+  it('joins pathname and query string', () => {
+    expect(
+      buildPathWithSearch('/profile', new URLSearchParams('tab=wallet'))
+    ).toBe('/profile?tab=wallet')
+    expect(buildPathWithSearch('/profile', new URLSearchParams())).toBe(
+      '/profile'
+    )
+  })
+})
+
+describe('appendNextToAuthPath', () => {
+  it('returns bare auth path when next is unsafe', () => {
+    expect(appendNextToAuthPath('/login', '//evil.com')).toBe('/login')
+  })
+
+  it('appends safe next param', () => {
+    expect(appendNextToAuthPath('/login', '/profile?tab=wallet')).toBe(
+      '/login?next=%2Fprofile%3Ftab%3Dwallet'
+    )
+    expect(appendNextToAuthPath('/register', '/profile')).toBe(
+      '/register?next=%2Fprofile'
+    )
+  })
+})

--- a/lib/profile/profileDestination.ts
+++ b/lib/profile/profileDestination.ts
@@ -1,0 +1,55 @@
+import {
+  buildProfileTabHref,
+  parseProfileTab,
+  type ProfileTabId,
+} from './profileTab'
+
+export const GENERIC_PROFILE_PATHS = ['/profile', '/settings/profile'] as const
+
+export type GenericProfilePath = (typeof GENERIC_PROFILE_PATHS)[number]
+
+export function buildGenericProfilePath(tab?: ProfileTabId): string {
+  if (!tab || tab === 'articles') return '/profile'
+  return `/profile?tab=${tab}`
+}
+
+export function resolveSignedInProfilePath(
+  username: string,
+  searchParams: URLSearchParams
+): string {
+  const pathname = `/${username}`
+  const tab = parseProfileTab(searchParams.get('tab'), true)
+  return buildProfileTabHref(pathname, searchParams, tab)
+}
+
+export function buildLoginRedirectPath(intendedPath: string): string {
+  const params = new URLSearchParams()
+  params.set('next', intendedPath)
+  return `/login?${params.toString()}`
+}
+
+export function parseSafeNextParam(next: string | null | undefined): string | null {
+  if (!next) return null
+  if (!next.startsWith('/') || next.startsWith('//')) return null
+  if (next.includes('://')) return null
+  return next
+}
+
+export function buildPathWithSearch(
+  pathname: string,
+  searchParams: URLSearchParams
+): string {
+  const qs = searchParams.toString()
+  return qs ? `${pathname}?${qs}` : pathname
+}
+
+export function appendNextToAuthPath(
+  authPath: '/login' | '/register',
+  next: string | null | undefined
+): string {
+  const safe = parseSafeNextParam(next)
+  if (!safe) return authPath
+  const params = new URLSearchParams()
+  params.set('next', safe)
+  return `${authPath}?${params.toString()}`
+}

--- a/lib/profile/profileDestination.ts
+++ b/lib/profile/profileDestination.ts
@@ -28,7 +28,9 @@ export function buildLoginRedirectPath(intendedPath: string): string {
   return `/login?${params.toString()}`
 }
 
-export function parseSafeNextParam(next: string | null | undefined): string | null {
+export function parseSafeNextParam(
+  next: string | null | undefined
+): string | null {
   if (!next) return null
   if (!next.startsWith('/') || next.startsWith('//')) return null
   if (next.includes('://')) return null


### PR DESCRIPTION
## Summary

Fixes ENG-160: generic profile URLs (`/profile`, `/settings/profile`) no longer resolve to the dynamic `[username]` route and 404. Signed-in users are redirected to their real profile; signed-out users are sent to login with profile setup intent preserved via `?next=`.

## Changes

- Add `/profile` and `/settings/profile` redirect pages using `GenericProfileRedirect`
- Add `lib/profile/profileDestination.ts` helpers (safe `next` parsing, signed-in path resolution)
- After login/register, honor safe `?next=` instead of always redirecting home
- Preserve `next` when switching between login and register (`AuthAlternateLink`)
- Update Wallet guide CTA to `/profile?tab=wallet`
- Update nav Profile links (desktop + mobile) to `/profile`

## Behavior

| User state | `/profile` | `/profile?tab=wallet` |
|------------|------------|------------------------|
| Signed in  | `/{username}` | `/{username}?tab=wallet` |
| Signed out | `/login?next=/profile` | `/login?next=/profile?tab=wallet` |



