### PR TITLE
feat(profile): deep-link profile tabs via URL query param (ENG-172)

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -65,10 +65,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
   // Check if this is the current user's profile
   const isOwnProfile = currentUser?.username === username
   const rawTab = searchParams?.get('tab') ?? null
-  const activeTab = parseProfileTab(
-    rawTab,
-    authLoading ? false : isOwnProfile
-  )
+  const activeTab = parseProfileTab(rawTab, authLoading ? false : isOwnProfile)
 
   useEffect(() => {
     if (authLoading) return
@@ -80,14 +77,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
         parseProfileTab(rawTab, isOwnProfile)
       )
     )
-  }, [
-    authLoading,
-    isOwnProfile,
-    pathname,
-    rawTab,
-    router,
-    searchParams,
-  ])
+  }, [authLoading, isOwnProfile, pathname, rawTab, router, searchParams])
 
   // Check if user exists
   if (user === null) {

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -3,10 +3,12 @@
 import { notFound } from 'next/navigation'
 import { useUserByUsername, useUserStats } from '@/hooks/convex'
 import { use, useState, useEffect } from 'react'
+import Link from 'next/link'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import {
   buildProfileTabHref,
   parseProfileTab,
+  profileTabUrlIsCanonical,
   type ProfileTabId,
 } from '@/lib/profile/profileTab'
 import { useAuth } from '@/components/providers/AuthContext'
@@ -31,7 +33,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
   const pathname = usePathname()
   const router = useRouter()
   const searchParams = useSearchParams()
-  const { user: currentUser } = useAuth()
+  const { user: currentUser, isLoading: authLoading } = useAuth()
   const [localWalletAddress, setLocalWalletAddress] = useState<
     string | null | undefined
   >()
@@ -62,10 +64,30 @@ export default function ProfilePage({ params }: ProfilePageProps) {
 
   // Check if this is the current user's profile
   const isOwnProfile = currentUser?.username === username
+  const rawTab = searchParams?.get('tab') ?? null
   const activeTab = parseProfileTab(
-    searchParams?.get('tab') ?? null,
-    isOwnProfile
+    rawTab,
+    authLoading ? false : isOwnProfile
   )
+
+  useEffect(() => {
+    if (authLoading) return
+    if (profileTabUrlIsCanonical(rawTab, isOwnProfile)) return
+    router.replace(
+      buildProfileTabHref(
+        pathname,
+        new URLSearchParams(searchParams?.toString() ?? ''),
+        parseProfileTab(rawTab, isOwnProfile)
+      )
+    )
+  }, [
+    authLoading,
+    isOwnProfile,
+    pathname,
+    rawTab,
+    router,
+    searchParams,
+  ])
 
   // Check if user exists
   if (user === null) {
@@ -147,21 +169,21 @@ export default function ProfilePage({ params }: ProfilePageProps) {
 
         {/* Tabs */}
         <div className="border-b border-border mb-8">
-          <nav className="-mb-px flex space-x-8">
-            {tabs.map((tab) => (
-              <button
-                key={tab.id}
-                data-tab={tab.id}
-                onClick={() =>
-                  router.push(
-                    buildProfileTabHref(
-                      pathname,
-                      new URLSearchParams(searchParams?.toString() ?? ''),
-                      tab.id
-                    )
-                  )
-                }
-                className={`
+          <nav className="-mb-px flex space-x-8" aria-label="Profile sections">
+            {tabs.map((tab) => {
+              const tabHref = buildProfileTabHref(
+                pathname,
+                new URLSearchParams(searchParams?.toString() ?? ''),
+                tab.id
+              )
+              return (
+                <Link
+                  key={tab.id}
+                  href={tabHref}
+                  scroll={false}
+                  data-tab={tab.id}
+                  aria-current={activeTab === tab.id ? 'page' : undefined}
+                  className={`
                   flex items-center gap-2 py-3 px-1 border-b-2 font-medium text-sm transition-colors
                   ${
                     activeTab === tab.id
@@ -169,16 +191,17 @@ export default function ProfilePage({ params }: ProfilePageProps) {
                       : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'
                   }
                 `}
-              >
-                <tab.icon className="w-4 h-4" />
-                <span>{tab.label}</span>
-                {tab.count !== null && tab.count > 0 && (
-                  <span className="ml-1 bg-muted text-muted-foreground px-2 py-0.5 rounded-full text-xs">
-                    {tab.count}
-                  </span>
-                )}
-              </button>
-            ))}
+                >
+                  <tab.icon className="w-4 h-4" />
+                  <span>{tab.label}</span>
+                  {tab.count !== null && tab.count > 0 && (
+                    <span className="ml-1 bg-muted text-muted-foreground px-2 py-0.5 rounded-full text-xs">
+                      {tab.count}
+                    </span>
+                  )}
+                </Link>
+              )
+            })}
           </nav>
         </div>
 

--- a/hooks/useProfileTabNavigation.ts
+++ b/hooks/useProfileTabNavigation.ts
@@ -2,6 +2,7 @@
 
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import {
+  buildCurrentProfilePath,
   buildProfileTabHref,
   type ProfileTabId,
 } from '@/lib/profile/profileTab'
@@ -12,12 +13,10 @@ export function useProfileTabNavigation() {
   const searchParams = useSearchParams()
 
   return (tab: ProfileTabId) => {
-    router.push(
-      buildProfileTabHref(
-        pathname,
-        new URLSearchParams(searchParams?.toString() ?? ''),
-        tab
-      )
-    )
+    const params = new URLSearchParams(searchParams?.toString() ?? '')
+    const href = buildProfileTabHref(pathname, params, tab)
+    const current = buildCurrentProfilePath(pathname, params)
+    if (href === current) return
+    router.push(href)
   }
 }

--- a/lib/profile/profileTab.test.ts
+++ b/lib/profile/profileTab.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { buildProfileTabHref, parseProfileTab } from './profileTab'
+import {
+  buildCurrentProfilePath,
+  buildProfileTabHref,
+  parseProfileTab,
+  profileTabUrlIsCanonical,
+} from './profileTab'
 
 describe('parseProfileTab', () => {
   it('defaults to articles when tab is missing', () => {
@@ -47,6 +52,32 @@ describe('buildProfileTabHref', () => {
     const sp = new URLSearchParams('nftOwnedPage=2&nftMintedPage=3')
     expect(buildProfileTabHref('/bob', sp, 'wallet')).toBe(
       '/bob?nftOwnedPage=2&nftMintedPage=3&tab=wallet'
+    )
+  })
+})
+
+describe('profileTabUrlIsCanonical', () => {
+  it('returns true when tab param is absent or valid', () => {
+    expect(profileTabUrlIsCanonical(null, false)).toBe(true)
+    expect(profileTabUrlIsCanonical('wallet', false)).toBe(true)
+    expect(profileTabUrlIsCanonical('earnings', true)).toBe(true)
+  })
+
+  it('returns false for invalid or disallowed tab params', () => {
+    expect(profileTabUrlIsCanonical('invalid', true)).toBe(false)
+    expect(profileTabUrlIsCanonical('earnings', false)).toBe(false)
+    expect(profileTabUrlIsCanonical('stats', false)).toBe(false)
+    expect(profileTabUrlIsCanonical('articles', true)).toBe(false)
+  })
+})
+
+describe('buildCurrentProfilePath', () => {
+  it('builds pathname with search string', () => {
+    expect(
+      buildCurrentProfilePath('/alice', new URLSearchParams('tab=wallet'))
+    ).toBe('/alice?tab=wallet')
+    expect(buildCurrentProfilePath('/alice', new URLSearchParams())).toBe(
+      '/alice'
     )
   })
 })

--- a/lib/profile/profileTab.ts
+++ b/lib/profile/profileTab.ts
@@ -34,3 +34,21 @@ export function buildProfileTabHref(
   const qs = next.toString()
   return qs ? `${pathname}?${qs}` : pathname
 }
+
+export function profileTabUrlIsCanonical(
+  raw: string | null,
+  isOwnProfile: boolean
+): boolean {
+  if (!raw) return true
+  const tab = parseProfileTab(raw, isOwnProfile)
+  if (tab === 'articles') return false
+  return tab === raw
+}
+
+export function buildCurrentProfilePath(
+  pathname: string,
+  searchParams: URLSearchParams
+): string {
+  const qs = searchParams.toString()
+  return qs ? `${pathname}?${qs}` : pathname
+}


### PR DESCRIPTION
## Summary

Profile tabs (Articles, NFTs, Wallet, Earnings, Stats) are driven by the `tab` query parameter instead of local React state. Each tab has a shareable URL, refresh restores the active tab, and browser back/forward navigates through tab changes. Private tabs (Earnings, Stats) are only available on the signed-in user's own profile; invalid or unauthorized `tab` values fall back to Articles and the URL is canonicalized.



## Changes

- Replace `useState` tab selection with `?tab=` on `/{username}` (`articles` omits the param)
- Add `parseProfileTab`, `buildProfileTabHref`, `profileTabUrlIsCanonical`, and `buildCurrentProfilePath` in `lib/profile/profileTab.ts`
- Render profile tab nav with Next.js `Link` for copyable, open-in-new-tab URLs
- Canonicalize disallowed/invalid `tab` params via `router.replace()` so the address bar matches the visible tab
- Defer own-profile tab resolution while auth is loading to avoid private-tab flicker
- Add `useProfileTabNavigation` hook; skip navigation when the target URL is unchanged
- Preserve existing query params (`page`, `nftOwnedPage`, `nftMintedPage`) when switching tabs
- `/profile?tab=...` continues to redirect to `/{username}?tab=...` via `GenericProfileRedirect`

## Tab URLs

| Tab      | URL param        | Who can open   |
|----------|------------------|----------------|
| Articles | (none)           | Everyone       |
| NFTs     | `?tab=nfts`      | Everyone       |
| Wallet   | `?tab=wallet`    | Everyone       |
| Earnings | `?tab=earnings`  | Own profile    |
| Stats    | `?tab=stats`     | Own profile    |

