### PR TITLE
fix(profile): make tab bar scrollable and keep active tab visible on mobile (ENG-173)

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -3,7 +3,6 @@
 import { notFound } from 'next/navigation'
 import { useUserByUsername, useUserStats } from '@/hooks/convex'
 import { use, useState, useEffect } from 'react'
-import Link from 'next/link'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import {
   buildProfileTabHref,
@@ -15,6 +14,7 @@ import { useAuth } from '@/components/providers/AuthContext'
 import AppNavigation from '@/components/layout/AppNavigation'
 import { SiteFooter } from '@/components/layout/SiteFooter'
 import ProfileHeader from '@/components/profile/ProfileHeader'
+import { ProfileTabBar } from '@/components/profile/ProfileTabBar'
 import { ProfileArticlesTabContent } from '@/components/profile/ProfileArticlesTabContent'
 import { ProfileNftsTabContent } from '@/components/profile/ProfileNftsTabContent'
 import { ProfilePageLoadingSkeleton } from '@/components/profile/ProfilePageLoadingSkeleton'
@@ -151,49 +151,23 @@ export default function ProfilePage({ params }: ProfilePageProps) {
     <div className="flex min-h-screen flex-col bg-background">
       <AppNavigation />
 
-      <main className="flex-1 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12 w-full">
+      <main className="flex-1 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12 w-full min-w-0">
         {/* Profile Header */}
         <div className="mb-8">
           <ProfileHeader user={userWithStats} isOwnProfile={isOwnProfile} />
         </div>
 
-        {/* Tabs */}
-        <div className="border-b border-border mb-8">
-          <nav className="-mb-px flex space-x-8" aria-label="Profile sections">
-            {tabs.map((tab) => {
-              const tabHref = buildProfileTabHref(
-                pathname,
-                new URLSearchParams(searchParams?.toString() ?? ''),
-                tab.id
-              )
-              return (
-                <Link
-                  key={tab.id}
-                  href={tabHref}
-                  scroll={false}
-                  data-tab={tab.id}
-                  aria-current={activeTab === tab.id ? 'page' : undefined}
-                  className={`
-                  flex items-center gap-2 py-3 px-1 border-b-2 font-medium text-sm transition-colors
-                  ${
-                    activeTab === tab.id
-                      ? 'border-brand-blue text-foreground dark:border-primary'
-                      : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'
-                  }
-                `}
-                >
-                  <tab.icon className="w-4 h-4" />
-                  <span>{tab.label}</span>
-                  {tab.count !== null && tab.count > 0 && (
-                    <span className="ml-1 bg-muted text-muted-foreground px-2 py-0.5 rounded-full text-xs">
-                      {tab.count}
-                    </span>
-                  )}
-                </Link>
-              )
-            })}
-          </nav>
-        </div>
+        <ProfileTabBar
+          tabs={tabs}
+          activeTab={activeTab}
+          getHref={(tabId) =>
+            buildProfileTabHref(
+              pathname,
+              new URLSearchParams(searchParams?.toString() ?? ''),
+              tabId
+            )
+          }
+        />
 
         {/* Tab Content */}
         <div>

--- a/components/profile/ProfileTabBar.tsx
+++ b/components/profile/ProfileTabBar.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import Link from 'next/link'
+import type { LucideIcon } from 'lucide-react'
+import type { ProfileTabId } from '@/lib/profile/profileTab'
+
+export type ProfileTabBarItem = {
+  id: ProfileTabId
+  label: string
+  icon: LucideIcon
+  count: number | null
+}
+
+type ProfileTabBarProps = {
+  tabs: ProfileTabBarItem[]
+  activeTab: ProfileTabId
+  getHref: (tabId: ProfileTabId) => string
+}
+
+export function ProfileTabBar({
+  tabs,
+  activeTab,
+  getHref,
+}: ProfileTabBarProps) {
+  const navRef = useRef<HTMLElement>(null)
+
+  useEffect(() => {
+    const el = navRef.current?.querySelector<HTMLElement>(
+      `[data-tab="${activeTab}"]`
+    )
+    el?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'nearest',
+      inline: 'nearest',
+    })
+  }, [activeTab, tabs.length])
+
+  return (
+    <div className="min-w-0 w-full overflow-hidden border-b border-border mb-8">
+      <nav
+        ref={navRef}
+        className="-mb-px flex flex-nowrap gap-4 sm:gap-8 overflow-x-auto overflow-y-hidden overscroll-x-contain [-webkit-overflow-scrolling:touch] pb-0.5 [scrollbar-width:thin]"
+        aria-label="Profile sections"
+      >
+        {tabs.map((tab) => (
+          <Link
+            key={tab.id}
+            href={getHref(tab.id)}
+            scroll={false}
+            data-tab={tab.id}
+            aria-current={activeTab === tab.id ? 'page' : undefined}
+            className={`shrink-0 flex items-center gap-2 py-3 px-3 min-h-[44px] touch-manipulation border-b-2 font-medium text-sm transition-colors ${
+              activeTab === tab.id
+                ? 'border-brand-blue text-foreground dark:border-primary'
+                : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'
+            }`}
+          >
+            <tab.icon className="w-4 h-4 shrink-0" />
+            <span>{tab.label}</span>
+            {tab.count !== null && tab.count > 0 && (
+              <span className="ml-1 bg-muted text-muted-foreground px-2 py-0.5 rounded-full text-xs">
+                {tab.count}
+              </span>
+            )}
+          </Link>
+        ))}
+      </nav>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Fixes ENG-173: on narrow screens, profile tabs (Wallet, Earnings, Stats, NFTs, etc.) could sit off-screen with no way to reach them, and the active tab could stay hidden after a deep link or when switching tabs.

- Extracts a dedicated `ProfileTabBar` component with a horizontally scrollable tab strip (overflow contained to the bar, not the page)
- Scrolls the active tab into view on tab change and deep link entry (`?tab=wallet`, `?tab=stats`, etc.)
- Improves mobile tap targets (`min-h-[44px]`, `px-3`, `touch-manipulation`)
- Adds `min-w-0` on profile `main` to prevent page-level horizontal overflow

## Changes

- **New:** `components/profile/ProfileTabBar.tsx` — scroll container, `scrollIntoView` for active tab, larger tap targets
- **Updated:** `app/[username]/page.tsx` — uses `ProfileTabBar`, `min-w-0` on `<main>`

Tab URL logic (`lib/profile/profileTab.ts`) is unchanged.

