### PR TITLE
fix(auth): allow empty full name on registration (ENG-157)

### DIFF
--- a/lib/validations/__tests__/auth.test.ts
+++ b/lib/validations/__tests__/auth.test.ts
@@ -73,6 +73,97 @@ describe('Auth Validation Schemas', () => {
       })
       expect(result.success).toBe(false)
     })
+
+    it('accepts registration with empty name', () => {
+      const result = registerSchema.safeParse({
+        email: 'user@example.com',
+        username: 'validuser',
+        password: 'Password1',
+        confirmPassword: 'Password1',
+        name: '',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts registration with name omitted', () => {
+      const result = registerSchema.safeParse({
+        email: 'user@example.com',
+        username: 'validuser',
+        password: 'Password1',
+        confirmPassword: 'Password1',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts registration with a provided name', () => {
+      const result = registerSchema.safeParse({
+        email: 'user@example.com',
+        username: 'validuser',
+        password: 'Password1',
+        confirmPassword: 'Password1',
+        name: 'Jane Doe',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects name longer than 50 characters', () => {
+      const result = registerSchema.safeParse({
+        email: 'user@example.com',
+        username: 'validuser',
+        password: 'Password1',
+        confirmPassword: 'Password1',
+        name: 'a'.repeat(51),
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          'Name must be at most 50 characters'
+        )
+      }
+    })
+
+    it('rejects empty email with a clear message', () => {
+      const result = registerSchema.safeParse({
+        email: '',
+        username: 'validuser',
+        password: 'Password1',
+        confirmPassword: 'Password1',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe('Email is required')
+      }
+    })
+
+    it('rejects empty username', () => {
+      const result = registerSchema.safeParse({
+        email: 'user@example.com',
+        username: '',
+        password: 'Password1',
+        confirmPassword: 'Password1',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          'Username must be at least 3 characters'
+        )
+      }
+    })
+
+    it('rejects empty password', () => {
+      const result = registerSchema.safeParse({
+        email: 'user@example.com',
+        username: 'validuser',
+        password: '',
+        confirmPassword: '',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          'Password must be at least 8 characters'
+        )
+      }
+    })
   })
 
   describe('profileUpdateSchema', () => {

--- a/lib/validations/auth.ts
+++ b/lib/validations/auth.ts
@@ -54,9 +54,10 @@ export const registerSchema = z
       ),
     confirmPassword: z.string().min(1, 'Please confirm your password'),
     name: z
-      .string()
-      .min(1, 'Name is required')
-      .max(50, 'Name must be at most 50 characters')
+      .union([
+        z.literal(''),
+        z.string().max(50, 'Name must be at most 50 characters'),
+      ])
       .optional(),
   })
   .refine((data) => data.password === data.confirmPassword, {


### PR DESCRIPTION
## Summary

Fixes ENG-157: registration labeled full name as optional but Zod rejected empty strings with "Name is required". Users can now register without a full name; required fields still show the same blocking errors.

## Problem

- UI: `Full Name (optional)` on `/register`
- Validation: `name` used `.min(1)` before `.optional()`, so React Hook Form’s `""` failed validation
- Backend already treated `name` as optional; no Convex changes

## Solution

- Update `registerSchema.name` in `lib/validations/auth.ts` to accept `""`, omitted, or a value up to 50 characters (union of `z.literal('')` and max-length string)
- Add regression tests in `lib/validations/__tests__/auth.test.ts` for empty/omitted/provided name, max length, and required-field errors
- No form or redirect changes; success still `router.replace('/')` with onboarding on home when applicable

