### PR TITLE
fix(auth): show redirect progress after login instead of stuck submit state (ENG-156)

### DIFF
--- a/components/auth/LoginForm.test.tsx
+++ b/components/auth/LoginForm.test.tsx
@@ -1,0 +1,84 @@
+/** @vitest-environment jsdom */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import LoginForm from '@/components/auth/LoginForm'
+
+const mockSignIn = vi.hoisted(() => vi.fn())
+const mockReplace = vi.hoisted(() => vi.fn())
+
+vi.mock('@convex-dev/auth/react', () => ({
+  useAuthActions: () => ({
+    signIn: mockSignIn,
+  }),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+  }),
+}))
+
+describe('LoginForm', () => {
+  beforeEach(() => {
+    mockSignIn.mockReset()
+    mockReplace.mockReset()
+  })
+
+  it('shows redirecting message and navigates home on successful sign in', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockSignIn.mockResolvedValue(undefined)
+
+    render(<LoginForm />)
+
+    await user.type(screen.getByLabelText(/email address/i), 'user@example.com')
+    await user.type(screen.getByLabelText(/^password$/i), 'password123')
+    await user.click(screen.getByRole('button', { name: /sign in/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/signed in successfully! redirecting to dashboard/i)
+      ).toBeInTheDocument()
+    })
+
+    expect(mockSignIn).toHaveBeenCalledWith('password', {
+      email: 'user@example.com',
+      password: 'password123',
+      flow: 'signIn',
+    })
+    expect(mockReplace).toHaveBeenCalledWith('/')
+    expect(
+      screen.queryByRole('button', { name: /signing in/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('restores an editable form with retry after failed sign in', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockSignIn.mockRejectedValue(new Error('Invalid credentials'))
+
+    render(<LoginForm />)
+
+    await user.type(screen.getByLabelText(/email address/i), 'user@example.com')
+    await user.type(screen.getByLabelText(/^password$/i), 'wrong-password')
+    await user.click(screen.getByRole('button', { name: /sign in/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/invalid email or password/i)
+      ).toBeInTheDocument()
+    })
+
+    const submitButton = screen.getByRole('button', { name: /sign in/i })
+    expect(submitButton).toBeEnabled()
+    expect(mockReplace).not.toHaveBeenCalled()
+
+    const emailInput = screen.getByLabelText(/email address/i)
+    const passwordInput = screen.getByLabelText(/^password$/i)
+    expect(emailInput).not.toBeDisabled()
+    expect(passwordInput).not.toBeDisabled()
+
+    await user.clear(passwordInput)
+    await user.type(passwordInput, 'new-attempt')
+    expect(passwordInput).toHaveValue('new-attempt')
+  })
+})

--- a/components/auth/LoginForm.test.tsx
+++ b/components/auth/LoginForm.test.tsx
@@ -63,9 +63,7 @@ describe('LoginForm', () => {
     await user.click(screen.getByRole('button', { name: /sign in/i }))
 
     await waitFor(() => {
-      expect(
-        screen.getByText(/invalid email or password/i)
-      ).toBeInTheDocument()
+      expect(screen.getByText(/invalid email or password/i)).toBeInTheDocument()
     })
 
     const submitButton = screen.getByRole('button', { name: /sign in/i })

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -80,9 +80,7 @@ export default function LoginForm() {
               aria-hidden="true"
               className="h-4 w-4 shrink-0 text-success-foreground"
             />
-            <span>
-              Signed in successfully! Redirecting to dashboard...
-            </span>
+            <span>Signed in successfully! Redirecting to dashboard...</span>
           </p>
         </div>
       </div>

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -1,17 +1,19 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useAuthActions } from '@convex-dev/auth/react'
 import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { loginSchema, type LoginFormData } from '@/lib/validations/auth'
-import { Eye, EyeOff, Loader2 } from 'lucide-react'
+import { CheckCircle, Eye, EyeOff, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 
 const authInputClassName =
   'rounded-lg bg-background text-foreground focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:border-transparent'
+
+const REDIRECT_TIMEOUT_MS = 15_000
 
 /**
  * Login Form Component
@@ -24,6 +26,7 @@ export default function LoginForm() {
   const [showPassword, setShowPassword] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
 
   const router = useRouter()
   const { signIn } = useAuthActions()
@@ -36,6 +39,18 @@ export default function LoginForm() {
     resolver: zodResolver(loginSchema),
   })
 
+  useEffect(() => {
+    if (!success) return
+
+    const timeout = setTimeout(() => {
+      setSuccess(false)
+      setIsLoading(false)
+      setError('Redirect is taking longer than expected. Try again.')
+    }, REDIRECT_TIMEOUT_MS)
+
+    return () => clearTimeout(timeout)
+  }, [success])
+
   const onSubmit = async (data: LoginFormData) => {
     setIsLoading(true)
     setError(null)
@@ -47,14 +62,31 @@ export default function LoginForm() {
         flow: 'signIn',
       })
 
-      // If we reach here, sign-in was successful
-      // Use replace to prevent back button returning to login
+      setSuccess(true)
       router.replace('/')
     } catch (error) {
       console.error('Login error:', error)
       setError('Invalid email or password. Please try again.')
       setIsLoading(false)
     }
+  }
+
+  if (success) {
+    return (
+      <div className="text-center space-y-4">
+        <div className="p-4 bg-muted border border-border rounded-lg">
+          <p className="inline-flex items-center justify-center gap-2 text-sm text-foreground">
+            <CheckCircle
+              aria-hidden="true"
+              className="h-4 w-4 shrink-0 text-success-foreground"
+            />
+            <span>
+              Signed in successfully! Redirecting to dashboard...
+            </span>
+          </p>
+        </div>
+      </div>
+    )
   }
 
   return (


### PR DESCRIPTION
## Summary

Fixes ENG-156: after a successful login, the form no longer sits on a disabled "Signing in..." button while navigation to `/` completes. Successful sign-in now shows an explicit redirect message (matching the register flow), failed sign-in restores an editable form, and a timeout prevents users from being stranded if redirect stalls.

## Changes

- **LoginForm**: add `success` state and post-sign-in UI ("Signed in successfully! Redirecting to dashboard...")
- **LoginForm**: call `setSuccess(true)` before `router.replace('/')` so progress is visible during client navigation
- **LoginForm**: 15s redirect timeout falls back to the form with a retry message if navigation does not complete
- **LoginForm.test.tsx**: regression tests for successful redirect flow and failed sign-in retry

