### PR TITLE
fix(auth): accessible registration field errors (ENG-167)

### DIFF
--- a/components/auth/RegisterForm.test.tsx
+++ b/components/auth/RegisterForm.test.tsx
@@ -1,0 +1,102 @@
+/** @vitest-environment jsdom */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import RegisterForm from '@/components/auth/RegisterForm'
+
+const mockSignIn = vi.hoisted(() => vi.fn())
+const mockReplace = vi.hoisted(() => vi.fn())
+
+vi.mock('@/components/providers/AuthContext', () => ({
+  useAuth: () => ({
+    signIn: mockSignIn,
+    signOut: vi.fn(),
+    user: null,
+    isLoading: false,
+    isAuthenticated: false,
+  }),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+  }),
+}))
+
+describe('RegisterForm accessibility', () => {
+  beforeEach(() => {
+    mockSignIn.mockReset()
+    mockReplace.mockReset()
+  })
+
+  it('marks the first invalid field and associates its error on empty submit', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<RegisterForm />)
+
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(document.getElementById('email-error')).toHaveTextContent(
+        'Email is required'
+      )
+    })
+
+    const emailInput = screen.getByLabelText(/email address/i)
+    expect(emailInput).toHaveAttribute('aria-invalid', 'true')
+    expect(emailInput).toHaveAttribute('aria-describedby', 'email-error')
+
+    const emailError = document.getElementById('email-error')
+    expect(emailError).toHaveTextContent('Email is required')
+
+    expect(screen.getByRole('alert', { hidden: true })).toHaveTextContent(
+      'Email is required'
+    )
+  })
+
+  it('clears email invalid state after the user enters a valid email', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<RegisterForm />)
+
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(document.getElementById('email-error')).toHaveTextContent(
+        'Email is required'
+      )
+    })
+
+    const emailInput = screen.getByLabelText(/email address/i)
+    await user.type(emailInput, 'user@example.com')
+
+    await waitFor(() => {
+      expect(emailInput).toHaveAttribute('aria-invalid', 'false')
+      expect(emailInput).not.toHaveAttribute('aria-describedby')
+    })
+
+    expect(document.getElementById('email-error')).toBeNull()
+  })
+
+  it('shows a server email conflict on the email field', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockSignIn.mockRejectedValue(new Error('Account already exists'))
+
+    render(<RegisterForm />)
+
+    await user.type(screen.getByLabelText(/email address/i), 'user@example.com')
+    await user.type(screen.getByLabelText(/^username$/i), 'myuser')
+    await user.type(screen.getByLabelText(/^password$/i), 'Password1')
+    await user.type(screen.getByLabelText(/confirm password/i), 'Password1')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(document.getElementById('email-error')).toHaveTextContent(
+        /an account with this email already exists/i
+      )
+    })
+
+    const emailInput = screen.getByLabelText(/email address/i)
+    expect(emailInput).toHaveAttribute('aria-invalid', 'true')
+    expect(emailInput).toHaveAttribute('aria-describedby', 'email-error')
+    expect(screen.queryByText(/registration failed/i)).not.toBeInTheDocument()
+  })
+})

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -175,8 +175,7 @@ export default function RegisterForm() {
         id="name"
         label={
           <>
-            Full Name{' '}
-            <span className="text-muted-foreground">(optional)</span>
+            Full Name <span className="text-muted-foreground">(optional)</span>
           </>
         }
         error={errors.name?.message}

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -2,17 +2,16 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { useForm } from 'react-hook-form'
+import { useForm, type FieldErrors } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { mapRegisterSignInError } from '@/lib/auth/map-register-error'
+import { parseRegisterSignInError } from '@/lib/auth/map-register-error'
+import { getFirstRegisterFieldError } from '@/lib/auth/register-form-a11y'
 import { registerSchema, type RegisterFormData } from '@/lib/validations/auth'
 import { CheckCircle, Eye, EyeOff, Loader2 } from 'lucide-react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-
-const authInputClassName =
-  'rounded-lg bg-background text-foreground focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:border-transparent'
+import { RegisterFormField } from '@/components/auth/RegisterFormField'
 
 /**
  * Register Form Component
@@ -25,7 +24,10 @@ export default function RegisterForm() {
   const [showPassword, setShowPassword] = useState(false)
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [formError, setFormError] = useState<string | null>(null)
+  const [submitAnnouncement, setSubmitAnnouncement] = useState<string | null>(
+    null
+  )
   const [success, setSuccess] = useState(false)
 
   const router = useRouter()
@@ -34,14 +36,36 @@ export default function RegisterForm() {
   const {
     register,
     handleSubmit,
+    setError,
+    clearErrors,
     formState: { errors },
   } = useForm<RegisterFormData>({
     resolver: zodResolver(registerSchema),
+    reValidateMode: 'onChange',
   })
+
+  const clearFieldFeedback = (name: keyof RegisterFormData) => {
+    clearErrors(name)
+    setFormError(null)
+    setSubmitAnnouncement(null)
+  }
+
+  const registerField = (name: keyof RegisterFormData) =>
+    register(name, {
+      onChange: () => clearFieldFeedback(name),
+    })
+
+  const announceFirstError = (formErrors: FieldErrors<RegisterFormData>) => {
+    const first = getFirstRegisterFieldError(formErrors)
+    if (!first) return
+    setSubmitAnnouncement(first.message)
+    document.getElementById(first.field)?.focus()
+  }
 
   const onSubmit = async (data: RegisterFormData) => {
     setIsLoading(true)
-    setError(null)
+    setFormError(null)
+    setSubmitAnnouncement(null)
 
     try {
       await signIn('password', {
@@ -53,12 +77,25 @@ export default function RegisterForm() {
       })
 
       setSuccess(true)
-      // Use replace to prevent back button returning to register
       router.replace('/')
     } catch (error) {
-      setError(mapRegisterSignInError(error))
+      const result = parseRegisterSignInError(error)
+      setSubmitAnnouncement(result.message)
+
+      if (result.field) {
+        setError(result.field, { type: 'server', message: result.message })
+        setFormError(null)
+        document.getElementById(result.field)?.focus()
+      } else {
+        setFormError(result.message)
+      }
+
       setIsLoading(false)
     }
+  }
+
+  const onInvalid = (formErrors: FieldErrors<RegisterFormData>) => {
+    announceFirstError(formErrors)
   }
 
   if (success) {
@@ -80,152 +117,156 @@ export default function RegisterForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-      {/* Error Message */}
-      {error && (
-        <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
-          <p className="text-sm text-red-700">{error}</p>
+    <form onSubmit={handleSubmit(onSubmit, onInvalid)} className="space-y-4">
+      {submitAnnouncement ? (
+        <p role="alert" className="sr-only">
+          {submitAnnouncement}
+        </p>
+      ) : null}
+
+      {formError ? (
+        <div
+          role="alert"
+          className="p-4 bg-red-50 border border-red-200 rounded-lg"
+        >
+          <p className="text-sm text-red-700">{formError}</p>
         </div>
-      )}
+      ) : null}
 
-      {/* Email Field */}
-      <div>
-        <label
-          htmlFor="email"
-          className="block text-sm font-medium text-foreground mb-2"
-        >
-          Email address
-        </label>
-        <Input
-          {...register('email')}
-          type="email"
-          id="email"
-          autoComplete="email"
-          className={authInputClassName}
-          placeholder="you@example.com"
-        />
-        {errors.email && (
-          <p className="mt-1 text-sm text-red-600">{errors.email.message}</p>
-        )}
-      </div>
-
-      {/* Username Field */}
-      <div>
-        <label
-          htmlFor="username"
-          className="block text-sm font-medium text-foreground mb-2"
-        >
-          Username
-        </label>
-        <Input
-          {...register('username')}
-          type="text"
-          id="username"
-          autoComplete="username"
-          className={authInputClassName}
-          placeholder="Choose a unique username"
-        />
-        {errors.username && (
-          <p className="mt-1 text-sm text-red-600">{errors.username.message}</p>
-        )}
-      </div>
-
-      {/* Name Field (Optional) */}
-      <div>
-        <label
-          htmlFor="name"
-          className="block text-sm font-medium text-foreground mb-2"
-        >
-          Full Name <span className="text-muted-foreground">(optional)</span>
-        </label>
-        <Input
-          {...register('name')}
-          type="text"
-          id="name"
-          autoComplete="name"
-          className={authInputClassName}
-          placeholder="Your full name"
-        />
-        {errors.name && (
-          <p className="mt-1 text-sm text-red-600">{errors.name.message}</p>
-        )}
-      </div>
-
-      {/* Password Field */}
-      <div>
-        <label
-          htmlFor="password"
-          className="block text-sm font-medium text-foreground mb-2"
-        >
-          Password
-        </label>
-        <div className="relative">
+      <RegisterFormField
+        id="email"
+        label="Email address"
+        error={errors.email?.message}
+      >
+        {(control) => (
           <Input
-            {...register('password')}
-            type={showPassword ? 'text' : 'password'}
-            id="password"
-            autoComplete="new-password"
-            className={`pr-10 ${authInputClassName}`}
-            placeholder="Create a secure password"
+            {...registerField('email')}
+            type="email"
+            id="email"
+            autoComplete="email"
+            placeholder="you@example.com"
+            aria-invalid={control['aria-invalid']}
+            aria-describedby={control['aria-describedby']}
+            className={control.inputClassName}
           />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={() => setShowPassword(!showPassword)}
-            className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-          >
-            {showPassword ? (
-              <EyeOff className="h-4 w-4" />
-            ) : (
-              <Eye className="h-4 w-4" />
-            )}
-          </Button>
-        </div>
-        {errors.password && (
-          <p className="mt-1 text-sm text-red-600">{errors.password.message}</p>
         )}
-      </div>
+      </RegisterFormField>
 
-      {/* Confirm Password Field */}
-      <div>
-        <label
-          htmlFor="confirmPassword"
-          className="block text-sm font-medium text-foreground mb-2"
-        >
-          Confirm Password
-        </label>
-        <div className="relative">
+      <RegisterFormField
+        id="username"
+        label="Username"
+        error={errors.username?.message}
+      >
+        {(control) => (
           <Input
-            {...register('confirmPassword')}
-            type={showConfirmPassword ? 'text' : 'password'}
-            id="confirmPassword"
-            autoComplete="new-password"
-            className={`pr-10 ${authInputClassName}`}
-            placeholder="Confirm your password"
+            {...registerField('username')}
+            type="text"
+            id="username"
+            autoComplete="username"
+            placeholder="Choose a unique username"
+            aria-invalid={control['aria-invalid']}
+            aria-describedby={control['aria-describedby']}
+            className={control.inputClassName}
           />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-            className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-          >
-            {showConfirmPassword ? (
-              <EyeOff className="h-4 w-4" />
-            ) : (
-              <Eye className="h-4 w-4" />
-            )}
-          </Button>
-        </div>
-        {errors.confirmPassword && (
-          <p className="mt-1 text-sm text-red-600">
-            {errors.confirmPassword.message}
-          </p>
         )}
-      </div>
+      </RegisterFormField>
 
-      {/* Submit Button */}
+      <RegisterFormField
+        id="name"
+        label={
+          <>
+            Full Name{' '}
+            <span className="text-muted-foreground">(optional)</span>
+          </>
+        }
+        error={errors.name?.message}
+      >
+        {(control) => (
+          <Input
+            {...registerField('name')}
+            type="text"
+            id="name"
+            autoComplete="name"
+            placeholder="Your full name"
+            aria-invalid={control['aria-invalid']}
+            aria-describedby={control['aria-describedby']}
+            className={control.inputClassName}
+          />
+        )}
+      </RegisterFormField>
+
+      <RegisterFormField
+        id="password"
+        label="Password"
+        error={errors.password?.message}
+      >
+        {(control) => (
+          <div className="relative">
+            <Input
+              {...registerField('password')}
+              type={showPassword ? 'text' : 'password'}
+              id="password"
+              autoComplete="new-password"
+              placeholder="Create a secure password"
+              aria-invalid={control['aria-invalid']}
+              aria-describedby={control['aria-describedby']}
+              className={`pr-10 ${control.inputClassName}`}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => setShowPassword(!showPassword)}
+              aria-label={showPassword ? 'Hide password' : 'Show password'}
+              className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              {showPassword ? (
+                <EyeOff className="h-4 w-4" aria-hidden="true" />
+              ) : (
+                <Eye className="h-4 w-4" aria-hidden="true" />
+              )}
+            </Button>
+          </div>
+        )}
+      </RegisterFormField>
+
+      <RegisterFormField
+        id="confirmPassword"
+        label="Confirm Password"
+        error={errors.confirmPassword?.message}
+      >
+        {(control) => (
+          <div className="relative">
+            <Input
+              {...registerField('confirmPassword')}
+              type={showConfirmPassword ? 'text' : 'password'}
+              id="confirmPassword"
+              autoComplete="new-password"
+              placeholder="Confirm your password"
+              aria-invalid={control['aria-invalid']}
+              aria-describedby={control['aria-describedby']}
+              className={`pr-10 ${control.inputClassName}`}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+              aria-label={
+                showConfirmPassword ? 'Hide password' : 'Show password'
+              }
+              className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              {showConfirmPassword ? (
+                <EyeOff className="h-4 w-4" aria-hidden="true" />
+              ) : (
+                <Eye className="h-4 w-4" aria-hidden="true" />
+              )}
+            </Button>
+          </div>
+        )}
+      </RegisterFormField>
+
       <Button
         type="submit"
         disabled={isLoading}
@@ -233,7 +274,7 @@ export default function RegisterForm() {
       >
         {isLoading ? (
           <>
-            <Loader2 className="h-4 w-4 animate-spin" />
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
             Creating account...
           </>
         ) : (

--- a/components/auth/RegisterFormField.tsx
+++ b/components/auth/RegisterFormField.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+export const authInputClassName =
+  'rounded-lg bg-background text-foreground focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:border-transparent'
+
+export type RegisterFieldControlProps = {
+  'aria-invalid': boolean
+  'aria-describedby'?: string
+  inputClassName: string
+  errorId: string
+}
+
+type RegisterFormFieldProps = {
+  id: string
+  label: ReactNode
+  error?: string
+  children: (control: RegisterFieldControlProps) => ReactNode
+}
+
+export function RegisterFormField({
+  id,
+  label,
+  error,
+  children,
+}: RegisterFormFieldProps) {
+  const errorId = `${id}-error`
+  const invalid = !!error
+  const control: RegisterFieldControlProps = {
+    'aria-invalid': invalid,
+    ...(invalid ? { 'aria-describedby': errorId } : {}),
+    inputClassName: cn(
+      authInputClassName,
+      invalid &&
+        'border-destructive focus-visible:ring-destructive focus-visible:border-destructive'
+    ),
+    errorId,
+  }
+
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className={cn(
+          'block text-sm font-medium text-foreground mb-2',
+          invalid && 'text-destructive'
+        )}
+      >
+        {label}
+      </label>
+      {children(control)}
+      {error ? (
+        <p id={errorId} className="mt-1 text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/lib/auth/map-register-error.test.ts
+++ b/lib/auth/map-register-error.test.ts
@@ -46,13 +46,13 @@ describe('mapRegisterSignInError', () => {
 
 describe('parseRegisterSignInError', () => {
   it('associates duplicate account errors with the email field', () => {
-    expect(parseRegisterSignInError(new Error('Account already exists'))).toEqual(
-      {
-        message:
-          'An account with this email already exists. Try signing in, or use a different email.',
-        field: 'email',
-      }
-    )
+    expect(
+      parseRegisterSignInError(new Error('Account already exists'))
+    ).toEqual({
+      message:
+        'An account with this email already exists. Try signing in, or use a different email.',
+      field: 'email',
+    })
   })
 
   it('associates username conflicts with the username field', () => {

--- a/lib/auth/map-register-error.test.ts
+++ b/lib/auth/map-register-error.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { mapRegisterSignInError } from './map-register-error'
+import {
+  mapRegisterSignInError,
+  parseRegisterSignInError,
+} from './map-register-error'
 
 describe('mapRegisterSignInError', () => {
   it('maps duplicate account messages from Convex-style errors', () => {
@@ -38,5 +41,36 @@ describe('mapRegisterSignInError', () => {
     expect(
       mapRegisterSignInError(new Error('Username "foo" is already taken'))
     ).toBe('This username is not available. Try another one.')
+  })
+})
+
+describe('parseRegisterSignInError', () => {
+  it('associates duplicate account errors with the email field', () => {
+    expect(parseRegisterSignInError(new Error('Account already exists'))).toEqual(
+      {
+        message:
+          'An account with this email already exists. Try signing in, or use a different email.',
+        field: 'email',
+      }
+    )
+  })
+
+  it('associates username conflicts with the username field', () => {
+    expect(
+      parseRegisterSignInError(new Error('Username "foo" is already taken'))
+    ).toEqual({
+      message: 'This username is not available. Try another one.',
+      field: 'username',
+    })
+  })
+
+  it('returns a form-level generic error without a field', () => {
+    expect(
+      parseRegisterSignInError(
+        new Error('[CONVEX A(auth:signIn)] Server Error Something went wrong')
+      )
+    ).toEqual({
+      message: 'Registration failed. Please try again.',
+    })
   })
 })

--- a/lib/auth/map-register-error.ts
+++ b/lib/auth/map-register-error.ts
@@ -5,11 +5,20 @@ const USERNAME_UNAVAILABLE = 'This username is not available. Try another one.'
 
 const GENERIC = 'Registration failed. Please try again.'
 
+export type RegisterSignInErrorField = 'email' | 'username'
+
+export type RegisterSignInErrorResult = {
+  message: string
+  field?: RegisterSignInErrorField
+}
+
 /**
  * Maps Convex Auth / network failures from sign-up into short user-facing copy.
  * Avoids showing raw stack traces or `[CONVEX ...]` payloads in the UI.
  */
-export function mapRegisterSignInError(error: unknown): string {
+export function parseRegisterSignInError(
+  error: unknown
+): RegisterSignInErrorResult {
   const raw = extractMessage(error)
   const lower = raw.toLowerCase()
 
@@ -18,7 +27,7 @@ export function mapRegisterSignInError(error: unknown): string {
     lower.includes('already registered') ||
     /email.+?\b(in use|taken)\b/i.test(raw)
   ) {
-    return DUPLICATE_ACCOUNT
+    return { message: DUPLICATE_ACCOUNT, field: 'email' }
   }
 
   if (
@@ -26,7 +35,7 @@ export function mapRegisterSignInError(error: unknown): string {
     lower.includes('username is not available') ||
     lower.includes('username not available')
   ) {
-    return USERNAME_UNAVAILABLE
+    return { message: USERNAME_UNAVAILABLE, field: 'username' }
   }
 
   if (
@@ -36,14 +45,18 @@ export function mapRegisterSignInError(error: unknown): string {
     lower.includes('request id:') ||
     raw.includes('\n')
   ) {
-    return GENERIC
+    return { message: GENERIC }
   }
 
   if (raw.length > 0 && raw.length <= 200 && !looksLikeStackSnippet(raw)) {
-    return raw
+    return { message: raw }
   }
 
-  return GENERIC
+  return { message: GENERIC }
+}
+
+export function mapRegisterSignInError(error: unknown): string {
+  return parseRegisterSignInError(error).message
 }
 
 function extractMessage(error: unknown): string {

--- a/lib/auth/register-form-a11y.test.ts
+++ b/lib/auth/register-form-a11y.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { getFirstRegisterFieldError } from './register-form-a11y'
+
+describe('getFirstRegisterFieldError', () => {
+  it('returns the first error in registration field order', () => {
+    const result = getFirstRegisterFieldError({
+      confirmPassword: { type: 'custom', message: "Passwords don't match" },
+      email: { type: 'required', message: 'Email is required' },
+      password: { type: 'min', message: 'Password must be at least 8 characters' },
+    })
+
+    expect(result).toEqual({
+      field: 'email',
+      message: 'Email is required',
+    })
+  })
+
+  it('skips fields without messages', () => {
+    const result = getFirstRegisterFieldError({
+      email: { type: 'required', message: '' },
+      username: { type: 'min', message: 'Username must be at least 3 characters' },
+    })
+
+    expect(result).toEqual({
+      field: 'username',
+      message: 'Username must be at least 3 characters',
+    })
+  })
+
+  it('returns null when there are no errors', () => {
+    expect(getFirstRegisterFieldError({})).toBeNull()
+  })
+})

--- a/lib/auth/register-form-a11y.test.ts
+++ b/lib/auth/register-form-a11y.test.ts
@@ -6,7 +6,10 @@ describe('getFirstRegisterFieldError', () => {
     const result = getFirstRegisterFieldError({
       confirmPassword: { type: 'custom', message: "Passwords don't match" },
       email: { type: 'required', message: 'Email is required' },
-      password: { type: 'min', message: 'Password must be at least 8 characters' },
+      password: {
+        type: 'min',
+        message: 'Password must be at least 8 characters',
+      },
     })
 
     expect(result).toEqual({
@@ -18,7 +21,10 @@ describe('getFirstRegisterFieldError', () => {
   it('skips fields without messages', () => {
     const result = getFirstRegisterFieldError({
       email: { type: 'required', message: '' },
-      username: { type: 'min', message: 'Username must be at least 3 characters' },
+      username: {
+        type: 'min',
+        message: 'Username must be at least 3 characters',
+      },
     })
 
     expect(result).toEqual({

--- a/lib/auth/register-form-a11y.ts
+++ b/lib/auth/register-form-a11y.ts
@@ -1,0 +1,24 @@
+import type { FieldErrors } from 'react-hook-form'
+import type { RegisterFormData } from '@/lib/validations/auth'
+
+export const REGISTER_FIELD_ORDER = [
+  'email',
+  'username',
+  'name',
+  'password',
+  'confirmPassword',
+] as const satisfies readonly (keyof RegisterFormData)[]
+
+export type RegisterFieldName = (typeof REGISTER_FIELD_ORDER)[number]
+
+export function getFirstRegisterFieldError(
+  errors: FieldErrors<RegisterFormData>
+): { field: RegisterFieldName; message: string } | null {
+  for (const field of REGISTER_FIELD_ORDER) {
+    const err = errors[field]
+    if (err?.message) {
+      return { field, message: String(err.message) }
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

Improves registration form accessibility so failed sign-up clearly communicates which field is wrong for sighted users and assistive technology.

- Marks invalid inputs with `aria-invalid`, destructive styling, and `aria-describedby` pointing at `{field}-error`
- Announces the first blocking error on submit via a visually hidden `role="alert"` live region and focuses the first invalid field
- Maps duplicate-email and username-taken server errors to the `email` and `username` fields via `setError` instead of only a form-level banner
- Clears field, banner, and live-region errors when the user edits the field (`reValidateMode: 'onChange'`)
- Adds `aria-label` on password visibility toggles





## Files

- `components/auth/RegisterForm.tsx`
- `components/auth/RegisterFormField.tsx` (new)
- `lib/auth/map-register-error.ts` — `parseRegisterSignInError()` with optional `field`
- `lib/auth/register-form-a11y.ts` (new)
- Tests: `RegisterForm.test.tsx`, `register-form-a11y.test.ts`, `map-register-error.test.ts`

