### PR TITLE
fix(a11y): add accessible names and pressed state to password visibility toggles (ENG-192)

### DIFF
--- a/components/auth/LoginForm.test.tsx
+++ b/components/auth/LoginForm.test.tsx
@@ -79,4 +79,19 @@ describe('LoginForm', () => {
     await user.type(passwordInput, 'new-attempt')
     expect(passwordInput).toHaveValue('new-attempt')
   })
+
+  it('password visibility toggle has accessible name and pressed state', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<LoginForm />)
+
+    const toggle = screen.getByRole('button', { name: /show password/i })
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
+    await user.click(toggle)
+
+    expect(screen.getByRole('button', { name: /hide password/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
 })

--- a/components/auth/LoginForm.test.tsx
+++ b/components/auth/LoginForm.test.tsx
@@ -89,9 +89,8 @@ describe('LoginForm', () => {
 
     await user.click(toggle)
 
-    expect(screen.getByRole('button', { name: /hide password/i })).toHaveAttribute(
-      'aria-pressed',
-      'true'
-    )
+    expect(
+      screen.getByRole('button', { name: /hide password/i })
+    ).toHaveAttribute('aria-pressed', 'true')
   })
 })

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -139,12 +139,14 @@ export default function LoginForm() {
             variant="ghost"
             size="icon"
             onClick={() => setShowPassword(!showPassword)}
+            aria-label={showPassword ? 'Hide password' : 'Show password'}
+            aria-pressed={showPassword}
             className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
           >
             {showPassword ? (
-              <EyeOff className="h-4 w-4" />
+              <EyeOff className="h-4 w-4" aria-hidden="true" />
             ) : (
-              <Eye className="h-4 w-4" />
+              <Eye className="h-4 w-4" aria-hidden="true" />
             )}
           </Button>
         </div>

--- a/components/auth/RegisterForm.test.tsx
+++ b/components/auth/RegisterForm.test.tsx
@@ -109,17 +109,18 @@ describe('RegisterForm accessibility', () => {
 
     await user.click(toggle)
 
-    expect(screen.getByRole('button', { name: /hide password/i })).toHaveAttribute(
-      'aria-pressed',
-      'true'
-    )
+    expect(
+      screen.getByRole('button', { name: /hide password/i })
+    ).toHaveAttribute('aria-pressed', 'true')
   })
 
   it('confirm password visibility toggle has accessible name and pressed state', async () => {
     const user = userEvent.setup({ delay: null })
     render(<RegisterForm />)
 
-    const toggle = screen.getByRole('button', { name: /show confirm password/i })
+    const toggle = screen.getByRole('button', {
+      name: /show confirm password/i,
+    })
     expect(toggle).toHaveAttribute('aria-pressed', 'false')
 
     await user.click(toggle)

--- a/components/auth/RegisterForm.test.tsx
+++ b/components/auth/RegisterForm.test.tsx
@@ -85,7 +85,7 @@ describe('RegisterForm accessibility', () => {
     await user.type(screen.getByLabelText(/email address/i), 'user@example.com')
     await user.type(screen.getByLabelText(/^username$/i), 'myuser')
     await user.type(screen.getByLabelText(/^password$/i), 'Password1')
-    await user.type(screen.getByLabelText(/confirm password/i), 'Password1')
+    await user.type(screen.getByLabelText(/^confirm password$/i), 'Password1')
     await user.click(screen.getByRole('button', { name: /create account/i }))
 
     await waitFor(() => {
@@ -98,5 +98,34 @@ describe('RegisterForm accessibility', () => {
     expect(emailInput).toHaveAttribute('aria-invalid', 'true')
     expect(emailInput).toHaveAttribute('aria-describedby', 'email-error')
     expect(screen.queryByText(/registration failed/i)).not.toBeInTheDocument()
+  })
+
+  it('password visibility toggle has accessible name and pressed state', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<RegisterForm />)
+
+    const toggle = screen.getByRole('button', { name: /show password/i })
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
+    await user.click(toggle)
+
+    expect(screen.getByRole('button', { name: /hide password/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
+
+  it('confirm password visibility toggle has accessible name and pressed state', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<RegisterForm />)
+
+    const toggle = screen.getByRole('button', { name: /show confirm password/i })
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
+    await user.click(toggle)
+
+    expect(
+      screen.getByRole('button', { name: /hide confirm password/i })
+    ).toHaveAttribute('aria-pressed', 'true')
   })
 })

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -217,6 +217,7 @@ export default function RegisterForm() {
               size="icon"
               onClick={() => setShowPassword(!showPassword)}
               aria-label={showPassword ? 'Hide password' : 'Show password'}
+              aria-pressed={showPassword}
               className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
             >
               {showPassword ? (
@@ -252,8 +253,11 @@ export default function RegisterForm() {
               size="icon"
               onClick={() => setShowConfirmPassword(!showConfirmPassword)}
               aria-label={
-                showConfirmPassword ? 'Hide password' : 'Show password'
+                showConfirmPassword
+                  ? 'Hide confirm password'
+                  : 'Show confirm password'
               }
+              aria-pressed={showConfirmPassword}
               className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
             >
               {showConfirmPassword ? (


### PR DESCRIPTION
## Summary

Fixes ENG-192: password reveal controls on login and registration were unlabeled icon-only buttons for assistive technology. Each visibility toggle now has an explicit accessible name, announces pressed/visible state, and does not rely on tooltips for labeling.

## Changes

- **Login** (`LoginForm.tsx`): Add `aria-label`, `aria-pressed`, and `aria-hidden` on the password visibility toggle and its icons.
- **Registration** (`RegisterForm.tsx`): Add `aria-pressed` on password and confirm toggles; use field-specific labels for confirm (`Show confirm password` / `Hide confirm password`).
- **Tests**: Add Vitest coverage for toggle names and `aria-pressed` on login and register; tighten confirm-password field query to avoid matching the toggle button.



