### PR TITLE
feat(auth): show live password requirements on registration (ENG-213)

### DIFF
--- a/components/auth/PasswordRequirements.tsx
+++ b/components/auth/PasswordRequirements.tsx
@@ -1,0 +1,52 @@
+import { Check, Circle } from 'lucide-react'
+import { getPasswordRuleStatuses } from '@/lib/validations/password-rules'
+import { cn } from '@/lib/utils'
+
+export const PASSWORD_REQUIREMENTS_ID = 'password-requirements'
+
+type PasswordRequirementsProps = {
+  password: string
+  highlightFailures?: boolean
+}
+
+export function PasswordRequirements({
+  password,
+  highlightFailures = false,
+}: PasswordRequirementsProps) {
+  const rules = getPasswordRuleStatuses(password)
+
+  return (
+    <ul
+      id={PASSWORD_REQUIREMENTS_ID}
+      aria-live="polite"
+      className="mt-2 space-y-1"
+    >
+      {rules.map((rule) => (
+        <li
+          key={rule.id}
+          className={cn(
+            'flex items-center gap-2 text-sm',
+            rule.met
+              ? 'text-success-foreground'
+              : highlightFailures
+                ? 'text-destructive'
+                : 'text-muted-foreground'
+          )}
+        >
+          {rule.met ? (
+            <Check className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          ) : (
+            <Circle
+              className={cn(
+                'h-3.5 w-3.5 shrink-0',
+                highlightFailures ? 'text-destructive' : 'text-muted-foreground'
+              )}
+              aria-hidden="true"
+            />
+          )}
+          <span>{rule.label}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/components/auth/RegisterForm.test.tsx
+++ b/components/auth/RegisterForm.test.tsx
@@ -114,6 +114,78 @@ describe('RegisterForm accessibility', () => {
     ).toHaveAttribute('aria-pressed', 'true')
   })
 
+  it('shows password requirements before submit', () => {
+    render(<RegisterForm />)
+
+    expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument()
+    expect(screen.getByText(/one uppercase letter/i)).toBeInTheDocument()
+    expect(screen.getByText(/one lowercase letter/i)).toBeInTheDocument()
+    expect(screen.getByText(/one number/i)).toBeInTheDocument()
+  })
+
+  it('updates password requirements as the user types', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<RegisterForm />)
+
+    const passwordInput = screen.getByLabelText(/^password$/i)
+    await user.type(passwordInput, 'Password1')
+
+    const requirements = document.getElementById('password-requirements')
+    expect(requirements).toBeInTheDocument()
+    const items = requirements?.querySelectorAll('li') ?? []
+    expect(items).toHaveLength(4)
+    items.forEach((item) => {
+      expect(item).toHaveClass('text-success-foreground')
+    })
+  })
+
+  it('highlights unmet password rules on failed submit', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<RegisterForm />)
+
+    await user.type(screen.getByLabelText(/email address/i), 'user@example.com')
+    await user.type(screen.getByLabelText(/^username$/i), 'myuser')
+    await user.type(screen.getByLabelText(/^password$/i), 'weak')
+    await user.type(screen.getByLabelText(/^confirm password$/i), 'weak')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(document.getElementById('password-error')).toHaveTextContent(
+        'Password does not meet all requirements'
+      )
+    })
+
+    const requirements = document.getElementById('password-requirements')
+    const unmetItems = requirements?.querySelectorAll('.text-destructive') ?? []
+    expect(unmetItems.length).toBeGreaterThan(0)
+  })
+
+  it('clears password failure highlight when all rules are met', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<RegisterForm />)
+
+    await user.type(screen.getByLabelText(/email address/i), 'user@example.com')
+    await user.type(screen.getByLabelText(/^username$/i), 'myuser')
+    await user.type(screen.getByLabelText(/^password$/i), 'weak')
+    await user.type(screen.getByLabelText(/^confirm password$/i), 'weak')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(document.getElementById('password-error')).toBeInTheDocument()
+    })
+
+    const passwordInput = screen.getByLabelText(/^password$/i)
+    await user.clear(passwordInput)
+    await user.type(passwordInput, 'Password1')
+
+    await waitFor(() => {
+      const requirements = document.getElementById('password-requirements')
+      const unmetItems =
+        requirements?.querySelectorAll('.text-destructive') ?? []
+      expect(unmetItems).toHaveLength(0)
+    })
+  })
+
   it('confirm password visibility toggle has accessible name and pressed state', async () => {
     const user = userEvent.setup({ delay: null })
     render(<RegisterForm />)

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -1,16 +1,24 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useForm, type FieldErrors } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { parseRegisterSignInError } from '@/lib/auth/map-register-error'
 import { getFirstRegisterFieldError } from '@/lib/auth/register-form-a11y'
 import { registerSchema, type RegisterFormData } from '@/lib/validations/auth'
+import { allPasswordRulesMet } from '@/lib/validations/password-rules'
+
+const PASSWORD_VALIDATION_MESSAGE =
+  'Password does not meet all requirements'
 import { CheckCircle, Eye, EyeOff, Loader2 } from 'lucide-react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import {
+  PasswordRequirements,
+  PASSWORD_REQUIREMENTS_ID,
+} from '@/components/auth/PasswordRequirements'
 import { RegisterFormField } from '@/components/auth/RegisterFormField'
 
 /**
@@ -29,6 +37,8 @@ export default function RegisterForm() {
     null
   )
   const [success, setSuccess] = useState(false)
+  const [highlightPasswordFailures, setHighlightPasswordFailures] =
+    useState(false)
 
   const router = useRouter()
   const { signIn } = useAuth()
@@ -38,11 +48,20 @@ export default function RegisterForm() {
     handleSubmit,
     setError,
     clearErrors,
+    watch,
     formState: { errors },
   } = useForm<RegisterFormData>({
     resolver: zodResolver(registerSchema),
     reValidateMode: 'onChange',
   })
+
+  const password = watch('password') ?? ''
+
+  useEffect(() => {
+    if (highlightPasswordFailures && allPasswordRulesMet(password)) {
+      setHighlightPasswordFailures(false)
+    }
+  }, [password, highlightPasswordFailures])
 
   const clearFieldFeedback = (name: keyof RegisterFormData) => {
     clearErrors(name)
@@ -53,6 +72,13 @@ export default function RegisterForm() {
   const registerField = (name: keyof RegisterFormData) =>
     register(name, {
       onChange: () => clearFieldFeedback(name),
+    })
+
+  const registerPasswordField = () =>
+    register('password', {
+      onChange: () => {
+        clearFieldFeedback('password')
+      },
     })
 
   const announceFirstError = (formErrors: FieldErrors<RegisterFormData>) => {
@@ -95,6 +121,19 @@ export default function RegisterForm() {
   }
 
   const onInvalid = (formErrors: FieldErrors<RegisterFormData>) => {
+    const first = getFirstRegisterFieldError(formErrors)
+
+    if (first?.field === 'password') {
+      setHighlightPasswordFailures(true)
+      setError('password', {
+        type: 'manual',
+        message: PASSWORD_VALIDATION_MESSAGE,
+      })
+      setSubmitAnnouncement(PASSWORD_VALIDATION_MESSAGE)
+      document.getElementById('password')?.focus()
+      return
+    }
+
     announceFirstError(formErrors)
   }
 
@@ -198,35 +237,42 @@ export default function RegisterForm() {
         id="password"
         label="Password"
         error={errors.password?.message}
+        extraDescribedBy={PASSWORD_REQUIREMENTS_ID}
       >
         {(control) => (
-          <div className="relative">
-            <Input
-              {...registerField('password')}
-              type={showPassword ? 'text' : 'password'}
-              id="password"
-              autoComplete="new-password"
-              placeholder="Create a secure password"
-              aria-invalid={control['aria-invalid']}
-              aria-describedby={control['aria-describedby']}
-              className={`pr-10 ${control.inputClassName}`}
+          <>
+            <div className="relative">
+              <Input
+                {...registerPasswordField()}
+                type={showPassword ? 'text' : 'password'}
+                id="password"
+                autoComplete="new-password"
+                placeholder="Create a secure password"
+                aria-invalid={control['aria-invalid']}
+                aria-describedby={control['aria-describedby']}
+                className={`pr-10 ${control.inputClassName}`}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => setShowPassword(!showPassword)}
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+                aria-pressed={showPassword}
+                className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              >
+                {showPassword ? (
+                  <EyeOff className="h-4 w-4" aria-hidden="true" />
+                ) : (
+                  <Eye className="h-4 w-4" aria-hidden="true" />
+                )}
+              </Button>
+            </div>
+            <PasswordRequirements
+              password={password}
+              highlightFailures={highlightPasswordFailures}
             />
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              onClick={() => setShowPassword(!showPassword)}
-              aria-label={showPassword ? 'Hide password' : 'Show password'}
-              aria-pressed={showPassword}
-              className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-            >
-              {showPassword ? (
-                <EyeOff className="h-4 w-4" aria-hidden="true" />
-              ) : (
-                <Eye className="h-4 w-4" aria-hidden="true" />
-              )}
-            </Button>
-          </div>
+          </>
         )}
       </RegisterFormField>
 

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -9,8 +9,7 @@ import { getFirstRegisterFieldError } from '@/lib/auth/register-form-a11y'
 import { registerSchema, type RegisterFormData } from '@/lib/validations/auth'
 import { allPasswordRulesMet } from '@/lib/validations/password-rules'
 
-const PASSWORD_VALIDATION_MESSAGE =
-  'Password does not meet all requirements'
+const PASSWORD_VALIDATION_MESSAGE = 'Password does not meet all requirements'
 import { CheckCircle, Eye, EyeOff, Loader2 } from 'lucide-react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { Button } from '@/components/ui/button'

--- a/components/auth/RegisterFormField.tsx
+++ b/components/auth/RegisterFormField.tsx
@@ -15,6 +15,7 @@ type RegisterFormFieldProps = {
   id: string
   label: ReactNode
   error?: string
+  extraDescribedBy?: string
   children: (control: RegisterFieldControlProps) => ReactNode
 }
 
@@ -22,13 +23,17 @@ export function RegisterFormField({
   id,
   label,
   error,
+  extraDescribedBy,
   children,
 }: RegisterFormFieldProps) {
   const errorId = `${id}-error`
   const invalid = !!error
+  const describedBy = [extraDescribedBy, invalid ? errorId : undefined]
+    .filter(Boolean)
+    .join(' ')
   const control: RegisterFieldControlProps = {
     'aria-invalid': invalid,
-    ...(invalid ? { 'aria-describedby': errorId } : {}),
+    ...(describedBy ? { 'aria-describedby': describedBy } : {}),
     inputClassName: cn(
       authInputClassName,
       invalid &&

--- a/lib/validations/__tests__/password-rules.test.ts
+++ b/lib/validations/__tests__/password-rules.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import {
-  allPasswordRulesMet,
-  getPasswordRuleStatuses,
-} from '../password-rules'
+import { allPasswordRulesMet, getPasswordRuleStatuses } from '../password-rules'
 
 describe('password-rules', () => {
   describe('getPasswordRuleStatuses', () => {

--- a/lib/validations/__tests__/password-rules.test.ts
+++ b/lib/validations/__tests__/password-rules.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import {
+  allPasswordRulesMet,
+  getPasswordRuleStatuses,
+} from '../password-rules'
+
+describe('password-rules', () => {
+  describe('getPasswordRuleStatuses', () => {
+    it('returns all rules unmet for an empty password', () => {
+      const statuses = getPasswordRuleStatuses('')
+      expect(statuses).toHaveLength(4)
+      expect(statuses.every((rule) => !rule.met)).toBe(true)
+    })
+
+    it('marks minLength met when password has 8+ characters', () => {
+      const statuses = getPasswordRuleStatuses('12345678')
+      expect(statuses.find((r) => r.id === 'minLength')?.met).toBe(true)
+      expect(statuses.find((r) => r.id === 'uppercase')?.met).toBe(false)
+      expect(statuses.find((r) => r.id === 'lowercase')?.met).toBe(false)
+      expect(statuses.find((r) => r.id === 'digit')?.met).toBe(true)
+    })
+
+    it('marks all rules met for a valid password', () => {
+      const statuses = getPasswordRuleStatuses('Password1')
+      expect(statuses.every((rule) => rule.met)).toBe(true)
+    })
+  })
+
+  describe('allPasswordRulesMet', () => {
+    it('returns false when any rule is unmet', () => {
+      expect(allPasswordRulesMet('password')).toBe(false)
+      expect(allPasswordRulesMet('PASSWORD1')).toBe(false)
+      expect(allPasswordRulesMet('Pass1')).toBe(false)
+    })
+
+    it('returns true when all rules are met', () => {
+      expect(allPasswordRulesMet('Password1')).toBe(true)
+    })
+  })
+})

--- a/lib/validations/auth.ts
+++ b/lib/validations/auth.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { PASSWORD_MIN_LENGTH, PASSWORD_REGEX } from './password-rules'
 
 /**
  * Authentication Validation Schemas
@@ -6,10 +7,6 @@ import { z } from 'zod'
  * Centralized validation schemas for authentication forms using Zod.
  * These schemas ensure consistent validation across the application.
  */
-
-// Password validation regex patterns
-const PASSWORD_MIN_LENGTH = 8
-const PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/
 
 // Username validation regex pattern
 const USERNAME_REGEX = /^[a-zA-Z0-9_-]+$/

--- a/lib/validations/password-rules.ts
+++ b/lib/validations/password-rules.ts
@@ -1,0 +1,54 @@
+export const PASSWORD_MIN_LENGTH = 8
+
+export const PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/
+
+export type PasswordRuleId =
+  | 'minLength'
+  | 'uppercase'
+  | 'lowercase'
+  | 'digit'
+
+export type PasswordRuleStatus = {
+  id: PasswordRuleId
+  label: string
+  met: boolean
+}
+
+const PASSWORD_RULES: {
+  id: PasswordRuleId
+  label: string
+  test: (password: string) => boolean
+}[] = [
+  {
+    id: 'minLength',
+    label: `At least ${PASSWORD_MIN_LENGTH} characters`,
+    test: (password) => password.length >= PASSWORD_MIN_LENGTH,
+  },
+  {
+    id: 'uppercase',
+    label: 'One uppercase letter',
+    test: (password) => /[A-Z]/.test(password),
+  },
+  {
+    id: 'lowercase',
+    label: 'One lowercase letter',
+    test: (password) => /[a-z]/.test(password),
+  },
+  {
+    id: 'digit',
+    label: 'One number',
+    test: (password) => /\d/.test(password),
+  },
+]
+
+export function getPasswordRuleStatuses(password: string): PasswordRuleStatus[] {
+  return PASSWORD_RULES.map(({ id, label, test }) => ({
+    id,
+    label,
+    met: test(password),
+  }))
+}
+
+export function allPasswordRulesMet(password: string): boolean {
+  return getPasswordRuleStatuses(password).every((rule) => rule.met)
+}

--- a/lib/validations/password-rules.ts
+++ b/lib/validations/password-rules.ts
@@ -2,11 +2,7 @@ export const PASSWORD_MIN_LENGTH = 8
 
 export const PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/
 
-export type PasswordRuleId =
-  | 'minLength'
-  | 'uppercase'
-  | 'lowercase'
-  | 'digit'
+export type PasswordRuleId = 'minLength' | 'uppercase' | 'lowercase' | 'digit'
 
 export type PasswordRuleStatus = {
   id: PasswordRuleId
@@ -41,7 +37,9 @@ const PASSWORD_RULES: {
   },
 ]
 
-export function getPasswordRuleStatuses(password: string): PasswordRuleStatus[] {
+export function getPasswordRuleStatuses(
+  password: string
+): PasswordRuleStatus[] {
   return PASSWORD_RULES.map(({ id, label, test }) => ({
     id,
     label,


### PR DESCRIPTION
## Summary

Fixes ENG-213 by surfacing password rules on the registration form before submit, updating them as the user types, and highlighting every unmet rule after a failed submit.

- Add shared password rule helpers in `lib/validations/password-rules.ts` and wire Zod in `lib/validations/auth.ts` to the same source of truth
- Add `PasswordRequirements` checklist under the password field (always visible, live updates via `watch('password')`)
- On invalid submit when password is the first failing field, show a concise summary error and emphasize all unmet rules in red; clear failure styling once all rules pass
- Extend `RegisterFormField` with `extraDescribedBy` for `aria-describedby` accessibility
<img width="1224" height="720" alt="Screenshot 2026-05-25 at 9 57 34 PM" src="https://github.com/user-attachments/assets/8d36a02f-b75e-4f29-b6a1-155c20ad8528" />
<img width="1221" height="719" alt="Screenshot 2026-05-25 at 9 59 52 PM" src="https://github.com/user-attachments/assets/53c55888-efeb-4b74-8465-a3d41f571745" />

