### PR TITLE
fix: hide incomplete articles from public discovery (ENG-162)

### DIFF
--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -59,6 +59,7 @@ import {
   shouldPersistDraftBackup,
   writeDraftBackup,
 } from '@/lib/draftBackup'
+import { getListingReadyPublishError } from '@/convex/lib/articleListingReady'
 
 const PUBLISH_EXCERPT_PREVIEW_MAX = 280
 const EXCERPT_MAX_CHARS = 500
@@ -463,13 +464,23 @@ export function WriteEditorWorkspace() {
     return () => window.removeEventListener('keydown', handler)
   }, [saveNow])
 
+  const publishListingError = getListingReadyPublishError({
+    title,
+    excerpt,
+  })
+
   const requestPublish = useCallback(() => {
     if (!editor || editor.isEmpty) {
       toast.warning('Please add content before publishing')
       return
     }
+    const listingError = getListingReadyPublishError({ title, excerpt })
+    if (listingError) {
+      toast.warning(listingError)
+      return
+    }
     setPublishConfirmOpen(true)
-  }, [editor])
+  }, [editor, title, excerpt])
 
   const handlePublish = useCallback(async () => {
     if (!editor || editor.isEmpty) {
@@ -480,6 +491,12 @@ export function WriteEditorWorkspace() {
     if (!editorContent) {
       setPublishConfirmOpen(false)
       toast.warning('Please add content before publishing')
+      return
+    }
+    const listingError = getListingReadyPublishError({ title, excerpt })
+    if (listingError) {
+      setPublishConfirmOpen(false)
+      toast.warning(listingError)
       return
     }
 
@@ -496,9 +513,9 @@ export function WriteEditorWorkspace() {
         resultId = published.id
       } else {
         resultId = await createArticleMutation({
-          title: title || 'Untitled',
+          title: title.trim(),
           content: editorContent,
-          excerpt: excerpt || undefined,
+          excerpt: excerpt.trim(),
           coverImage: coverImage || undefined,
           tags: tags
             .split(',')
@@ -779,7 +796,7 @@ export function WriteEditorWorkspace() {
         error={error?.message ?? null}
         isPublished={publishStatus.published}
         isPublishing={isPublishing}
-        canPublish={!!editor}
+        canPublish={!!editor && !editor.isEmpty && publishListingError === null}
         lastSavedAt={lastSavedAt ?? undefined}
         onDelete={handleRequestDelete}
         isDeleting={isDeleting}
@@ -949,7 +966,8 @@ export function WriteEditorWorkspace() {
                     </span>
                   </div>
                   <p className="mt-0.5 text-xs text-muted-foreground">
-                    Optional. Shown on article cards and in the publish preview.
+                    Required for publishing. Shown on article cards and in the
+                    publish preview (at least 10 characters).
                   </p>
                   {!excerptOpen && excerpt.trim().length > 0 && (
                     <p className="mt-2 line-clamp-2 whitespace-pre-wrap break-words text-sm text-foreground/80">

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as highlightTips from "../highlightTips.js";
 import type * as highlights from "../highlights.js";
 import type * as http from "../http.js";
 import type * as lib_articleListing from "../lib/articleListing.js";
+import type * as lib_articleListingReady from "../lib/articleListingReady.js";
 import type * as lib_articleSlug from "../lib/articleSlug.js";
 import type * as lib_constants from "../lib/constants.js";
 import type * as lib_enrich from "../lib/enrich.js";
@@ -53,6 +54,7 @@ declare const fullApi: ApiFromModules<{
   highlights: typeof highlights;
   http: typeof http;
   "lib/articleListing": typeof lib_articleListing;
+  "lib/articleListingReady": typeof lib_articleListingReady;
   "lib/articleSlug": typeof lib_articleSlug;
   "lib/constants": typeof lib_constants;
   "lib/enrich": typeof lib_enrich;

--- a/convex/articles.listArticles.test.ts
+++ b/convex/articles.listArticles.test.ts
@@ -10,6 +10,9 @@ import {
 
 const emptyDoc = { type: 'doc', content: [] }
 
+/** Meets MIN_LISTING_EXCERPT_CHARS for public discovery lists */
+const listingExcerpt = 'A valid excerpt for public listing.'
+
 const modules = import.meta.glob(['./**/*.ts', '!./**/*.test.ts'])
 
 describe('listArticles', () => {
@@ -26,6 +29,7 @@ describe('listArticles', () => {
       const a1 = await ctx.db.insert('articles', {
         slug: 'one',
         title: 'One',
+        excerpt: listingExcerpt,
         content: emptyDoc,
         published: true,
         publishedAt: now,
@@ -87,6 +91,7 @@ describe('listArticles', () => {
         const id = await ctx.db.insert('articles', {
           slug: `p-${i}`,
           title: `P${i}`,
+          excerpt: listingExcerpt,
           content: emptyDoc,
           published: true,
           publishedAt: now + i * 1000,
@@ -137,6 +142,7 @@ describe('listArticles', () => {
       await ctx.db.insert('articles', {
         slug: 'old',
         title: 'Banana guide',
+        excerpt: listingExcerpt,
         content: emptyDoc,
         published: true,
         publishedAt: now,
@@ -154,6 +160,7 @@ describe('listArticles', () => {
       await ctx.db.insert('articles', {
         slug: 'new',
         title: 'Fresh banana',
+        excerpt: listingExcerpt,
         content: emptyDoc,
         published: true,
         publishedAt: now + 99999,
@@ -196,6 +203,7 @@ describe('listArticles', () => {
       await ctx.db.insert('articles', {
         slug: 'tagged',
         title: 'Only Title',
+        excerpt: listingExcerpt,
         content: emptyDoc,
         published: true,
         publishedAt: now,
@@ -240,6 +248,7 @@ describe('listArticles', () => {
       const id = await ctx.db.insert('articles', {
         slug: 'at',
         title: 'T',
+        excerpt: listingExcerpt,
         content: emptyDoc,
         published: true,
         publishedAt: now,
@@ -257,6 +266,7 @@ describe('listArticles', () => {
       const idB = await ctx.db.insert('articles', {
         slug: 'bt',
         title: 'T2',
+        excerpt: listingExcerpt,
         content: emptyDoc,
         published: true,
         publishedAt: now,
@@ -284,6 +294,63 @@ describe('listArticles', () => {
       })
       expect(res.total).toBe(1)
       expect(res.articles[0]!.authorUsername).toBe('alice')
+    })
+  })
+
+  it('excludes incomplete published articles from default listing', async () => {
+    const t = convexTest(schema, modules)
+    await t.run(async (ctx) => {
+      const now = Date.now()
+      const u = await ctx.db.insert('users', {
+        email: 'ready@x.test',
+        username: 'readywriter',
+        createdAt: now,
+        updatedAt: now,
+      })
+      await ctx.db.insert('articles', {
+        slug: 'untitled',
+        title: 'Untitled',
+        content: emptyDoc,
+        published: true,
+        publishedAt: now,
+        authorId: u,
+        authorUsername: 'readywriter',
+        tags: [],
+        searchContent: 'Untitled',
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      const readyId = await ctx.db.insert('articles', {
+        slug: 'complete',
+        title: 'Complete Article',
+        excerpt: listingExcerpt,
+        content: emptyDoc,
+        published: true,
+        publishedAt: now + 1,
+        authorId: u,
+        authorUsername: 'readywriter',
+        tags: [],
+        searchContent: 'Complete Article',
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      const res = await ctx.runQuery(api.articles.listArticles, {
+        page: 1,
+        limit: 10,
+      })
+      expect(res.total).toBe(1)
+      expect(res.articles).toHaveLength(1)
+      expect(res.articles[0]!._id).toBe(readyId)
+      expect(res.articles[0]!.title).toBe('Complete Article')
     })
   })
 })

--- a/convex/articles.publishListingReady.test.ts
+++ b/convex/articles.publishListingReady.test.ts
@@ -1,0 +1,173 @@
+/// <reference types="vite/client" />
+import { convexTest } from 'convex-test'
+import { describe, expect, it } from 'vitest'
+import { api } from './_generated/api'
+import schema from './schema'
+import type { Id } from './_generated/dataModel'
+import { MIN_LISTING_EXCERPT_CHARS } from './lib/articleListingReady'
+
+const docWithBody = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'Hello body' }],
+    },
+  ],
+}
+
+const listingExcerpt = 'a'.repeat(MIN_LISTING_EXCERPT_CHARS)
+
+const modules = import.meta.glob(['./**/*.ts', '!./**/*.test.ts'])
+
+async function seedAuthor(t: ReturnType<typeof convexTest>) {
+  return await t.run(async (ctx) => {
+    const now = Date.now()
+    const userId = await ctx.db.insert('users', {
+      email: 'pub@x.test',
+      username: 'pubwriter',
+      createdAt: now,
+      updatedAt: now,
+    })
+    return { userId, now }
+  })
+}
+
+describe('publish listing readiness', () => {
+  it('rejects publishArticle when title is Untitled', async () => {
+    const t = convexTest(schema, modules)
+    const { userId, now } = await seedAuthor(t)
+    const asAuthor = t.withIdentity({ subject: userId })
+
+    const articleId = await t.run(async (ctx) => {
+      return await ctx.db.insert('articles', {
+        slug: 'untitled-draft',
+        title: 'Untitled',
+        excerpt: listingExcerpt,
+        content: docWithBody,
+        published: false,
+        authorId: userId,
+        authorUsername: 'pubwriter',
+        tags: [],
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+    })
+
+    await expect(
+      asAuthor.mutation(api.articles.publishArticle, {
+        id: articleId as Id<'articles'>,
+      })
+    ).rejects.toThrow(/real title/)
+  })
+
+  it('rejects publishArticle when excerpt is too short', async () => {
+    const t = convexTest(schema, modules)
+    const { userId, now } = await seedAuthor(t)
+    const asAuthor = t.withIdentity({ subject: userId })
+
+    const articleId = await t.run(async (ctx) => {
+      return await ctx.db.insert('articles', {
+        slug: 'short-excerpt',
+        title: 'Real Title',
+        excerpt: 'short',
+        content: docWithBody,
+        published: false,
+        authorId: userId,
+        authorUsername: 'pubwriter',
+        tags: [],
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+    })
+
+    await expect(
+      asAuthor.mutation(api.articles.publishArticle, {
+        id: articleId as Id<'articles'>,
+      })
+    ).rejects.toThrow(/excerpt/)
+  })
+
+  it('publishes when title and excerpt are listing-ready', async () => {
+    const t = convexTest(schema, modules)
+    const { userId, now } = await seedAuthor(t)
+    const asAuthor = t.withIdentity({ subject: userId })
+
+    const articleId = await t.run(async (ctx) => {
+      return await ctx.db.insert('articles', {
+        slug: 'ready-draft',
+        title: 'Real Title',
+        excerpt: listingExcerpt,
+        content: docWithBody,
+        published: false,
+        authorId: userId,
+        authorUsername: 'pubwriter',
+        tags: [],
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+    })
+
+    await asAuthor.mutation(api.articles.publishArticle, {
+      id: articleId as Id<'articles'>,
+    })
+    await new Promise((r) => setTimeout(r, 0))
+    await t.finishAllScheduledFunctions(() => {})
+
+    const row = await t.run(async (ctx) => ctx.db.get(articleId as Id<'articles'>))
+    expect(row?.published).toBe(true)
+  })
+
+  it('rejects createArticle with published when not listing-ready', async () => {
+    const t = convexTest(schema, modules)
+    const { userId } = await seedAuthor(t)
+    const asAuthor = t.withIdentity({ subject: userId })
+
+    await expect(
+      asAuthor.mutation(api.articles.createArticle, {
+        title: 'Untitled',
+        content: docWithBody,
+        excerpt: listingExcerpt,
+        published: true,
+      })
+    ).rejects.toThrow(/real title/)
+
+    await expect(
+      asAuthor.mutation(api.articles.createArticle, {
+        title: 'Good Title',
+        content: docWithBody,
+        published: true,
+      })
+    ).rejects.toThrow(/excerpt/)
+  })
+
+  it('allows createArticle published when listing-ready', async () => {
+    const t = convexTest(schema, modules)
+    const { userId } = await seedAuthor(t)
+    const asAuthor = t.withIdentity({ subject: userId })
+
+    const id = await asAuthor.mutation(api.articles.createArticle, {
+      title: 'Good Title',
+      content: docWithBody,
+      excerpt: listingExcerpt,
+      published: true,
+    })
+    await new Promise((r) => setTimeout(r, 0))
+    await t.finishAllScheduledFunctions(() => {})
+
+    const row = await t.run(async (ctx) => ctx.db.get(id as Id<'articles'>))
+    expect(row?.published).toBe(true)
+  })
+})

--- a/convex/articles.publishListingReady.test.ts
+++ b/convex/articles.publishListingReady.test.ts
@@ -126,7 +126,9 @@ describe('publish listing readiness', () => {
     await new Promise((r) => setTimeout(r, 0))
     await t.finishAllScheduledFunctions(() => {})
 
-    const row = await t.run(async (ctx) => ctx.db.get(articleId as Id<'articles'>))
+    const row = await t.run(async (ctx) =>
+      ctx.db.get(articleId as Id<'articles'>)
+    )
     expect(row?.published).toBe(true)
   })
 

--- a/convex/articles.ts
+++ b/convex/articles.ts
@@ -14,6 +14,10 @@ import {
   replaceTagLinksForArticle,
 } from './lib/articleListing'
 import {
+  assertArticleListingReady,
+  isArticleListingReady,
+} from './lib/articleListingReady'
+import {
   extractTextFromTiptapJson,
   tiptapJsonHasNonEmptyText,
 } from './lib/tiptapContent'
@@ -117,6 +121,7 @@ export const listArticles = query({
       if (tag) {
         rows = rows.filter((a) => a.tags?.includes(tag))
       }
+      rows = rows.filter(isArticleListingReady)
       rows.sort((a, b) => (b.publishedAt ?? 0) - (a.publishedAt ?? 0))
       const total = rows.length
       const slice = rows.slice(offset, offset + limit)
@@ -149,16 +154,17 @@ export const listArticles = query({
             .withIndex('by_tag_publishedAt', (q) => q.eq('tag', tag))
             .order('desc')
             .collect()
-      const total = linkRows.length
-      const pageLinks = linkRows.slice(offset, offset + limit)
       const fetched = await Promise.all(
-        pageLinks.map((row) => ctx.db.get(row.articleId))
+        linkRows.map((row) => ctx.db.get(row.articleId))
       )
       const articles = fetched.filter(
-        (a): a is NonNullable<typeof a> => a?.published === true
+        (a): a is NonNullable<typeof a> =>
+          a?.published === true && isArticleListingReady(a)
       )
+      const total = articles.length
+      const pageSlice = articles.slice(offset, offset + limit)
       const enrichedArticles = await Promise.all(
-        articles.map(async (article) => ({
+        pageSlice.map(async (article) => ({
           ...stripWriterNotes(article),
           author: await enrichWithUser(ctx, article.authorId),
         }))
@@ -181,7 +187,8 @@ export const listArticles = query({
       rowsQuery = rowsQuery.filter((q) => q.eq(q.field('authorId'), authorId!))
     }
 
-    const rows = await rowsQuery.collect()
+    let rows = await rowsQuery.collect()
+    rows = rows.filter(isArticleListingReady)
     const total = rows.length
     const slice = rows.slice(offset, offset + limit)
     const enrichedArticles = await Promise.all(
@@ -330,6 +337,14 @@ export const createArticle = mutation({
     const user = await ctx.db.get(userId)
     if (!user) throw new Error('User not found')
 
+    if (args.published) {
+      assertArticleListingReady({
+        title: args.title,
+        excerpt: args.excerpt,
+        authorUsername: user.username,
+      })
+    }
+
     const finalSlug = await generateUniqueArticleSlugForAuthor(ctx, {
       title: args.title,
       authorId: userId,
@@ -450,6 +465,19 @@ export const updateArticle = mutation({
       )
     }
 
+    if (article.published) {
+      const merged = {
+        title: updates.title ?? article.title,
+        excerpt: updates.excerpt !== undefined ? updates.excerpt : article.excerpt,
+        authorUsername: article.authorUsername,
+      }
+      if (!isArticleListingReady(merged)) {
+        throw new Error(
+          'Cannot update: published articles must keep a real title and excerpt for public discovery'
+        )
+      }
+    }
+
     await ctx.db.patch(args.id, updates)
 
     const updated = await ctx.db.get(args.id)
@@ -485,6 +513,12 @@ export const publishArticle = mutation({
     if (!tiptapJsonHasNonEmptyText(article.content)) {
       throw new Error('Cannot publish: article body is empty')
     }
+
+    assertArticleListingReady({
+      title: article.title,
+      excerpt: article.excerpt,
+      authorUsername: article.authorUsername,
+    })
 
     const now = Date.now()
 

--- a/convex/articles.ts
+++ b/convex/articles.ts
@@ -468,7 +468,8 @@ export const updateArticle = mutation({
     if (article.published) {
       const merged = {
         title: updates.title ?? article.title,
-        excerpt: updates.excerpt !== undefined ? updates.excerpt : article.excerpt,
+        excerpt:
+          updates.excerpt !== undefined ? updates.excerpt : article.excerpt,
         authorUsername: article.authorUsername,
       }
       if (!isArticleListingReady(merged)) {

--- a/convex/lib/articleListingReady.test.ts
+++ b/convex/lib/articleListingReady.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getListingReadyPublishError,
+  isArticleListingReady,
+  isPlaceholderListingTitle,
+  MIN_LISTING_EXCERPT_CHARS,
+} from './articleListingReady'
+
+describe('isPlaceholderListingTitle', () => {
+  it('treats Untitled as placeholder', () => {
+    expect(isPlaceholderListingTitle('Untitled')).toBe(true)
+    expect(isPlaceholderListingTitle('  untitled  ')).toBe(true)
+  })
+
+  it('does not treat real titles as placeholder', () => {
+    expect(isPlaceholderListingTitle('My Article')).toBe(false)
+    expect(isPlaceholderListingTitle('Untitled Adventures')).toBe(false)
+  })
+})
+
+describe('getListingReadyPublishError', () => {
+  it('returns null when title and excerpt meet requirements', () => {
+    expect(
+      getListingReadyPublishError({
+        title: 'My Post',
+        excerpt: 'a'.repeat(MIN_LISTING_EXCERPT_CHARS),
+      })
+    ).toBeNull()
+  })
+
+  it('returns messages for invalid title or excerpt', () => {
+    expect(
+      getListingReadyPublishError({ title: 'Untitled', excerpt: 'abcdefghij' })
+    ).toMatch(/real title/)
+    expect(
+      getListingReadyPublishError({ title: 'OK', excerpt: 'short' })
+    ).toMatch(/excerpt/)
+  })
+})
+
+describe('isArticleListingReady', () => {
+  const ready = {
+    title: 'Real Title',
+    excerpt: 'a'.repeat(MIN_LISTING_EXCERPT_CHARS),
+    authorUsername: 'writer',
+  }
+
+  it('accepts a listing-ready article', () => {
+    expect(isArticleListingReady(ready)).toBe(true)
+  })
+
+  it('rejects Untitled', () => {
+    expect(
+      isArticleListingReady({ ...ready, title: 'Untitled' })
+    ).toBe(false)
+  })
+
+  it('rejects whitespace-only title', () => {
+    expect(isArticleListingReady({ ...ready, title: '   ' })).toBe(false)
+  })
+
+  it('rejects short or missing excerpt', () => {
+    expect(isArticleListingReady({ ...ready, excerpt: '' })).toBe(false)
+    expect(
+      isArticleListingReady({
+        ...ready,
+        excerpt: 'a'.repeat(MIN_LISTING_EXCERPT_CHARS - 1),
+      })
+    ).toBe(false)
+  })
+
+  it('rejects missing author username', () => {
+    expect(
+      isArticleListingReady({ ...ready, authorUsername: undefined })
+    ).toBe(false)
+    expect(
+      isArticleListingReady({ ...ready, authorUsername: '  ' })
+    ).toBe(false)
+  })
+})

--- a/convex/lib/articleListingReady.test.ts
+++ b/convex/lib/articleListingReady.test.ts
@@ -50,9 +50,7 @@ describe('isArticleListingReady', () => {
   })
 
   it('rejects Untitled', () => {
-    expect(
-      isArticleListingReady({ ...ready, title: 'Untitled' })
-    ).toBe(false)
+    expect(isArticleListingReady({ ...ready, title: 'Untitled' })).toBe(false)
   })
 
   it('rejects whitespace-only title', () => {
@@ -70,11 +68,11 @@ describe('isArticleListingReady', () => {
   })
 
   it('rejects missing author username', () => {
-    expect(
-      isArticleListingReady({ ...ready, authorUsername: undefined })
-    ).toBe(false)
-    expect(
-      isArticleListingReady({ ...ready, authorUsername: '  ' })
-    ).toBe(false)
+    expect(isArticleListingReady({ ...ready, authorUsername: undefined })).toBe(
+      false
+    )
+    expect(isArticleListingReady({ ...ready, authorUsername: '  ' })).toBe(
+      false
+    )
   })
 })

--- a/convex/lib/articleListingReady.ts
+++ b/convex/lib/articleListingReady.ts
@@ -1,0 +1,58 @@
+export const MIN_LISTING_EXCERPT_CHARS = 10
+
+export function isPlaceholderListingTitle(title: string): boolean {
+  return title.trim().toLowerCase() === 'untitled'
+}
+
+export function isArticleListingReady(article: {
+  title: string
+  excerpt?: string
+  authorUsername?: string
+}): boolean {
+  const title = article.title.trim()
+  const excerpt = (article.excerpt ?? '').trim()
+  return (
+    title.length > 0 &&
+    !isPlaceholderListingTitle(title) &&
+    excerpt.length >= MIN_LISTING_EXCERPT_CHARS &&
+    Boolean(article.authorUsername?.trim())
+  )
+}
+
+export function getListingReadyPublishError(input: {
+  title: string
+  excerpt: string
+}): string | null {
+  const title = input.title.trim()
+  if (title.length === 0) {
+    return 'Please add a title before publishing'
+  }
+  if (isPlaceholderListingTitle(title)) {
+    return 'Please replace "Untitled" with a real title before publishing'
+  }
+  const excerpt = input.excerpt.trim()
+  if (excerpt.length < MIN_LISTING_EXCERPT_CHARS) {
+    return `Please add an excerpt of at least ${MIN_LISTING_EXCERPT_CHARS} characters before publishing`
+  }
+  return null
+}
+
+export function assertArticleListingReady(article: {
+  title: string
+  excerpt?: string
+  authorUsername?: string
+}): void {
+  const title = article.title.trim()
+  if (title.length === 0 || isPlaceholderListingTitle(title)) {
+    throw new Error('Cannot publish: add a real title (not "Untitled")')
+  }
+  const excerpt = (article.excerpt ?? '').trim()
+  if (excerpt.length < MIN_LISTING_EXCERPT_CHARS) {
+    throw new Error(
+      `Cannot publish: add an excerpt of at least ${MIN_LISTING_EXCERPT_CHARS} characters`
+    )
+  }
+  if (!article.authorUsername?.trim()) {
+    throw new Error('Cannot publish: author username is required')
+  }
+}

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,6 +1,7 @@
 import { v } from 'convex/values'
 import { query, mutation } from './_generated/server'
 import { getAuthUserId } from '@convex-dev/auth/server'
+import { isArticleListingReady } from './lib/articleListingReady'
 
 /**
  * Validate Stellar address format
@@ -156,6 +157,7 @@ export const getUserStats = query({
       .withIndex('by_author', (q) => q.eq('authorId', userId))
       .filter((q) => q.eq(q.field('published'), true))
       .collect()
+    const listingReadyCount = articles.filter(isArticleListingReady).length
 
     // Get total tips received
     const tipsReceived = await ctx.db
@@ -170,7 +172,7 @@ export const getUserStats = query({
     )
 
     return {
-      articleCount: articles.length,
+      articleCount: listingReadyCount,
       totalEarnings,
       tipsReceivedCount: tipsReceived.length,
     }


### PR DESCRIPTION
## Summary

Public article cards could show "Untitled", missing excerpts, or thin metadata on home, browse, and profile surfaces. This change defines listing-ready content and applies it consistently across discovery lists, publish flows, and profile stats.

- Add shared listing-ready rules: real title (not "Untitled"), excerpt at least 10 characters, and author username present
- Filter `listArticles` (default, search, and tag paths) so only listing-ready published articles appear on home, `/articles`, profile, and landing
- Block `publishArticle` and `createArticle(published: true)` when metadata is incomplete
- Gate the editor publish action and require excerpt copy before publishing
- Align `getUserStats` article count with visible listing-ready articles
- Prevent published `updateArticle` saves that would drop an article below listing-ready thresholds

Direct article URLs (`/{username}/{slug}`) still work for published articles that fail listing rules; they are only hidden from public list surfaces.

