### PR TITLE
feat(profile): add author-specific not-found page for invalid handles (ENG-161)

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { notFound } from 'next/navigation'
 import { useUserByUsername, useUserStats } from '@/hooks/convex'
 import { use, useState, useEffect } from 'react'
 import { useSearchParams } from 'next/navigation'
@@ -10,6 +9,7 @@ import { SiteFooter } from '@/components/layout/SiteFooter'
 import ProfileHeader from '@/components/profile/ProfileHeader'
 import { ProfileArticlesTabContent } from '@/components/profile/ProfileArticlesTabContent'
 import { ProfileNftsTabContent } from '@/components/profile/ProfileNftsTabContent'
+import { AuthorNotFoundPage } from '@/components/profile/AuthorNotFoundPage'
 import { ProfilePageLoadingSkeleton } from '@/components/profile/ProfilePageLoadingSkeleton'
 import { EarningsDashboard } from '@/components/dashboard/EarningsDashboard'
 import { WalletSettings } from '@/components/stellar'
@@ -59,9 +59,8 @@ export default function ProfilePage({ params }: ProfilePageProps) {
   // Check if this is the current user's profile
   const isOwnProfile = currentUser?.username === username
 
-  // Check if user exists
   if (user === null) {
-    notFound()
+    return <AuthorNotFoundPage username={username} />
   }
 
   // Show loading while data is being fetched

--- a/components/articles/SearchInput.tsx
+++ b/components/articles/SearchInput.tsx
@@ -9,6 +9,7 @@ interface SearchInputProps {
   placeholder?: string
   className?: string
   debounceMs?: number
+  id?: string
 }
 
 export default function SearchInput({
@@ -17,6 +18,7 @@ export default function SearchInput({
   placeholder = 'Search articles...',
   className = '',
   debounceMs = 300,
+  id,
 }: SearchInputProps) {
   const [localValue, setLocalValue] = useState(value)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -64,6 +66,7 @@ export default function SearchInput({
       <div className="relative">
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-quill-500" />
         <input
+          id={id}
           type="text"
           value={localValue}
           onChange={handleInputChange}

--- a/components/profile/AuthorNotFoundPage.test.tsx
+++ b/components/profile/AuthorNotFoundPage.test.tsx
@@ -1,0 +1,88 @@
+/** @vitest-environment jsdom */
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+import { AuthorNotFoundPage } from '@/components/profile/AuthorNotFoundPage'
+
+const push = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => '/badhandle',
+}))
+
+vi.mock('@/components/layout/AppNavigation', () => ({
+  default: () => <nav data-testid="app-nav" />,
+}))
+
+vi.mock('@/components/layout/SiteFooter', () => ({
+  SiteFooter: () => <footer data-testid="site-footer" />,
+}))
+
+vi.mock('@/components/providers/AuthContext', () => ({
+  useAuth: () => ({ user: null, isAuthenticated: false, signOut: vi.fn() }),
+}))
+
+describe('AuthorNotFoundPage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    push.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders profile unavailable heading and username', () => {
+    render(<AuthorNotFoundPage username="badhandle" />)
+
+    expect(screen.getByText('Profile unavailable')).toBeInTheDocument()
+    expect(screen.getByText('@badhandle')).toBeInTheDocument()
+    expect(
+      screen.getByText(/No writer profile exists for/i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders search input with accessible label', () => {
+    render(<AuthorNotFoundPage username="badhandle" />)
+
+    expect(screen.getByLabelText('Search for articles')).toBeInTheDocument()
+    expect(
+      screen.getByPlaceholderText('Search articles and writers...')
+    ).toBeInTheDocument()
+  })
+
+  it('links Browse articles to /articles and Go home to /', () => {
+    render(<AuthorNotFoundPage username="badhandle" />)
+
+    expect(screen.getByRole('link', { name: 'Browse articles' })).toHaveAttribute(
+      'href',
+      '/articles'
+    )
+    expect(screen.getByRole('link', { name: 'Go home' })).toHaveAttribute(
+      'href',
+      '/'
+    )
+  })
+
+  it('navigates to articles search after debounced input', () => {
+    render(<AuthorNotFoundPage username="badhandle" />)
+    const input = screen.getByRole('textbox')
+
+    fireEvent.change(input, { target: { value: 'stellar' } })
+    act(() => vi.advanceTimersByTime(300))
+
+    expect(push).toHaveBeenCalledTimes(1)
+    expect(push).toHaveBeenCalledWith('/articles?search=stellar&page=1')
+  })
+
+  it('does not navigate when search is empty or whitespace', () => {
+    render(<AuthorNotFoundPage username="badhandle" />)
+    const input = screen.getByRole('textbox')
+
+    fireEvent.change(input, { target: { value: '   ' } })
+    act(() => vi.advanceTimersByTime(300))
+
+    expect(push).not.toHaveBeenCalled()
+  })
+})

--- a/components/profile/AuthorNotFoundPage.test.tsx
+++ b/components/profile/AuthorNotFoundPage.test.tsx
@@ -55,10 +55,9 @@ describe('AuthorNotFoundPage', () => {
   it('links Browse articles to /articles and Go home to /', () => {
     render(<AuthorNotFoundPage username="badhandle" />)
 
-    expect(screen.getByRole('link', { name: 'Browse articles' })).toHaveAttribute(
-      'href',
-      '/articles'
-    )
+    expect(
+      screen.getByRole('link', { name: 'Browse articles' })
+    ).toHaveAttribute('href', '/articles')
     expect(screen.getByRole('link', { name: 'Go home' })).toHaveAttribute(
       'href',
       '/'

--- a/components/profile/AuthorNotFoundPage.tsx
+++ b/components/profile/AuthorNotFoundPage.tsx
@@ -72,9 +72,7 @@ export function AuthorNotFoundPage({ username }: AuthorNotFoundPageProps) {
     (search: string) => {
       const trimmed = search.trim()
       if (!trimmed) return
-      router.push(
-        `/articles?search=${encodeURIComponent(trimmed)}&page=1`
-      )
+      router.push(`/articles?search=${encodeURIComponent(trimmed)}&page=1`)
     },
     [router]
   )

--- a/components/profile/AuthorNotFoundPage.tsx
+++ b/components/profile/AuthorNotFoundPage.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useCallback } from 'react'
+
+import SearchInput from '@/components/articles/SearchInput'
+import { FailurePageShell } from '@/components/error/FailurePageShell'
+import AppNavigation from '@/components/layout/AppNavigation'
+import { SiteFooter } from '@/components/layout/SiteFooter'
+import { Button } from '@/components/ui/button'
+
+type AuthorNotFoundPageProps = {
+  username: string
+}
+
+function AuthorNotFoundIllustration() {
+  return (
+    <div className="mx-auto mb-6 w-full max-w-[220px]">
+      <svg
+        viewBox="0 0 200 168"
+        className="h-auto w-full"
+        aria-hidden
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="100"
+          cy="52"
+          r="28"
+          className="fill-card stroke-border"
+          strokeWidth="2"
+        />
+        <path
+          d="M56 120c8-22 28-34 44-34s36 12 44 34"
+          className="fill-none stroke-border"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <line
+          x1="88"
+          y1="48"
+          x2="112"
+          y2="56"
+          className="stroke-muted-foreground/70"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        />
+        <line
+          x1="112"
+          y1="48"
+          x2="88"
+          y2="56"
+          className="stroke-muted-foreground/70"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        />
+        <path
+          d="M158 36l18 18M176 36l-18 18"
+          className="stroke-brand-accent"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        />
+      </svg>
+    </div>
+  )
+}
+
+export function AuthorNotFoundPage({ username }: AuthorNotFoundPageProps) {
+  const router = useRouter()
+
+  const handleSearchChange = useCallback(
+    (search: string) => {
+      const trimmed = search.trim()
+      if (!trimmed) return
+      router.push(
+        `/articles?search=${encodeURIComponent(trimmed)}&page=1`
+      )
+    },
+    [router]
+  )
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <AppNavigation />
+      <main className="flex flex-1 flex-col">
+        <FailurePageShell
+          className="flex-1 py-12"
+          illustration={<AuthorNotFoundIllustration />}
+          heading={
+            <h1 className="font-display text-2xl font-medium tracking-[-0.01em] text-foreground sm:text-3xl">
+              Profile unavailable
+            </h1>
+          }
+          description={
+            <>
+              <p>
+                No writer profile exists for{' '}
+                <span className="font-medium text-foreground">@{username}</span>
+                .
+              </p>
+              <p className="mt-2">
+                Check the spelling or search for their articles.
+              </p>
+            </>
+          }
+          actionsClassName="flex w-full flex-col items-stretch gap-4 sm:flex-col"
+          actions={
+            <>
+              <div className="w-full text-left">
+                <label
+                  id="author-not-found-search-label"
+                  htmlFor="author-not-found-search"
+                  className="mb-2 block text-sm font-medium text-foreground"
+                >
+                  Search for articles
+                </label>
+                <SearchInput
+                  id="author-not-found-search"
+                  value=""
+                  onChange={handleSearchChange}
+                  placeholder="Search articles and writers..."
+                  className="w-full"
+                />
+              </div>
+              <Button asChild size="lg" className="w-full sm:w-auto sm:mx-auto">
+                <Link href="/articles">Browse articles</Link>
+              </Button>
+              <Link
+                href="/"
+                className="text-center text-sm font-medium text-primary underline-offset-4 transition-colors hover:underline sm:mx-auto"
+              >
+                Go home
+              </Link>
+            </>
+          }
+        />
+      </main>
+      <SiteFooter variant="default" />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Invalid author profile URLs (`/{username}`) previously fell through to the generic 404 page, with no indication that the handle itself was missing and no way to recover in context.

This PR adds an author-specific missing-profile state for invalid handles:

- Shows a dedicated **Profile unavailable** page naming the requested `@username`
- Keeps app chrome consistent with normal profile pages (`AppNavigation`, `SiteFooter`, `FailurePageShell`)
- Adds recovery paths:
  - **Search** — debounced article search redirects to `/articles?search=...&page=1`
  - **Browse articles** — link to `/articles`
  - **Go home** — link to `/`
- Renders inline on the profile route only, so missing articles at `/{username}/{slug}` still use the global not-found page



## Changes

- Add `components/profile/AuthorNotFoundPage.tsx`
- Add `components/profile/AuthorNotFoundPage.test.tsx`
- Update `app/[username]/page.tsx` to render `AuthorNotFoundPage` when `useUserByUsername` returns `null`
- Add optional `id` prop to `components/articles/SearchInput.tsx` for accessible label association

<img width="1222" height="721" alt="Screenshot 2026-05-26 at 1 48 20 AM" src="https://github.com/user-attachments/assets/4c8007df-5176-415a-8355-1f47b5a3471a" />
