### PR TITLE
fix(a11y): add persistent label and keyboard-accessible clear on article search (ENG-195)

### DIFF
--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -91,12 +91,18 @@ export default function ArticlesPage() {
         </div>
 
         {/* Search Input */}
-        <div className="mb-6">
+        <div className="mb-6 max-w-md">
+          <label
+            htmlFor="articles-browse-search"
+            className="mb-2 block text-sm font-medium text-foreground"
+          >
+            Search articles
+          </label>
           <SearchInput
+            id="articles-browse-search"
             value={searchTerm}
             onChange={handleSearchChange}
             placeholder="Search articles by title or excerpt..."
-            className="max-w-md"
           />
         </div>
 

--- a/components/articles/SearchInput.test.tsx
+++ b/components/articles/SearchInput.test.tsx
@@ -1,7 +1,22 @@
 /** @vitest-environment jsdom */
 import { render, screen, fireEvent, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import SearchInput from '@/components/articles/SearchInput'
+
+function renderWithLabel() {
+  return render(
+    <>
+      <label htmlFor="articles-browse-search">Search articles</label>
+      <SearchInput
+        id="articles-browse-search"
+        value=""
+        onChange={vi.fn()}
+        debounceMs={300}
+      />
+    </>
+  )
+}
 
 describe('SearchInput debounce', () => {
   beforeEach(() => {
@@ -111,5 +126,65 @@ describe('SearchInput controlled value sync', () => {
 
     rerender(<SearchInput value="bar" onChange={vi.fn()} />)
     expect(screen.getByRole('textbox')).toHaveValue('bar')
+  })
+})
+
+describe('SearchInput accessibility', () => {
+  it('keeps the visible label when the user types', () => {
+    renderWithLabel()
+    const input = screen.getByLabelText('Search articles')
+
+    expect(screen.getByText('Search articles')).toBeVisible()
+    fireEvent.change(input, { target: { value: 'stellar' } })
+    expect(screen.getByText('Search articles')).toBeVisible()
+    expect(input).toHaveValue('stellar')
+  })
+
+  it('associates the input with an external label via id', () => {
+    renderWithLabel()
+    expect(screen.getByLabelText('Search articles')).toHaveAttribute(
+      'id',
+      'articles-browse-search'
+    )
+  })
+
+  it('renders decorative icons as aria-hidden', () => {
+    const { container } = render(
+      <SearchInput value="query" onChange={vi.fn()} />
+    )
+    const icons = container.querySelectorAll('svg[aria-hidden="true"]')
+    expect(icons.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('exposes the clear button as type button with an accessible name', () => {
+    render(<SearchInput value="test" onChange={vi.fn()} />)
+    const clearButton = screen.getByRole('button', { name: /clear search/i })
+    expect(clearButton).toHaveAttribute('type', 'button')
+  })
+
+  it('clears search when the clear button is activated with Enter', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<SearchInput value="test" onChange={onChange} debounceMs={300} />)
+
+    const clearButton = screen.getByRole('button', { name: /clear search/i })
+    clearButton.focus()
+    await user.keyboard('{Enter}')
+
+    expect(onChange).toHaveBeenCalledWith('')
+    expect(screen.getByRole('textbox')).toHaveValue('')
+  })
+
+  it('clears search when the clear button is activated with Space', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<SearchInput value="test" onChange={onChange} debounceMs={300} />)
+
+    const clearButton = screen.getByRole('button', { name: /clear search/i })
+    clearButton.focus()
+    await user.keyboard(' ')
+
+    expect(onChange).toHaveBeenCalledWith('')
+    expect(screen.getByRole('textbox')).toHaveValue('')
   })
 })

--- a/components/articles/SearchInput.tsx
+++ b/components/articles/SearchInput.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useId } from 'react'
 import { Search, X } from 'lucide-react'
 
 interface SearchInputProps {
@@ -18,8 +18,10 @@ export default function SearchInput({
   placeholder = 'Search articles...',
   className = '',
   debounceMs = 300,
-  id,
+  id: idProp,
 }: SearchInputProps) {
+  const generatedId = useId()
+  const inputId = idProp ?? generatedId
   const [localValue, setLocalValue] = useState(value)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const onChangeRef = useRef(onChange)
@@ -64,22 +66,26 @@ export default function SearchInput({
   return (
     <div className={`relative ${className}`}>
       <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-quill-500" />
+        <Search
+          className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-quill-500"
+          aria-hidden
+        />
         <input
-          id={id}
+          id={inputId}
           type="text"
           value={localValue}
           onChange={handleInputChange}
           placeholder={placeholder}
-          className="w-full pl-10 pr-10 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue focus:border-transparent text-foreground placeholder:text-muted-foreground"
+          className="w-full pl-10 pr-10 py-2 border border-input rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:border-transparent text-foreground placeholder:text-muted-foreground"
         />
         {localValue && (
           <button
+            type="button"
             onClick={clearSearch}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-quill-500 hover:text-quill-700 transition-colors"
+            className="absolute right-3 top-1/2 -translate-y-1/2 rounded-sm text-quill-500 transition-colors hover:text-quill-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue"
             aria-label="Clear search"
           >
-            <X className="h-4 w-4" />
+            <X className="h-4 w-4" aria-hidden />
           </button>
         )}
       </div>


### PR DESCRIPTION
## Summary

Fixes ENG-195 by improving accessibility of the article search field on `/articles`.

- Adds a persistent visible **"Search articles"** label wired to the input via `htmlFor` / `id`, so placeholder text is no longer the only cue once the user starts typing
- Hardens shared `SearchInput`: `useId()` fallback, `aria-hidden` decorative icons, `type="button"` on clear, and `focus-visible` rings on input and clear button
- Adds regression tests for label persistence, label association, and keyboard activation of the clear control (Enter / Space)



