### PR TITLE
fix: link article byline to author profile (ENG-204)

### DIFF
--- a/components/articles/ArticleAuthorByline.test.tsx
+++ b/components/articles/ArticleAuthorByline.test.tsx
@@ -1,0 +1,70 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import {
+  ArticleAuthorByline,
+  canLinkAuthorProfile,
+} from '@/components/articles/ArticleAuthorByline'
+import type { ArticleAuthorBylineAuthor } from '@/components/articles/ArticleAuthorByline'
+
+const linkableAuthor: ArticleAuthorBylineAuthor = {
+  id: 'user-1',
+  name: 'Jane Writer',
+  username: 'janewriter',
+  avatar: null,
+}
+
+const missingAuthor: ArticleAuthorBylineAuthor = {
+  id: '',
+  name: 'Former Author',
+  username: 'unknown',
+  avatar: null,
+}
+
+describe('canLinkAuthorProfile', () => {
+  it('returns true when id and username are valid', () => {
+    expect(canLinkAuthorProfile(linkableAuthor)).toBe(true)
+  })
+
+  it('returns false when username is unknown or empty', () => {
+    expect(canLinkAuthorProfile(missingAuthor)).toBe(false)
+    expect(canLinkAuthorProfile({ id: 'x', username: '' })).toBe(false)
+    expect(canLinkAuthorProfile({ id: '', username: 'janewriter' })).toBe(false)
+  })
+})
+
+describe('ArticleAuthorByline', () => {
+  it('renders profile link with accessible label and href', () => {
+    render(<ArticleAuthorByline author={linkableAuthor} />)
+
+    const link = screen.getByRole('link', {
+      name: "View Jane Writer's profile",
+    })
+    expect(link).toHaveAttribute('href', '/janewriter')
+    expect(screen.getByText('Jane Writer')).toBeInTheDocument()
+  })
+
+  it('renders non-link fallback when profile is unavailable', () => {
+    render(<ArticleAuthorByline author={missingAuthor} showHandle />)
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(screen.getByText('Former Author')).toBeInTheDocument()
+    expect(screen.getByText('Author profile unavailable')).toBeInTheDocument()
+    expect(screen.getByText('@unknown')).toBeInTheDocument()
+  })
+
+  it('renders metadata children outside the profile link', () => {
+    render(
+      <ArticleAuthorByline author={linkableAuthor}>
+        <p>3 min read</p>
+      </ArticleAuthorByline>
+    )
+
+    const link = screen.getByRole('link', {
+      name: "View Jane Writer's profile",
+    })
+    expect(link).not.toHaveTextContent('3 min read')
+    expect(screen.getByText('3 min read')).toBeInTheDocument()
+  })
+})

--- a/components/articles/ArticleAuthorByline.tsx
+++ b/components/articles/ArticleAuthorByline.tsx
@@ -41,7 +41,9 @@ export function ArticleAuthorByline({
       ? 'text-sm font-medium text-foreground'
       : 'font-medium text-foreground'
   const handleClassName =
-    size === 'sm' ? 'text-xs text-muted-foreground' : 'text-sm text-muted-foreground'
+    size === 'sm'
+      ? 'text-xs text-muted-foreground'
+      : 'text-sm text-muted-foreground'
 
   const identityBlock = (
     <>
@@ -54,11 +56,11 @@ export function ArticleAuthorByline({
       />
       <div>
         <p className={nameClassName}>{displayName}</p>
-        {showHandle && (
-          <p className={handleClassName}>@{author.username}</p>
-        )}
+        {showHandle && <p className={handleClassName}>@{author.username}</p>}
         {!linkable && (
-          <p className="text-xs text-muted-foreground">Author profile unavailable</p>
+          <p className="text-xs text-muted-foreground">
+            Author profile unavailable
+          </p>
         )}
       </div>
     </>

--- a/components/articles/ArticleAuthorByline.tsx
+++ b/components/articles/ArticleAuthorByline.tsx
@@ -1,0 +1,90 @@
+import Link from 'next/link'
+import { UserAvatar } from '@/components/ui/user-avatar'
+import type { ArticleForDisplay } from '@/types/index'
+import { cn } from '@/lib/utils'
+
+export type ArticleAuthorBylineAuthor = ArticleForDisplay['author']
+
+export function canLinkAuthorProfile(author: {
+  id: string
+  username: string
+}): boolean {
+  const u = author.username?.trim()
+  return Boolean(author.id && u && u !== 'unknown')
+}
+
+function profileAriaLabel(displayName: string): string {
+  return `View ${displayName}'s profile`
+}
+
+type ArticleAuthorBylineProps = {
+  author: ArticleAuthorBylineAuthor
+  size?: 'sm' | 'md'
+  showHandle?: boolean
+  className?: string
+  children?: React.ReactNode
+}
+
+export function ArticleAuthorByline({
+  author,
+  size = 'md',
+  showHandle = false,
+  className,
+  children,
+}: ArticleAuthorBylineProps) {
+  const displayName = author.name || author.username
+  const linkable = canLinkAuthorProfile(author)
+  const avatarClassName = size === 'sm' ? 'h-9 w-9' : 'h-12 w-12'
+  const fallbackClassName = size === 'sm' ? undefined : 'text-base'
+  const nameClassName =
+    size === 'sm'
+      ? 'text-sm font-medium text-foreground'
+      : 'font-medium text-foreground'
+  const handleClassName =
+    size === 'sm' ? 'text-xs text-muted-foreground' : 'text-sm text-muted-foreground'
+
+  const identityBlock = (
+    <>
+      <UserAvatar
+        src={author.avatar}
+        alt={displayName}
+        name={displayName}
+        className={avatarClassName}
+        fallbackClassName={fallbackClassName}
+      />
+      <div>
+        <p className={nameClassName}>{displayName}</p>
+        {showHandle && (
+          <p className={handleClassName}>@{author.username}</p>
+        )}
+        {!linkable && (
+          <p className="text-xs text-muted-foreground">Author profile unavailable</p>
+        )}
+      </div>
+    </>
+  )
+
+  const wrapperClassName = cn('flex flex-col gap-1', className)
+
+  if (linkable) {
+    return (
+      <div className={wrapperClassName}>
+        <Link
+          href={`/${author.username}`}
+          aria-label={profileAriaLabel(displayName)}
+          className="focus-ring flex items-center gap-3 rounded-md hover:opacity-80 transition-opacity w-fit"
+        >
+          {identityBlock}
+        </Link>
+        {children}
+      </div>
+    )
+  }
+
+  return (
+    <div className={wrapperClassName} aria-label={`Author: ${displayName}`}>
+      <div className="flex items-center gap-3">{identityBlock}</div>
+      {children}
+    </div>
+  )
+}

--- a/components/articles/ArticleCard.tsx
+++ b/components/articles/ArticleCard.tsx
@@ -83,11 +83,7 @@ export default function ArticleCard({
 
         {/* Author Info */}
         <div className="flex items-center justify-between pt-4 border-t border-border">
-          <ArticleAuthorByline
-            author={article.author}
-            size="sm"
-            showHandle
-          />
+          <ArticleAuthorByline author={article.author} size="sm" showHandle />
 
           {/* Published Date */}
           {publishedDate && (

--- a/components/articles/ArticleCard.tsx
+++ b/components/articles/ArticleCard.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link'
 import Image from 'next/image'
-import { UserAvatar } from '@/components/ui/user-avatar'
 import { formatDistanceToNow } from 'date-fns'
 import { ArticleForDisplay } from '@/types/index'
+import { ArticleAuthorByline } from '@/components/articles/ArticleAuthorByline'
 import { TagFilterLink } from '@/components/articles/TagFilterLink'
 
 interface ArticleCardProps {
@@ -83,25 +83,11 @@ export default function ArticleCard({
 
         {/* Author Info */}
         <div className="flex items-center justify-between pt-4 border-t border-border">
-          <Link
-            href={`/${article.author.username}`}
-            className="focus-ring flex items-center gap-3 rounded-md hover:opacity-80 transition-opacity"
-          >
-            <UserAvatar
-              src={article.author.avatar}
-              alt={article.author.name || article.author.username}
-              name={article.author.name || article.author.username}
-              className="h-9 w-9"
-            />
-            <div>
-              <p className="text-sm font-medium text-foreground">
-                {article.author.name || article.author.username}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                @{article.author.username}
-              </p>
-            </div>
-          </Link>
+          <ArticleAuthorByline
+            author={article.author}
+            size="sm"
+            showHandle
+          />
 
           {/* Published Date */}
           {publishedDate && (

--- a/components/articles/ArticleDisplay.tsx
+++ b/components/articles/ArticleDisplay.tsx
@@ -5,7 +5,7 @@ import { type JSONContent } from '@tiptap/core'
 import { useEffect, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import Image from 'next/image'
-import { UserAvatar } from '@/components/ui/user-avatar'
+import { ArticleAuthorByline } from '@/components/articles/ArticleAuthorByline'
 import ShareButtons from './ShareButtons'
 import { ArticleReadOnlyBody } from '@/components/articles/ArticleReadOnlyBody'
 import { ArticleBodySkeleton } from '@/components/articles/ArticleBodySkeleton'
@@ -66,31 +66,19 @@ export default function ArticleDisplay({
         </h1>
 
         <div className="flex items-center gap-4 mb-6">
-          <div className="flex items-center gap-3">
-            <UserAvatar
-              src={article.author.avatar}
-              alt={article.author.name || article.author.username}
-              name={article.author.name || article.author.username}
-              className="h-12 w-12"
-              fallbackClassName="text-base"
-            />
-            <div>
-              <p className="font-medium text-foreground">
-                {article.author.name || article.author.username}
-              </p>
-              <p className="text-sm text-muted-foreground">
-                @{article.author.username}
-                <span className="mx-1">•</span>
-                {publishedDate && (
-                  <>
-                    {publishedDate}
-                    <span className="mx-1">•</span>
-                  </>
-                )}
-                {readingMinutes} min read
-              </p>
-            </div>
-          </div>
+          <ArticleAuthorByline author={article.author} size="md">
+            <p className="text-sm text-muted-foreground">
+              @{article.author.username}
+              <span className="mx-1">•</span>
+              {publishedDate && (
+                <>
+                  {publishedDate}
+                  <span className="mx-1">•</span>
+                </>
+              )}
+              {readingMinutes} min read
+            </p>
+          </ArticleAuthorByline>
         </div>
 
         {article.coverImage && (

--- a/lib/articles/mapListArticleToDisplay.ts
+++ b/lib/articles/mapListArticleToDisplay.ts
@@ -20,9 +20,9 @@ export function mapListArticleRowToDisplay(
         }
       : {
           id: '',
-          name: null,
-          username: 'unknown',
-          avatar: null,
+          name: article.authorName ?? null,
+          username: article.authorUsername?.trim() || 'unknown',
+          avatar: article.authorAvatar ?? null,
         },
     tags: (article.tags ?? []).map((tagName, index) => ({
       id: `tag-${index}`,


### PR DESCRIPTION
## Summary

Readers on an article page could not click the author byline to open that writer's public profile. This adds a shared `ArticleAuthorByline` component that links the avatar and display name to `/{username}`, uses a clear accessible label, and shows a non-link fallback when profile data is missing.

## Changes

- Add `ArticleAuthorByline` with profile link, `aria-label` (`View {name}'s profile`), and "Author profile unavailable" when the author cannot be linked
- Wire the byline into `ArticleDisplay`; keep `@username`, publish date, and read time outside the link
- Reuse the same byline in `ArticleCard` for consistent browse + article behavior
- Improve `mapListArticleToDisplay` to use denormalized `authorName`, `authorUsername`, and `authorAvatar` when user enrichment is null
- Add unit tests for link href, accessible name, metadata outside the link, and missing-author fallback

