### PR TITLE
fix(profile): fall back to username on public wallet headings (ENG-206)

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -73,6 +73,8 @@ export default function ProfilePage({ params }: ProfilePageProps) {
     )
   }
 
+  const profileDisplayName = user.name || user.username
+
   // Prepare user data with stats
   const userWithStats = {
     id: user._id,
@@ -170,7 +172,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
                 page={page}
                 basePath={`/${username}`}
                 isOwnProfile={isOwnProfile}
-                displayName={user.name || user.username}
+                displayName={profileDisplayName}
               />
             </div>
           )}
@@ -183,7 +185,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
               nftOwnedPage={nftOwnedPage}
               nftMintedPage={nftMintedPage}
               isOwnProfile={isOwnProfile}
-              displayName={user.name || user.username}
+              displayName={profileDisplayName}
             />
           )}
 
@@ -243,7 +245,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
                 <h2 className="text-2xl font-bold text-foreground mb-2">
                   {isOwnProfile
                     ? 'Wallet Management'
-                    : `${user?.name}'s Wallet`}
+                    : `${profileDisplayName}'s Wallet`}
                 </h2>
                 <p className="text-muted-foreground">
                   {isOwnProfile
@@ -255,8 +257,9 @@ export default function ProfilePage({ params }: ProfilePageProps) {
               {/* Wallet Settings */}
               <div className="max-w-2xl">
                 <WalletSettings
-                  walletAddress={localWalletAddress ?? user?.stellarAddress}
+                  walletAddress={localWalletAddress ?? user.stellarAddress}
                   isOwnProfile={isOwnProfile}
+                  profileDisplayName={profileDisplayName}
                   onAddressChange={(address) => {
                     // Immediately update local state for instant UI feedback
                     setLocalWalletAddress(address || undefined)

--- a/components/stellar/WalletSettings.test.tsx
+++ b/components/stellar/WalletSettings.test.tsx
@@ -1,0 +1,75 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { WalletSettings } from '@/components/stellar/WalletSettings'
+
+vi.mock('convex/react', () => ({
+  useMutation: () => vi.fn(),
+}))
+
+vi.mock('@/components/providers/WalletProvider', () => ({
+  useWallet: () => ({
+    isLoading: false,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('@/components/guide/WalletTooltip', () => ({
+  WalletTooltip: () => null,
+}))
+
+vi.mock('@/components/stellar/InstallWalletDialog', () => ({
+  InstallWalletDialog: () => null,
+}))
+
+vi.mock('@/components/legal/LegalLinks', () => ({
+  LegalLinks: () => null,
+}))
+
+describe('WalletSettings', () => {
+  it('shows visitor empty alert with profile display name', () => {
+    render(
+      <WalletSettings
+        isOwnProfile={false}
+        walletAddress={null}
+        profileDisplayName="alice"
+      />
+    )
+
+    expect(
+      screen.getByText("alice hasn't set up their Stellar wallet yet.")
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/undefined/i)).not.toBeInTheDocument()
+  })
+
+  it('falls back to generic visitor empty alert without profile display name', () => {
+    render(<WalletSettings isOwnProfile={false} walletAddress={null} />)
+
+    expect(
+      screen.getByText("This user hasn't set up their Stellar wallet yet.")
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/undefined/i)).not.toBeInTheDocument()
+  })
+
+  it('shows owner connect CTA when wallet address is missing', () => {
+    render(<WalletSettings isOwnProfile walletAddress={null} />)
+
+    expect(
+      screen.getByRole('button', { name: /Connect Stellar Wallet/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        /Connect your Stellar testnet wallet to send and receive practice tips/i
+      )
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/undefined/i)).not.toBeInTheDocument()
+  })
+})

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -40,6 +40,7 @@ interface WalletSettingsProps {
   walletAddress?: string | null
   onAddressChange?: (address: string) => void
   isOwnProfile: boolean
+  profileDisplayName?: string
   className?: string
 }
 
@@ -47,6 +48,7 @@ export function WalletSettings({
   walletAddress,
   onAddressChange,
   isOwnProfile,
+  profileDisplayName,
   className = '',
 }: WalletSettingsProps) {
   const updateProfile = useMutation(api.users.updateProfile)
@@ -160,7 +162,9 @@ export function WalletSettings({
       <Alert className={className}>
         <AlertCircle className="h-4 w-4" />
         <AlertDescription>
-          This user hasn&apos;t set up their Stellar wallet yet.
+          {profileDisplayName
+            ? `${profileDisplayName} hasn't set up their Stellar wallet yet.`
+            : "This user hasn't set up their Stellar wallet yet."}
         </AlertDescription>
       </Alert>
     )


### PR DESCRIPTION
## Summary

- Fixes public profile Wallet tab visitor headings that showed `undefined's Wallet` when a user has no display name
- Uses `user.name || user.username` as `profileDisplayName`, consistent with Articles, NFTs, and ProfileHeader
- Personalizes visitor empty-wallet copy when `profileDisplayName` is available; keeps generic fallback otherwise
- Adds `WalletSettings` regression tests for owner and visitor empty states

## Problem

On `/{username}` → Wallet tab, visitors saw possessive copy built from `user?.name` only. Because `name` is optional in Convex, profiles without a display name rendered `undefined's Wallet`, which made the profile feel broken.

## Solution

- Introduce `profileDisplayName = user.name || user.username` on the profile page
- Visitor heading: `{profileDisplayName}'s Wallet`
- Pass `profileDisplayName` into `WalletSettings` for visitor empty-state messaging
- Reuse `profileDisplayName` for Articles/NFTs tab props

<img width="1224" height="717" alt="1" src="https://github.com/user-attachments/assets/23ee4337-09a9-4a07-b357-493a846516eb" />
