### PR TITLE
fix: strip profile query params from article tag links (ENG-218)

### DIFF
--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -6,6 +6,7 @@ import AppNavigation from '@/components/layout/AppNavigation'
 import { SiteFooter } from '@/components/layout/SiteFooter'
 import SearchInput from '@/components/articles/SearchInput'
 import { ArticlesBrowseContent } from '@/components/articles/ArticlesBrowseContent'
+import { buildArticlesBrowseHref } from '@/lib/articles/buildArticlesBrowseHref'
 import {
   buildArticlesBrowseScrollStorageKey,
   writeBrowseScrollY,
@@ -61,14 +62,13 @@ export default function ArticlesPage() {
   }, [urlSearch])
 
   const handleSearchChange = (search: string) => {
-    const params = new URLSearchParams(searchParams?.toString() || '')
-    if (search.trim()) {
-      params.set('search', search.trim())
-    } else {
-      params.delete('search')
-    }
-    params.set('page', '1') // Reset to first page when searching
-    router.push(`/articles?${params.toString()}`)
+    router.push(
+      buildArticlesBrowseHref({
+        search,
+        page: 1,
+        sourceParams: searchParams,
+      })
+    )
   }
 
   const clearFilters = () => {
@@ -115,12 +115,13 @@ export default function ArticlesPage() {
                 Tag: {tag}
                 <button
                   onClick={() => {
-                    const params = new URLSearchParams(
-                      searchParams?.toString() || ''
+                    router.push(
+                      buildArticlesBrowseHref({
+                        tag: '',
+                        page: 1,
+                        sourceParams: searchParams,
+                      })
                     )
-                    params.delete('tag')
-                    params.set('page', '1')
-                    router.push(`/articles?${params.toString()}`)
                   }}
                   className="ml-2 hover:text-primary-foreground/80"
                   aria-label="Remove tag filter"
@@ -134,12 +135,13 @@ export default function ArticlesPage() {
                 Author: @{author}
                 <button
                   onClick={() => {
-                    const params = new URLSearchParams(
-                      searchParams?.toString() || ''
+                    router.push(
+                      buildArticlesBrowseHref({
+                        author: '',
+                        page: 1,
+                        sourceParams: searchParams,
+                      })
                     )
-                    params.delete('author')
-                    params.set('page', '1')
-                    router.push(`/articles?${params.toString()}`)
                   }}
                   className="ml-2 hover:text-primary-foreground/80"
                   aria-label="Remove author filter"
@@ -153,12 +155,13 @@ export default function ArticlesPage() {
                 Search: &ldquo;{urlSearch}&rdquo;
                 <button
                   onClick={() => {
-                    const params = new URLSearchParams(
-                      searchParams?.toString() || ''
+                    router.push(
+                      buildArticlesBrowseHref({
+                        search: '',
+                        page: 1,
+                        sourceParams: searchParams,
+                      })
                     )
-                    params.delete('search')
-                    params.set('page', '1')
-                    router.push(`/articles?${params.toString()}`)
                   }}
                   className="ml-2 hover:text-primary-foreground/80"
                   aria-label="Remove search filter"

--- a/components/articles/ArticleCard.tsx
+++ b/components/articles/ArticleCard.tsx
@@ -9,12 +9,14 @@ interface ArticleCardProps {
   article: ArticleForDisplay
   priority?: boolean
   onArticleNavigate?: () => void
+  tagLinkAuthor?: string
 }
 
 export default function ArticleCard({
   article,
   priority,
   onArticleNavigate,
+  tagLinkAuthor,
 }: ArticleCardProps) {
   const publishedDate = article.publishedAt
     ? formatDistanceToNow(new Date(article.publishedAt), { addSuffix: true })
@@ -69,7 +71,11 @@ export default function ArticleCard({
         {article.tags.length > 0 && (
           <div className="flex flex-wrap gap-2 mb-4">
             {article.tags.slice(0, 3).map((tag) => (
-              <TagFilterLink key={tag.id} tag={tag.name}>
+              <TagFilterLink
+                key={tag.id}
+                tag={tag.name}
+                author={tagLinkAuthor}
+              >
                 {tag.name}
               </TagFilterLink>
             ))}

--- a/components/articles/ArticleCard.tsx
+++ b/components/articles/ArticleCard.tsx
@@ -71,11 +71,7 @@ export default function ArticleCard({
         {article.tags.length > 0 && (
           <div className="flex flex-wrap gap-2 mb-4">
             {article.tags.slice(0, 3).map((tag) => (
-              <TagFilterLink
-                key={tag.id}
-                tag={tag.name}
-                author={tagLinkAuthor}
-              >
+              <TagFilterLink key={tag.id} tag={tag.name} author={tagLinkAuthor}>
                 {tag.name}
               </TagFilterLink>
             ))}

--- a/components/articles/ArticleGrid.tsx
+++ b/components/articles/ArticleGrid.tsx
@@ -7,12 +7,14 @@ interface ArticleGridProps {
   articles: ArticleForDisplay[]
   variant?: 'home' | 'articles'
   onArticleNavigate?: () => void
+  tagLinkAuthor?: string
 }
 
 export default function ArticleGrid({
   articles,
   variant = 'articles',
   onArticleNavigate,
+  tagLinkAuthor,
 }: ArticleGridProps) {
   if (articles.length === 0) {
     if (variant === 'home') {
@@ -81,6 +83,7 @@ export default function ArticleGrid({
           article={article}
           priority={index === 0}
           onArticleNavigate={onArticleNavigate}
+          tagLinkAuthor={tagLinkAuthor}
         />
       ))}
     </div>

--- a/components/articles/ArticlesBrowseContent.tsx
+++ b/components/articles/ArticlesBrowseContent.tsx
@@ -7,6 +7,7 @@ import { mapListArticlesToDisplay } from '@/lib/articles/mapListArticleToDisplay
 import ArticleGrid from '@/components/articles/ArticleGrid'
 import Pagination from '@/components/articles/Pagination'
 import { ArticleGridSkeleton } from '@/components/articles/ArticleCardSkeleton'
+import { buildArticlesBrowseHref } from '@/lib/articles/buildArticlesBrowseHref'
 import { readBrowseScrollY } from '@/lib/articles/browseListScrollStorage'
 
 function buildPagination(result: {
@@ -69,9 +70,12 @@ export function ArticlesBrowseContent({
   const pagination = buildPagination(result)
 
   const handlePageChange = (page: number) => {
-    const params = new URLSearchParams(searchParams?.toString() || '')
-    params.set('page', page.toString())
-    router.push(`/articles?${params.toString()}`)
+    router.push(
+      buildArticlesBrowseHref({
+        page,
+        sourceParams: searchParams,
+      })
+    )
   }
 
   return (

--- a/components/articles/TagFilterLink.test.tsx
+++ b/components/articles/TagFilterLink.test.tsx
@@ -1,0 +1,64 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { TagFilterLink } from './TagFilterLink'
+
+const useSearchParams = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => useSearchParams(),
+}))
+
+function hrefParams(href: string) {
+  const qs = href.split('?')[1] ?? ''
+  return new URLSearchParams(qs)
+}
+
+describe('TagFilterLink', () => {
+  beforeEach(() => {
+    useSearchParams.mockReset()
+  })
+
+  it('strips profile-only params from the articles browse href', () => {
+    useSearchParams.mockReturnValue(
+      new URLSearchParams('page=2&nftOwnedPage=3&nftMintedPage=1')
+    )
+    render(<TagFilterLink tag="rust">rust</TagFilterLink>)
+    const href = screen.getByRole('link', { name: 'Filter by tag rust' }).getAttribute(
+      'href'
+    )
+    expect(href).toBeTruthy()
+    const params = hrefParams(href!)
+    expect(params.get('tag')).toBe('rust')
+    expect(params.has('page')).toBe(false)
+    expect(params.has('nftOwnedPage')).toBe(false)
+    expect(params.has('nftMintedPage')).toBe(false)
+  })
+
+  it('includes author when the prop is provided', () => {
+    useSearchParams.mockReturnValue(new URLSearchParams('page=2&nftOwnedPage=3'))
+    render(
+      <TagFilterLink tag="rust" author="alice">
+        rust
+      </TagFilterLink>
+    )
+    const params = hrefParams(
+      screen.getByRole('link', { name: 'Filter by tag rust' }).getAttribute('href')!
+    )
+    expect(params.get('author')).toBe('alice')
+    expect(params.get('tag')).toBe('rust')
+  })
+
+  it('preserves search from the current articles browse URL', () => {
+    useSearchParams.mockReturnValue(
+      new URLSearchParams('search=stellar&tag=old&page=3')
+    )
+    render(<TagFilterLink tag="rust">rust</TagFilterLink>)
+    const params = hrefParams(
+      screen.getByRole('link', { name: 'Filter by tag rust' }).getAttribute('href')!
+    )
+    expect(params.get('search')).toBe('stellar')
+    expect(params.get('tag')).toBe('rust')
+    expect(params.has('page')).toBe(false)
+  })
+})

--- a/components/articles/TagFilterLink.test.tsx
+++ b/components/articles/TagFilterLink.test.tsx
@@ -24,9 +24,9 @@ describe('TagFilterLink', () => {
       new URLSearchParams('page=2&nftOwnedPage=3&nftMintedPage=1')
     )
     render(<TagFilterLink tag="rust">rust</TagFilterLink>)
-    const href = screen.getByRole('link', { name: 'Filter by tag rust' }).getAttribute(
-      'href'
-    )
+    const href = screen
+      .getByRole('link', { name: 'Filter by tag rust' })
+      .getAttribute('href')
     expect(href).toBeTruthy()
     const params = hrefParams(href!)
     expect(params.get('tag')).toBe('rust')
@@ -36,14 +36,18 @@ describe('TagFilterLink', () => {
   })
 
   it('includes author when the prop is provided', () => {
-    useSearchParams.mockReturnValue(new URLSearchParams('page=2&nftOwnedPage=3'))
+    useSearchParams.mockReturnValue(
+      new URLSearchParams('page=2&nftOwnedPage=3')
+    )
     render(
       <TagFilterLink tag="rust" author="alice">
         rust
       </TagFilterLink>
     )
     const params = hrefParams(
-      screen.getByRole('link', { name: 'Filter by tag rust' }).getAttribute('href')!
+      screen
+        .getByRole('link', { name: 'Filter by tag rust' })
+        .getAttribute('href')!
     )
     expect(params.get('author')).toBe('alice')
     expect(params.get('tag')).toBe('rust')
@@ -55,7 +59,9 @@ describe('TagFilterLink', () => {
     )
     render(<TagFilterLink tag="rust">rust</TagFilterLink>)
     const params = hrefParams(
-      screen.getByRole('link', { name: 'Filter by tag rust' }).getAttribute('href')!
+      screen
+        .getByRole('link', { name: 'Filter by tag rust' })
+        .getAttribute('href')!
     )
     expect(params.get('search')).toBe('stellar')
     expect(params.get('tag')).toBe('rust')

--- a/components/articles/TagFilterLink.tsx
+++ b/components/articles/TagFilterLink.tsx
@@ -2,23 +2,27 @@
 
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
+import { buildArticlesBrowseHref } from '@/lib/articles/buildArticlesBrowseHref'
 
 export function TagFilterLink({
   tag,
+  author,
   className = '',
   children,
 }: {
   tag: string
+  author?: string
   className?: string
   children?: React.ReactNode
 }) {
   const searchParams = useSearchParams()
 
-  const params = new URLSearchParams(searchParams?.toString() || '')
-  params.set('tag', tag)
-  params.set('page', '1')
-
-  const href = `/articles?${params.toString()}`
+  const href = buildArticlesBrowseHref({
+    tag,
+    page: 1,
+    author,
+    sourceParams: searchParams,
+  })
 
   return (
     <Link

--- a/components/profile/ProfileArticlesTabContent.tsx
+++ b/components/profile/ProfileArticlesTabContent.tsx
@@ -62,7 +62,7 @@ export function ProfileArticlesTabContent({
   return (
     <>
       <PaginationTransition isPaginating={isPaginating}>
-        <ArticleGrid articles={articles} />
+        <ArticleGrid articles={articles} tagLinkAuthor={username} />
       </PaginationTransition>
 
       {totalPages > 1 && (

--- a/lib/articles/buildArticlesBrowseHref.test.ts
+++ b/lib/articles/buildArticlesBrowseHref.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildArticlesBrowseHref,
+  pickArticlesBrowseParams,
+} from './buildArticlesBrowseHref'
+
+describe('pickArticlesBrowseParams', () => {
+  it('keeps only tag, page, search, and author', () => {
+    const source = new URLSearchParams(
+      'page=2&tag=rust&search=foo&author=alice&nftOwnedPage=3&tab=earnings'
+    )
+    const picked = pickArticlesBrowseParams(source)
+    expect(Object.fromEntries(picked)).toEqual({
+      tag: 'rust',
+      page: '2',
+      search: 'foo',
+      author: 'alice',
+    })
+  })
+
+  it('returns empty when no browse keys are present', () => {
+    const source = new URLSearchParams('nftOwnedPage=3&nftMintedPage=1')
+    expect(pickArticlesBrowseParams(source).toString()).toBe('')
+  })
+})
+
+describe('buildArticlesBrowseHref', () => {
+  it('strips profile params and sets tag with page 1', () => {
+    const source = new URLSearchParams(
+      'page=2&nftOwnedPage=3&nftMintedPage=1'
+    )
+    expect(
+      buildArticlesBrowseHref({
+        tag: 'rust',
+        page: 1,
+        sourceParams: source,
+      })
+    ).toBe('/articles?tag=rust')
+  })
+
+  it('preserves search and replaces tag when building from articles browse', () => {
+    const source = new URLSearchParams('search=foo&tag=old&page=3')
+    expect(
+      buildArticlesBrowseHref({
+        tag: 'new',
+        page: 1,
+        sourceParams: source,
+      })
+    ).toBe('/articles?tag=new&search=foo')
+  })
+
+  it('sets author and overrides picked author from source', () => {
+    const source = new URLSearchParams('author=other&page=2')
+    expect(
+      buildArticlesBrowseHref({
+        tag: 'rust',
+        page: 1,
+        author: 'alice',
+        sourceParams: source,
+      })
+    ).toBe('/articles?author=alice&tag=rust')
+  })
+
+  it('returns /articles when clearing all filters', () => {
+    expect(
+      buildArticlesBrowseHref({
+        tag: '',
+        search: '',
+        author: '',
+        page: 1,
+        sourceParams: new URLSearchParams('tag=old&search=x'),
+      })
+    ).toBe('/articles')
+  })
+
+  it('sets page greater than 1', () => {
+    expect(
+      buildArticlesBrowseHref({
+        tag: 'rust',
+        page: 2,
+      })
+    ).toBe('/articles?tag=rust&page=2')
+  })
+})

--- a/lib/articles/buildArticlesBrowseHref.test.ts
+++ b/lib/articles/buildArticlesBrowseHref.test.ts
@@ -26,9 +26,7 @@ describe('pickArticlesBrowseParams', () => {
 
 describe('buildArticlesBrowseHref', () => {
   it('strips profile params and sets tag with page 1', () => {
-    const source = new URLSearchParams(
-      'page=2&nftOwnedPage=3&nftMintedPage=1'
-    )
+    const source = new URLSearchParams('page=2&nftOwnedPage=3&nftMintedPage=1')
     expect(
       buildArticlesBrowseHref({
         tag: 'rust',

--- a/lib/articles/buildArticlesBrowseHref.ts
+++ b/lib/articles/buildArticlesBrowseHref.ts
@@ -1,0 +1,58 @@
+export const ARTICLES_BROWSE_QUERY_KEYS = [
+  'tag',
+  'page',
+  'search',
+  'author',
+] as const
+
+export type ArticlesBrowseQueryKey =
+  (typeof ARTICLES_BROWSE_QUERY_KEYS)[number]
+
+export function pickArticlesBrowseParams(
+  searchParams: URLSearchParams
+): URLSearchParams {
+  const picked = new URLSearchParams()
+  for (const key of ARTICLES_BROWSE_QUERY_KEYS) {
+    const value = searchParams.get(key)
+    if (value) picked.set(key, value)
+  }
+  return picked
+}
+
+export function buildArticlesBrowseHref(options: {
+  tag?: string
+  page?: number
+  search?: string
+  author?: string
+  sourceParams?: URLSearchParams | null
+}): string {
+  const params = options.sourceParams
+    ? pickArticlesBrowseParams(options.sourceParams)
+    : new URLSearchParams()
+
+  if (options.tag !== undefined) {
+    const trimmed = options.tag.trim()
+    if (trimmed) params.set('tag', trimmed)
+    else params.delete('tag')
+  }
+
+  if (options.search !== undefined) {
+    const trimmed = options.search.trim()
+    if (trimmed) params.set('search', trimmed)
+    else params.delete('search')
+  }
+
+  if (options.author !== undefined) {
+    const trimmed = options.author.trim()
+    if (trimmed) params.set('author', trimmed)
+    else params.delete('author')
+  }
+
+  if (options.page !== undefined) {
+    if (options.page <= 1) params.delete('page')
+    else params.set('page', String(options.page))
+  }
+
+  const qs = params.toString()
+  return qs ? `/articles?${qs}` : '/articles'
+}

--- a/lib/articles/buildArticlesBrowseHref.ts
+++ b/lib/articles/buildArticlesBrowseHref.ts
@@ -5,8 +5,7 @@ export const ARTICLES_BROWSE_QUERY_KEYS = [
   'author',
 ] as const
 
-export type ArticlesBrowseQueryKey =
-  (typeof ARTICLES_BROWSE_QUERY_KEYS)[number]
+export type ArticlesBrowseQueryKey = (typeof ARTICLES_BROWSE_QUERY_KEYS)[number]
 
 export function pickArticlesBrowseParams(
   searchParams: URLSearchParams


### PR DESCRIPTION


## Summary

Profile tag clicks were copying the full current query string into `/articles`, so profile-only params (`page`, `nftOwnedPage`, `nftMintedPage`, etc.) leaked into article browse URLs and cluttered filter state.

This PR adds an allowlisted URL builder for article browse links and uses it everywhere browse URLs are built from query state.

## Changes

- Add `buildArticlesBrowseHref` / `pickArticlesBrowseParams` to only allow `tag`, `page`, `search`, and `author`
- Update `TagFilterLink` to use the builder instead of cloning all `searchParams`
- Pass `tagLinkAuthor` from profile articles grid so profile tag links are author-scoped (`/articles?tag=...&author=<username>`)
- Use the same builder for articles browse search, filter chip removal, and pagination (prevents junk params from reappearing)

<img width="1219" height="719" alt="Screenshot 2026-05-26 at 5 51 51 PM" src="https://github.com/user-attachments/assets/aa850bcc-b7a0-4c03-b665-426dc5b2456e" />
<img width="1216" height="721" alt="Screenshot 2026-05-26 at 5 53 09 PM" src="https://github.com/user-attachments/assets/478dac07-a82b-4c87-81d4-2007098849ae" />
