### PR TITLE
fix(articles): require meaningful title before publish (ENG-178)

### DIFF
--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -607,8 +607,7 @@ export function WriteEditorWorkspace() {
       toast.success('Article published successfully!')
     } catch (error) {
       console.error('Publish error:', error)
-      const message =
-        error instanceof Error ? error.message : 'Unknown error'
+      const message = error instanceof Error ? error.message : 'Unknown error'
       if (message.toLowerCase().includes('title')) {
         setTitleError(TITLE_PUBLISH_ERROR)
         focusTitleField()
@@ -1213,9 +1212,7 @@ export function WriteEditorWorkspace() {
               placeholder="Untitled"
               rows={1}
               aria-invalid={!!titleError}
-              aria-describedby={
-                titleError ? ARTICLE_TITLE_ERROR_ID : undefined
-              }
+              aria-describedby={titleError ? ARTICLE_TITLE_ERROR_ID : undefined}
               className={cn(
                 'w-full resize-none overflow-hidden bg-transparent py-2 text-3xl font-semibold leading-snug text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
                 titleError

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -60,8 +60,11 @@ import {
   writeDraftBackup,
 } from '@/lib/draftBackup'
 import { getWriteUrlWithDraftId } from '@/lib/writeDraftUrl'
+import { isPlaceholderArticleTitle } from '@/convex/lib/articleTitle'
 
 const PUBLISH_EXCERPT_PREVIEW_MAX = 280
+const ARTICLE_TITLE_ERROR_ID = 'article-title-error'
+const TITLE_PUBLISH_ERROR = 'Add a title before publishing'
 const EXCERPT_MAX_CHARS = 500
 
 const COVER_FILE_INPUT_ID = 'cover-image-file-input'
@@ -111,6 +114,7 @@ function getInternalNavHref(
 export function WriteEditorWorkspace() {
   const convex = useConvex()
   const [title, setTitle] = useState('')
+  const [titleError, setTitleError] = useState<string | null>(null)
   const [excerpt, setExcerpt] = useState('')
   const [tags, setTags] = useState('')
   const [coverImage, setCoverImage] = useState('')
@@ -521,13 +525,33 @@ export function WriteEditorWorkspace() {
     return () => window.removeEventListener('keydown', handler)
   }, [saveNow])
 
+  const focusTitleField = useCallback(() => {
+    document
+      .getElementById('field-article-title')
+      ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    requestAnimationFrame(() => {
+      document.getElementById('article-title')?.focus()
+    })
+  }, [])
+
+  const blockPublishForPlaceholderTitle = useCallback((): boolean => {
+    if (isPlaceholderArticleTitle(title)) {
+      setTitleError(TITLE_PUBLISH_ERROR)
+      focusTitleField()
+      return true
+    }
+    setTitleError(null)
+    return false
+  }, [title, focusTitleField])
+
   const requestPublish = useCallback(() => {
     if (!editor || editor.isEmpty) {
       toast.warning('Please add content before publishing')
       return
     }
+    if (blockPublishForPlaceholderTitle()) return
     setPublishConfirmOpen(true)
-  }, [editor])
+  }, [editor, blockPublishForPlaceholderTitle])
 
   const handlePublish = useCallback(async () => {
     if (!editor || editor.isEmpty) {
@@ -538,6 +562,10 @@ export function WriteEditorWorkspace() {
     if (!editorContent) {
       setPublishConfirmOpen(false)
       toast.warning('Please add content before publishing')
+      return
+    }
+    if (blockPublishForPlaceholderTitle()) {
+      setPublishConfirmOpen(false)
       return
     }
 
@@ -554,7 +582,7 @@ export function WriteEditorWorkspace() {
         resultId = published.id
       } else {
         resultId = await createArticleMutation({
-          title: title || 'Untitled',
+          title: title.trim(),
           content: editorContent,
           excerpt: excerpt || undefined,
           coverImage: coverImage || undefined,
@@ -579,9 +607,14 @@ export function WriteEditorWorkspace() {
       toast.success('Article published successfully!')
     } catch (error) {
       console.error('Publish error:', error)
-      toast.error(
-        `Failed to publish: ${error instanceof Error ? error.message : 'Unknown error'}`
-      )
+      const message =
+        error instanceof Error ? error.message : 'Unknown error'
+      if (message.toLowerCase().includes('title')) {
+        setTitleError(TITLE_PUBLISH_ERROR)
+        focusTitleField()
+      } else {
+        toast.error(`Failed to publish: ${message}`)
+      }
     } finally {
       setIsPublishing(false)
     }
@@ -597,6 +630,8 @@ export function WriteEditorWorkspace() {
     createArticleMutation,
     editor,
     syncDraftIdInUrl,
+    blockPublishForPlaceholderTitle,
+    focusTitleField,
   ])
 
   const handleRequestDelete = useCallback(() => {
@@ -1167,6 +1202,7 @@ export function WriteEditorWorkspace() {
               onChange={(e) => {
                 setTitle(e.target.value)
                 setHasUnsavedChanges(true)
+                if (titleError) setTitleError(null)
               }}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') {
@@ -1176,8 +1212,26 @@ export function WriteEditorWorkspace() {
               }}
               placeholder="Untitled"
               rows={1}
-              className="w-full resize-none overflow-hidden bg-transparent py-2 text-3xl font-semibold leading-snug text-foreground placeholder:text-muted-foreground/50 focus:outline-none"
+              aria-invalid={!!titleError}
+              aria-describedby={
+                titleError ? ARTICLE_TITLE_ERROR_ID : undefined
+              }
+              className={cn(
+                'w-full resize-none overflow-hidden bg-transparent py-2 text-3xl font-semibold leading-snug text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                titleError
+                  ? 'rounded-md border border-destructive px-2 focus-visible:ring-destructive'
+                  : 'border border-transparent'
+              )}
             />
+            {titleError ? (
+              <p
+                id={ARTICLE_TITLE_ERROR_ID}
+                role="alert"
+                className="mt-1 text-sm text-destructive"
+              >
+                {titleError}
+              </p>
+            ) : null}
             {savedArticleForLink?.authorUsername &&
               savedArticleForLink.slug && (
                 <p className="mt-1 font-mono text-xs text-muted-foreground">

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -18,6 +18,7 @@ import type * as highlights from "../highlights.js";
 import type * as http from "../http.js";
 import type * as lib_articleListing from "../lib/articleListing.js";
 import type * as lib_articleSlug from "../lib/articleSlug.js";
+import type * as lib_articleTitle from "../lib/articleTitle.js";
 import type * as lib_constants from "../lib/constants.js";
 import type * as lib_enrich from "../lib/enrich.js";
 import type * as lib_highlightHash from "../lib/highlightHash.js";
@@ -54,6 +55,7 @@ declare const fullApi: ApiFromModules<{
   http: typeof http;
   "lib/articleListing": typeof lib_articleListing;
   "lib/articleSlug": typeof lib_articleSlug;
+  "lib/articleTitle": typeof lib_articleTitle;
   "lib/constants": typeof lib_constants;
   "lib/enrich": typeof lib_enrich;
   "lib/highlightHash": typeof lib_highlightHash;

--- a/convex/articles.publishTitle.test.ts
+++ b/convex/articles.publishTitle.test.ts
@@ -1,0 +1,142 @@
+/// <reference types="vite/client" />
+import { convexTest } from 'convex-test'
+import { describe, expect, it } from 'vitest'
+import { api, internal } from './_generated/api'
+import schema from './schema'
+import type { Id } from './_generated/dataModel'
+
+const docWithText = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'Hello world' }],
+    },
+  ],
+}
+
+const modules = import.meta.glob(['./**/*.ts', '!./**/*.test.ts'])
+
+async function drainScheduler(t: ReturnType<typeof convexTest>) {
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  await t.finishAllScheduledFunctions(() => {})
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  await t.finishAllScheduledFunctions(() => {})
+}
+
+async function seedAuthor(t: ReturnType<typeof convexTest>) {
+  return await t.run(async (ctx) => {
+    const now = Date.now()
+    const userId = await ctx.db.insert('users', {
+      email: 'writer@x.test',
+      username: 'writer',
+      createdAt: now,
+      updatedAt: now,
+    })
+    return { userId, now }
+  })
+}
+
+describe('publish title validation', () => {
+  it('rejects publishArticle when draft title is Untitled', async () => {
+    const t = convexTest(schema, modules)
+    const { userId } = await seedAuthor(t)
+    const asAuthor = t.withIdentity({ subject: userId })
+
+    const draftId = await asAuthor.mutation(api.articles.saveDraft, {
+      title: 'Untitled',
+      content: docWithText,
+    })
+
+    await expect(
+      asAuthor.mutation(api.articles.publishArticle, {
+        id: draftId as Id<'articles'>,
+      })
+    ).rejects.toThrow('Cannot publish: add a title before publishing')
+  })
+
+  it('rejects createArticle with published true when title is Untitled', async () => {
+    const t = convexTest(schema, modules)
+    const { userId } = await seedAuthor(t)
+    const asAuthor = t.withIdentity({ subject: userId })
+
+    await expect(
+      asAuthor.mutation(api.articles.createArticle, {
+        title: 'Untitled',
+        content: docWithText,
+        published: true,
+      })
+    ).rejects.toThrow('Cannot publish: add a title before publishing')
+  })
+
+  it('publishes a draft with a real title and lists it publicly', async () => {
+    const t = convexTest(schema, modules)
+    const { userId } = await seedAuthor(t)
+    const asAuthor = t.withIdentity({ subject: userId })
+
+    const draftId = await asAuthor.mutation(api.articles.saveDraft, {
+      title: 'My meaningful post',
+      content: docWithText,
+    })
+
+    await asAuthor.mutation(api.articles.publishArticle, {
+      id: draftId as Id<'articles'>,
+    })
+    await drainScheduler(t)
+
+    const listed = await t.query(api.articles.listArticles, {
+      page: 1,
+      limit: 10,
+    })
+    expect(listed.total).toBe(1)
+    expect(listed.articles[0]?.title).toBe('My meaningful post')
+  })
+
+  it('unpublishes existing public articles with placeholder titles', async () => {
+    const t = convexTest(schema, modules)
+    const { userId, now } = await seedAuthor(t)
+
+    const articleId = await t.run(async (ctx) => {
+      return await ctx.db.insert('articles', {
+        slug: 'untitled',
+        title: 'Untitled',
+        content: docWithText,
+        published: true,
+        publishedAt: now,
+        authorId: userId,
+        authorUsername: 'writer',
+        tags: [],
+        searchContent: 'Untitled',
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+    })
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(userId, { articleCount: 1 })
+    })
+
+    const result = await t.mutation(
+      internal.articles.unpublishArticlesWithPlaceholderTitles,
+      {}
+    )
+    expect(result.updated).toBe(1)
+
+    const article = await t.run(async (ctx) => ctx.db.get(articleId))
+    expect(article?.published).toBe(false)
+    expect(article?.publishedAt).toBeUndefined()
+
+    const user = await t.run(async (ctx) => ctx.db.get(userId))
+    expect(user?.articleCount).toBe(0)
+
+    const listed = await t.query(api.articles.listArticles, {
+      page: 1,
+      limit: 10,
+    })
+    expect(listed.total).toBe(0)
+  })
+})

--- a/convex/articles.ts
+++ b/convex/articles.ts
@@ -14,6 +14,10 @@ import {
   replaceTagLinksForArticle,
 } from './lib/articleListing'
 import {
+  assertPublishableArticleTitle,
+  isPlaceholderArticleTitle,
+} from './lib/articleTitle'
+import {
   extractTextFromTiptapJson,
   tiptapJsonHasNonEmptyText,
 } from './lib/tiptapContent'
@@ -323,8 +327,11 @@ export const createArticle = mutation({
     // Validate input
     validateArticleInput(args)
 
-    if (args.published && !tiptapJsonHasNonEmptyText(args.content)) {
-      throw new Error('Cannot publish: article body is empty')
+    if (args.published) {
+      assertPublishableArticleTitle(args.title)
+      if (!tiptapJsonHasNonEmptyText(args.content)) {
+        throw new Error('Cannot publish: article body is empty')
+      }
     }
 
     const user = await ctx.db.get(userId)
@@ -476,9 +483,7 @@ export const publishArticle = mutation({
     if (article.published) throw new Error('Already published')
 
     // Validate article has required content before publishing
-    if (!article.title || article.title.trim().length === 0) {
-      throw new Error('Cannot publish: title is required')
-    }
+    assertPublishableArticleTitle(article.title)
     if (!article.content) {
       throw new Error('Cannot publish: content is required')
     }
@@ -718,6 +723,48 @@ export const backfillArticleTagsAndSearchContent = internalMutation({
       if (fresh?.published) await replaceTagLinksForArticle(ctx, fresh)
       updated += 1
     }
+    return { updated }
+  },
+})
+
+// One-off after deploy: bunx convex run internal/articles:unpublishArticlesWithPlaceholderTitles
+export const unpublishArticlesWithPlaceholderTitles = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const articles = await ctx.db.query('articles').collect()
+    const now = Date.now()
+    let updated = 0
+    const articleCountDeltaByAuthor = new Map<Id<'users'>, number>()
+
+    for (const article of articles) {
+      if (!article.published || !isPlaceholderArticleTitle(article.title)) {
+        continue
+      }
+
+      await removeTagLinksForArticle(ctx, article._id)
+      await ctx.db.patch(article._id, {
+        published: false,
+        publishedAt: undefined,
+        updatedAt: now,
+      })
+
+      articleCountDeltaByAuthor.set(
+        article.authorId,
+        (articleCountDeltaByAuthor.get(article.authorId) ?? 0) + 1
+      )
+      updated += 1
+    }
+
+    for (const [authorId, delta] of articleCountDeltaByAuthor) {
+      const user = await ctx.db.get(authorId)
+      if (user) {
+        await ctx.db.patch(authorId, {
+          articleCount: Math.max(0, (user.articleCount || 0) - delta),
+          updatedAt: now,
+        })
+      }
+    }
+
     return { updated }
   },
 })

--- a/convex/lib/articleTitle.test.ts
+++ b/convex/lib/articleTitle.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertPublishableArticleTitle,
+  isPlaceholderArticleTitle,
+} from './articleTitle'
+
+describe('isPlaceholderArticleTitle', () => {
+  it('treats empty and whitespace-only titles as placeholder', () => {
+    expect(isPlaceholderArticleTitle('')).toBe(true)
+    expect(isPlaceholderArticleTitle('   ')).toBe(true)
+  })
+
+  it('treats Untitled case-insensitively as placeholder', () => {
+    expect(isPlaceholderArticleTitle('Untitled')).toBe(true)
+    expect(isPlaceholderArticleTitle('untitled')).toBe(true)
+    expect(isPlaceholderArticleTitle('UNTITLED')).toBe(true)
+    expect(isPlaceholderArticleTitle('  Untitled  ')).toBe(true)
+  })
+
+  it('allows real titles that mention untitled', () => {
+    expect(isPlaceholderArticleTitle('Untitled Story')).toBe(false)
+    expect(isPlaceholderArticleTitle('My first post')).toBe(false)
+  })
+})
+
+describe('assertPublishableArticleTitle', () => {
+  it('throws for placeholder titles', () => {
+    expect(() => assertPublishableArticleTitle('Untitled')).toThrow(
+      'Cannot publish: add a title before publishing'
+    )
+  })
+
+  it('does not throw for meaningful titles', () => {
+    expect(() => assertPublishableArticleTitle('A real title')).not.toThrow()
+  })
+})

--- a/convex/lib/articleTitle.ts
+++ b/convex/lib/articleTitle.ts
@@ -1,0 +1,12 @@
+export function isPlaceholderArticleTitle(title: string): boolean {
+  const trimmed = title.trim()
+  if (trimmed.length === 0) return true
+  if (trimmed.toLowerCase() === 'untitled') return true
+  return false
+}
+
+export function assertPublishableArticleTitle(title: string): void {
+  if (isPlaceholderArticleTitle(title)) {
+    throw new Error('Cannot publish: add a title before publishing')
+  }
+}


### PR DESCRIPTION
## Summary

Blocks publishing when an article title is empty or the placeholder "Untitled", surfaces validation on the title field in the write editor, and adds a one-off migration to unpublish existing public articles that still use placeholder titles.

## Changes

- Add `isPlaceholderArticleTitle` / `assertPublishableArticleTitle` in `convex/lib/articleTitle.ts` and enforce in `publishArticle` and `createArticle` when `published: true`
- Block publish in `WriteEditorWorkspace` before the confirm dialog; show inline error on the title field with focus/scroll
- Remove `title || 'Untitled'` on the direct publish (`createArticle`) path
- Add `unpublishArticlesWithPlaceholderTitles` internal mutation to move existing public placeholder-title articles back to drafts (tag cleanup + `articleCount` decrement)
- Add regression tests in `convex/lib/articleTitle.test.ts` and `convex/articles.publishTitle.test.ts`
<img width="1219" height="718" alt="Screenshot 2026-05-26 at 6 41 10 PM" src="https://github.com/user-attachments/assets/51ce7e78-5dfa-47c5-9284-04b9c9bb94d9" />

