### PR TITLE
fix(editor): insert and render YouTube embeds on write and publish (ENG-176)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -47,6 +47,27 @@
   word-break: break-word;
 }
 
+/* YouTube embeds: responsive iframe inside editor and article body */
+.editor-content [data-youtube-video],
+.article-content [data-youtube-video] {
+  position: relative;
+  width: 100%;
+  max-width: 100%;
+  margin: 1rem 0;
+  overflow: hidden;
+  border-radius: var(--radius-lg, 0.5rem);
+}
+
+.editor-content [data-youtube-video] iframe,
+.article-content [data-youtube-video] iframe {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  aspect-ratio: 16 / 9;
+  height: auto;
+  border: 0;
+}
+
 /* Highlight creation feedback */
 .highlight-creating {
   animation: highlight-fade-in 0.4s ease-out;

--- a/components/articles/HighlightableArticle.tsx
+++ b/components/articles/HighlightableArticle.tsx
@@ -10,6 +10,7 @@ import { lowlight } from '@/lib/lowlight'
 import { ResizableImage } from '@/components/editor/extensions/ResizableImage'
 import HighlightExtension from '@/components/editor/extensions/HighlightExtension'
 import { EditorKeymap } from '@/components/editor/extensions/EditorKeymap'
+import { createYoutubeExtension } from '@/lib/tiptap/youtubeExtension'
 import { HighlightConverter } from '@/lib/highlights/HighlightConverter'
 import { useMutation } from 'convex/react'
 import { api } from '@/convex/_generated/api'
@@ -136,6 +137,7 @@ export function HighlightableArticle({
           lowlight,
         }),
         ResizableImage,
+        createYoutubeExtension(),
         ...(editable ? [EditorKeymap] : []),
         ...(highlightsActive
           ? [

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -6,7 +6,7 @@ import Underline from '@tiptap/extension-underline'
 import Link from '@tiptap/extension-link'
 import Placeholder from '@tiptap/extension-placeholder'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
-import Youtube from '@tiptap/extension-youtube'
+import { createYoutubeExtension } from '@/lib/tiptap/youtubeExtension'
 import { lowlight } from '@/lib/lowlight'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ResizableImage } from './extensions/ResizableImage'
@@ -88,17 +88,7 @@ export function Editor({
       }),
       // Add Underline extension
       Underline,
-      // YouTube extension
-      Youtube.configure({
-        width: 640,
-        height: 480,
-        controls: true,
-        nocookie: true,
-        allowFullscreen: true,
-        HTMLAttributes: {
-          class: 'youtube-embed rounded-lg my-4',
-        },
-      }),
+      createYoutubeExtension(),
       ResizableImage.configure({
         HTMLAttributes: {
           class: 'max-w-full h-auto rounded-lg my-4',

--- a/components/editor/EditorToolbar.tsx
+++ b/components/editor/EditorToolbar.tsx
@@ -800,17 +800,12 @@ export function EditorToolbar({
           onClose={() => setShowYouTubeDialog(false)}
           triggerRef={youtubeDialogTriggerRef}
           onVideoEmbed={(url, width, height) => {
-            const chain = editor.chain().focus() as {
-              setYoutubeVideo: (opts: {
-                src: string
-                width?: number
-                height?: number
-              }) => { run: () => void }
-            }
-            if (typeof chain.setYoutubeVideo === 'function') {
-              chain.setYoutubeVideo({ src: url, width, height }).run()
-            }
-            setShowYouTubeDialog(false)
+            if (!editor) return false
+            return editor
+              .chain()
+              .focus()
+              .setYoutubeVideo({ src: url, width, height })
+              .run()
           }}
         />
       )}

--- a/components/editor/EditorWithToolbar.tsx
+++ b/components/editor/EditorWithToolbar.tsx
@@ -6,7 +6,7 @@ import Underline from '@tiptap/extension-underline'
 import Link from '@tiptap/extension-link'
 import Placeholder from '@tiptap/extension-placeholder'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
-import Youtube from '@tiptap/extension-youtube'
+import { createYoutubeExtension } from '@/lib/tiptap/youtubeExtension'
 import { lowlight } from '@/lib/lowlight'
 import { useEffect } from 'react'
 import { EditorToolbar } from './EditorToolbar'
@@ -54,17 +54,7 @@ export function EditorWithToolbar({
       }),
       // Add Underline extension
       Underline,
-      // YouTube extension
-      Youtube.configure({
-        width: 640,
-        height: 480,
-        controls: true,
-        nocookie: true,
-        allowFullscreen: true,
-        HTMLAttributes: {
-          class: 'youtube-embed rounded-lg my-4',
-        },
-      }),
+      createYoutubeExtension(),
       ResizableImage.configure({
         HTMLAttributes: {
           class: 'max-w-full h-auto rounded-lg my-4',

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -11,6 +11,7 @@ import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import TextAlign from '@tiptap/extension-text-align'
 import { lowlight } from '@/lib/lowlight'
 import { ResizableImage } from '@/components/editor/extensions/ResizableImage'
+import { createYoutubeExtension } from '@/lib/tiptap/youtubeExtension'
 import { EditorKeymap } from '@/components/editor/extensions/EditorKeymap'
 import { EditorToolbar } from '@/components/editor/EditorToolbar'
 import { EditorActionBar } from '@/components/editor/EditorActionBar'
@@ -229,6 +230,7 @@ export function WriteEditorWorkspace() {
           class: 'max-w-full h-auto rounded-lg my-4',
         },
       }),
+      createYoutubeExtension(),
       Placeholder.configure({
         placeholder: 'Start writing your story...',
       }),

--- a/components/editor/YouTubeEmbedDialog.test.tsx
+++ b/components/editor/YouTubeEmbedDialog.test.tsx
@@ -1,0 +1,97 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { YouTubeEmbedDialog } from '@/components/editor/YouTubeEmbedDialog'
+
+describe('YouTubeEmbedDialog', () => {
+  it('shows an error when submitting an empty URL', async () => {
+    const user = userEvent.setup()
+    const onVideoEmbed = vi.fn(() => true)
+
+    render(
+      <YouTubeEmbedDialog
+        isOpen
+        onClose={vi.fn()}
+        onVideoEmbed={onVideoEmbed}
+      />
+    )
+
+    await user.click(screen.getByLabelText('YouTube URL'))
+    await user.keyboard('{Enter}')
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Please enter a YouTube URL'
+    )
+    expect(onVideoEmbed).not.toHaveBeenCalled()
+  })
+
+  it('shows an error for an invalid URL', async () => {
+    const user = userEvent.setup()
+    const onVideoEmbed = vi.fn(() => true)
+
+    render(
+      <YouTubeEmbedDialog
+        isOpen
+        onClose={vi.fn()}
+        onVideoEmbed={onVideoEmbed}
+      />
+    )
+
+    await user.type(
+      screen.getByLabelText('YouTube URL'),
+      'https://example.com/video'
+    )
+    await user.click(screen.getByRole('button', { name: 'Embed Video' }))
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Please enter a valid YouTube URL'
+    )
+    expect(onVideoEmbed).not.toHaveBeenCalled()
+  })
+
+  it('shows an error when embed command fails and keeps dialog open', async () => {
+    const user = userEvent.setup()
+    const onVideoEmbed = vi.fn(() => false)
+    const onClose = vi.fn()
+
+    render(
+      <YouTubeEmbedDialog
+        isOpen
+        onClose={onClose}
+        onVideoEmbed={onVideoEmbed}
+      />
+    )
+
+    await user.type(
+      screen.getByLabelText('YouTube URL'),
+      'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+    )
+    await user.click(screen.getByRole('button', { name: 'Embed Video' }))
+
+    expect(onVideoEmbed).toHaveBeenCalled()
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Could not embed this video'
+    )
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('clears the error while typing', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <YouTubeEmbedDialog
+        isOpen
+        onClose={vi.fn()}
+        onVideoEmbed={vi.fn(() => true)}
+      />
+    )
+
+    const urlInput = screen.getByLabelText('YouTube URL')
+    await user.click(urlInput)
+    await user.keyboard('{Enter}')
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+
+    await user.type(urlInput, 'https://')
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})

--- a/components/editor/YouTubeEmbedDialog.tsx
+++ b/components/editor/YouTubeEmbedDialog.tsx
@@ -12,11 +12,13 @@ import {
 } from '@/components/ui/dialog'
 
 interface YouTubeEmbedDialogProps {
-  onVideoEmbed: (url: string, width?: number, height?: number) => void
+  onVideoEmbed: (url: string, width?: number, height?: number) => boolean
   onClose: () => void
   isOpen: boolean
   triggerRef?: RefObject<HTMLElement | null>
 }
+
+const YOUTUBE_URL_ERROR_ID = 'youtube-url-error'
 
 function extractYouTubeId(url: string): string | null {
   const patterns = [
@@ -79,11 +81,18 @@ export function YouTubeEmbedDialog({
       return
     }
 
-    onVideoEmbed(
+    const ok = onVideoEmbed(
       videoUrl.trim(),
       customDimensions ? width : undefined,
       customDimensions ? height : undefined
     )
+
+    if (!ok) {
+      setError(
+        'Could not embed this video. Use a youtube.com or youtu.be link.'
+      )
+      return
+    }
 
     handleClose()
   }
@@ -145,12 +154,17 @@ export function YouTubeEmbedDialog({
                 type="url"
                 placeholder="https://www.youtube.com/watch?v=..."
                 value={videoUrl}
-                onChange={(e) => setVideoUrl(e.target.value)}
+                onChange={(e) => {
+                  setVideoUrl(e.target.value)
+                  if (error) setError('')
+                }}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {
                     handleSubmit()
                   }
                 }}
+                aria-invalid={error ? true : undefined}
+                aria-describedby={error ? YOUTUBE_URL_ERROR_ID : undefined}
                 className="w-full pl-10 pr-3 py-2 border border-input bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
               />
             </div>
@@ -263,7 +277,11 @@ export function YouTubeEmbedDialog({
           </div>
 
           {error && (
-            <div className="rounded-lg border border-destructive/25 bg-destructive/10 p-3">
+            <div
+              id={YOUTUBE_URL_ERROR_ID}
+              role="alert"
+              className="rounded-lg border border-destructive/25 bg-destructive/10 p-3"
+            >
               <p className="text-sm text-destructive">{error}</p>
             </div>
           )}

--- a/lib/tiptap/readExtensions.ts
+++ b/lib/tiptap/readExtensions.ts
@@ -4,6 +4,7 @@ import Underline from '@tiptap/extension-underline'
 import Link from '@tiptap/extension-link'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import { lowlight } from '@/lib/lowlight'
+import { createYoutubeExtension } from '@/lib/tiptap/youtubeExtension'
 
 /** Read-only image node matching editor `resizableImage` output (no React node view). */
 const ReadOnlyResizableImage = Node.create({
@@ -43,5 +44,6 @@ export function getReadOnlyExtensions() {
       lowlight,
     }),
     ReadOnlyResizableImage,
+    createYoutubeExtension(),
   ]
 }

--- a/lib/tiptap/youtubeExtension.test.ts
+++ b/lib/tiptap/youtubeExtension.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, afterEach } from 'vitest'
+import { Editor } from '@tiptap/core'
+import { generateHTML } from '@tiptap/html'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+import { createYoutubeExtension } from '@/lib/tiptap/youtubeExtension'
+import { getReadOnlyExtensions } from '@/lib/tiptap/readExtensions'
+
+const SAMPLE_WATCH_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+
+function createYoutubeEditor() {
+  return new Editor({
+    extensions: [Document, Paragraph, Text, createYoutubeExtension()],
+    content: {
+      type: 'doc',
+      content: [{ type: 'paragraph' }],
+    },
+  })
+}
+
+describe('createYoutubeExtension', () => {
+  let editor: Editor | undefined
+
+  afterEach(() => {
+    editor?.destroy()
+    editor = undefined
+  })
+
+  it('inserts a youtube node from a watch URL', () => {
+    editor = createYoutubeEditor()
+    const ok = editor.commands.setYoutubeVideo({ src: SAMPLE_WATCH_URL })
+    expect(ok).toBe(true)
+
+    const json = editor.getJSON()
+    const youtubeNode = json.content?.find((node) => node.type === 'youtube')
+    expect(youtubeNode?.type).toBe('youtube')
+    expect(youtubeNode?.attrs?.src).toBe(SAMPLE_WATCH_URL)
+  })
+
+  it('renders an iframe via generateHTML', () => {
+    editor = createYoutubeEditor()
+    editor.commands.setYoutubeVideo({ src: SAMPLE_WATCH_URL })
+
+    const html = generateHTML(editor.getJSON(), [
+      Document,
+      Paragraph,
+      Text,
+      createYoutubeExtension(),
+    ])
+    expect(html).toContain('<iframe')
+    expect(html).toContain('youtube-nocookie.com/embed/')
+  })
+
+  it('renders youtube nodes with read-only extensions', () => {
+    const content = {
+      type: 'doc',
+      content: [
+        {
+          type: 'youtube',
+          attrs: { src: SAMPLE_WATCH_URL },
+        },
+      ],
+    }
+
+    const html = generateHTML(content, getReadOnlyExtensions())
+    expect(html).toContain('<iframe')
+    expect(html).toMatch(/youtube-nocookie\.com\/embed\/|youtube\.com\/embed\//)
+  })
+})

--- a/lib/tiptap/youtubeExtension.ts
+++ b/lib/tiptap/youtubeExtension.ts
@@ -1,0 +1,14 @@
+import Youtube from '@tiptap/extension-youtube'
+
+export function createYoutubeExtension() {
+  return Youtube.configure({
+    width: 640,
+    height: 480,
+    controls: true,
+    nocookie: true,
+    allowFullscreen: true,
+    HTMLAttributes: {
+      class: 'youtube-embed rounded-lg my-4',
+    },
+  })
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -36,7 +36,7 @@ export function proxy(request: NextRequest) {
       // so there is no per-oracle host to allowlist here.
       "connect-src 'self' *.convex.cloud wss://*.convex.cloud *.convex.site wss://*.convex.site *.stellar.org arweave.net ar-io.dev",
       "font-src 'self'",
-      "frame-src 'self' www.youtube.com",
+      "frame-src 'self' www.youtube.com www.youtube-nocookie.com",
       "frame-ancestors 'none'",
       "form-action 'self'",
       "base-uri 'self'",


### PR DESCRIPTION
## Summary

Fixes ENG-176: writers could submit a valid YouTube URL in the embed dialog, but no video appeared in the editor or on published articles.

- Register `@tiptap/extension-youtube` on the `/write` editor (`WriteEditorWorkspace`), which was missing while the toolbar still exposed the embed control
- Share YouTube extension config via `createYoutubeExtension()` across write, read, and highlight views
- Only close the embed dialog when `setYoutubeVideo` succeeds; show inline errors for invalid URLs and failed embeds
- Render YouTube nodes on published articles (`getReadOnlyExtensions`, `HighlightableArticle`)
- Allow `www.youtube-nocookie.com` in production CSP `frame-src` (matches `nocookie: true` embeds)
- Add responsive iframe styling for editor and article content

<img width="1223" height="719" alt="Screenshot 2026-05-26 at 7 31 47 PM" src="https://github.com/user-attachments/assets/00c560a7-66a2-4c6e-a470-835b0248982b" />

<img width="1218" height="718" alt="Screenshot 2026-05-26 at 7 35 46 PM" src="https://github.com/user-attachments/assets/907209f6-067a-4414-a99e-59b6b34a4c43" />

<img width="1224" height="720" alt="Screenshot 2026-05-26 at 7 35 31 PM" src="https://github.com/user-attachments/assets/fed50e99-de42-489f-91c0-b14de892216d" />
