### PR TITLE
feat(editor): add persistent post-publish success actions (ENG-181)

### DIFF
--- a/components/editor/PublishSuccessPanel.tsx
+++ b/components/editor/PublishSuccessPanel.tsx
@@ -4,7 +4,10 @@ import Link from 'next/link'
 import { ExternalLink, CheckCircle2, Loader2 } from 'lucide-react'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import ShareButtons from '@/components/articles/ShareButtons'
-import { buildArticlePublicPath, buildArticlePublicUrl } from '@/lib/articles/public-url'
+import {
+  buildArticlePublicPath,
+  buildArticlePublicUrl,
+} from '@/lib/articles/public-url'
 
 type PublishSuccessPanelProps = {
   title: string
@@ -26,9 +29,13 @@ export function PublishSuccessPanel({
   onLeave,
 }: PublishSuccessPanelProps) {
   const hasLinkParts = Boolean(username && slug)
-  const publicPath = hasLinkParts ? buildArticlePublicPath(username!, slug!) : null
+  const publicPath = hasLinkParts
+    ? buildArticlePublicPath(username!, slug!)
+    : null
   const publicUrl =
-    hasLinkParts && origin ? buildArticlePublicUrl(origin, username!, slug!) : null
+    hasLinkParts && origin
+      ? buildArticlePublicUrl(origin, username!, slug!)
+      : null
 
   return (
     <Alert className="border-success/30 bg-success/10">
@@ -107,4 +114,3 @@ export function PublishSuccessPanel({
     </Alert>
   )
 }
-

--- a/components/editor/PublishSuccessPanel.tsx
+++ b/components/editor/PublishSuccessPanel.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import Link from 'next/link'
+import { ExternalLink, CheckCircle2, Loader2 } from 'lucide-react'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import ShareButtons from '@/components/articles/ShareButtons'
+import { buildArticlePublicPath, buildArticlePublicUrl } from '@/lib/articles/public-url'
+
+type PublishSuccessPanelProps = {
+  title: string
+  excerpt?: string | null
+  username: string | null
+  slug: string | null
+  origin: string | null
+  onDismiss: () => void
+  onLeave: () => void
+}
+
+export function PublishSuccessPanel({
+  title,
+  excerpt,
+  username,
+  slug,
+  origin,
+  onDismiss,
+  onLeave,
+}: PublishSuccessPanelProps) {
+  const hasLinkParts = Boolean(username && slug)
+  const publicPath = hasLinkParts ? buildArticlePublicPath(username!, slug!) : null
+  const publicUrl =
+    hasLinkParts && origin ? buildArticlePublicUrl(origin, username!, slug!) : null
+
+  return (
+    <Alert className="border-success/30 bg-success/10">
+      <CheckCircle2 className="h-4 w-4 text-success" />
+      <div className="flex min-w-0 flex-col gap-3">
+        <div className="min-w-0">
+          <AlertTitle className="text-success">Article published</AlertTitle>
+          <AlertDescription>
+            {publicUrl ? (
+              <div className="mt-1 min-w-0 font-mono text-xs text-muted-foreground">
+                <span className="block truncate" title={publicUrl}>
+                  {publicUrl}
+                </span>
+              </div>
+            ) : (
+              <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+                <span>Preparing your link…</span>
+              </div>
+            )}
+          </AlertDescription>
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            {publicPath ? (
+              <Link
+                href={publicPath}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+              >
+                View article
+                <ExternalLink className="h-4 w-4" aria-hidden />
+              </Link>
+            ) : (
+              <button
+                type="button"
+                disabled
+                className="inline-flex items-center gap-2 rounded-full bg-muted px-4 py-2 text-sm font-medium text-muted-foreground opacity-70"
+                aria-busy="true"
+              >
+                View article
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              </button>
+            )}
+          </div>
+
+          {publicUrl ? (
+            <ShareButtons
+              title={title}
+              url={publicUrl}
+              excerpt={excerpt}
+              className="min-w-0"
+            />
+          ) : null}
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end sm:gap-3">
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+          >
+            Keep editing this article
+          </button>
+          <button
+            type="button"
+            onClick={onLeave}
+            className="rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+          >
+            Leave editor
+          </button>
+        </div>
+      </div>
+    </Alert>
+  )
+}
+

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -62,6 +62,7 @@ import {
 } from '@/lib/draftBackup'
 import { getWriteUrlWithDraftId } from '@/lib/writeDraftUrl'
 import { isPlaceholderArticleTitle } from '@/convex/lib/articleTitle'
+import { PublishSuccessPanel } from '@/components/editor/PublishSuccessPanel'
 
 const PUBLISH_EXCERPT_PREVIEW_MAX = 280
 const ARTICLE_TITLE_ERROR_ID = 'article-title-error'
@@ -153,6 +154,11 @@ export function WriteEditorWorkspace() {
     published: false,
     publishedAt: null,
   })
+  const [publishSuccessVisible, setPublishSuccessVisible] = useState(false)
+  const [publishedSlugOverride, setPublishedSlugOverride] = useState<
+    string | null
+  >(null)
+  const [pageOrigin, setPageOrigin] = useState<string | null>(null)
   const [publishConfirmOpen, setPublishConfirmOpen] = useState(false)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
@@ -170,6 +176,10 @@ export function WriteEditorWorkspace() {
   const hydratedDraftIdRef = useRef<string | null>(null)
 
   const draftIdParam = searchParams.get('id')
+
+  useEffect(() => {
+    setPageOrigin(window.location.origin)
+  }, [])
 
   const syncDraftIdInUrl = useCallback(
     (id: string) => {
@@ -576,12 +586,14 @@ export function WriteEditorWorkspace() {
       await saveNow()
 
       let resultId: string
+      let publishedSlug: string | undefined
 
       if (articleId) {
         const published = await publishArticleMutation({
           id: articleId as Id<'articles'>,
         })
         resultId = published.id
+        publishedSlug = published.slug
       } else {
         resultId = await createArticleMutation({
           title: title.trim(),
@@ -606,7 +618,8 @@ export function WriteEditorWorkspace() {
         publishedAt: new Date(),
       })
 
-      toast.success('Article published successfully!')
+      if (publishedSlug) setPublishedSlugOverride(publishedSlug)
+      setPublishSuccessVisible(true)
     } catch (error) {
       console.error('Publish error:', error)
       const message = error instanceof Error ? error.message : 'Unknown error'
@@ -956,6 +969,12 @@ export function WriteEditorWorkspace() {
         ? excerptTrimmed
         : `${excerptTrimmed.slice(0, PUBLISH_EXCERPT_PREVIEW_MAX).trimEnd()}...`
 
+  const publishUsername =
+    savedArticleForLink?.authorUsername ??
+    savedArticleForLink?.author?.username ??
+    null
+  const publishSlug = publishedSlugOverride ?? savedArticleForLink?.slug ?? null
+
   return (
     <div className="flex flex-col pt-16">
       <EditorActionBar
@@ -975,6 +994,28 @@ export function WriteEditorWorkspace() {
         isDeleting={isDeleting}
         hasUnsavedChanges={hasUnsavedChanges}
       />
+      {publishSuccessVisible ? (
+        <div className="mx-auto w-full max-w-4xl px-4 pt-4 sm:px-6">
+          <PublishSuccessPanel
+            title={title.trim() || 'Untitled'}
+            excerpt={excerptTrimmed.length ? excerptTrimmed : null}
+            username={publishUsername}
+            slug={publishSlug}
+            origin={pageOrigin}
+            onDismiss={() => {
+              setPublishSuccessVisible(false)
+              queueMicrotask(() => {
+                const titleEl = document.getElementById(
+                  'article-title'
+                ) as HTMLTextAreaElement | null
+                if (titleEl) titleEl.focus()
+                else editor?.commands.focus()
+              })
+            }}
+            onLeave={handleBack}
+          />
+        </div>
+      ) : null}
       <div className="flex min-w-0 flex-1 flex-col pb-8">
         <div className="sticky top-16 z-40 mb-6 w-full bg-background">
           <div className="mx-auto w-full max-w-4xl px-4 sm:px-6">

--- a/lib/articles/public-url.test.ts
+++ b/lib/articles/public-url.test.ts
@@ -11,10 +11,11 @@ describe('buildArticlePublicPath', () => {
 
 describe('buildArticlePublicUrl', () => {
   it('builds an absolute URL and trims trailing slashes', () => {
-    expect(buildArticlePublicUrl('https://example.com', 'alice', 'hello-world'))
-      .toBe('https://example.com/alice/hello-world')
-    expect(buildArticlePublicUrl('https://example.com/', 'alice', 'hello-world'))
-      .toBe('https://example.com/alice/hello-world')
+    expect(
+      buildArticlePublicUrl('https://example.com', 'alice', 'hello-world')
+    ).toBe('https://example.com/alice/hello-world')
+    expect(
+      buildArticlePublicUrl('https://example.com/', 'alice', 'hello-world')
+    ).toBe('https://example.com/alice/hello-world')
   })
 })
-

--- a/lib/articles/public-url.test.ts
+++ b/lib/articles/public-url.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { buildArticlePublicPath, buildArticlePublicUrl } from './public-url'
+
+describe('buildArticlePublicPath', () => {
+  it('builds /{username}/{slug}', () => {
+    expect(buildArticlePublicPath('alice', 'hello-world')).toBe(
+      '/alice/hello-world'
+    )
+  })
+})
+
+describe('buildArticlePublicUrl', () => {
+  it('builds an absolute URL and trims trailing slashes', () => {
+    expect(buildArticlePublicUrl('https://example.com', 'alice', 'hello-world'))
+      .toBe('https://example.com/alice/hello-world')
+    expect(buildArticlePublicUrl('https://example.com/', 'alice', 'hello-world'))
+      .toBe('https://example.com/alice/hello-world')
+  })
+})
+

--- a/lib/articles/public-url.ts
+++ b/lib/articles/public-url.ts
@@ -1,0 +1,13 @@
+export function buildArticlePublicPath(username: string, slug: string): string {
+  return `/${username}/${slug}`
+}
+
+export function buildArticlePublicUrl(
+  origin: string,
+  username: string,
+  slug: string
+): string {
+  const base = origin.replace(/\/$/, '')
+  return `${base}${buildArticlePublicPath(username, slug)}`
+}
+

--- a/lib/articles/public-url.ts
+++ b/lib/articles/public-url.ts
@@ -10,4 +10,3 @@ export function buildArticlePublicUrl(
   const base = origin.replace(/\/$/, '')
   return `${base}${buildArticlePublicPath(username, slug)}`
 }
-


### PR DESCRIPTION
## Summary

After publishing, writers now see a persistent success panel on `/write` with clear next steps: view the live article, copy the link, share, keep editing, or leave the editor. The transient success toast was removed so success feedback stays on screen until the writer dismisses it or navigates away.



## Changes

- Add `PublishSuccessPanel` with:
  - **View article** (opens `/{username}/{slug}` in a new tab)
  - **Copy link** and **share** actions (reuses `ShareButtons`)
  - **Keep editing this article** (dismisses panel, returns focus to editor)
  - **Leave editor** (uses existing back + unsaved-changes confirm flow)
- Wire panel in `WriteEditorWorkspace` after a successful publish only (not when reopening an already-published article)
- Capture `slug` from `publishArticle` response for immediate correct links when slug is fixed at publish time
- Add `buildArticlePublicPath` / `buildArticlePublicUrl` helpers in `lib/articles/public-url.ts`
- Remove `toast.success('Article published successfully!')` in favor of the persistent panel

<img width="1222" height="721" alt="Screenshot 2026-05-26 at 8 18 02 PM" src="https://github.com/user-attachments/assets/d1e56d82-454c-4220-9575-0cb5d598bf14" />
