### PR TITLE
feat(auth): post-login return paths, tip resume, and onboarding destinations (ENG-141)

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,17 +1,17 @@
-import Link from 'next/link'
+import { Suspense } from 'react'
 import LoginForm from '@/components/auth/LoginForm'
+import { AuthReturnLinks } from '@/components/auth/AuthReturnLinks'
 
 /**
  * Login Page
  *
  * Provides user login functionality with email and password.
- * Integrates with NextAuth for authentication.
+ * Integrates with Convex Auth for authentication.
  */
 
 export default function LoginPage() {
   return (
     <div className="space-y-6">
-      {/* Page Header */}
       <div className="text-center">
         <h2 className="text-2xl font-bold text-foreground">
           Sign in to your account
@@ -21,21 +21,11 @@ export default function LoginPage() {
         </p>
       </div>
 
-      {/* Login Form */}
-      <LoginForm />
+      <Suspense fallback={null}>
+        <LoginForm />
+      </Suspense>
 
-      {/* Registration Link */}
-      <div className="text-center">
-        <p className="text-sm text-muted-foreground">
-          Don&apos;t have an account?{' '}
-          <Link
-            href="/register"
-            className="font-medium text-brand-blue hover:text-brand-accent transition-colors"
-          >
-            Sign up for free
-          </Link>
-        </p>
-      </div>
+      <AuthReturnLinks variant="login" />
     </div>
   )
 }

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,5 +1,6 @@
-import Link from 'next/link'
+import { Suspense } from 'react'
 import RegisterForm from '@/components/auth/RegisterForm'
+import { AuthReturnLinks } from '@/components/auth/AuthReturnLinks'
 
 /**
  * Registration Page
@@ -11,7 +12,6 @@ import RegisterForm from '@/components/auth/RegisterForm'
 export default function RegisterPage() {
   return (
     <div className="space-y-6">
-      {/* Page Header */}
       <div className="text-center">
         <h2 className="text-2xl font-bold text-foreground">
           Create your account
@@ -21,21 +21,11 @@ export default function RegisterPage() {
         </p>
       </div>
 
-      {/* Registration Form */}
-      <RegisterForm />
+      <Suspense fallback={null}>
+        <RegisterForm />
+      </Suspense>
 
-      {/* Login Link */}
-      <div className="text-center">
-        <p className="text-sm text-muted-foreground">
-          Already have an account?{' '}
-          <Link
-            href="/login"
-            className="font-medium text-brand-blue hover:text-brand-accent transition-colors"
-          >
-            Sign in here
-          </Link>
-        </p>
-      </div>
+      <AuthReturnLinks variant="register" />
     </div>
   )
 }

--- a/app/[username]/[slug]/page.tsx
+++ b/app/[username]/[slug]/page.tsx
@@ -3,6 +3,7 @@
 import nextDynamic from 'next/dynamic'
 import { notFound } from 'next/navigation'
 import { use, useState, useMemo } from 'react'
+import { ArticleTipActions } from '@/components/tipping/ArticleTipActions'
 import {
   useArticleBySlug,
   useArticleHighlightTipStatsOptional,
@@ -13,19 +14,7 @@ import { ArticlePageLoadingSkeleton } from '@/components/articles/ArticlePageLoa
 import AppNavigation from '@/components/layout/AppNavigation'
 import { SiteFooter } from '@/components/layout/SiteFooter'
 import { TipStats } from '@/components/tipping/TipStats'
-import { PendingTipResume } from '@/components/tipping/PendingTipResume'
-import {
-  TipButtonSkeleton,
-  NftSidebarSkeleton,
-} from '@/components/articles/ArticleEngagementSkeleton'
-
-const TipButton = nextDynamic(
-  () =>
-    import('@/components/tipping/TipButton').then((mod) => ({
-      default: mod.TipButton,
-    })),
-  { ssr: false, loading: () => <TipButtonSkeleton /> }
-)
+import { NftSidebarSkeleton } from '@/components/articles/ArticleEngagementSkeleton'
 
 const NFTIntegration = nextDynamic(
   () =>
@@ -143,6 +132,7 @@ export default function ArticlePage({ params }: ArticlePageProps) {
                 <ArticleDisplay
                   article={articleForDisplay}
                   tocHeadings={tocHeadings}
+                  authorStellarAddress={article.author.stellarAddress}
                 />
               </ErrorBoundary>
             </div>
@@ -162,14 +152,7 @@ export default function ArticlePage({ params }: ArticlePageProps) {
                       <Heart className="w-5 h-5 text-red-500" />
                       Support the Author
                     </h3>
-                    <TipButton
-                      articleId={article._id}
-                      authorName={
-                        article.author.name || article.author.username
-                      }
-                      authorStellarAddress={article.author.stellarAddress}
-                    />
-                    <PendingTipResume
+                    <ArticleTipActions
                       articleId={article._id}
                       articleSlug={article.slug}
                       authorName={

--- a/app/[username]/[slug]/page.tsx
+++ b/app/[username]/[slug]/page.tsx
@@ -13,6 +13,7 @@ import { ArticlePageLoadingSkeleton } from '@/components/articles/ArticlePageLoa
 import AppNavigation from '@/components/layout/AppNavigation'
 import { SiteFooter } from '@/components/layout/SiteFooter'
 import { TipStats } from '@/components/tipping/TipStats'
+import { PendingTipResume } from '@/components/tipping/PendingTipResume'
 import {
   TipButtonSkeleton,
   NftSidebarSkeleton,
@@ -163,6 +164,14 @@ export default function ArticlePage({ params }: ArticlePageProps) {
                     </h3>
                     <TipButton
                       articleId={article._id}
+                      authorName={
+                        article.author.name || article.author.username
+                      }
+                      authorStellarAddress={article.author.stellarAddress}
+                    />
+                    <PendingTipResume
+                      articleId={article._id}
+                      articleSlug={article.slug}
                       authorName={
                         article.author.name || article.author.username
                       }

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -23,6 +23,18 @@ interface ProfilePageProps {
 
 type TabType = 'articles' | 'nfts' | 'earnings' | 'stats' | 'wallet'
 
+const PROFILE_TAB_IDS: TabType[] = [
+  'articles',
+  'nfts',
+  'wallet',
+  'earnings',
+  'stats',
+]
+
+function isProfileTab(value: string | null): value is TabType {
+  return value !== null && PROFILE_TAB_IDS.includes(value as TabType)
+}
+
 export default function ProfilePage({ params }: ProfilePageProps) {
   const { username } = use(params)
   const searchParams = useSearchParams()
@@ -42,6 +54,13 @@ export default function ProfilePage({ params }: ProfilePageProps) {
   const nftMintedPage = parsePositivePage(
     searchParams?.get('nftMintedPage') ?? null
   )
+
+  useEffect(() => {
+    const tab = searchParams?.get('tab') ?? null
+    if (isProfileTab(tab)) {
+      setActiveTab(tab)
+    }
+  }, [searchParams])
 
   // Fetch user profile
   const user = useUserByUsername(username)

--- a/app/drafts/page.tsx
+++ b/app/drafts/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useState } from 'react'
 import { useAuth } from '@/components/providers/AuthContext'
+import { useRedirectWhenUnauthenticated } from '@/hooks/useRedirectWhenUnauthenticated'
 import Link from 'next/link'
 import AppNavigation from '@/components/layout/AppNavigation'
 import { useMutation } from 'convex/react'
@@ -34,8 +34,9 @@ import { Loader2, MoreHorizontal, Pencil, Trash2 } from 'lucide-react'
 import { mutationWithTimeout } from '@/lib/convexMutationWithTimeout'
 
 export default function DraftsPage() {
-  const router = useRouter()
   const { isAuthenticated, isLoading } = useAuth()
+
+  useRedirectWhenUnauthenticated(isLoading, isAuthenticated)
 
   const draftsQuery = useUserDrafts()
   const loading = draftsQuery === undefined
@@ -60,11 +61,6 @@ export default function DraftsPage() {
       setIsDeleting(false)
     }
   }
-
-  useEffect(() => {
-    if (isLoading || isAuthenticated) return
-    router.replace('/login')
-  }, [isLoading, isAuthenticated, router])
 
   if (isLoading) {
     return (

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/components/providers/AuthContext'
+import { buildLoginHref } from '@/lib/auth/safeReturnPath'
+import AppNavigation from '@/components/layout/AppNavigation'
+import { Skeleton } from '@/components/ui/skeleton'
+
+const WALLET_RETURN_PATH = '/profile?tab=wallet'
+
+export default function ProfilePage() {
+  const router = useRouter()
+  const { user, isAuthenticated, isLoading } = useAuth()
+
+  useEffect(() => {
+    if (isLoading) return
+    if (isAuthenticated && user?.username) {
+      router.replace(`/${user.username}?tab=wallet`)
+      return
+    }
+    if (!isAuthenticated) {
+      router.replace(buildLoginHref(WALLET_RETURN_PATH))
+    }
+  }, [isAuthenticated, isLoading, router, user?.username])
+
+  return (
+    <div className="min-h-screen bg-background">
+      <AppNavigation />
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12">
+        <Skeleton className="h-9 w-48 mb-8" />
+        <Skeleton className="h-64 w-full max-w-2xl" />
+      </div>
+    </div>
+  )
+}

--- a/app/write/page.tsx
+++ b/app/write/page.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import { useEffect } from 'react'
-import { useRouter } from 'next/navigation'
 import { useAuth } from '@/components/providers/AuthContext'
+import { useRedirectWhenUnauthenticated } from '@/hooks/useRedirectWhenUnauthenticated'
 import AppNavigation from '@/components/layout/AppNavigation'
 import { EditorChromeSkeleton } from '@/components/editor/EditorChromeSkeleton'
 import { ErrorBoundary } from '@/components/error/ErrorBoundary'
@@ -10,13 +9,9 @@ import { EditorWorkspaceErrorFallback } from '@/components/error/SectionErrorFal
 import { WriteEditorWorkspace } from '@/components/editor/WriteEditorWorkspace'
 
 export default function WritePage() {
-  const router = useRouter()
   const { isAuthenticated, isLoading } = useAuth()
 
-  useEffect(() => {
-    if (isLoading || isAuthenticated) return
-    router.replace('/login')
-  }, [isLoading, isAuthenticated, router])
+  useRedirectWhenUnauthenticated(isLoading, isAuthenticated)
 
   if (isLoading) {
     return (

--- a/components/articles/ArticleDisplay.tsx
+++ b/components/articles/ArticleDisplay.tsx
@@ -9,7 +9,6 @@ import { UserAvatar } from '@/components/ui/user-avatar'
 import ShareButtons from './ShareButtons'
 import { ArticleReadOnlyBody } from '@/components/articles/ArticleReadOnlyBody'
 import { ArticleBodySkeleton } from '@/components/articles/ArticleBodySkeleton'
-
 const HighlightableArticle = dynamic(
   () =>
     import('@/components/articles/HighlightableArticle').then((mod) => ({
@@ -29,12 +28,14 @@ const EMPTY_DOC: JSONContent = { type: 'doc', content: [] }
 
 interface ArticleDisplayProps {
   article: ArticleForDisplay
+  authorStellarAddress?: string | null
   showHighlights?: boolean
   tocHeadings?: TocHeading[]
 }
 
 export default function ArticleDisplay({
   article,
+  authorStellarAddress,
   showHighlights = true,
   tocHeadings = [],
 }: ArticleDisplayProps) {
@@ -119,13 +120,15 @@ export default function ArticleDisplay({
 
       <div className="article-content">
         {showHighlights ? (
-          <HighlightableArticle
-            articleId={article.id as Id<'articles'>}
-            content={article.content ?? EMPTY_DOC}
-            editable={false}
-            showHighlights={showHighlights}
-            tocHeadings={tocHeadings}
-          />
+          <>
+            <HighlightableArticle
+              articleId={article.id as Id<'articles'>}
+              content={article.content ?? EMPTY_DOC}
+              editable={false}
+              showHighlights={showHighlights}
+              tocHeadings={tocHeadings}
+            />
+          </>
         ) : (
           <ArticleReadOnlyBody
             content={article.content ?? EMPTY_DOC}

--- a/components/articles/ArticleDisplay.tsx
+++ b/components/articles/ArticleDisplay.tsx
@@ -35,7 +35,7 @@ interface ArticleDisplayProps {
 
 export default function ArticleDisplay({
   article,
-  authorStellarAddress,
+  authorStellarAddress: _authorStellarAddress,
   showHighlights = true,
   tocHeadings = [],
 }: ArticleDisplayProps) {

--- a/components/articles/HighlightableArticle.tsx
+++ b/components/articles/HighlightableArticle.tsx
@@ -45,7 +45,6 @@ import {
   writePendingHighlightSelection,
 } from '@/lib/highlight/pendingHighlightSelection'
 import {
-  clearPendingTipIntent,
   matchesHighlightPendingIntent,
   readPendingTipIntent,
 } from '@/lib/tip/pendingTipIntent'
@@ -142,12 +141,7 @@ export function HighlightableArticle({
   const createHighlight = useMutation(api.highlights.createHighlight)
 
   const applySignedOutTextSelection = useCallback(
-    (
-      text: string,
-      from: number,
-      to: number,
-      range: Range
-    ) => {
+    (text: string, from: number, to: number, range: Range) => {
       const anchor = getRangeTopCenterAnchor(range)
       if (!anchor) return
 
@@ -375,7 +369,9 @@ export function HighlightableArticle({
     // Clear storage only after we can observe the popover in the DOM.
     const raf1 = requestAnimationFrame(() => {
       const raf2 = requestAnimationFrame(() => {
-        const popover = document.querySelector('[data-testid="highlight-popover"]')
+        const popover = document.querySelector(
+          '[data-testid="highlight-popover"]'
+        )
         if (popover) {
           clearPendingHighlightSelection()
           pendingSelectionNeedsClearRef.current = false
@@ -558,25 +554,26 @@ export function HighlightableArticle({
         {popoverPosition &&
           selectedText &&
           article &&
-          (highlightsActive ||
-            (signInPromptActive && canTipHighlight)) && (
-          <HighlightPopover
-            position={popoverPosition}
-            onCreateHighlight={handleCreateHighlight}
-            onClose={handlePopoverClose}
-            selectedText={selectedText.text}
-            articleId={articleId}
-            articleSlug={article.slug}
-            authorName={article.author?.name || article.authorName || 'Author'}
-            authorStellarAddress={article.author?.stellarAddress}
-            startOffset={selectedText.from}
-            endOffset={selectedText.to}
-            resumeHighlightTip={resumeHighlightTip}
-            onHighlightTipResumeOpened={() => {
-              setResumeHighlightTip(null)
-            }}
-          />
-        )}
+          (highlightsActive || (signInPromptActive && canTipHighlight)) && (
+            <HighlightPopover
+              position={popoverPosition}
+              onCreateHighlight={handleCreateHighlight}
+              onClose={handlePopoverClose}
+              selectedText={selectedText.text}
+              articleId={articleId}
+              articleSlug={article.slug}
+              authorName={
+                article.author?.name || article.authorName || 'Author'
+              }
+              authorStellarAddress={article.author?.stellarAddress}
+              startOffset={selectedText.from}
+              endOffset={selectedText.to}
+              resumeHighlightTip={resumeHighlightTip}
+              onHighlightTipResumeOpened={() => {
+                setResumeHighlightTip(null)
+              }}
+            />
+          )}
       </AnimatePresence>
 
       <AnimatePresence>
@@ -584,14 +581,14 @@ export function HighlightableArticle({
           signInPromptPosition &&
           signInSelection &&
           !canTipHighlight && (
-          <HighlightSignInPrompt
-            position={signInPromptPosition}
-            selectedText={signInSelection.text}
-            returnPath={returnPath}
-            onBeforeAuthNavigate={saveHighlightSelectionBeforeAuth}
-            onClose={handleSignInPromptClose}
-          />
-        )}
+            <HighlightSignInPrompt
+              position={signInPromptPosition}
+              selectedText={signInSelection.text}
+              returnPath={returnPath}
+              onBeforeAuthNavigate={saveHighlightSelectionBeforeAuth}
+              onClose={handleSignInPromptClose}
+            />
+          )}
       </AnimatePresence>
 
       <AnimatePresence>

--- a/components/articles/HighlightableArticle.tsx
+++ b/components/articles/HighlightableArticle.tsx
@@ -1,7 +1,13 @@
 'use client'
 
 import { useEffect, useState, useCallback, useRef } from 'react'
-import { useEditor, EditorContent, type JSONContent } from '@tiptap/react'
+import { usePathname, useSearchParams } from 'next/navigation'
+import {
+  useEditor,
+  EditorContent,
+  type Editor,
+  type JSONContent,
+} from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
 import Link from '@tiptap/extension-link'
@@ -24,20 +30,25 @@ import { useAuth } from '@/components/providers/AuthContext'
 import { toast } from 'sonner'
 import { EDITOR_PROSE_CLASS } from '@/lib/constants'
 import { handleArticleHighlightOverlayPointerDown } from '@/lib/highlights/articleOverlayPointerDismiss'
-import { getRangeBoundingBox } from '@/lib/highlights/utils'
+import { getRangeTopCenterAnchor } from '@/lib/highlights/utils'
+import {
+  applyPendingHighlightToEditor,
+  readPendingHighlightPopoverAnchor,
+  shouldKeepTryingHighlightSelectionResume,
+} from '@/lib/highlight/resumePendingHighlightSelection'
 import type { TocHeading } from '@/lib/tiptap/headings'
 import { useEnsureHeadingIds } from '@/components/articles/useEnsureHeadingIds'
-
-function getRangeTopCenterAnchor(
-  range: Range
-): { top: number; left: number } | null {
-  const box = getRangeBoundingBox(range)
-  if (!box) return null
-  return {
-    top: box.top,
-    left: box.left + box.width / 2,
-  }
-}
+import { getCurrentReturnPath } from '@/lib/auth/safeReturnPath'
+import {
+  clearPendingHighlightSelection,
+  readPendingHighlightSelection,
+  writePendingHighlightSelection,
+} from '@/lib/highlight/pendingHighlightSelection'
+import {
+  clearPendingTipIntent,
+  matchesHighlightPendingIntent,
+  readPendingTipIntent,
+} from '@/lib/tip/pendingTipIntent'
 
 interface HighlightData {
   _id: Id<'highlights'>
@@ -92,22 +103,34 @@ export function HighlightableArticle({
     top: number
     left: number
   } | null>(null)
-  const [signInPreviewText, setSignInPreviewText] = useState<string | null>(
-    null
-  )
+  const [signInSelection, setSignInSelection] = useState<{
+    text: string
+    from: number
+    to: number
+  } | null>(null)
   const editorRef = useRef<HTMLDivElement>(null)
   const isApplyingHighlightsRef = useRef(false)
+  const selectionRestoredEditorRef = useRef<Editor | null>(null)
+  const [resumeHighlightTip, setResumeHighlightTip] = useState<{
+    amountCents?: number
+    customAmount?: string
+  } | null>(null)
+  const pendingSelectionNeedsClearRef = useRef(false)
   // During a drag, onSelectionUpdate fires on every move; if we mount the
   // popover at 3 chars, HighlightPopover's FocusScope trap steals focus from
   // the article body and the native selection collapses. Defer popover to pointerup.
   const isDraggingRef = useRef(false)
 
   const { user, isAuthenticated } = useAuth()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const returnPath = getCurrentReturnPath(pathname, searchParams)
   const highlightsActive = showHighlights && isAuthenticated
   const signInPromptActive = showHighlights && !isAuthenticated
 
   useEnsureHeadingIds(tocHeadings, { rootSelector: '.highlightable-article' })
   const article = useArticleById(articleId)
+  const canTipHighlight = Boolean(article?.author?.stellarAddress)
 
   const highlights = useArticleHighlightsQuery(articleId, highlightsActive)
 
@@ -117,6 +140,30 @@ export function HighlightableArticle({
   }, [highlights])
 
   const createHighlight = useMutation(api.highlights.createHighlight)
+
+  const applySignedOutTextSelection = useCallback(
+    (
+      text: string,
+      from: number,
+      to: number,
+      range: Range
+    ) => {
+      const anchor = getRangeTopCenterAnchor(range)
+      if (!anchor) return
+
+      if (canTipHighlight) {
+        setSelectedText({ text, from, to })
+        setPopoverPosition(anchor)
+        setSignInSelection(null)
+      } else {
+        setSignInSelection({ text, from, to })
+        setSignInPromptPosition(anchor)
+        setSelectedText(null)
+        setPopoverPosition(null)
+      }
+    },
+    [canTipHighlight]
+  )
 
   const editor = useEditor(
     {
@@ -210,13 +257,7 @@ export function HighlightableArticle({
             const range = domSelection.getRangeAt(0)
 
             if (signInPromptActive) {
-              const anchor = getRangeTopCenterAnchor(range)
-              if (anchor) {
-                setSignInPreviewText(text)
-                setSignInPromptPosition(anchor)
-              }
-              setSelectedText(null)
-              setPopoverPosition(null)
+              applySignedOutTextSelection(text, from, to, range)
             } else if (highlightsActive) {
               const rect = range.getBoundingClientRect()
               const containerRect = editorRef.current?.getBoundingClientRect()
@@ -228,19 +269,26 @@ export function HighlightableArticle({
                   left: rect.left - containerRect.left + rect.width / 2,
                 })
               }
-              setSignInPreviewText(null)
+              setSignInSelection(null)
               setSignInPromptPosition(null)
             }
           }
         } else {
           setSelectedText(null)
           setPopoverPosition(null)
-          setSignInPreviewText(null)
+          setSignInSelection(null)
           setSignInPromptPosition(null)
         }
       },
     },
-    [showHighlights, highlightsActive, signInPromptActive, editable, articleId]
+    [
+      showHighlights,
+      highlightsActive,
+      signInPromptActive,
+      editable,
+      articleId,
+      applySignedOutTextSelection,
+    ]
   )
 
   useEffect(() => {
@@ -248,17 +296,95 @@ export function HighlightableArticle({
       setSelectedText(null)
       setPopoverPosition(null)
       setHighlightTooltip(null)
-      setSignInPreviewText(null)
+      setSignInSelection(null)
       setSignInPromptPosition(null)
     }
   }, [showHighlights])
 
   useEffect(() => {
-    if (isAuthenticated) {
-      setSignInPreviewText(null)
-      setSignInPromptPosition(null)
+    if (!isAuthenticated || !highlightsActive || !editor) return
+
+    const pending = readPendingHighlightSelection()
+    if (
+      !shouldKeepTryingHighlightSelectionResume(
+        pending,
+        String(articleId),
+        selectionRestoredEditorRef.current,
+        editor
+      )
+    ) {
+      return
     }
-  }, [isAuthenticated])
+
+    let cancelled = false
+
+    const tryRestoreSelection = (): boolean => {
+      if (cancelled || !pending) return true
+      if (selectionRestoredEditorRef.current === editor) return true
+
+      applyPendingHighlightToEditor(editor, pending)
+
+      const anchor = readPendingHighlightPopoverAnchor(editor)
+      if (!anchor) return false
+
+      selectionRestoredEditorRef.current = editor
+      pendingSelectionNeedsClearRef.current = true
+      setSelectedText({
+        text: pending.highlightText,
+        from: pending.startOffset,
+        to: pending.endOffset,
+      })
+      setPopoverPosition(anchor)
+      setSignInSelection(null)
+      setSignInPromptPosition(null)
+
+      const tipIntent = readPendingTipIntent()
+      if (matchesHighlightPendingIntent(tipIntent, articleId)) {
+        setResumeHighlightTip({
+          amountCents: tipIntent.amountCents,
+          customAmount: tipIntent.customAmount,
+        })
+      }
+
+      return true
+    }
+
+    if (tryRestoreSelection()) return
+
+    const intervalId = window.setInterval(() => {
+      if (tryRestoreSelection()) {
+        window.clearInterval(intervalId)
+      }
+    }, 100)
+
+    const timeoutId = window.setTimeout(() => {
+      window.clearInterval(intervalId)
+    }, 15_000)
+
+    return () => {
+      cancelled = true
+      window.clearInterval(intervalId)
+      window.clearTimeout(timeoutId)
+    }
+  }, [isAuthenticated, highlightsActive, articleId, editor])
+
+  useEffect(() => {
+    if (!pendingSelectionNeedsClearRef.current) return
+    if (!popoverPosition || !selectedText) return
+
+    // Clear storage only after we can observe the popover in the DOM.
+    const raf1 = requestAnimationFrame(() => {
+      const raf2 = requestAnimationFrame(() => {
+        const popover = document.querySelector('[data-testid="highlight-popover"]')
+        if (popover) {
+          clearPendingHighlightSelection()
+          pendingSelectionNeedsClearRef.current = false
+        }
+      })
+      return () => cancelAnimationFrame(raf2)
+    })
+    return () => cancelAnimationFrame(raf1)
+  }, [popoverPosition, selectedText])
 
   useEffect(() => {
     if (!editor || !highlights || !highlightsActive) return
@@ -283,12 +409,12 @@ export function HighlightableArticle({
           isDraggingRef.current = true
           setSelectedText(null)
           setPopoverPosition(null)
-          setSignInPreviewText(null)
+          setSignInSelection(null)
           setSignInPromptPosition(null)
         },
         closeDetailsPanel: () => setHighlightTooltip(null),
         closeSignInPrompt: () => {
-          setSignInPreviewText(null)
+          setSignInSelection(null)
           setSignInPromptPosition(null)
         },
       })
@@ -310,14 +436,11 @@ export function HighlightableArticle({
         if (!anchor) return
 
         if (signInPromptActive) {
-          setSignInPreviewText(text)
-          setSignInPromptPosition(anchor)
-          setSelectedText(null)
-          setPopoverPosition(null)
+          applySignedOutTextSelection(text, from, to, range)
         } else if (highlightsActive) {
           setSelectedText({ text, from, to })
           setPopoverPosition(anchor)
-          setSignInPreviewText(null)
+          setSignInSelection(null)
           setSignInPromptPosition(null)
         }
       })
@@ -336,7 +459,14 @@ export function HighlightableArticle({
       document.removeEventListener('mouseup', handlePointerUp)
       document.removeEventListener('touchend', handlePointerUp)
     }
-  }, [editor, editable, showHighlights, highlightsActive, signInPromptActive])
+  }, [
+    editor,
+    editable,
+    showHighlights,
+    highlightsActive,
+    signInPromptActive,
+    applySignedOutTextSelection,
+  ])
 
   const handleCreateHighlight = useCallback(
     async (color: string, note?: string, isPublic: boolean = true) => {
@@ -401,11 +531,21 @@ export function HighlightableArticle({
         editor.chain().setTextSelection(from).run()
       }
     }
-    setSignInPreviewText(null)
+    setSignInSelection(null)
     setSignInPromptPosition(null)
     window.getSelection()?.removeAllRanges()
     editor?.commands.focus()
   }, [editor])
+
+  const saveHighlightSelectionBeforeAuth = useCallback(() => {
+    if (!signInSelection) return
+    writePendingHighlightSelection({
+      articleId: String(articleId),
+      highlightText: signInSelection.text,
+      startOffset: signInSelection.from,
+      endOffset: signInSelection.to,
+    })
+  }, [articleId, signInSelection])
 
   return (
     <div
@@ -415,7 +555,11 @@ export function HighlightableArticle({
       <EditorContent editor={editor} />
 
       <AnimatePresence>
-        {highlightsActive && popoverPosition && selectedText && article && (
+        {popoverPosition &&
+          selectedText &&
+          article &&
+          (highlightsActive ||
+            (signInPromptActive && canTipHighlight)) && (
           <HighlightPopover
             position={popoverPosition}
             onCreateHighlight={handleCreateHighlight}
@@ -427,15 +571,24 @@ export function HighlightableArticle({
             authorStellarAddress={article.author?.stellarAddress}
             startOffset={selectedText.from}
             endOffset={selectedText.to}
+            resumeHighlightTip={resumeHighlightTip}
+            onHighlightTipResumeOpened={() => {
+              setResumeHighlightTip(null)
+            }}
           />
         )}
       </AnimatePresence>
 
       <AnimatePresence>
-        {signInPromptActive && signInPromptPosition && signInPreviewText && (
+        {signInPromptActive &&
+          signInPromptPosition &&
+          signInSelection &&
+          !canTipHighlight && (
           <HighlightSignInPrompt
             position={signInPromptPosition}
-            selectedText={signInPreviewText}
+            selectedText={signInSelection.text}
+            returnPath={returnPath}
+            onBeforeAuthNavigate={saveHighlightSelectionBeforeAuth}
             onClose={handleSignInPromptClose}
           />
         )}

--- a/components/auth/AuthReturnLinks.tsx
+++ b/components/auth/AuthReturnLinks.tsx
@@ -8,6 +8,7 @@ import {
   buildRegisterHref,
   getSafeReturnPath,
 } from '@/lib/auth/safeReturnPath'
+import { clearPendingHighlightSelection } from '@/lib/highlight/pendingHighlightSelection'
 import { clearPendingTipIntent } from '@/lib/tip/pendingTipIntent'
 
 function AuthReturnLinksInner({ variant }: { variant: 'login' | 'register' }) {
@@ -16,6 +17,7 @@ function AuthReturnLinksInner({ variant }: { variant: 'login' | 'register' }) {
 
   const handleCancel = () => {
     clearPendingTipIntent()
+    clearPendingHighlightSelection()
   }
 
   if (variant === 'login') {

--- a/components/auth/AuthReturnLinks.tsx
+++ b/components/auth/AuthReturnLinks.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { Suspense } from 'react'
+import {
+  buildLoginHref,
+  buildRegisterHref,
+  getSafeReturnPath,
+} from '@/lib/auth/safeReturnPath'
+import { clearPendingTipIntent } from '@/lib/tip/pendingTipIntent'
+
+function AuthReturnLinksInner({
+  variant,
+}: {
+  variant: 'login' | 'register'
+}) {
+  const searchParams = useSearchParams()
+  const returnTo = getSafeReturnPath(searchParams.get('returnTo'))
+
+  const handleCancel = () => {
+    clearPendingTipIntent()
+  }
+
+  if (variant === 'login') {
+    return (
+      <div className="space-y-4">
+        <div className="text-center">
+          <p className="text-sm text-muted-foreground">
+            Don&apos;t have an account?{' '}
+            <Link
+              href={buildRegisterHref(returnTo)}
+              className="font-medium text-brand-blue hover:text-brand-accent transition-colors"
+            >
+              Sign up for free
+            </Link>
+          </p>
+        </div>
+        <div className="text-center">
+          <Link
+            href={returnTo}
+            onClick={handleCancel}
+            className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Cancel
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="text-center">
+        <p className="text-sm text-muted-foreground">
+          Already have an account?{' '}
+          <Link
+            href={buildLoginHref(returnTo)}
+            className="font-medium text-brand-blue hover:text-brand-accent transition-colors"
+          >
+            Sign in here
+          </Link>
+        </p>
+      </div>
+      <div className="text-center">
+        <Link
+          href={returnTo}
+          onClick={handleCancel}
+          className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Cancel
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+export function AuthReturnLinks({
+  variant,
+}: {
+  variant: 'login' | 'register'
+}) {
+  return (
+    <Suspense fallback={null}>
+      <AuthReturnLinksInner variant={variant} />
+    </Suspense>
+  )
+}

--- a/components/auth/AuthReturnLinks.tsx
+++ b/components/auth/AuthReturnLinks.tsx
@@ -10,11 +10,7 @@ import {
 } from '@/lib/auth/safeReturnPath'
 import { clearPendingTipIntent } from '@/lib/tip/pendingTipIntent'
 
-function AuthReturnLinksInner({
-  variant,
-}: {
-  variant: 'login' | 'register'
-}) {
+function AuthReturnLinksInner({ variant }: { variant: 'login' | 'register' }) {
   const searchParams = useSearchParams()
   const returnTo = getSafeReturnPath(searchParams.get('returnTo'))
 

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useAuthActions } from '@convex-dev/auth/react'
 import { useRouter } from 'next/navigation'
 import { useAuthReturnPath } from '@/components/auth/useAuthReturnPath'
+import { readPendingTipIntent } from '@/lib/tip/pendingTipIntent'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { loginSchema, type LoginFormData } from '@/lib/validations/auth'
@@ -49,8 +50,17 @@ export default function LoginForm() {
         flow: 'signIn',
       })
 
-      // If we reach here, sign-in was successful
-      // Use replace to prevent back button returning to login
+      // Full navigation for tip-resume flows so auth + URL params are stable
+      // before the article page mounts (avoids inconsistent client-side resume).
+      const pendingTipIntent = readPendingTipIntent()
+      if (
+        returnPath.includes('resumeArticleTip=1') ||
+        pendingTipIntent?.kind === 'highlight'
+      ) {
+        window.location.assign(returnPath)
+        return
+      }
+
       router.replace(returnPath)
     } catch (error) {
       console.error('Login error:', error)

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useAuthActions } from '@convex-dev/auth/react'
 import { useRouter } from 'next/navigation'
+import { useAuthReturnPath } from '@/components/auth/useAuthReturnPath'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { loginSchema, type LoginFormData } from '@/lib/validations/auth'
@@ -26,6 +27,7 @@ export default function LoginForm() {
   const [error, setError] = useState<string | null>(null)
 
   const router = useRouter()
+  const returnPath = useAuthReturnPath()
   const { signIn } = useAuthActions()
 
   const {
@@ -49,7 +51,7 @@ export default function LoginForm() {
 
       // If we reach here, sign-in was successful
       // Use replace to prevent back button returning to login
-      router.replace('/')
+      router.replace(returnPath)
     } catch (error) {
       console.error('Login error:', error)
       setError('Invalid email or password. Please try again.')

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { useAuthReturnPath } from '@/components/auth/useAuthReturnPath'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { mapRegisterSignInError } from '@/lib/auth/map-register-error'
@@ -29,6 +30,7 @@ export default function RegisterForm() {
   const [success, setSuccess] = useState(false)
 
   const router = useRouter()
+  const returnPath = useAuthReturnPath()
   const { signIn } = useAuth()
 
   const {
@@ -54,7 +56,7 @@ export default function RegisterForm() {
 
       setSuccess(true)
       // Use replace to prevent back button returning to register
-      router.replace('/')
+      router.replace(returnPath)
     } catch (error) {
       setError(mapRegisterSignInError(error))
       setIsLoading(false)

--- a/components/auth/useAuthReturnPath.ts
+++ b/components/auth/useAuthReturnPath.ts
@@ -1,0 +1,9 @@
+'use client'
+
+import { useSearchParams } from 'next/navigation'
+import { getSafeReturnPath } from '@/lib/auth/safeReturnPath'
+
+export function useAuthReturnPath(): string {
+  const searchParams = useSearchParams()
+  return getSafeReturnPath(searchParams.get('returnTo'))
+}

--- a/components/highlights/HighlightPopover.test.tsx
+++ b/components/highlights/HighlightPopover.test.tsx
@@ -6,6 +6,10 @@ vi.mock('@/components/highlights/HighlightTipButton', () => ({
   HighlightTipButton: () => null,
 }))
 
+vi.mock('@/components/providers/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: true, isLoading: false, user: null }),
+}))
+
 import { HighlightPopover } from '@/components/highlights/HighlightPopover'
 
 describe('HighlightPopover', () => {

--- a/components/highlights/HighlightPopover.tsx
+++ b/components/highlights/HighlightPopover.tsx
@@ -128,80 +128,82 @@ export function HighlightPopover({
 
         {isAuthenticated && (
           <>
-        <div className="mb-4">
-          <div className="text-xs font-medium text-muted-foreground mb-2">
-            Choose Highlight Color
-          </div>
-          <div className="color-picker-container">
-            {PREMIUM_HIGHLIGHT_COLORS.map((color) => (
+            <div className="mb-4">
+              <div className="text-xs font-medium text-muted-foreground mb-2">
+                Choose Highlight Color
+              </div>
+              <div className="color-picker-container">
+                {PREMIUM_HIGHLIGHT_COLORS.map((color) => (
+                  <button
+                    key={color.value}
+                    onClick={() => handleColorSelect(color.value)}
+                    className={cn(
+                      'color-picker-button',
+                      selectedColor === color.value && 'selected'
+                    )}
+                    style={{
+                      background: `linear-gradient(135deg, ${color.value}, ${color.value}dd)`,
+                    }}
+                    aria-label={`Select ${color.name} highlight`}
+                  >
+                    <div className="color-tooltip">
+                      <div className="font-medium">{color.name}</div>
+                      <div className="text-xs opacity-80">
+                        {color.description}
+                      </div>
+                      <div className="color-tooltip-arrow" />
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Actions */}
+            <div className="flex items-center gap-2 mb-3">
               <button
-                key={color.value}
-                onClick={() => handleColorSelect(color.value)}
+                onClick={() => setShowNoteInput(!showNoteInput)}
                 className={cn(
-                  'color-picker-button',
-                  selectedColor === color.value && 'selected'
+                  'highlight-action-button flex items-center gap-2',
+                  'bg-muted hover:bg-muted/80 text-foreground',
+                  showNoteInput && 'bg-muted/90'
                 )}
-                style={{
-                  background: `linear-gradient(135deg, ${color.value}, ${color.value}dd)`,
-                }}
-                aria-label={`Select ${color.name} highlight`}
               >
-                <div className="color-tooltip">
-                  <div className="font-medium">{color.name}</div>
-                  <div className="text-xs opacity-80">{color.description}</div>
-                  <div className="color-tooltip-arrow" />
-                </div>
+                <MessageSquare className="w-4 h-4" />
+                <span>Add Note</span>
               </button>
-            ))}
-          </div>
-        </div>
 
-        {/* Actions */}
-        <div className="flex items-center gap-2 mb-3">
-          <button
-            onClick={() => setShowNoteInput(!showNoteInput)}
-            className={cn(
-              'highlight-action-button flex items-center gap-2',
-              'bg-muted hover:bg-muted/80 text-foreground',
-              showNoteInput && 'bg-muted/90'
+              <button
+                onClick={() => setIsPublic(!isPublic)}
+                className="privacy-toggle"
+              >
+                {isPublic ? (
+                  <>
+                    <Globe className="w-4 h-4 text-green-800 dark:text-green-300" />
+                    <span className="text-sm text-foreground">Public</span>
+                  </>
+                ) : (
+                  <>
+                    <Lock className="w-4 h-4 text-muted-foreground" />
+                    <span className="text-sm text-foreground">Private</span>
+                  </>
+                )}
+              </button>
+            </div>
+
+            {/* Note Input */}
+            {showNoteInput && (
+              <div className="mb-3">
+                <textarea
+                  value={note}
+                  onChange={(e) => setNote(e.target.value)}
+                  placeholder="Add a note to your highlight..."
+                  className="w-full px-3 py-2 text-sm border border-input bg-background text-foreground rounded-lg focus:ring-2 focus:ring-ring focus:border-transparent resize-none"
+                  rows={3}
+                  // eslint-disable-next-line jsx-a11y/no-autofocus
+                  autoFocus
+                />
+              </div>
             )}
-          >
-            <MessageSquare className="w-4 h-4" />
-            <span>Add Note</span>
-          </button>
-
-          <button
-            onClick={() => setIsPublic(!isPublic)}
-            className="privacy-toggle"
-          >
-            {isPublic ? (
-              <>
-                <Globe className="w-4 h-4 text-green-800 dark:text-green-300" />
-                <span className="text-sm text-foreground">Public</span>
-              </>
-            ) : (
-              <>
-                <Lock className="w-4 h-4 text-muted-foreground" />
-                <span className="text-sm text-foreground">Private</span>
-              </>
-            )}
-          </button>
-        </div>
-
-        {/* Note Input */}
-        {showNoteInput && (
-          <div className="mb-3">
-            <textarea
-              value={note}
-              onChange={(e) => setNote(e.target.value)}
-              placeholder="Add a note to your highlight..."
-              className="w-full px-3 py-2 text-sm border border-input bg-background text-foreground rounded-lg focus:ring-2 focus:ring-ring focus:border-transparent resize-none"
-              rows={3}
-              // eslint-disable-next-line jsx-a11y/no-autofocus
-              autoFocus
-            />
-          </div>
-        )}
           </>
         )}
 

--- a/components/highlights/HighlightPopover.tsx
+++ b/components/highlights/HighlightPopover.tsx
@@ -22,6 +22,11 @@ interface HighlightPopoverProps {
   authorStellarAddress?: string | null
   startOffset?: number
   endOffset?: number
+  resumeHighlightTip?: {
+    amountCents?: number
+    customAmount?: string
+  } | null
+  onHighlightTipResumeOpened?: () => void
 }
 
 const PREMIUM_HIGHLIGHT_COLORS = [
@@ -74,6 +79,8 @@ export function HighlightPopover({
   authorStellarAddress,
   startOffset,
   endOffset,
+  resumeHighlightTip,
+  onHighlightTipResumeOpened,
 }: HighlightPopoverProps) {
   const { isAuthenticated } = useAuth()
   const [selectedColor, setSelectedColor] = useState(
@@ -110,6 +117,7 @@ export function HighlightPopover({
     <FocusScope trapped loop>
       <div
         ref={popoverRef}
+        data-testid="highlight-popover"
         className="highlight-popover fixed z-50 w-[360px] max-w-[calc(100vw-24px)] rounded-2xl p-4 outline-none"
         style={{
           top: clampedPosition.top,
@@ -247,6 +255,14 @@ export function HighlightPopover({
                   startOffset={startOffset}
                   endOffset={endOffset}
                   className="flex-1"
+                  resumeOpen={Boolean(resumeHighlightTip)}
+                  resumeAmountCents={resumeHighlightTip?.amountCents}
+                  resumeCustomAmount={resumeHighlightTip?.customAmount}
+                  onResumeDialogVisible={() => {
+                    if (resumeHighlightTip) {
+                      onHighlightTipResumeOpened?.()
+                    }
+                  }}
                   onSuccess={
                     isAuthenticated
                       ? () => {

--- a/components/highlights/HighlightPopover.tsx
+++ b/components/highlights/HighlightPopover.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/utils'
 import { HighlightTipButton } from './HighlightTipButton'
 import { Id } from '@/convex/_generated/dataModel'
 import { useClampedFixedPosition } from '@/hooks/useClampedFixedPosition'
+import { useAuth } from '@/components/providers/AuthContext'
 
 interface HighlightPopoverProps {
   position: { top: number; left: number }
@@ -74,6 +75,7 @@ export function HighlightPopover({
   startOffset,
   endOffset,
 }: HighlightPopoverProps) {
+  const { isAuthenticated } = useAuth()
   const [selectedColor, setSelectedColor] = useState(
     PREMIUM_HIGHLIGHT_COLORS[0]?.value || '#F59E0B'
   )
@@ -124,7 +126,8 @@ export function HighlightPopover({
           {selectedText.length > 150 ? '...' : ''}&rdquo;
         </div>
 
-        {/* Color Picker */}
+        {isAuthenticated && (
+          <>
         <div className="mb-4">
           <div className="text-xs font-medium text-muted-foreground mb-2">
             Choose Highlight Color
@@ -199,30 +202,35 @@ export function HighlightPopover({
             />
           </div>
         )}
+          </>
+        )}
 
-        {/* Action Buttons Section */}
         <div className="pt-3 border-t border-border">
           <div className="text-xs font-medium text-muted-foreground mb-3 text-center">
-            Save highlight{' '}
-            {articleId &&
-              articleSlug &&
-              authorStellarAddress &&
-              startOffset !== undefined &&
-              endOffset !== undefined &&
-              'or tip the author'}
+            {isAuthenticated
+              ? `Save highlight${
+                  articleId &&
+                  articleSlug &&
+                  authorStellarAddress &&
+                  startOffset !== undefined &&
+                  endOffset !== undefined
+                    ? ' or tip the author'
+                    : ''
+                }`
+              : 'Tip the author for this selection'}
           </div>
 
           <div className="flex gap-2 mb-3">
-            {/* Save Highlight Button */}
-            <button
-              onClick={handleSaveHighlight}
-              className="highlight-action-button flex-1 bg-gradient-to-r from-blue-500 to-blue-600 text-white hover:from-blue-600 hover:to-blue-700 flex items-center justify-center"
-            >
-              <Highlighter className="w-4 h-4 mr-2" />
-              <span>Save</span>
-            </button>
+            {isAuthenticated && (
+              <button
+                onClick={handleSaveHighlight}
+                className="highlight-action-button flex-1 bg-gradient-to-r from-blue-500 to-blue-600 text-white hover:from-blue-600 hover:to-blue-700 flex items-center justify-center"
+              >
+                <Highlighter className="w-4 h-4 mr-2" />
+                <span>Save</span>
+              </button>
+            )}
 
-            {/* Tip Highlight Button - Show if article data is available */}
             {articleId &&
               articleSlug &&
               authorStellarAddress &&
@@ -237,15 +245,18 @@ export function HighlightPopover({
                   startOffset={startOffset}
                   endOffset={endOffset}
                   className="flex-1"
-                  onSuccess={() => {
-                    // Create highlight with selected settings, then close
-                    onCreateHighlight(
-                      selectedColor,
-                      note || undefined,
-                      isPublic
-                    )
-                    onClose()
-                  }}
+                  onSuccess={
+                    isAuthenticated
+                      ? () => {
+                          onCreateHighlight(
+                            selectedColor,
+                            note || undefined,
+                            isPublic
+                          )
+                          onClose()
+                        }
+                      : undefined
+                  }
                 />
               )}
           </div>

--- a/components/highlights/HighlightSignInPrompt.test.tsx
+++ b/components/highlights/HighlightSignInPrompt.test.tsx
@@ -11,6 +11,7 @@ describe('HighlightSignInPrompt', () => {
       <HighlightSignInPrompt
         position={{ top: 0, left: 0 }}
         selectedText="Enough text for the preview area"
+        returnPath="/author/my-article"
         onClose={onClose}
       />
     )
@@ -32,6 +33,7 @@ describe('HighlightSignInPrompt', () => {
       <HighlightSignInPrompt
         position={{ top: 0, left: 0 }}
         selectedText="Enough text for the preview area"
+        returnPath="/author/my-article"
         onClose={onClose}
       />
     )
@@ -55,6 +57,7 @@ describe('HighlightSignInPrompt', () => {
       <HighlightSignInPrompt
         position={{ top: 0, left: 0 }}
         selectedText="Enough text for the preview area"
+        returnPath="/author/my-article"
         onClose={onClose}
       />
     )
@@ -64,22 +67,40 @@ describe('HighlightSignInPrompt', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  it('links Sign in to /login and register to /register', () => {
+  it('links Sign in and register with returnTo', () => {
     render(
       <HighlightSignInPrompt
         position={{ top: 0, left: 0 }}
         selectedText="Enough text for the preview area"
+        returnPath="/author/my-article"
         onClose={vi.fn()}
       />
     )
 
     expect(screen.getByRole('link', { name: 'Sign in' })).toHaveAttribute(
       'href',
-      '/login'
+      '/login?returnTo=%2Fauthor%2Fmy-article'
     )
     expect(
       screen.getByRole('link', { name: 'Create a free account' })
-    ).toHaveAttribute('href', '/register')
+    ).toHaveAttribute('href', '/register?returnTo=%2Fauthor%2Fmy-article')
+  })
+
+  it('calls onBeforeAuthNavigate when Sign in is clicked', () => {
+    const onBeforeAuthNavigate = vi.fn()
+    render(
+      <HighlightSignInPrompt
+        position={{ top: 0, left: 0 }}
+        selectedText="Enough text for the preview area"
+        returnPath="/author/my-article"
+        onClose={vi.fn()}
+        onBeforeAuthNavigate={onBeforeAuthNavigate}
+      />
+    )
+
+    screen.getByRole('link', { name: 'Sign in' }).click()
+
+    expect(onBeforeAuthNavigate).toHaveBeenCalledTimes(1)
   })
 
   it('exposes dialog semantics for assistive tech', () => {
@@ -87,6 +108,7 @@ describe('HighlightSignInPrompt', () => {
       <HighlightSignInPrompt
         position={{ top: 0, left: 0 }}
         selectedText="Enough text for the preview area"
+        returnPath="/author/my-article"
         onClose={vi.fn()}
       />
     )

--- a/components/highlights/HighlightSignInPrompt.tsx
+++ b/components/highlights/HighlightSignInPrompt.tsx
@@ -6,10 +6,7 @@ import { FocusScope } from '@radix-ui/react-focus-scope'
 import { Highlighter } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useClampedFixedPosition } from '@/hooks/useClampedFixedPosition'
-import {
-  buildLoginHref,
-  buildRegisterHref,
-} from '@/lib/auth/safeReturnPath'
+import { buildLoginHref, buildRegisterHref } from '@/lib/auth/safeReturnPath'
 
 interface HighlightSignInPromptProps {
   position: { top: number; left: number }

--- a/components/highlights/HighlightSignInPrompt.tsx
+++ b/components/highlights/HighlightSignInPrompt.tsx
@@ -6,17 +6,25 @@ import { FocusScope } from '@radix-ui/react-focus-scope'
 import { Highlighter } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useClampedFixedPosition } from '@/hooks/useClampedFixedPosition'
+import {
+  buildLoginHref,
+  buildRegisterHref,
+} from '@/lib/auth/safeReturnPath'
 
 interface HighlightSignInPromptProps {
   position: { top: number; left: number }
   selectedText: string
+  returnPath: string
   onClose: () => void
+  onBeforeAuthNavigate?: () => void
 }
 
 export function HighlightSignInPrompt({
   position,
   selectedText,
+  returnPath,
   onClose,
+  onBeforeAuthNavigate,
 }: HighlightSignInPromptProps) {
   const titleId = useId()
   const descriptionId = useId()
@@ -45,6 +53,13 @@ export function HighlightSignInPrompt({
     selectedText.length > 150
       ? `${selectedText.slice(0, 150)}...`
       : selectedText
+
+  const loginHref = buildLoginHref(returnPath)
+  const registerHref = buildRegisterHref(returnPath)
+
+  const handleAuthNavigate = () => {
+    onBeforeAuthNavigate?.()
+  }
 
   return (
     <FocusScope trapped loop>
@@ -86,12 +101,15 @@ export function HighlightSignInPrompt({
 
         <div className="flex flex-col gap-2">
           <Button asChild className="w-full">
-            <Link href="/login">Sign in</Link>
+            <Link href={loginHref} onClick={handleAuthNavigate}>
+              Sign in
+            </Link>
           </Button>
           <p className="text-center text-xs text-muted-foreground">
             New here?{' '}
             <Link
-              href="/register"
+              href={registerHref}
+              onClick={handleAuthNavigate}
               className="font-medium text-brand-blue hover:text-brand-accent transition-colors"
             >
               Create a free account

--- a/components/highlights/HighlightTipButton.test.tsx
+++ b/components/highlights/HighlightTipButton.test.tsx
@@ -65,9 +65,9 @@ vi.mock('@/lib/stellar/stellar-flow-emitter', () => ({
 const clearPendingTipIntent = vi.fn()
 const readPendingTipIntent = vi.fn()
 vi.mock('@/lib/tip/pendingTipIntent', async () => {
-  const actual = await vi.importActual<typeof import('@/lib/tip/pendingTipIntent')>(
-    '@/lib/tip/pendingTipIntent'
-  )
+  const actual = await vi.importActual<
+    typeof import('@/lib/tip/pendingTipIntent')
+  >('@/lib/tip/pendingTipIntent')
   return {
     ...actual,
     clearPendingTipIntent: () => clearPendingTipIntent(),
@@ -156,4 +156,3 @@ describe('HighlightTipButton', () => {
     raf.mockRestore()
   })
 })
-

--- a/components/highlights/HighlightTipButton.test.tsx
+++ b/components/highlights/HighlightTipButton.test.tsx
@@ -1,0 +1,159 @@
+/** @vitest-environment jsdom */
+import { act, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+const writePendingHighlightSelection = vi.fn()
+vi.mock('@/lib/highlight/pendingHighlightSelection', () => ({
+  writePendingHighlightSelection: (args: unknown) =>
+    writePendingHighlightSelection(args),
+}))
+
+const signInToTip = vi.fn()
+vi.mock('@/lib/tip/signInToTip', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/tip/signInToTip')>(
+    '@/lib/tip/signInToTip'
+  )
+  return {
+    ...actual,
+    signInToTip: (...args: unknown[]) => signInToTip(...args),
+  }
+})
+
+const mockAuth = vi.hoisted(() => ({
+  isAuthenticated: false,
+}))
+vi.mock('@/components/providers/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: mockAuth.isAuthenticated }),
+}))
+
+vi.mock('@/components/providers/WalletProvider', () => ({
+  useWallet: () => ({
+    isConnected: false,
+    publicKey: null,
+    signTransaction: vi.fn(),
+    connect: vi.fn(),
+  }),
+}))
+
+vi.mock('@/components/providers/WalletActivationContext', () => ({
+  useWalletActivation: () => ({ activateWallet: vi.fn() }),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  usePathname: () => '/author/my-article',
+}))
+
+vi.mock('convex/react', () => ({
+  useConvex: () => ({ query: vi.fn() }),
+  useMutation: () => vi.fn(),
+}))
+
+vi.mock('@/hooks/useTipDialogXlmUsdRate', () => ({
+  useTipDialogXlmUsdRate: () => ({ priceUsd: 0.12 }),
+}))
+
+vi.mock('@/lib/stellar/client', () => ({
+  stellarClient: {},
+}))
+
+vi.mock('@/lib/stellar/stellar-flow-emitter', () => ({
+  stellarFlowEmitter: { subscribe: () => () => {} },
+  tipFlowProgressLabel: () => '',
+}))
+
+const clearPendingTipIntent = vi.fn()
+const readPendingTipIntent = vi.fn()
+vi.mock('@/lib/tip/pendingTipIntent', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/tip/pendingTipIntent')>(
+    '@/lib/tip/pendingTipIntent'
+  )
+  return {
+    ...actual,
+    clearPendingTipIntent: () => clearPendingTipIntent(),
+    readPendingTipIntent: () => readPendingTipIntent(),
+  }
+})
+
+vi.mock('@/components/stellar/InstallWalletDialog', () => ({
+  InstallWalletDialog: () => null,
+}))
+
+vi.mock('@/components/guide/WalletTooltip', () => ({
+  WalletTooltip: () => null,
+}))
+
+import { HighlightTipButton } from '@/components/highlights/HighlightTipButton'
+
+describe('HighlightTipButton', () => {
+  it('persists pending highlight selection before Sign in to tip', () => {
+    mockAuth.isAuthenticated = false
+    render(
+      <HighlightTipButton
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        articleId={'articles:123' as any}
+        articleSlug="my-article"
+        authorName="Author"
+        authorStellarAddress="GABC"
+        highlightText="Some highlighted text"
+        startOffset={10}
+        endOffset={20}
+        resumeOpen
+        resumeAmountCents={500}
+      />
+    )
+
+    screen.getByRole('button', { name: 'Sign in to tip' }).click()
+
+    expect(writePendingHighlightSelection).toHaveBeenCalledWith({
+      articleId: 'articles:123',
+      highlightText: 'Some highlighted text',
+      startOffset: 10,
+      endOffset: 20,
+    })
+    expect(signInToTip).toHaveBeenCalled()
+  })
+
+  it('restores amount from pending tip intent when opening dialog', async () => {
+    mockAuth.isAuthenticated = true
+    readPendingTipIntent.mockReturnValue({
+      kind: 'highlight',
+      articleId: 'articles:123',
+      articleSlug: 'my-article',
+      highlightText: 'Some highlighted text',
+      startOffset: 10,
+      endOffset: 20,
+      amountCents: 500,
+    })
+
+    render(
+      <HighlightTipButton
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        articleId={'articles:123' as any}
+        articleSlug="my-article"
+        authorName="Author"
+        authorStellarAddress="GABC"
+        highlightText="Some highlighted text"
+        startOffset={10}
+        endOffset={20}
+      />
+    )
+
+    const raf = vi
+      .spyOn(globalThis, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        cb(0)
+        return 0
+      })
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'Tip Highlight' }).click()
+    })
+
+    // When restored, the dialog should show the chosen amount as selected.
+    expect(await screen.findByTestId('highlight-tip-dialog')).toBeTruthy()
+    expect(clearPendingTipIntent).toHaveBeenCalled()
+    raf.mockRestore()
+  })
+})
+

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -126,12 +126,7 @@ export function HighlightTipButton({
     )
     activateWallet()
     setIsOpen(true)
-  }, [
-    resumeOpen,
-    resumeAmountCents,
-    resumeCustomAmount,
-    activateWallet,
-  ])
+  }, [resumeOpen, resumeAmountCents, resumeCustomAmount, activateWallet])
 
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useConvex, useMutation } from 'convex/react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { useWallet } from '@/components/providers/WalletProvider'
 import { useWalletActivation } from '@/components/providers/WalletActivationContext'
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 import { AlertCircle, Coins, Heart, Loader2, Wallet } from 'lucide-react'
 import { api } from '@/convex/_generated/api'
@@ -50,6 +50,9 @@ import {
   type TipFailureMessage,
 } from '@/lib/stellar/tip-error-messages'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { redirectToLoginForTip } from '@/lib/tip/redirectToLoginForTip'
+import { applyPendingAmountFields } from '@/lib/tip/applyPendingTipFormState'
+import { clearPendingTipIntent } from '@/lib/tip/pendingTipIntent'
 
 interface HighlightTipButtonProps {
   articleId: Id<'articles'>
@@ -63,6 +66,9 @@ interface HighlightTipButtonProps {
   endContainerPath?: string
   className?: string
   onSuccess?: () => void
+  resumeOpen?: boolean
+  resumeAmountCents?: number
+  resumeCustomAmount?: string
 }
 
 export function HighlightTipButton({
@@ -77,12 +83,17 @@ export function HighlightTipButton({
   endContainerPath,
   className = '',
   onSuccess,
+  resumeOpen = false,
+  resumeAmountCents,
+  resumeCustomAmount,
 }: HighlightTipButtonProps) {
   const { isAuthenticated } = useAuth()
   const { isConnected, publicKey, signTransaction, connect } = useWallet()
   const { activateWallet } = useWalletActivation()
   const router = useRouter()
-  const [isOpen, setIsOpen] = useState(false)
+  const pathname = usePathname()
+  const [isOpen, setIsOpen] = useState(resumeOpen)
+  const resumedRef = useRef(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
   const [selectedAmount, setSelectedAmount] = useState<number | null>(null)
   const [customAmount, setCustomAmount] = useState('')
@@ -102,6 +113,26 @@ export function HighlightTipButton({
     })
   }, [])
 
+  useEffect(() => {
+    if (!resumeOpen || resumedRef.current) return
+    resumedRef.current = true
+    applyPendingAmountFields(
+      {
+        amountCents: resumeAmountCents,
+        customAmount: resumeCustomAmount,
+      },
+      setSelectedAmount,
+      setCustomAmount
+    )
+    activateWallet()
+    setIsOpen(true)
+  }, [
+    resumeOpen,
+    resumeAmountCents,
+    resumeCustomAmount,
+    activateWallet,
+  ])
+
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
     if (open) {
@@ -116,9 +147,32 @@ export function HighlightTipButton({
   }
 
   const handleTip = async () => {
+    const amountCents = selectedAmount || parseFloat(customAmount) * 100
+
+    if (!amountCents || amountCents < TIP_MIN_CENTS) {
+      toast.error('Please select or enter a valid amount')
+      return
+    }
+
+    if (amountCents > TIP_MAX_CENTS) {
+      toast.error(`Maximum tip amount is $${TIP_MAX_USD.toFixed(2)}`)
+      return
+    }
+
     if (!isAuthenticated) {
       toast.error('Please sign in to send tips')
-      router.push('/login')
+      redirectToLoginForTip(router, pathname, {
+        kind: 'highlight',
+        articleId: articleId,
+        articleSlug,
+        highlightText,
+        startOffset,
+        endOffset,
+        ...(startContainerPath ? { startContainerPath } : {}),
+        ...(endContainerPath ? { endContainerPath } : {}),
+        ...(selectedAmount != null ? { amountCents: selectedAmount } : {}),
+        ...(customAmount ? { customAmount } : {}),
+      })
       return
     }
 
@@ -129,18 +183,6 @@ export function HighlightTipButton({
 
     if (!authorStellarAddress) {
       toast.error('Author has not set up their Stellar wallet yet')
-      return
-    }
-
-    const amountCents = selectedAmount || parseFloat(customAmount) * 100
-
-    if (!amountCents || amountCents < TIP_MIN_CENTS) {
-      toast.error('Please select or enter a valid amount')
-      return
-    }
-
-    if (amountCents > TIP_MAX_CENTS) {
-      toast.error(`Maximum tip amount is $${TIP_MAX_USD.toFixed(2)}`)
       return
     }
 
@@ -212,6 +254,7 @@ export function HighlightTipButton({
         authorShare: transactionData.authorReceived,
       })
 
+      clearPendingTipIntent()
       setTipFailure(null)
       setIsOpen(false)
       setSelectedAmount(null)

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -26,8 +26,6 @@ import { TipUsdXlmRateLine } from '@/components/tipping/TipUsdXlmRateLine'
 import { useTipDialogXlmUsdRate } from '@/hooks/useTipDialogXlmUsdRate'
 import {
   TIP_PRESETS_HIGHLIGHT,
-  TIP_MIN_CENTS,
-  TIP_MAX_CENTS,
   TIP_MIN_USD,
   TIP_MAX_USD,
 } from '@/lib/constants'
@@ -50,9 +48,14 @@ import {
   type TipFailureMessage,
 } from '@/lib/stellar/tip-error-messages'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
-import { redirectToLoginForTip } from '@/lib/tip/redirectToLoginForTip'
+import { signInToTip, validateTipAmountForm } from '@/lib/tip/signInToTip'
 import { applyPendingAmountFields } from '@/lib/tip/applyPendingTipFormState'
-import { clearPendingTipIntent } from '@/lib/tip/pendingTipIntent'
+import {
+  clearPendingTipIntent,
+  matchesHighlightPendingIntent,
+  readPendingTipIntent,
+} from '@/lib/tip/pendingTipIntent'
+import { writePendingHighlightSelection } from '@/lib/highlight/pendingHighlightSelection'
 
 interface HighlightTipButtonProps {
   articleId: Id<'articles'>
@@ -69,6 +72,8 @@ interface HighlightTipButtonProps {
   resumeOpen?: boolean
   resumeAmountCents?: number
   resumeCustomAmount?: string
+  onResumeOpenChange?: (open: boolean) => void
+  onResumeDialogVisible?: () => void
 }
 
 export function HighlightTipButton({
@@ -86,6 +91,8 @@ export function HighlightTipButton({
   resumeOpen = false,
   resumeAmountCents,
   resumeCustomAmount,
+  onResumeOpenChange,
+  onResumeDialogVisible,
 }: HighlightTipButtonProps) {
   const { isAuthenticated } = useAuth()
   const { isConnected, publicKey, signTransaction, connect } = useWallet()
@@ -97,6 +104,7 @@ export function HighlightTipButton({
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
   const [selectedAmount, setSelectedAmount] = useState<number | null>(null)
   const [customAmount, setCustomAmount] = useState('')
+  const restoredFromPendingIntentRef = useRef(false)
   const [isLoading, setIsLoading] = useState(false)
   const [tipFlowStep, setTipFlowStep] = useState<TipFlowStep | null>(null)
   const [tipFailure, setTipFailure] = useState<TipFailureMessage | null>(null)
@@ -126,14 +134,70 @@ export function HighlightTipButton({
     )
     activateWallet()
     setIsOpen(true)
-  }, [resumeOpen, resumeAmountCents, resumeCustomAmount, activateWallet])
+    onResumeOpenChange?.(true)
+  }, [
+    resumeOpen,
+    resumeAmountCents,
+    resumeCustomAmount,
+    activateWallet,
+    onResumeOpenChange,
+  ])
+
+  useEffect(() => {
+    // Only signal "visible" once the dialog is actually open (mounted).
+    if (!isOpen || !resumedRef.current) return
+    onResumeDialogVisible?.()
+  }, [isOpen, onResumeDialogVisible])
+
+  useEffect(() => {
+    if (!isOpen || !isAuthenticated) return
+    if (resumedRef.current) return
+    if (restoredFromPendingIntentRef.current) return
+    if (selectedAmount != null || customAmount) return
+
+    const pending = readPendingTipIntent()
+    if (
+      !matchesHighlightPendingIntent(pending, articleId) ||
+      pending.startOffset !== startOffset ||
+      pending.endOffset !== endOffset ||
+      pending.highlightText !== highlightText
+    ) {
+      return
+    }
+
+    restoredFromPendingIntentRef.current = true
+    applyPendingAmountFields(
+      {
+        amountCents: pending.amountCents,
+        customAmount: pending.customAmount,
+      },
+      setSelectedAmount,
+      setCustomAmount
+    )
+
+    // Clear only after we know the dialog is open (it is, we're in this effect),
+    // and after the amount fields have been applied.
+    requestAnimationFrame(() => {
+      clearPendingTipIntent()
+    })
+  }, [
+    isOpen,
+    isAuthenticated,
+    articleId,
+    startOffset,
+    endOffset,
+    highlightText,
+    selectedAmount,
+    customAmount,
+  ])
 
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
-    if (open) {
+    if (open && isAuthenticated) {
       activateWallet()
     }
     setIsOpen(open)
+    onResumeOpenChange?.(open)
     setTipFailure(null)
     if (!open) {
       setSelectedAmount(null)
@@ -141,22 +205,18 @@ export function HighlightTipButton({
     }
   }
 
-  const handleTip = async () => {
-    const amountCents = selectedAmount || parseFloat(customAmount) * 100
-
-    if (!amountCents || amountCents < TIP_MIN_CENTS) {
-      toast.error('Please select or enter a valid amount')
-      return
-    }
-
-    if (amountCents > TIP_MAX_CENTS) {
-      toast.error(`Maximum tip amount is $${TIP_MAX_USD.toFixed(2)}`)
-      return
-    }
-
-    if (!isAuthenticated) {
-      toast.error('Please sign in to send tips')
-      redirectToLoginForTip(router, pathname, {
+  const handleSignInToTip = () => {
+    writePendingHighlightSelection({
+      articleId: String(articleId),
+      highlightText,
+      startOffset,
+      endOffset,
+    })
+    signInToTip(
+      router,
+      pathname,
+      { selectedAmount, customAmount },
+      {
         kind: 'highlight',
         articleId: articleId,
         articleSlug,
@@ -167,9 +227,17 @@ export function HighlightTipButton({
         ...(endContainerPath ? { endContainerPath } : {}),
         ...(selectedAmount != null ? { amountCents: selectedAmount } : {}),
         ...(customAmount ? { customAmount } : {}),
-      })
-      return
-    }
+      }
+    )
+  }
+
+  const handleTip = async () => {
+    const validation = validateTipAmountForm({
+      selectedAmount,
+      customAmount,
+    })
+    if (!validation.ok) return
+    const amountCents = validation.amountCents
 
     if (!isConnected || !publicKey) {
       toast.error('Please connect your Stellar wallet to send tips')
@@ -332,6 +400,7 @@ export function HighlightTipButton({
           </button>
         </DialogTrigger>
         <DialogContent
+          data-testid="highlight-tip-dialog"
           className="max-w-md max-h-[min(90dvh,calc(100%-2rem))] overflow-y-auto"
           onEscapeKeyDown={(e) => {
             if (isLoading) e.preventDefault()
@@ -368,11 +437,18 @@ export function HighlightTipButton({
             the author!
           </p>
 
-          {!isConnected && (
+          {!isAuthenticated ? (
+            <div className="mb-4 p-3 bg-muted border border-border rounded-lg text-sm text-muted-foreground">
+              <p>Sign in to tip this highlight.</p>
+              <p className="mt-1">
+                You can connect your Stellar wallet after signing in.
+              </p>
+            </div>
+          ) : !isConnected ? (
             <div className="mb-4 p-3 bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-lg text-sm text-amber-900 dark:text-amber-100">
               <p>Connect your Stellar wallet to tip this highlight.</p>
             </div>
-          )}
+          ) : null}
 
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-4">
             {TIP_PRESETS_HIGHLIGHT.map((amount) => (
@@ -452,7 +528,17 @@ export function HighlightTipButton({
               Cancel
             </button>
 
-            {!isConnected ? (
+            {!isAuthenticated ? (
+              <button
+                type="button"
+                onClick={handleSignInToTip}
+                disabled={isLoading || (!selectedAmount && !customAmount)}
+                className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              >
+                <Heart className="w-4 h-4" />
+                <span>Sign in to tip</span>
+              </button>
+            ) : !isConnected ? (
               <button
                 type="button"
                 onClick={handleConnectWallet}

--- a/components/onboarding/OnboardingDialog.test.tsx
+++ b/components/onboarding/OnboardingDialog.test.tsx
@@ -1,0 +1,124 @@
+/** @vitest-environment jsdom */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import { OnboardingDialog } from '@/components/onboarding/OnboardingDialog'
+
+const mockCompleteOnboarding = vi.hoisted(() => vi.fn())
+const mockPush = vi.hoisted(() => vi.fn())
+
+vi.mock('convex/react', () => ({
+  useMutation: () => mockCompleteOnboarding,
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}))
+
+describe('OnboardingDialog', () => {
+  beforeEach(() => {
+    mockCompleteOnboarding.mockReset()
+    mockPush.mockReset()
+    vi.mocked(toast.error).mockClear()
+    mockCompleteOnboarding.mockResolvedValue(undefined)
+  })
+
+  it('shows step progress on first step', () => {
+    render(<OnboardingDialog />)
+
+    expect(screen.getByText('Step 1 of 3')).toBeInTheDocument()
+    expect(screen.getByRole('group', { name: 'Step 1 of 3' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^Next/i })).toBeInTheDocument()
+  })
+
+  it('advances step progress when Next is clicked', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<OnboardingDialog />)
+
+    await user.click(screen.getByRole('button', { name: /^Next/i }))
+
+    expect(screen.getByText('Step 2 of 3')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Set Up Now/i })
+    ).toBeInTheDocument()
+  })
+
+  it('calls completeOnboarding when Skip is clicked', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<OnboardingDialog />)
+
+    await user.click(screen.getByRole('button', { name: /Skip onboarding/i }))
+
+    await waitFor(() => {
+      expect(mockCompleteOnboarding).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('calls completeOnboarding when close button is clicked', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<OnboardingDialog />)
+
+    await user.click(screen.getByRole('button', { name: /Close onboarding/i }))
+
+    await waitFor(() => {
+      expect(mockCompleteOnboarding).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('shows Get Started on final step and completes onboarding', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<OnboardingDialog />)
+
+    await user.click(screen.getByRole('button', { name: /^Next/i }))
+    await user.click(screen.getByRole('button', { name: /I'll do this later/i }))
+    expect(screen.getByText('Step 3 of 3')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /Get Started/i }))
+
+    await waitFor(() => {
+      expect(mockCompleteOnboarding).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('navigates after completing via shortcut on final step', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<OnboardingDialog />)
+
+    await user.click(screen.getByRole('button', { name: /^Next/i }))
+    await user.click(screen.getByRole('button', { name: /I'll do this later/i }))
+    await user.click(screen.getByRole('button', { name: /^Read$/i }))
+
+    await waitFor(() => {
+      expect(mockCompleteOnboarding).toHaveBeenCalledTimes(1)
+      expect(mockPush).toHaveBeenCalledWith('/articles')
+    })
+  })
+
+  it('shows error toast when completeOnboarding fails', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockCompleteOnboarding.mockRejectedValue(new Error('Network error'))
+    render(<OnboardingDialog />)
+
+    await user.click(screen.getByRole('button', { name: /Skip onboarding/i }))
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Could not save your progress. Please try again.'
+      )
+    })
+    expect(screen.getByRole('button', { name: /Skip onboarding/i })).toBeInTheDocument()
+  })
+
+  it('renders a modal dialog', () => {
+    render(<OnboardingDialog />)
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+})

--- a/components/onboarding/OnboardingDialog.test.tsx
+++ b/components/onboarding/OnboardingDialog.test.tsx
@@ -34,7 +34,9 @@ describe('OnboardingDialog', () => {
     render(<OnboardingDialog />)
 
     expect(screen.getByText('Step 1 of 3')).toBeInTheDocument()
-    expect(screen.getByRole('group', { name: 'Step 1 of 3' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('group', { name: 'Step 1 of 3' })
+    ).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /^Next/i })).toBeInTheDocument()
   })
 
@@ -77,7 +79,9 @@ describe('OnboardingDialog', () => {
     render(<OnboardingDialog />)
 
     await user.click(screen.getByRole('button', { name: /^Next/i }))
-    await user.click(screen.getByRole('button', { name: /I'll do this later/i }))
+    await user.click(
+      screen.getByRole('button', { name: /I'll do this later/i })
+    )
     expect(screen.getByText('Step 3 of 3')).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: /Get Started/i }))
@@ -92,7 +96,9 @@ describe('OnboardingDialog', () => {
     render(<OnboardingDialog />)
 
     await user.click(screen.getByRole('button', { name: /^Next/i }))
-    await user.click(screen.getByRole('button', { name: /I'll do this later/i }))
+    await user.click(
+      screen.getByRole('button', { name: /I'll do this later/i })
+    )
     await user.click(screen.getByRole('button', { name: /^Read$/i }))
 
     await waitFor(() => {
@@ -113,7 +119,9 @@ describe('OnboardingDialog', () => {
         'Could not save your progress. Please try again.'
       )
     })
-    expect(screen.getByRole('button', { name: /Skip onboarding/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Skip onboarding/i })
+    ).toBeInTheDocument()
   })
 
   it('renders a modal dialog', () => {

--- a/components/onboarding/OnboardingDialog.tsx
+++ b/components/onboarding/OnboardingDialog.tsx
@@ -22,6 +22,7 @@ import {
   ArrowRight,
   HelpCircle,
   X,
+  Loader2,
 } from 'lucide-react'
 import Link from 'next/link'
 import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
@@ -76,6 +77,12 @@ export function OnboardingDialog() {
     }
   }
 
+  const handleOpenChange = (next: boolean) => {
+    if (!next && open && !isCompleting) {
+      void handleComplete()
+    }
+  }
+
   const navigateAfterComplete = async (href: string) => {
     const ok = await handleComplete()
     if (ok) {
@@ -94,17 +101,21 @@ export function OnboardingDialog() {
   const step = steps[currentStep]
   if (!step) return null
   const StepIcon = step.icon
+  const stepLabel = `Step ${currentStep + 1} of ${steps.length}`
 
   return (
-    <Dialog modal={false} open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
-        className="sm:max-w-md pointer-events-auto"
-        overlayClassName="pointer-events-none bg-black/40"
+        className="sm:max-w-md"
+        overlayClassName="bg-black/40"
         hideCloseButton
+        onInteractOutside={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => e.preventDefault()}
         onEscapeKeyDown={(e) => {
           e.preventDefault()
-          void handleComplete()
+          if (!isCompleting) void handleComplete()
         }}
+        aria-busy={isCompleting}
       >
         <Button
           type="button"
@@ -124,15 +135,25 @@ export function OnboardingDialog() {
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex justify-center gap-2 mb-2">
-          {steps.map((_, i) => (
-            <div
-              key={i}
-              className={`h-1.5 rounded-full transition-all duration-300 ${
-                i === currentStep ? 'w-8 bg-foreground' : 'w-4 bg-muted'
-              }`}
-            />
-          ))}
+        <div
+          role="group"
+          aria-label={stepLabel}
+          className="flex flex-col items-center gap-2 mb-2"
+        >
+          <p className="text-xs text-muted-foreground font-medium">
+            {stepLabel}
+          </p>
+          <div className="flex justify-center gap-2">
+            {steps.map((_, i) => (
+              <div
+                key={i}
+                aria-current={i === currentStep ? 'step' : undefined}
+                className={`h-1.5 rounded-full transition-all duration-300 ${
+                  i === currentStep ? 'w-8 bg-foreground' : 'w-4 bg-muted'
+                }`}
+              />
+            ))}
+          </div>
         </div>
 
         <AnimatePresence mode="wait">
@@ -172,7 +193,11 @@ export function OnboardingDialog() {
                   variant="default"
                   disabled={isCompleting}
                 >
-                  <HelpCircle className="w-4 h-4 mr-2" />
+                  {isCompleting ? (
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  ) : (
+                    <HelpCircle className="w-4 h-4 mr-2" />
+                  )}
                   Set Up Now
                 </Button>
               </Link>
@@ -249,8 +274,17 @@ export function OnboardingDialog() {
               className="w-full min-h-11"
               disabled={isCompleting}
             >
-              Next
-              <ArrowRight className="w-4 h-4 ml-2" />
+              {isCompleting ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                <>
+                  Next
+                  <ArrowRight className="w-4 h-4 ml-2" />
+                </>
+              )}
             </Button>
           )}
 
@@ -260,7 +294,14 @@ export function OnboardingDialog() {
               className="w-full min-h-11"
               disabled={isCompleting}
             >
-              Get Started
+              {isCompleting ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                'Get Started'
+              )}
             </Button>
           )}
 
@@ -273,7 +314,14 @@ export function OnboardingDialog() {
             disabled={isCompleting}
             aria-label="Skip onboarding"
           >
-            Skip onboarding
+            {isCompleting ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              'Skip onboarding'
+            )}
           </Button>
         </div>
       </DialogContent>

--- a/components/tipping/ArticleTipActions.tsx
+++ b/components/tipping/ArticleTipActions.tsx
@@ -14,7 +14,7 @@ interface ArticleTipActionsProps {
 
 function ArticleTipActionsInner({
   articleId,
-  articleSlug,
+  articleSlug: _articleSlug,
   authorName,
   authorStellarAddress,
 }: ArticleTipActionsProps) {

--- a/components/tipping/ArticleTipActions.tsx
+++ b/components/tipping/ArticleTipActions.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { Suspense } from 'react'
+import { TipButton } from '@/components/tipping/TipButton'
+import { TipButtonSkeleton } from '@/components/articles/ArticleEngagementSkeleton'
+import type { Id } from '@/convex/_generated/dataModel'
+
+interface ArticleTipActionsProps {
+  articleId: Id<'articles'>
+  articleSlug: string
+  authorName: string
+  authorStellarAddress?: string | null
+}
+
+function ArticleTipActionsInner({
+  articleId,
+  articleSlug,
+  authorName,
+  authorStellarAddress,
+}: ArticleTipActionsProps) {
+  return (
+    <>
+      <TipButton
+        articleId={articleId}
+        authorName={authorName}
+        authorStellarAddress={authorStellarAddress}
+      />
+    </>
+  )
+}
+
+export function ArticleTipActions(props: ArticleTipActionsProps) {
+  return (
+    <Suspense fallback={<TipButtonSkeleton />}>
+      <ArticleTipActionsInner {...props} />
+    </Suspense>
+  )
+}

--- a/components/tipping/PendingTipResume.test.tsx
+++ b/components/tipping/PendingTipResume.test.tsx
@@ -1,0 +1,61 @@
+/** @vitest-environment jsdom */
+import { act, render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+const HighlightTipButtonSpy = vi.fn((_props: unknown) => null)
+
+vi.mock('@/components/highlights/HighlightTipButton', () => ({
+  HighlightTipButton: (props: unknown) => {
+    HighlightTipButtonSpy(props)
+    return null
+  },
+}))
+
+vi.mock('@/components/providers/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: true, isLoading: false }),
+}))
+
+vi.mock('@/lib/tip/pendingTipIntent', () => ({
+  matchesHighlightPendingIntent: () => true,
+  readPendingTipIntent: () => ({
+    kind: 'highlight',
+    articleId: 'articles:123',
+    articleSlug: 'my-article',
+    highlightText: 'Selected highlight text',
+    startOffset: 10,
+    endOffset: 20,
+    amountCents: 500,
+  }),
+  clearPendingTipIntent: vi.fn(),
+}))
+
+import { PendingTipResume } from '@/components/tipping/PendingTipResume'
+
+describe('PendingTipResume', () => {
+  it('reopens highlight tip with restored amount', async () => {
+    await act(async () => {
+      render(
+        <PendingTipResume
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          articleId={'articles:123' as any}
+          articleSlug="my-article"
+          authorName="Author"
+          authorStellarAddress="GABC"
+        />
+      )
+      await new Promise((r) => setTimeout(r, 150))
+    })
+
+    expect(HighlightTipButtonSpy).toHaveBeenCalledTimes(1)
+    const props = HighlightTipButtonSpy.mock.calls[0]![0] as {
+      resumeOpen?: boolean
+      resumeAmountCents?: number
+      highlightText?: string
+      onResumeOpenChange?: (open: boolean) => void
+    }
+    expect(props.resumeOpen).toBe(true)
+    expect(props.resumeAmountCents).toBe(500)
+    expect(props.highlightText).toBe('Selected highlight text')
+    expect(props.onResumeOpenChange).toBeTypeOf('function')
+  })
+})

--- a/components/tipping/PendingTipResume.tsx
+++ b/components/tipping/PendingTipResume.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useAuth } from '@/components/providers/AuthContext'
+import { HighlightTipButton } from '@/components/highlights/HighlightTipButton'
+import {
+  clearPendingTipIntent,
+  matchesHighlightPendingIntent,
+  readPendingTipIntent,
+  type HighlightPendingTipIntent,
+} from '@/lib/tip/pendingTipIntent'
+import type { Id } from '@/convex/_generated/dataModel'
+
+interface PendingTipResumeProps {
+  articleId: Id<'articles'>
+  articleSlug: string
+  authorName: string
+  authorStellarAddress?: string | null
+}
+
+export function PendingTipResume({
+  articleId,
+  articleSlug,
+  authorName,
+  authorStellarAddress,
+}: PendingTipResumeProps) {
+  const { isAuthenticated } = useAuth()
+  const resumedRef = useRef(false)
+  const [intent, setIntent] = useState<HighlightPendingTipIntent | null>(null)
+
+  useEffect(() => {
+    if (!isAuthenticated || resumedRef.current) return
+    const pending = readPendingTipIntent()
+    if (!matchesHighlightPendingIntent(pending, articleId)) return
+    resumedRef.current = true
+    clearPendingTipIntent()
+    setIntent(pending)
+  }, [isAuthenticated, articleId])
+
+  if (!intent) return null
+
+  return (
+    <div className="sr-only" aria-hidden>
+      <HighlightTipButton
+        articleId={articleId}
+        articleSlug={articleSlug}
+        authorName={authorName}
+        authorStellarAddress={authorStellarAddress}
+        highlightText={intent.highlightText}
+        startOffset={intent.startOffset}
+        endOffset={intent.endOffset}
+        startContainerPath={intent.startContainerPath}
+        endContainerPath={intent.endContainerPath}
+        resumeOpen
+        resumeAmountCents={intent.amountCents}
+        resumeCustomAmount={intent.customAmount}
+      />
+    </div>
+  )
+}

--- a/components/tipping/PendingTipResume.tsx
+++ b/components/tipping/PendingTipResume.tsx
@@ -1,14 +1,9 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
-import { useAuth } from '@/components/providers/AuthContext'
+import { useState } from 'react'
 import { HighlightTipButton } from '@/components/highlights/HighlightTipButton'
-import {
-  clearPendingTipIntent,
-  matchesHighlightPendingIntent,
-  readPendingTipIntent,
-  type HighlightPendingTipIntent,
-} from '@/lib/tip/pendingTipIntent'
+import { useHighlightTipResume } from '@/hooks/useHighlightTipResume'
+import type { HighlightPendingTipIntent } from '@/lib/tip/pendingTipIntent'
 import type { Id } from '@/convex/_generated/dataModel'
 
 interface PendingTipResumeProps {
@@ -24,23 +19,22 @@ export function PendingTipResume({
   authorName,
   authorStellarAddress,
 }: PendingTipResumeProps) {
-  const { isAuthenticated } = useAuth()
-  const resumedRef = useRef(false)
   const [intent, setIntent] = useState<HighlightPendingTipIntent | null>(null)
+  const [isOpen, setIsOpen] = useState(false)
 
-  useEffect(() => {
-    if (!isAuthenticated || resumedRef.current) return
-    const pending = readPendingTipIntent()
-    if (!matchesHighlightPendingIntent(pending, articleId)) return
-    resumedRef.current = true
-    clearPendingTipIntent()
-    setIntent(pending)
-  }, [isAuthenticated, articleId])
+  useHighlightTipResume({
+    articleId,
+    isOpen,
+    onResume: (pending) => {
+      setIntent(pending)
+      setIsOpen(true)
+    },
+  })
 
   if (!intent) return null
 
   return (
-    <div className="sr-only" aria-hidden>
+    <div className="sr-only">
       <HighlightTipButton
         articleId={articleId}
         articleSlug={articleSlug}
@@ -54,6 +48,7 @@ export function PendingTipResume({
         resumeOpen
         resumeAmountCents={intent.amountCents}
         resumeCustomAmount={intent.customAmount}
+        onResumeOpenChange={setIsOpen}
       />
     </div>
   )

--- a/components/tipping/TipButton.test.tsx
+++ b/components/tipping/TipButton.test.tsx
@@ -40,7 +40,8 @@ vi.mock('@/hooks/useTipDialogXlmUsdRate', () => ({
 }))
 
 vi.mock('@/lib/tip/redirectToLoginForTip', () => ({
-  redirectToLoginForTip: (...args: unknown[]) => mockRedirectToLoginForTip(...args),
+  redirectToLoginForTip: (...args: unknown[]) =>
+    mockRedirectToLoginForTip(...args),
 }))
 
 vi.mock('@/lib/tip/pendingTipIntent', () => ({
@@ -140,5 +141,4 @@ describe('TipButton auth-first CTA', () => {
     await user.click(screen.getByRole('button', { name: /Tip Author/i }))
     expect(screen.getByRole('button', { name: 'Send Tip' })).toBeInTheDocument()
   })
-
 })

--- a/components/tipping/TipButton.test.tsx
+++ b/components/tipping/TipButton.test.tsx
@@ -1,0 +1,144 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TipButton } from '@/components/tipping/TipButton'
+
+const mockRedirectToLoginForTip = vi.hoisted(() => vi.fn())
+const mockIsAuthenticated = vi.hoisted(() => vi.fn(() => false))
+const mockIsConnected = vi.hoisted(() => vi.fn(() => false))
+
+vi.mock('convex/react', () => ({
+  useConvex: () => ({ query: vi.fn() }),
+  useMutation: () => vi.fn(),
+}))
+
+vi.mock('@/components/providers/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: mockIsAuthenticated() }),
+}))
+
+vi.mock('@/components/providers/WalletProvider', () => ({
+  useWallet: () => ({
+    isConnected: mockIsConnected(),
+    publicKey: null,
+    signTransaction: vi.fn(),
+    connect: vi.fn(),
+  }),
+}))
+
+vi.mock('@/components/providers/WalletActivationContext', () => ({
+  useWalletActivation: () => ({ activateWallet: vi.fn() }),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  usePathname: () => '/author/article-slug',
+}))
+
+vi.mock('@/hooks/useTipDialogXlmUsdRate', () => ({
+  useTipDialogXlmUsdRate: () => ({ priceUsd: null }),
+}))
+
+vi.mock('@/lib/tip/redirectToLoginForTip', () => ({
+  redirectToLoginForTip: (...args: unknown[]) => mockRedirectToLoginForTip(...args),
+}))
+
+vi.mock('@/lib/tip/pendingTipIntent', () => ({
+  clearPendingTipIntent: vi.fn(),
+}))
+
+vi.mock('@/hooks/useArticleTipResume', () => ({
+  useArticleTipResume: vi.fn(),
+}))
+
+vi.mock('@/lib/stellar/stellar-flow-emitter', () => ({
+  stellarFlowEmitter: { subscribe: () => () => {} },
+  tipFlowProgressLabel: () => 'Processing',
+}))
+
+describe('TipButton auth-first CTA', () => {
+  beforeEach(() => {
+    mockRedirectToLoginForTip.mockClear()
+    mockIsAuthenticated.mockReturnValue(false)
+    mockIsConnected.mockReturnValue(false)
+  })
+
+  it('shows Sign in to tip when signed out', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(
+      <TipButton
+        articleId={'articles:abc' as never}
+        authorName="Author"
+        authorStellarAddress="GABC"
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /Tip Author/i }))
+    await user.click(screen.getByRole('button', { name: '$1' }))
+    expect(
+      screen.getByRole('button', { name: 'Sign in to tip' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Connect Wallet' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('redirects to login with article intent when Sign in to tip is clicked', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(
+      <TipButton
+        articleId={'articles:abc' as never}
+        authorName="Author"
+        authorStellarAddress="GABC"
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /Tip Author/i }))
+    await user.click(screen.getByRole('button', { name: '$1' }))
+    await user.click(screen.getByRole('button', { name: 'Sign in to tip' }))
+
+    expect(mockRedirectToLoginForTip).toHaveBeenCalledWith(
+      expect.anything(),
+      '/author/article-slug',
+      expect.objectContaining({
+        kind: 'article',
+        articleId: 'articles:abc',
+        amountCents: 100,
+      })
+    )
+  })
+
+  it('shows Connect Wallet when signed in without wallet', async () => {
+    mockIsAuthenticated.mockReturnValue(true)
+    const user = userEvent.setup({ delay: null })
+    render(
+      <TipButton
+        articleId={'articles:abc' as never}
+        authorName="Author"
+        authorStellarAddress="GABC"
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /Tip Author/i }))
+    expect(
+      screen.getByRole('button', { name: 'Connect Wallet' })
+    ).toBeInTheDocument()
+  })
+
+  it('shows Send Tip when signed in with wallet', async () => {
+    mockIsAuthenticated.mockReturnValue(true)
+    mockIsConnected.mockReturnValue(true)
+    const user = userEvent.setup({ delay: null })
+    render(
+      <TipButton
+        articleId={'articles:abc' as never}
+        authorName="Author"
+        authorStellarAddress="GABC"
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /Tip Author/i }))
+    expect(screen.getByRole('button', { name: 'Send Tip' })).toBeInTheDocument()
+  })
+
+})

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useConvex, useMutation } from 'convex/react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { useWallet } from '@/components/providers/WalletProvider'
@@ -27,9 +27,7 @@ import { TipUsdXlmRateLine } from '@/components/tipping/TipUsdXlmRateLine'
 import { useTipDialogXlmUsdRate } from '@/hooks/useTipDialogXlmUsdRate'
 import {
   TIP_PRESETS_ARTICLE,
-  TIP_MIN_CENTS,
   TIP_MIN_USD,
-  TIP_MAX_CENTS,
   TIP_MAX_USD,
 } from '@/lib/constants'
 import {
@@ -50,13 +48,11 @@ import {
   type TipFailureMessage,
 } from '@/lib/stellar/tip-error-messages'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
-import { redirectToLoginForTip } from '@/lib/tip/redirectToLoginForTip'
+import { signInToTip, validateTipAmountForm } from '@/lib/tip/signInToTip'
 import { applyPendingAmountFields } from '@/lib/tip/applyPendingTipFormState'
-import {
-  clearPendingTipIntent,
-  matchesArticlePendingIntent,
-  readPendingTipIntent,
-} from '@/lib/tip/pendingTipIntent'
+import { clearPendingTipIntent } from '@/lib/tip/pendingTipIntent'
+import type { ArticlePendingTipIntent } from '@/lib/tip/pendingTipIntent'
+import { useArticleTipResume } from '@/hooks/useArticleTipResume'
 
 interface TipButtonProps {
   articleId: Id<'articles'>
@@ -84,7 +80,6 @@ export function TipButton({
   const [tipFlowStep, setTipFlowStep] = useState<TipFlowStep | null>(null)
   const [tipFailure, setTipFailure] = useState<TipFailureMessage | null>(null)
   const [tipMessage, setTipMessage] = useState('')
-  const resumedRef = useRef(false)
 
   const convex = useConvex()
   const sendTip = useMutation(api.tips.sendTip)
@@ -98,56 +93,59 @@ export function TipButton({
     })
   }, [])
 
-  useEffect(() => {
-    if (!isAuthenticated || resumedRef.current) return
-    const pending = readPendingTipIntent()
-    if (!matchesArticlePendingIntent(pending, articleId)) return
-    resumedRef.current = true
-    applyPendingAmountFields(pending, setSelectedAmount, setCustomAmount)
-    if (pending.message) setTipMessage(pending.message)
-    clearPendingTipIntent()
-    activateWallet()
-    setIsOpen(true)
-  }, [isAuthenticated, articleId, activateWallet])
+  const applyResumeIntent = useCallback(
+    (intent: ArticlePendingTipIntent) => {
+      applyPendingAmountFields(intent, setSelectedAmount, setCustomAmount)
+      if (intent.message) setTipMessage(intent.message)
+      activateWallet()
+      setIsOpen(true)
+      requestAnimationFrame(() => setIsOpen(true))
+    },
+    [activateWallet]
+  )
+
+  useArticleTipResume({
+    articleId,
+    isOpen,
+    onResume: applyResumeIntent,
+  })
 
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
-    if (open) {
+    if (open && isAuthenticated) {
       activateWallet()
     }
     setIsOpen(open)
     setTipFailure(null)
   }
 
-  const handleTip = async () => {
-    const amountCents = selectedAmount || parseFloat(customAmount) * 100
-
-    if (!amountCents || amountCents < TIP_MIN_CENTS) {
-      toast.error('Please select or enter a valid amount')
-      return
-    }
-
-    if (amountCents > TIP_MAX_CENTS) {
-      toast.error(`Maximum tip amount is $${TIP_MAX_USD.toFixed(2)}`)
-      return
-    }
-
-    if (tipMessage.length > 500) {
-      toast.error('Message must be 500 characters or less')
-      return
-    }
-
-    if (!isAuthenticated) {
-      toast.error('Please sign in to send tips')
-      redirectToLoginForTip(router, pathname, {
+  const handleSignInToTip = () => {
+    signInToTip(
+      router,
+      pathname,
+      {
+        selectedAmount,
+        customAmount,
+        message: tipMessage,
+      },
+      {
         kind: 'article',
         articleId: articleId,
         ...(selectedAmount != null ? { amountCents: selectedAmount } : {}),
         ...(customAmount ? { customAmount } : {}),
         ...(tipMessage.trim() ? { message: tipMessage.trim() } : {}),
-      })
-      return
-    }
+      }
+    )
+  }
+
+  const handleTip = async () => {
+    const validation = validateTipAmountForm({
+      selectedAmount,
+      customAmount,
+      message: tipMessage,
+    })
+    if (!validation.ok) return
+    const amountCents = validation.amountCents
 
     if (!isConnected || !publicKey) {
       toast.error('Please connect your Stellar wallet to send tips')
@@ -317,7 +315,14 @@ export function TipButton({
             </Alert>
           )}
 
-          {!isConnected && (
+          {!isAuthenticated ? (
+            <div className="p-3 bg-muted border border-border rounded-lg text-sm text-muted-foreground">
+              <p>Sign in to send a tip to {authorName}.</p>
+              <p className="mt-1">
+                You can connect your Stellar wallet after signing in.
+              </p>
+            </div>
+          ) : !isConnected ? (
             <div className="p-3 bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-lg text-sm text-amber-900 dark:text-amber-100">
               <p>Connect your Stellar wallet to send tips to {authorName}.</p>
               <p className="mt-1">
@@ -330,7 +335,7 @@ export function TipButton({
                 </Link>
               </p>
             </div>
-          )}
+          ) : null}
 
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
             {TIP_PRESETS_ARTICLE.map((amount) => (
@@ -432,7 +437,17 @@ export function TipButton({
               Cancel
             </button>
 
-            {!isConnected ? (
+            {!isAuthenticated ? (
+              <button
+                type="button"
+                onClick={handleSignInToTip}
+                disabled={isLoading || (!selectedAmount && !customAmount)}
+                className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              >
+                <Heart className="w-4 h-4" />
+                <span>Sign in to tip</span>
+              </button>
+            ) : !isConnected ? (
               <button
                 type="button"
                 onClick={handleConnectWallet}

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -25,11 +25,7 @@ import {
 import { TipBreakdownSummaryLine } from '@/components/tipping/TipBreakdownSummaryLine'
 import { TipUsdXlmRateLine } from '@/components/tipping/TipUsdXlmRateLine'
 import { useTipDialogXlmUsdRate } from '@/hooks/useTipDialogXlmUsdRate'
-import {
-  TIP_PRESETS_ARTICLE,
-  TIP_MIN_USD,
-  TIP_MAX_USD,
-} from '@/lib/constants'
+import { TIP_PRESETS_ARTICLE, TIP_MIN_USD, TIP_MAX_USD } from '@/lib/constants'
 import {
   Dialog,
   DialogContent,

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useConvex, useMutation } from 'convex/react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { useWallet } from '@/components/providers/WalletProvider'
 import { useWalletActivation } from '@/components/providers/WalletActivationContext'
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 import { AlertCircle, Coins, Heart, Loader2, Wallet } from 'lucide-react'
 import { WalletTooltip } from '@/components/guide/WalletTooltip'
@@ -50,6 +50,13 @@ import {
   type TipFailureMessage,
 } from '@/lib/stellar/tip-error-messages'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { redirectToLoginForTip } from '@/lib/tip/redirectToLoginForTip'
+import { applyPendingAmountFields } from '@/lib/tip/applyPendingTipFormState'
+import {
+  clearPendingTipIntent,
+  matchesArticlePendingIntent,
+  readPendingTipIntent,
+} from '@/lib/tip/pendingTipIntent'
 
 interface TipButtonProps {
   articleId: Id<'articles'>
@@ -68,6 +75,7 @@ export function TipButton({
   const { isConnected, publicKey, signTransaction, connect } = useWallet()
   const { activateWallet } = useWalletActivation()
   const router = useRouter()
+  const pathname = usePathname()
   const [isOpen, setIsOpen] = useState(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
   const [selectedAmount, setSelectedAmount] = useState<number | null>(null)
@@ -76,6 +84,7 @@ export function TipButton({
   const [tipFlowStep, setTipFlowStep] = useState<TipFlowStep | null>(null)
   const [tipFailure, setTipFailure] = useState<TipFailureMessage | null>(null)
   const [tipMessage, setTipMessage] = useState('')
+  const resumedRef = useRef(false)
 
   const convex = useConvex()
   const sendTip = useMutation(api.tips.sendTip)
@@ -89,6 +98,18 @@ export function TipButton({
     })
   }, [])
 
+  useEffect(() => {
+    if (!isAuthenticated || resumedRef.current) return
+    const pending = readPendingTipIntent()
+    if (!matchesArticlePendingIntent(pending, articleId)) return
+    resumedRef.current = true
+    applyPendingAmountFields(pending, setSelectedAmount, setCustomAmount)
+    if (pending.message) setTipMessage(pending.message)
+    clearPendingTipIntent()
+    activateWallet()
+    setIsOpen(true)
+  }, [isAuthenticated, articleId, activateWallet])
+
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
     if (open) {
@@ -99,17 +120,6 @@ export function TipButton({
   }
 
   const handleTip = async () => {
-    if (!isAuthenticated) {
-      toast.error('Please sign in to send tips')
-      router.push('/login')
-      return
-    }
-
-    if (!isConnected || !publicKey) {
-      toast.error('Please connect your Stellar wallet to send tips')
-      return
-    }
-
     const amountCents = selectedAmount || parseFloat(customAmount) * 100
 
     if (!amountCents || amountCents < TIP_MIN_CENTS) {
@@ -122,15 +132,32 @@ export function TipButton({
       return
     }
 
+    if (tipMessage.length > 500) {
+      toast.error('Message must be 500 characters or less')
+      return
+    }
+
+    if (!isAuthenticated) {
+      toast.error('Please sign in to send tips')
+      redirectToLoginForTip(router, pathname, {
+        kind: 'article',
+        articleId: articleId,
+        ...(selectedAmount != null ? { amountCents: selectedAmount } : {}),
+        ...(customAmount ? { customAmount } : {}),
+        ...(tipMessage.trim() ? { message: tipMessage.trim() } : {}),
+      })
+      return
+    }
+
+    if (!isConnected || !publicKey) {
+      toast.error('Please connect your Stellar wallet to send tips')
+      return
+    }
+
     if (!authorStellarAddress) {
       toast.error(
         'Author has not set up their Stellar wallet for receiving tips'
       )
-      return
-    }
-
-    if (tipMessage.length > 500) {
-      toast.error('Message must be 500 characters or less')
       return
     }
 
@@ -188,6 +215,7 @@ export function TipButton({
         authorShare: transactionData.authorReceived,
       })
 
+      clearPendingTipIntent()
       setTipFailure(null)
       setIsOpen(false)
       setSelectedAmount(null)

--- a/hooks/useArticleTipResume.test.ts
+++ b/hooks/useArticleTipResume.test.ts
@@ -1,0 +1,126 @@
+/** @vitest-environment jsdom */
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useArticleTipResume } from './useArticleTipResume'
+import {
+  PENDING_TIP_INTENT_STORAGE_KEY,
+  writePendingTipIntent,
+} from '@/lib/tip/pendingTipIntent'
+import type { Id } from '@/convex/_generated/dataModel'
+
+const mockAuth = vi.hoisted(() => ({
+  isAuthenticated: false,
+  isLoading: true,
+}))
+
+const mockRouter = vi.hoisted(() => ({
+  replace: vi.fn(),
+}))
+
+const mockSearchParams = vi.hoisted(() => new URLSearchParams())
+
+vi.mock('@/components/providers/AuthContext', () => ({
+  useAuth: () => ({
+    isAuthenticated: mockAuth.isAuthenticated,
+    isLoading: mockAuth.isLoading,
+  }),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => mockRouter,
+  usePathname: () => '/alice/post',
+  useSearchParams: () => mockSearchParams,
+}))
+
+describe('useArticleTipResume', () => {
+  const store: Record<string, string> = {}
+  const local: Record<string, string> = {}
+  const articleId = 'articles:abc' as Id<'articles'>
+
+  beforeEach(() => {
+    mockAuth.isAuthenticated = false
+    mockAuth.isLoading = true
+    mockRouter.replace.mockClear()
+    for (const key of mockSearchParams.keys()) {
+      mockSearchParams.delete(key)
+    }
+    vi.stubGlobal('window', {
+      sessionStorage: {
+        getItem: (k: string) => (k in store ? store[k] : null),
+        setItem: (k: string, v: string) => {
+          store[k] = v
+        },
+        removeItem: (k: string) => {
+          delete store[k]
+        },
+      },
+      localStorage: {
+        getItem: (k: string) => (k in local ? local[k] : null),
+        setItem: (k: string, v: string) => {
+          local[k] = v
+        },
+        removeItem: (k: string) => {
+          delete local[k]
+        },
+      },
+      setInterval: globalThis.setInterval,
+      clearInterval: globalThis.clearInterval,
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout,
+    })
+    writePendingTipIntent({
+      kind: 'article',
+      articleId: 'articles:abc',
+      amountCents: 100,
+      customAmount: '1.00',
+      message: 'Nice',
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    for (const key of Object.keys(store)) delete store[key]
+    for (const key of Object.keys(local)) delete local[key]
+  })
+
+  it('waits for auth then calls onResume without clearing until modal opens', async () => {
+    const onResume = vi.fn()
+    mockSearchParams.set('resumeArticleTip', '1')
+
+    const { rerender } = renderHook(
+      ({ isOpen }) =>
+        useArticleTipResume({ articleId, isOpen, onResume }),
+      { initialProps: { isOpen: false } }
+    )
+
+    expect(onResume).not.toHaveBeenCalled()
+    expect(store[PENDING_TIP_INTENT_STORAGE_KEY]).toBeDefined()
+
+    mockAuth.isLoading = false
+    mockAuth.isAuthenticated = true
+    rerender({ isOpen: false })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(onResume).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'article',
+        articleId: 'articles:abc',
+        amountCents: 100,
+      })
+    )
+    expect(store[PENDING_TIP_INTENT_STORAGE_KEY]).toBeDefined()
+
+    rerender({ isOpen: true })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(store[PENDING_TIP_INTENT_STORAGE_KEY]).toBeUndefined()
+    expect(mockRouter.replace).toHaveBeenCalledWith('/alice/post', {
+      scroll: false,
+    })
+  })
+})

--- a/hooks/useArticleTipResume.test.ts
+++ b/hooks/useArticleTipResume.test.ts
@@ -88,8 +88,7 @@ describe('useArticleTipResume', () => {
     mockSearchParams.set('resumeArticleTip', '1')
 
     const { rerender } = renderHook(
-      ({ isOpen }) =>
-        useArticleTipResume({ articleId, isOpen, onResume }),
+      ({ isOpen }) => useArticleTipResume({ articleId, isOpen, onResume }),
       { initialProps: { isOpen: false } }
     )
 

--- a/hooks/useArticleTipResume.ts
+++ b/hooks/useArticleTipResume.ts
@@ -1,0 +1,84 @@
+'use client'
+
+import { useCallback, useEffect, useRef } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { useAuth } from '@/components/providers/AuthContext'
+import type { Id } from '@/convex/_generated/dataModel'
+import { hasArticleTipResumeFlag } from '@/lib/tip/articleTipResumeUrl'
+import { clearPendingTipIntent } from '@/lib/tip/pendingTipIntent'
+import type { ArticlePendingTipIntent } from '@/lib/tip/pendingTipIntent'
+import {
+  resolveArticleTipResume,
+  shouldKeepTryingArticleTipResume,
+} from '@/lib/tip/resolveArticleTipResume'
+
+const RESUME_RETRY_MS = 100
+const RESUME_TIMEOUT_MS = 15_000
+
+type UseArticleTipResumeOptions = {
+  articleId: Id<'articles'>
+  isOpen: boolean
+  onResume: (intent: ArticlePendingTipIntent) => void
+}
+
+/**
+ * After login, restores a pending article tip and opens the modal.
+ * Retries until auth is ready; defers clearing storage/URL until the modal opens.
+ */
+export function useArticleTipResume({
+  articleId,
+  isOpen,
+  onResume,
+}: UseArticleTipResumeOptions): void {
+  const { isAuthenticated, isLoading: authLoading } = useAuth()
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const pathname = usePathname()
+  const resumedRef = useRef(false)
+  const onResumeRef = useRef(onResume)
+  onResumeRef.current = onResume
+
+  const stripResumeQueryFromUrl = useCallback(() => {
+    if (!hasArticleTipResumeFlag(searchParams)) return
+    router.replace(pathname, { scroll: false })
+  }, [pathname, router, searchParams])
+
+  const tryResume = useCallback((): boolean => {
+    if (resumedRef.current) return true
+    if (authLoading || !isAuthenticated) return false
+
+    const intent = resolveArticleTipResume(articleId, searchParams)
+    if (!intent) return false
+
+    resumedRef.current = true
+    onResumeRef.current(intent)
+    return true
+  }, [articleId, authLoading, isAuthenticated, searchParams])
+
+  useEffect(() => {
+    if (!isOpen || !resumedRef.current) return
+    clearPendingTipIntent()
+    stripResumeQueryFromUrl()
+  }, [isOpen, stripResumeQueryFromUrl])
+
+  useEffect(() => {
+    if (tryResume()) return
+
+    if (!shouldKeepTryingArticleTipResume(articleId, searchParams)) return
+
+    const intervalId = window.setInterval(() => {
+      if (tryResume()) {
+        window.clearInterval(intervalId)
+      }
+    }, RESUME_RETRY_MS)
+
+    const timeoutId = window.setTimeout(() => {
+      window.clearInterval(intervalId)
+    }, RESUME_TIMEOUT_MS)
+
+    return () => {
+      window.clearInterval(intervalId)
+      window.clearTimeout(timeoutId)
+    }
+  }, [articleId, searchParams, tryResume])
+}

--- a/hooks/useHighlightTipResume.test.ts
+++ b/hooks/useHighlightTipResume.test.ts
@@ -73,8 +73,7 @@ describe('useHighlightTipResume', () => {
     const onResume = vi.fn()
 
     const { rerender } = renderHook(
-      ({ isOpen }) =>
-        useHighlightTipResume({ articleId, isOpen, onResume }),
+      ({ isOpen }) => useHighlightTipResume({ articleId, isOpen, onResume }),
       { initialProps: { isOpen: false } }
     )
 
@@ -105,5 +104,4 @@ describe('useHighlightTipResume', () => {
 
     expect(store[PENDING_TIP_INTENT_STORAGE_KEY]).toBeUndefined()
   })
-
 })

--- a/hooks/useHighlightTipResume.test.ts
+++ b/hooks/useHighlightTipResume.test.ts
@@ -1,0 +1,109 @@
+/** @vitest-environment jsdom */
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useHighlightTipResume } from './useHighlightTipResume'
+import {
+  PENDING_TIP_INTENT_STORAGE_KEY,
+  writePendingTipIntent,
+} from '@/lib/tip/pendingTipIntent'
+import type { Id } from '@/convex/_generated/dataModel'
+
+const mockAuth = vi.hoisted(() => ({
+  isAuthenticated: false,
+  isLoading: true,
+}))
+
+vi.mock('@/components/providers/AuthContext', () => ({
+  useAuth: () => ({
+    isAuthenticated: mockAuth.isAuthenticated,
+    isLoading: mockAuth.isLoading,
+  }),
+}))
+
+describe('useHighlightTipResume', () => {
+  const store: Record<string, string> = {}
+  const local: Record<string, string> = {}
+  const articleId = 'articles:abc' as Id<'articles'>
+
+  beforeEach(() => {
+    mockAuth.isAuthenticated = false
+    mockAuth.isLoading = true
+    vi.stubGlobal('window', {
+      sessionStorage: {
+        getItem: (k: string) => (k in store ? store[k] : null),
+        setItem: (k: string, v: string) => {
+          store[k] = v
+        },
+        removeItem: (k: string) => {
+          delete store[k]
+        },
+      },
+      localStorage: {
+        getItem: (k: string) => (k in local ? local[k] : null),
+        setItem: (k: string, v: string) => {
+          local[k] = v
+        },
+        removeItem: (k: string) => {
+          delete local[k]
+        },
+      },
+      setInterval: globalThis.setInterval,
+      clearInterval: globalThis.clearInterval,
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout,
+    })
+    writePendingTipIntent({
+      kind: 'highlight',
+      articleId: 'articles:abc',
+      articleSlug: 'slug',
+      highlightText: 'Selected text',
+      startOffset: 1,
+      endOffset: 10,
+      amountCents: 500,
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    for (const key of Object.keys(store)) delete store[key]
+    for (const key of Object.keys(local)) delete local[key]
+  })
+
+  it('waits for auth then calls onResume without clearing until modal opens', async () => {
+    const onResume = vi.fn()
+
+    const { rerender } = renderHook(
+      ({ isOpen }) =>
+        useHighlightTipResume({ articleId, isOpen, onResume }),
+      { initialProps: { isOpen: false } }
+    )
+
+    expect(onResume).not.toHaveBeenCalled()
+    expect(store[PENDING_TIP_INTENT_STORAGE_KEY]).toBeDefined()
+
+    mockAuth.isLoading = false
+    mockAuth.isAuthenticated = true
+    rerender({ isOpen: false })
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 150))
+    })
+
+    expect(onResume).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'highlight',
+        amountCents: 500,
+        highlightText: 'Selected text',
+      })
+    )
+    expect(store[PENDING_TIP_INTENT_STORAGE_KEY]).toBeDefined()
+
+    rerender({ isOpen: true })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(store[PENDING_TIP_INTENT_STORAGE_KEY]).toBeUndefined()
+  })
+
+})

--- a/hooks/useHighlightTipResume.ts
+++ b/hooks/useHighlightTipResume.ts
@@ -1,0 +1,77 @@
+'use client'
+
+import { useCallback, useEffect, useRef } from 'react'
+import { useAuth } from '@/components/providers/AuthContext'
+import type { Id } from '@/convex/_generated/dataModel'
+import {
+  clearPendingTipIntent,
+  matchesHighlightPendingIntent,
+  readPendingTipIntent,
+  type HighlightPendingTipIntent,
+} from '@/lib/tip/pendingTipIntent'
+
+const RESUME_RETRY_MS = 100
+const RESUME_TIMEOUT_MS = 15_000
+
+type UseHighlightTipResumeOptions = {
+  articleId: Id<'articles'>
+  isOpen: boolean
+  onResume: (intent: HighlightPendingTipIntent) => void
+}
+
+/**
+ * After login, restores a pending highlight tip and opens the modal.
+ * Retries until auth is ready; defers clearing storage until the modal opens.
+ */
+export function useHighlightTipResume({
+  articleId,
+  isOpen,
+  onResume,
+}: UseHighlightTipResumeOptions): void {
+  const { isAuthenticated, isLoading: authLoading } = useAuth()
+  const resumedRef = useRef(false)
+  const claimedRef = useRef(false)
+  const onResumeRef = useRef(onResume)
+  onResumeRef.current = onResume
+
+  const tryResume = useCallback((): boolean => {
+    if (resumedRef.current) return true
+    if (authLoading || !isAuthenticated) return false
+
+    const intent = readPendingTipIntent()
+    if (!matchesHighlightPendingIntent(intent, articleId)) return false
+
+    if (claimedRef.current) return false
+    claimedRef.current = true
+    resumedRef.current = true
+    onResumeRef.current(intent)
+    return true
+  }, [articleId, authLoading, isAuthenticated])
+
+  useEffect(() => {
+    if (!isOpen || !resumedRef.current) return
+    clearPendingTipIntent()
+  }, [isOpen])
+
+  useEffect(() => {
+    if (tryResume()) return
+
+    const pending = readPendingTipIntent()
+    if (!matchesHighlightPendingIntent(pending, articleId)) return
+
+    const intervalId = window.setInterval(() => {
+      if (tryResume()) {
+        window.clearInterval(intervalId)
+      }
+    }, RESUME_RETRY_MS)
+
+    const timeoutId = window.setTimeout(() => {
+      window.clearInterval(intervalId)
+    }, RESUME_TIMEOUT_MS)
+
+    return () => {
+      window.clearInterval(intervalId)
+      window.clearTimeout(timeoutId)
+    }
+  }, [articleId, tryResume])
+}

--- a/hooks/useRedirectWhenUnauthenticated.ts
+++ b/hooks/useRedirectWhenUnauthenticated.ts
@@ -2,10 +2,7 @@
 
 import { useEffect } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import {
-  buildLoginHref,
-  getCurrentReturnPath,
-} from '@/lib/auth/safeReturnPath'
+import { buildLoginHref, getCurrentReturnPath } from '@/lib/auth/safeReturnPath'
 
 export function useRedirectWhenUnauthenticated(
   isLoading: boolean,

--- a/hooks/useRedirectWhenUnauthenticated.ts
+++ b/hooks/useRedirectWhenUnauthenticated.ts
@@ -1,18 +1,23 @@
 'use client'
 
 import { useEffect } from 'react'
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import {
+  buildLoginHref,
+  getCurrentReturnPath,
+} from '@/lib/auth/safeReturnPath'
 
 export function useRedirectWhenUnauthenticated(
   isLoading: boolean,
-  isAuthenticated: boolean,
-  loginPath = '/login'
+  isAuthenticated: boolean
 ): void {
   const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
   useEffect(() => {
-    if (isLoading) return
-    if (!isAuthenticated) {
-      router.push(loginPath)
-    }
-  }, [isAuthenticated, isLoading, loginPath, router])
+    if (isLoading || isAuthenticated) return
+    const returnPath = getCurrentReturnPath(pathname, searchParams)
+    router.replace(buildLoginHref(returnPath))
+  }, [isAuthenticated, isLoading, pathname, router, searchParams])
 }

--- a/lib/auth/safeReturnPath.test.ts
+++ b/lib/auth/safeReturnPath.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   buildLoginHref,
   buildRegisterHref,
+  getCurrentReturnPath,
   getSafeReturnPath,
 } from './safeReturnPath'
 
@@ -42,6 +43,30 @@ describe('getSafeReturnPath', () => {
 
   it('uses custom fallback', () => {
     expect(getSafeReturnPath(null, '/articles')).toBe('/articles')
+  })
+})
+
+describe('getCurrentReturnPath', () => {
+  it('returns pathname only when search is empty', () => {
+    expect(getCurrentReturnPath('/write', new URLSearchParams())).toBe('/write')
+  })
+
+  it('combines pathname and query string', () => {
+    expect(
+      getCurrentReturnPath(
+        '/write',
+        new URLSearchParams('id=abc123')
+      )
+    ).toBe('/write?id=abc123')
+  })
+
+  it('preserves multiple query params', () => {
+    expect(
+      getCurrentReturnPath(
+        '/profile',
+        new URLSearchParams('tab=wallet')
+      )
+    ).toBe('/profile?tab=wallet')
   })
 })
 

--- a/lib/auth/safeReturnPath.test.ts
+++ b/lib/auth/safeReturnPath.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildLoginHref,
+  buildRegisterHref,
+  getSafeReturnPath,
+} from './safeReturnPath'
+
+describe('getSafeReturnPath', () => {
+  it('returns fallback for null, undefined, and empty', () => {
+    expect(getSafeReturnPath(null)).toBe('/')
+    expect(getSafeReturnPath(undefined)).toBe('/')
+    expect(getSafeReturnPath('')).toBe('/')
+    expect(getSafeReturnPath('   ')).toBe('/')
+  })
+
+  it('accepts valid relative paths', () => {
+    expect(getSafeReturnPath('/alice/my-article')).toBe('/alice/my-article')
+    expect(getSafeReturnPath('/articles?page=2')).toBe('/articles?page=2')
+  })
+
+  it('rejects protocol-relative and absolute URLs', () => {
+    expect(getSafeReturnPath('//evil.com')).toBe('/')
+    expect(getSafeReturnPath('https://evil.com')).toBe('/')
+    expect(getSafeReturnPath('http://evil.com/path')).toBe('/')
+  })
+
+  it('rejects paths without leading slash', () => {
+    expect(getSafeReturnPath('alice/article')).toBe('/')
+  })
+
+  it('rejects javascript and data URLs', () => {
+    expect(getSafeReturnPath('javascript:alert(1)')).toBe('/')
+    expect(getSafeReturnPath('/x?next=data:text/html,bad')).toBe(
+      '/x?next=data:text/html,bad'
+    )
+    expect(getSafeReturnPath('data:text/html,bad')).toBe('/')
+  })
+
+  it('rejects paths with backslashes', () => {
+    expect(getSafeReturnPath('/path\\evil')).toBe('/')
+  })
+
+  it('uses custom fallback', () => {
+    expect(getSafeReturnPath(null, '/articles')).toBe('/articles')
+  })
+})
+
+describe('buildLoginHref / buildRegisterHref', () => {
+  it('encodes safe return path in login URL', () => {
+    expect(buildLoginHref('/user/slug')).toBe(
+      '/login?returnTo=%2Fuser%2Fslug'
+    )
+  })
+
+  it('falls back for unsafe paths', () => {
+    expect(buildLoginHref('https://evil.com')).toBe('/login?returnTo=%2F')
+  })
+
+  it('encodes safe return path in register URL', () => {
+    expect(buildRegisterHref('/user/slug')).toBe(
+      '/register?returnTo=%2Fuser%2Fslug'
+    )
+  })
+})

--- a/lib/auth/safeReturnPath.test.ts
+++ b/lib/auth/safeReturnPath.test.ts
@@ -47,9 +47,7 @@ describe('getSafeReturnPath', () => {
 
 describe('buildLoginHref / buildRegisterHref', () => {
   it('encodes safe return path in login URL', () => {
-    expect(buildLoginHref('/user/slug')).toBe(
-      '/login?returnTo=%2Fuser%2Fslug'
-    )
+    expect(buildLoginHref('/user/slug')).toBe('/login?returnTo=%2Fuser%2Fslug')
   })
 
   it('falls back for unsafe paths', () => {

--- a/lib/auth/safeReturnPath.test.ts
+++ b/lib/auth/safeReturnPath.test.ts
@@ -53,19 +53,13 @@ describe('getCurrentReturnPath', () => {
 
   it('combines pathname and query string', () => {
     expect(
-      getCurrentReturnPath(
-        '/write',
-        new URLSearchParams('id=abc123')
-      )
+      getCurrentReturnPath('/write', new URLSearchParams('id=abc123'))
     ).toBe('/write?id=abc123')
   })
 
   it('preserves multiple query params', () => {
     expect(
-      getCurrentReturnPath(
-        '/profile',
-        new URLSearchParams('tab=wallet')
-      )
+      getCurrentReturnPath('/profile', new URLSearchParams('tab=wallet'))
     ).toBe('/profile?tab=wallet')
   })
 })

--- a/lib/auth/safeReturnPath.ts
+++ b/lib/auth/safeReturnPath.ts
@@ -41,6 +41,14 @@ export function getSafeReturnPath(
   return trimmed
 }
 
+export function getCurrentReturnPath(
+  pathname: string,
+  searchParams: URLSearchParams | { toString(): string }
+): string {
+  const qs = searchParams.toString()
+  return qs ? `${pathname}?${qs}` : pathname
+}
+
 export function buildLoginHref(returnPath: string): string {
   const safe = getSafeReturnPath(returnPath)
   return `/login?returnTo=${encodeURIComponent(safe)}`

--- a/lib/auth/safeReturnPath.ts
+++ b/lib/auth/safeReturnPath.ts
@@ -1,0 +1,52 @@
+/**
+ * Validates a post-auth return path from query params.
+ * Only same-origin relative paths are allowed (open-redirect protection).
+ */
+export function getSafeReturnPath(
+  returnTo: string | null | undefined,
+  fallback = '/'
+): string {
+  if (!returnTo || typeof returnTo !== 'string') {
+    return fallback
+  }
+
+  const trimmed = returnTo.trim()
+  if (trimmed.length === 0) {
+    return fallback
+  }
+
+  if (!trimmed.startsWith('/')) {
+    return fallback
+  }
+
+  if (trimmed.startsWith('//')) {
+    return fallback
+  }
+
+  const lower = trimmed.toLowerCase()
+  if (
+    lower.startsWith('http:') ||
+    lower.startsWith('https:') ||
+    lower.startsWith('javascript:') ||
+    lower.startsWith('data:') ||
+    lower.startsWith('vbscript:')
+  ) {
+    return fallback
+  }
+
+  if (trimmed.includes('\\')) {
+    return fallback
+  }
+
+  return trimmed
+}
+
+export function buildLoginHref(returnPath: string): string {
+  const safe = getSafeReturnPath(returnPath)
+  return `/login?returnTo=${encodeURIComponent(safe)}`
+}
+
+export function buildRegisterHref(returnPath: string): string {
+  const safe = getSafeReturnPath(returnPath)
+  return `/register?returnTo=${encodeURIComponent(safe)}`
+}

--- a/lib/highlight/pendingHighlightSelection.test.ts
+++ b/lib/highlight/pendingHighlightSelection.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  PENDING_HIGHLIGHT_SELECTION_STORAGE_KEY,
+  clearPendingHighlightSelection,
+  matchesPendingHighlightSelection,
+  readPendingHighlightSelection,
+  writePendingHighlightSelection,
+} from './pendingHighlightSelection'
+import type { Id } from '@/convex/_generated/dataModel'
+
+describe('pendingHighlightSelection storage', () => {
+  const store: Record<string, string> = {}
+
+  beforeEach(() => {
+    vi.stubGlobal('window', {
+      sessionStorage: {
+        getItem: (k: string) => (k in store ? store[k] : null),
+        setItem: (k: string, v: string) => {
+          store[k] = v
+        },
+        removeItem: (k: string) => {
+          delete store[k]
+        },
+        clear: () => {
+          for (const key of Object.keys(store)) delete store[key]
+        },
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    for (const key of Object.keys(store)) delete store[key]
+  })
+
+  it('writes and reads highlight selection', () => {
+    writePendingHighlightSelection({
+      articleId: 'articles:abc',
+      highlightText: 'Selected passage',
+      startOffset: 10,
+      endOffset: 28,
+    })
+    expect(readPendingHighlightSelection()).toEqual({
+      articleId: 'articles:abc',
+      highlightText: 'Selected passage',
+      startOffset: 10,
+      endOffset: 28,
+    })
+    expect(store[PENDING_HIGHLIGHT_SELECTION_STORAGE_KEY]).toBeDefined()
+  })
+
+  it('clears stored selection', () => {
+    writePendingHighlightSelection({
+      articleId: 'articles:abc',
+      highlightText: 'text',
+      startOffset: 0,
+      endOffset: 4,
+    })
+    clearPendingHighlightSelection()
+    expect(readPendingHighlightSelection()).toBeNull()
+  })
+
+  it('matches selection by article id', () => {
+    writePendingHighlightSelection({
+      articleId: 'articles:abc',
+      highlightText: 'text',
+      startOffset: 0,
+      endOffset: 4,
+    })
+    const pending = readPendingHighlightSelection()
+    expect(
+      matchesPendingHighlightSelection(pending, 'articles:abc' as Id<'articles'>)
+    ).toBe(true)
+    expect(
+      matchesPendingHighlightSelection(pending, 'articles:other' as Id<'articles'>)
+    ).toBe(false)
+  })
+})

--- a/lib/highlight/pendingHighlightSelection.test.ts
+++ b/lib/highlight/pendingHighlightSelection.test.ts
@@ -69,10 +69,16 @@ describe('pendingHighlightSelection storage', () => {
     })
     const pending = readPendingHighlightSelection()
     expect(
-      matchesPendingHighlightSelection(pending, 'articles:abc' as Id<'articles'>)
+      matchesPendingHighlightSelection(
+        pending,
+        'articles:abc' as Id<'articles'>
+      )
     ).toBe(true)
     expect(
-      matchesPendingHighlightSelection(pending, 'articles:other' as Id<'articles'>)
+      matchesPendingHighlightSelection(
+        pending,
+        'articles:other' as Id<'articles'>
+      )
     ).toBe(false)
   })
 })

--- a/lib/highlight/pendingHighlightSelection.ts
+++ b/lib/highlight/pendingHighlightSelection.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod'
+import type { Id } from '@/convex/_generated/dataModel'
+
+export const PENDING_HIGHLIGHT_SELECTION_STORAGE_KEY =
+  'quilltip:pendingHighlightSelection'
+
+const pendingHighlightSelectionSchema = z.object({
+  articleId: z.string(),
+  highlightText: z.string(),
+  startOffset: z.number().int().nonnegative(),
+  endOffset: z.number().int().nonnegative(),
+})
+
+export type PendingHighlightSelection = z.infer<
+  typeof pendingHighlightSelectionSchema
+>
+
+export function writePendingHighlightSelection(
+  selection: PendingHighlightSelection
+): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(
+      PENDING_HIGHLIGHT_SELECTION_STORAGE_KEY,
+      JSON.stringify(selection)
+    )
+  } catch {
+    // Quota or private mode
+  }
+}
+
+export function readPendingHighlightSelection(): PendingHighlightSelection | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.sessionStorage.getItem(
+      PENDING_HIGHLIGHT_SELECTION_STORAGE_KEY
+    )
+    if (raw === null) return null
+    const parsed: unknown = JSON.parse(raw)
+    const result = pendingHighlightSelectionSchema.safeParse(parsed)
+    return result.success ? result.data : null
+  } catch {
+    return null
+  }
+}
+
+export function clearPendingHighlightSelection(): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.removeItem(PENDING_HIGHLIGHT_SELECTION_STORAGE_KEY)
+  } catch {
+    // Ignore
+  }
+}
+
+export function matchesPendingHighlightSelection(
+  selection: PendingHighlightSelection | null,
+  articleId: Id<'articles'> | string
+): selection is PendingHighlightSelection {
+  return selection !== null && selection.articleId === String(articleId)
+}

--- a/lib/highlight/resumePendingHighlightSelection.test.ts
+++ b/lib/highlight/resumePendingHighlightSelection.test.ts
@@ -1,0 +1,104 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it, vi } from 'vitest'
+import {
+  applyPendingHighlightToEditor,
+  readEditorSelectionAnchor,
+  readPendingHighlightPopoverAnchor,
+  shouldKeepTryingHighlightSelectionResume,
+} from './resumePendingHighlightSelection'
+
+describe('resumePendingHighlightSelection', () => {
+  it('shouldKeepTrying when pending matches and editor not yet restored', () => {
+    expect(
+      shouldKeepTryingHighlightSelectionResume(
+        {
+          articleId: 'articles:1',
+          highlightText: 'hello world',
+          startOffset: 0,
+          endOffset: 11,
+        },
+        'articles:1',
+        null,
+        {} as never
+      )
+    ).toBe(true)
+  })
+
+  it('stops retrying after selection restored on current editor', () => {
+    const editor = {} as never
+    expect(
+      shouldKeepTryingHighlightSelectionResume(
+        {
+          articleId: 'articles:1',
+          highlightText: 'hello world',
+          startOffset: 0,
+          endOffset: 11,
+        },
+        'articles:1',
+        editor,
+        editor
+      )
+    ).toBe(false)
+  })
+
+  it('applyPendingHighlightToEditor focuses and sets text selection', () => {
+    const run = vi.fn()
+    const chain = {
+      focus: vi.fn().mockReturnThis(),
+      setTextSelection: vi.fn().mockReturnThis(),
+      scrollIntoView: vi.fn().mockReturnThis(),
+      run,
+    }
+    const editor = {
+      chain: vi.fn(() => chain),
+    }
+
+    applyPendingHighlightToEditor(editor as never, {
+      articleId: 'articles:1',
+      highlightText: 'hello',
+      startOffset: 2,
+      endOffset: 7,
+    })
+
+    expect(chain.focus).toHaveBeenCalled()
+    expect(chain.setTextSelection).toHaveBeenCalledWith({ from: 2, to: 7 })
+    expect(chain.scrollIntoView).toHaveBeenCalled()
+    expect(run).toHaveBeenCalled()
+  })
+
+  it('readEditorSelectionAnchor uses coordsAtPos', () => {
+    const editor = {
+      state: { selection: { from: 2, to: 7, empty: false } },
+      view: {
+        coordsAtPos: (pos: number) =>
+          pos === 2
+            ? { top: 100, left: 50, bottom: 120, right: 80 }
+            : { top: 100, left: 150, bottom: 120, right: 180 },
+      },
+    }
+
+    expect(readEditorSelectionAnchor(editor as never)).toEqual({
+      top: 100,
+      left: 100,
+    })
+  })
+
+  it('readPendingHighlightPopoverAnchor prefers editor coords', () => {
+    const editor = {
+      state: { selection: { from: 1, to: 5, empty: false } },
+      view: {
+        coordsAtPos: () => ({
+          top: 200,
+          left: 80,
+          bottom: 220,
+          right: 120,
+        }),
+      },
+    }
+
+    expect(readPendingHighlightPopoverAnchor(editor as never)).toEqual({
+      top: 200,
+      left: 80,
+    })
+  })
+})

--- a/lib/highlight/resumePendingHighlightSelection.ts
+++ b/lib/highlight/resumePendingHighlightSelection.ts
@@ -1,0 +1,60 @@
+import type { Editor } from '@tiptap/react'
+import {
+  getRangeTopCenterAnchor,
+  getSafeSelection,
+} from '@/lib/highlights/utils'
+import type { PendingHighlightSelection } from '@/lib/highlight/pendingHighlightSelection'
+
+export function applyPendingHighlightToEditor(
+  editor: Editor,
+  pending: PendingHighlightSelection
+): void {
+  editor
+    .chain()
+    .focus()
+    .setTextSelection({ from: pending.startOffset, to: pending.endOffset })
+    .scrollIntoView()
+    .run()
+}
+
+/** Viewport anchor from the editor selection (works without a native DOM range). */
+export function readEditorSelectionAnchor(
+  editor: Editor
+): { top: number; left: number } | null {
+  const { from, to, empty } = editor.state.selection
+  if (empty || to <= from) return null
+
+  try {
+    const start = editor.view.coordsAtPos(from)
+    const end = editor.view.coordsAtPos(to)
+    return {
+      top: Math.min(start.top, end.top),
+      left: (start.left + end.left) / 2,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function readPendingHighlightPopoverAnchor(
+  editor: Editor
+): { top: number; left: number } | null {
+  const fromEditor = readEditorSelectionAnchor(editor)
+  if (fromEditor) return fromEditor
+
+  const domSelection = getSafeSelection()
+  if (!domSelection || domSelection.rangeCount === 0) return null
+  const range = domSelection.getRangeAt(0)
+  return getRangeTopCenterAnchor(range)
+}
+
+export function shouldKeepTryingHighlightSelectionResume(
+  pending: PendingHighlightSelection | null,
+  articleId: string,
+  restoredEditor: Editor | null,
+  currentEditor: Editor | null
+): boolean {
+  if (pending === null || pending.articleId !== articleId) return false
+  if (currentEditor === null) return false
+  return restoredEditor !== currentEditor
+}

--- a/lib/highlights/utils.ts
+++ b/lib/highlights/utils.ts
@@ -147,3 +147,15 @@ export function getRangeBoundingBox(range: Range): RangeBoundingBox | null {
     height: r.height,
   }
 }
+
+/** Viewport anchor above the horizontal center of a DOM range (for popovers). */
+export function getRangeTopCenterAnchor(
+  range: Range
+): { top: number; left: number } | null {
+  const box = getRangeBoundingBox(range)
+  if (!box) return null
+  return {
+    top: box.top,
+    left: box.left + box.width / 2,
+  }
+}

--- a/lib/tip/applyPendingTipFormState.test.ts
+++ b/lib/tip/applyPendingTipFormState.test.ts
@@ -26,6 +26,18 @@ describe('applyPendingAmountFields', () => {
     expect(setSelectedAmount).toHaveBeenCalledWith(null)
   })
 
+  it('prefers custom amount when both fields are present', () => {
+    const setSelectedAmount = vi.fn()
+    const setCustomAmount = vi.fn()
+    applyPendingAmountFields(
+      { amountCents: 5000, customAmount: '50' },
+      setSelectedAmount,
+      setCustomAmount
+    )
+    expect(setCustomAmount).toHaveBeenCalledWith('50')
+    expect(setSelectedAmount).toHaveBeenCalledWith(null)
+  })
+
   it('does nothing when no amount fields', () => {
     const setSelectedAmount = vi.fn()
     const setCustomAmount = vi.fn()

--- a/lib/tip/applyPendingTipFormState.test.ts
+++ b/lib/tip/applyPendingTipFormState.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyPendingAmountFields } from './applyPendingTipFormState'
+
+describe('applyPendingAmountFields', () => {
+  it('sets preset amount and clears custom amount', () => {
+    const setSelectedAmount = vi.fn()
+    const setCustomAmount = vi.fn()
+    applyPendingAmountFields(
+      { amountCents: 100 },
+      setSelectedAmount,
+      setCustomAmount
+    )
+    expect(setSelectedAmount).toHaveBeenCalledWith(100)
+    expect(setCustomAmount).toHaveBeenCalledWith('')
+  })
+
+  it('sets custom amount and clears preset when no amountCents', () => {
+    const setSelectedAmount = vi.fn()
+    const setCustomAmount = vi.fn()
+    applyPendingAmountFields(
+      { customAmount: '2.50' },
+      setSelectedAmount,
+      setCustomAmount
+    )
+    expect(setCustomAmount).toHaveBeenCalledWith('2.50')
+    expect(setSelectedAmount).toHaveBeenCalledWith(null)
+  })
+
+  it('does nothing when no amount fields', () => {
+    const setSelectedAmount = vi.fn()
+    const setCustomAmount = vi.fn()
+    applyPendingAmountFields({}, setSelectedAmount, setCustomAmount)
+    expect(setSelectedAmount).not.toHaveBeenCalled()
+    expect(setCustomAmount).not.toHaveBeenCalled()
+  })
+})

--- a/lib/tip/applyPendingTipFormState.ts
+++ b/lib/tip/applyPendingTipFormState.ts
@@ -1,0 +1,17 @@
+import type { PendingTipIntent } from '@/lib/tip/pendingTipIntent'
+
+type AmountFields = Pick<PendingTipIntent, 'amountCents' | 'customAmount'>
+
+export function applyPendingAmountFields(
+  intent: AmountFields,
+  setSelectedAmount: (value: number | null) => void,
+  setCustomAmount: (value: string) => void
+): void {
+  if (intent.amountCents != null) {
+    setSelectedAmount(intent.amountCents)
+    setCustomAmount('')
+  } else if (intent.customAmount) {
+    setCustomAmount(intent.customAmount)
+    setSelectedAmount(null)
+  }
+}

--- a/lib/tip/applyPendingTipFormState.ts
+++ b/lib/tip/applyPendingTipFormState.ts
@@ -7,11 +7,13 @@ export function applyPendingAmountFields(
   setSelectedAmount: (value: number | null) => void,
   setCustomAmount: (value: string) => void
 ): void {
-  if (intent.amountCents != null) {
-    setSelectedAmount(intent.amountCents)
-    setCustomAmount('')
-  } else if (intent.customAmount) {
+  // When resuming from login we may store both `amountCents` (validated) and
+  // `customAmount` (what the user typed). Prefer custom input when present.
+  if (intent.customAmount) {
     setCustomAmount(intent.customAmount)
     setSelectedAmount(null)
+  } else if (intent.amountCents != null) {
+    setSelectedAmount(intent.amountCents)
+    setCustomAmount('')
   }
 }

--- a/lib/tip/articleTipResumeUrl.test.ts
+++ b/lib/tip/articleTipResumeUrl.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  appendArticleTipResumeToReturnPath,
+  hasArticleTipResumeFlag,
+  parseArticleTipResumeFromSearchParams,
+  RESUME_ARTICLE_TIP_PARAM,
+} from './articleTipResumeUrl'
+import type { Id } from '@/convex/_generated/dataModel'
+
+describe('articleTipResumeUrl', () => {
+  const articleId = 'articles:abc' as Id<'articles'>
+
+  it('appends resume flags to a clean path', () => {
+    const path = appendArticleTipResumeToReturnPath('/alice/post', {
+      kind: 'article',
+      articleId: 'articles:abc',
+      amountCents: 100,
+      message: 'Thanks',
+    })
+    expect(path).toContain(`${RESUME_ARTICLE_TIP_PARAM}=1`)
+    expect(path).toContain('tipCents=100')
+    expect(path).toContain('tipMsg=Thanks')
+  })
+
+  it('merges with existing query params', () => {
+    const path = appendArticleTipResumeToReturnPath('/alice/post?ref=1', {
+      kind: 'article',
+      articleId: 'articles:abc',
+      amountCents: 50,
+    })
+    expect(path).toContain('ref=1')
+    expect(path).toContain('tipCents=50')
+  })
+
+  it('parses resume data from search params', () => {
+    const params = new URLSearchParams(
+      'resumeArticleTip=1&tipCents=100&tipMsg=Hello'
+    )
+    expect(hasArticleTipResumeFlag(params)).toBe(true)
+    expect(parseArticleTipResumeFromSearchParams(params, articleId)).toEqual({
+      kind: 'article',
+      articleId: 'articles:abc',
+      amountCents: 100,
+      message: 'Hello',
+    })
+  })
+})

--- a/lib/tip/articleTipResumeUrl.ts
+++ b/lib/tip/articleTipResumeUrl.ts
@@ -1,0 +1,77 @@
+import type { Id } from '@/convex/_generated/dataModel'
+import type { ArticlePendingTipIntent } from '@/lib/tip/pendingTipIntent'
+
+export const RESUME_ARTICLE_TIP_PARAM = 'resumeArticleTip'
+export const TIP_CENTS_PARAM = 'tipCents'
+export const TIP_CUSTOM_PARAM = 'tipCustom'
+export const TIP_MSG_PARAM = 'tipMsg'
+
+const MAX_URL_MESSAGE_LENGTH = 200
+
+export function appendArticleTipResumeToReturnPath(
+  returnPath: string,
+  intent: ArticlePendingTipIntent
+): string {
+  const questionIndex = returnPath.indexOf('?')
+  const pathname =
+    questionIndex === -1 ? returnPath : returnPath.slice(0, questionIndex)
+  const params = new URLSearchParams(
+    questionIndex === -1 ? '' : returnPath.slice(questionIndex + 1)
+  )
+
+  params.set(RESUME_ARTICLE_TIP_PARAM, '1')
+  if (intent.amountCents != null) {
+    params.set(TIP_CENTS_PARAM, String(intent.amountCents))
+  }
+  if (intent.customAmount) {
+    params.set(TIP_CUSTOM_PARAM, intent.customAmount)
+  }
+  if (intent.message) {
+    params.set(
+      TIP_MSG_PARAM,
+      intent.message.slice(0, MAX_URL_MESSAGE_LENGTH)
+    )
+  }
+
+  const qs = params.toString()
+  return qs ? `${pathname}?${qs}` : pathname
+}
+
+export function hasArticleTipResumeFlag(
+  searchParams: URLSearchParams
+): boolean {
+  return searchParams.get(RESUME_ARTICLE_TIP_PARAM) === '1'
+}
+
+export function parseArticleTipResumeFromSearchParams(
+  searchParams: URLSearchParams,
+  articleId: Id<'articles'>
+): ArticlePendingTipIntent | null {
+  if (!hasArticleTipResumeFlag(searchParams)) return null
+
+  const centsRaw = searchParams.get(TIP_CENTS_PARAM)
+  const amountCents =
+    centsRaw !== null ? Number.parseInt(centsRaw, 10) : undefined
+  const customAmount = searchParams.get(TIP_CUSTOM_PARAM) ?? undefined
+  const message = searchParams.get(TIP_MSG_PARAM) ?? undefined
+
+  if (
+    amountCents !== undefined &&
+    (!Number.isFinite(amountCents) || amountCents <= 0)
+  ) {
+    return {
+      kind: 'article',
+      articleId: String(articleId),
+      ...(customAmount ? { customAmount } : {}),
+      ...(message ? { message } : {}),
+    }
+  }
+
+  return {
+    kind: 'article',
+    articleId: String(articleId),
+    ...(amountCents !== undefined ? { amountCents } : {}),
+    ...(customAmount ? { customAmount } : {}),
+    ...(message ? { message } : {}),
+  }
+}

--- a/lib/tip/articleTipResumeUrl.ts
+++ b/lib/tip/articleTipResumeUrl.ts
@@ -27,10 +27,7 @@ export function appendArticleTipResumeToReturnPath(
     params.set(TIP_CUSTOM_PARAM, intent.customAmount)
   }
   if (intent.message) {
-    params.set(
-      TIP_MSG_PARAM,
-      intent.message.slice(0, MAX_URL_MESSAGE_LENGTH)
-    )
+    params.set(TIP_MSG_PARAM, intent.message.slice(0, MAX_URL_MESSAGE_LENGTH))
   }
 
   const qs = params.toString()

--- a/lib/tip/pendingTipIntent.test.ts
+++ b/lib/tip/pendingTipIntent.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  PENDING_TIP_INTENT_STORAGE_KEY,
+  clearPendingTipIntent,
+  matchesArticlePendingIntent,
+  matchesHighlightPendingIntent,
+  readPendingTipIntent,
+  writePendingTipIntent,
+} from './pendingTipIntent'
+import type { Id } from '@/convex/_generated/dataModel'
+
+describe('pendingTipIntent storage', () => {
+  const store: Record<string, string> = {}
+
+  beforeEach(() => {
+    vi.stubGlobal('window', {
+      sessionStorage: {
+        getItem: (k: string) => (k in store ? store[k] : null),
+        setItem: (k: string, v: string) => {
+          store[k] = v
+        },
+        removeItem: (k: string) => {
+          delete store[k]
+        },
+        clear: () => {
+          for (const key of Object.keys(store)) delete store[key]
+        },
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    for (const key of Object.keys(store)) delete store[key]
+  })
+
+  it('writes and reads article intent', () => {
+    writePendingTipIntent({
+      kind: 'article',
+      articleId: 'articles:abc',
+      amountCents: 100,
+      message: 'Great read',
+    })
+    expect(readPendingTipIntent()).toEqual({
+      kind: 'article',
+      articleId: 'articles:abc',
+      amountCents: 100,
+      message: 'Great read',
+    })
+    expect(store[PENDING_TIP_INTENT_STORAGE_KEY]).toBeDefined()
+  })
+
+  it('writes and reads highlight intent', () => {
+    writePendingTipIntent({
+      kind: 'highlight',
+      articleId: 'articles:abc',
+      articleSlug: 'my-post',
+      highlightText: 'insightful phrase',
+      startOffset: 10,
+      endOffset: 28,
+      amountCents: 50,
+    })
+    expect(readPendingTipIntent()).toEqual({
+      kind: 'highlight',
+      articleId: 'articles:abc',
+      articleSlug: 'my-post',
+      highlightText: 'insightful phrase',
+      startOffset: 10,
+      endOffset: 28,
+      amountCents: 50,
+    })
+  })
+
+  it('returns null for missing or invalid stored data', () => {
+    expect(readPendingTipIntent()).toBeNull()
+    store[PENDING_TIP_INTENT_STORAGE_KEY] = 'not-json'
+    expect(readPendingTipIntent()).toBeNull()
+    store[PENDING_TIP_INTENT_STORAGE_KEY] = JSON.stringify({ kind: 'unknown' })
+    expect(readPendingTipIntent()).toBeNull()
+  })
+
+  it('clears stored intent', () => {
+    writePendingTipIntent({
+      kind: 'article',
+      articleId: 'articles:abc',
+    })
+    clearPendingTipIntent()
+    expect(readPendingTipIntent()).toBeNull()
+    expect(store[PENDING_TIP_INTENT_STORAGE_KEY]).toBeUndefined()
+  })
+})
+
+describe('matchesArticlePendingIntent / matchesHighlightPendingIntent', () => {
+  const articleId = 'articles:abc' as Id<'articles'>
+
+  it('matches article intent by id', () => {
+    const intent = {
+      kind: 'article' as const,
+      articleId: 'articles:abc',
+    }
+    expect(matchesArticlePendingIntent(intent, articleId)).toBe(true)
+    expect(matchesHighlightPendingIntent(intent, articleId)).toBe(false)
+  })
+
+  it('matches highlight intent by id', () => {
+    const intent = {
+      kind: 'highlight' as const,
+      articleId: 'articles:abc',
+      articleSlug: 'slug',
+      highlightText: 'text',
+      startOffset: 0,
+      endOffset: 4,
+    }
+    expect(matchesHighlightPendingIntent(intent, articleId)).toBe(true)
+    expect(matchesArticlePendingIntent(intent, articleId)).toBe(false)
+  })
+
+  it('returns false for null or mismatched id', () => {
+    expect(matchesArticlePendingIntent(null, articleId)).toBe(false)
+    expect(
+      matchesArticlePendingIntent(
+        { kind: 'article', articleId: 'articles:other' },
+        articleId
+      )
+    ).toBe(false)
+  })
+})

--- a/lib/tip/pendingTipIntent.test.ts
+++ b/lib/tip/pendingTipIntent.test.ts
@@ -11,8 +11,10 @@ import type { Id } from '@/convex/_generated/dataModel'
 
 describe('pendingTipIntent storage', () => {
   const store: Record<string, string> = {}
+  const local: Record<string, string> = {}
 
   beforeEach(() => {
+    clearPendingTipIntent()
     vi.stubGlobal('window', {
       sessionStorage: {
         getItem: (k: string) => (k in store ? store[k] : null),
@@ -26,12 +28,25 @@ describe('pendingTipIntent storage', () => {
           for (const key of Object.keys(store)) delete store[key]
         },
       },
+      localStorage: {
+        getItem: (k: string) => (k in local ? local[k] : null),
+        setItem: (k: string, v: string) => {
+          local[k] = v
+        },
+        removeItem: (k: string) => {
+          delete local[k]
+        },
+        clear: () => {
+          for (const key of Object.keys(local)) delete local[key]
+        },
+      },
     })
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
     for (const key of Object.keys(store)) delete store[key]
+    for (const key of Object.keys(local)) delete local[key]
   })
 
   it('writes and reads article intent', () => {
@@ -48,6 +63,7 @@ describe('pendingTipIntent storage', () => {
       message: 'Great read',
     })
     expect(store[PENDING_TIP_INTENT_STORAGE_KEY]).toBeDefined()
+    expect(local[PENDING_TIP_INTENT_STORAGE_KEY]).toBeDefined()
   })
 
   it('writes and reads highlight intent', () => {
@@ -87,6 +103,7 @@ describe('pendingTipIntent storage', () => {
     clearPendingTipIntent()
     expect(readPendingTipIntent()).toBeNull()
     expect(store[PENDING_TIP_INTENT_STORAGE_KEY]).toBeUndefined()
+    expect(local[PENDING_TIP_INTENT_STORAGE_KEY]).toBeUndefined()
   })
 })
 

--- a/lib/tip/pendingTipIntent.ts
+++ b/lib/tip/pendingTipIntent.ts
@@ -38,23 +38,39 @@ export type HighlightPendingTipIntent = z.infer<
   typeof highlightPendingTipIntentSchema
 >
 
-export function writePendingTipIntent(intent: PendingTipIntent): void {
-  if (typeof window === 'undefined') return
+/** Survives React remounts within the same tab (e.g. Suspense / client navigation). */
+let memoryPendingTipIntent: PendingTipIntent | null = null
+
+function normalizeArticleId(articleId: Id<'articles'> | string): string {
+  return String(articleId)
+}
+
+function persistPendingTipJson(json: string): void {
   try {
-    window.sessionStorage.setItem(
-      PENDING_TIP_INTENT_STORAGE_KEY,
-      JSON.stringify(intent)
-    )
+    window.sessionStorage.setItem(PENDING_TIP_INTENT_STORAGE_KEY, json)
+  } catch {
+    // Quota or private mode
+  }
+  try {
+    window.localStorage.setItem(PENDING_TIP_INTENT_STORAGE_KEY, json)
   } catch {
     // Quota or private mode
   }
 }
 
-export function readPendingTipIntent(): PendingTipIntent | null {
-  if (typeof window === 'undefined') return null
+function readPendingTipJson(): string | null {
   try {
-    const raw = window.sessionStorage.getItem(PENDING_TIP_INTENT_STORAGE_KEY)
-    if (raw === null) return null
+    return (
+      window.sessionStorage.getItem(PENDING_TIP_INTENT_STORAGE_KEY) ??
+      window.localStorage.getItem(PENDING_TIP_INTENT_STORAGE_KEY)
+    )
+  } catch {
+    return null
+  }
+}
+
+function parsePendingTipJson(raw: string): PendingTipIntent | null {
+  try {
     const parsed: unknown = JSON.parse(raw)
     const result = pendingTipIntentSchema.safeParse(parsed)
     return result.success ? result.data : null
@@ -63,10 +79,43 @@ export function readPendingTipIntent(): PendingTipIntent | null {
   }
 }
 
+export function writePendingTipIntent(intent: PendingTipIntent): void {
+  if (typeof window === 'undefined') return
+  const normalized: PendingTipIntent = {
+    ...intent,
+    articleId: normalizeArticleId(intent.articleId),
+  }
+  memoryPendingTipIntent = normalized
+  persistPendingTipJson(JSON.stringify(normalized))
+}
+
+export function readPendingTipIntent(): PendingTipIntent | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = readPendingTipJson()
+    if (raw !== null) {
+      const parsed = parsePendingTipJson(raw)
+      if (parsed) {
+        memoryPendingTipIntent = parsed
+        return parsed
+      }
+    }
+  } catch {
+    // Fall through to memory
+  }
+  return memoryPendingTipIntent
+}
+
 export function clearPendingTipIntent(): void {
+  memoryPendingTipIntent = null
   if (typeof window === 'undefined') return
   try {
     window.sessionStorage.removeItem(PENDING_TIP_INTENT_STORAGE_KEY)
+  } catch {
+    // Ignore
+  }
+  try {
+    window.localStorage.removeItem(PENDING_TIP_INTENT_STORAGE_KEY)
   } catch {
     // Ignore
   }
@@ -76,12 +125,18 @@ export function matchesArticlePendingIntent(
   intent: PendingTipIntent | null,
   articleId: Id<'articles'>
 ): intent is ArticlePendingTipIntent {
-  return intent?.kind === 'article' && intent.articleId === articleId
+  return (
+    intent?.kind === 'article' &&
+    intent.articleId === normalizeArticleId(articleId)
+  )
 }
 
 export function matchesHighlightPendingIntent(
   intent: PendingTipIntent | null,
   articleId: Id<'articles'>
 ): intent is HighlightPendingTipIntent {
-  return intent?.kind === 'highlight' && intent.articleId === articleId
+  return (
+    intent?.kind === 'highlight' &&
+    intent.articleId === normalizeArticleId(articleId)
+  )
 }

--- a/lib/tip/pendingTipIntent.ts
+++ b/lib/tip/pendingTipIntent.ts
@@ -1,0 +1,87 @@
+import { z } from 'zod'
+import type { Id } from '@/convex/_generated/dataModel'
+
+export const PENDING_TIP_INTENT_STORAGE_KEY = 'quilltip:pendingTipIntent'
+
+const amountFieldsSchema = z.object({
+  amountCents: z.number().int().positive().optional(),
+  customAmount: z.string().optional(),
+})
+
+const articlePendingTipIntentSchema = amountFieldsSchema.extend({
+  kind: z.literal('article'),
+  articleId: z.string(),
+  message: z.string().max(500).optional(),
+})
+
+const highlightPendingTipIntentSchema = amountFieldsSchema.extend({
+  kind: z.literal('highlight'),
+  articleId: z.string(),
+  articleSlug: z.string(),
+  highlightText: z.string(),
+  startOffset: z.number().int().nonnegative(),
+  endOffset: z.number().int().nonnegative(),
+  startContainerPath: z.string().optional(),
+  endContainerPath: z.string().optional(),
+})
+
+export const pendingTipIntentSchema = z.discriminatedUnion('kind', [
+  articlePendingTipIntentSchema,
+  highlightPendingTipIntentSchema,
+])
+
+export type PendingTipIntent = z.infer<typeof pendingTipIntentSchema>
+export type ArticlePendingTipIntent = z.infer<
+  typeof articlePendingTipIntentSchema
+>
+export type HighlightPendingTipIntent = z.infer<
+  typeof highlightPendingTipIntentSchema
+>
+
+export function writePendingTipIntent(intent: PendingTipIntent): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(
+      PENDING_TIP_INTENT_STORAGE_KEY,
+      JSON.stringify(intent)
+    )
+  } catch {
+    // Quota or private mode
+  }
+}
+
+export function readPendingTipIntent(): PendingTipIntent | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.sessionStorage.getItem(PENDING_TIP_INTENT_STORAGE_KEY)
+    if (raw === null) return null
+    const parsed: unknown = JSON.parse(raw)
+    const result = pendingTipIntentSchema.safeParse(parsed)
+    return result.success ? result.data : null
+  } catch {
+    return null
+  }
+}
+
+export function clearPendingTipIntent(): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.removeItem(PENDING_TIP_INTENT_STORAGE_KEY)
+  } catch {
+    // Ignore
+  }
+}
+
+export function matchesArticlePendingIntent(
+  intent: PendingTipIntent | null,
+  articleId: Id<'articles'>
+): intent is ArticlePendingTipIntent {
+  return intent?.kind === 'article' && intent.articleId === articleId
+}
+
+export function matchesHighlightPendingIntent(
+  intent: PendingTipIntent | null,
+  articleId: Id<'articles'>
+): intent is HighlightPendingTipIntent {
+  return intent?.kind === 'highlight' && intent.articleId === articleId
+}

--- a/lib/tip/redirectToLoginForTip.ts
+++ b/lib/tip/redirectToLoginForTip.ts
@@ -1,0 +1,15 @@
+import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
+import { buildLoginHref } from '@/lib/auth/safeReturnPath'
+import {
+  writePendingTipIntent,
+  type PendingTipIntent,
+} from '@/lib/tip/pendingTipIntent'
+
+export function redirectToLoginForTip(
+  router: AppRouterInstance,
+  returnPath: string,
+  intent: PendingTipIntent
+): void {
+  writePendingTipIntent(intent)
+  router.push(buildLoginHref(returnPath))
+}

--- a/lib/tip/redirectToLoginForTip.ts
+++ b/lib/tip/redirectToLoginForTip.ts
@@ -1,7 +1,9 @@
 import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
 import { buildLoginHref } from '@/lib/auth/safeReturnPath'
+import { appendArticleTipResumeToReturnPath } from '@/lib/tip/articleTipResumeUrl'
 import {
   writePendingTipIntent,
+  type ArticlePendingTipIntent,
   type PendingTipIntent,
 } from '@/lib/tip/pendingTipIntent'
 
@@ -11,5 +13,14 @@ export function redirectToLoginForTip(
   intent: PendingTipIntent
 ): void {
   writePendingTipIntent(intent)
-  router.replace(buildLoginHref(returnPath))
+
+  const returnWithResume =
+    intent.kind === 'article'
+      ? appendArticleTipResumeToReturnPath(
+          returnPath,
+          intent as ArticlePendingTipIntent
+        )
+      : returnPath
+
+  router.replace(buildLoginHref(returnWithResume))
 }

--- a/lib/tip/redirectToLoginForTip.ts
+++ b/lib/tip/redirectToLoginForTip.ts
@@ -11,5 +11,5 @@ export function redirectToLoginForTip(
   intent: PendingTipIntent
 ): void {
   writePendingTipIntent(intent)
-  router.push(buildLoginHref(returnPath))
+  router.replace(buildLoginHref(returnPath))
 }

--- a/lib/tip/resolveArticleTipResume.ts
+++ b/lib/tip/resolveArticleTipResume.ts
@@ -1,0 +1,33 @@
+import type { Id } from '@/convex/_generated/dataModel'
+import {
+  hasArticleTipResumeFlag,
+  parseArticleTipResumeFromSearchParams,
+} from '@/lib/tip/articleTipResumeUrl'
+import {
+  matchesArticlePendingIntent,
+  readPendingTipIntent,
+  type ArticlePendingTipIntent,
+} from '@/lib/tip/pendingTipIntent'
+
+export function resolveArticleTipResume(
+  articleId: Id<'articles'>,
+  searchParams: URLSearchParams
+): ArticlePendingTipIntent | null {
+  const fromStorage = readPendingTipIntent()
+  if (matchesArticlePendingIntent(fromStorage, articleId)) {
+    return fromStorage
+  }
+
+  return parseArticleTipResumeFromSearchParams(searchParams, articleId)
+}
+
+export function shouldKeepTryingArticleTipResume(
+  articleId: Id<'articles'> | undefined,
+  searchParams: URLSearchParams
+): boolean {
+  if (articleId === undefined) return false
+  if (hasArticleTipResumeFlag(searchParams)) return true
+
+  const pending = readPendingTipIntent()
+  return matchesArticlePendingIntent(pending, articleId)
+}

--- a/lib/tip/signInToTip.test.ts
+++ b/lib/tip/signInToTip.test.ts
@@ -1,0 +1,60 @@
+import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
+import { describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import { validateTipAmountForm, signInToTip } from './signInToTip'
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn() },
+}))
+
+const mockRedirect = vi.hoisted(() => vi.fn())
+
+vi.mock('./redirectToLoginForTip', () => ({
+  redirectToLoginForTip: (...args: unknown[]) => mockRedirect(...args),
+}))
+
+describe('signInToTip', () => {
+  it('rejects invalid amount', () => {
+    const router = { replace: vi.fn() } as unknown as AppRouterInstance
+    const result = validateTipAmountForm({
+      selectedAmount: null,
+      customAmount: '',
+    })
+    expect(result.ok).toBe(false)
+    signInToTip(router, '/article', { selectedAmount: null, customAmount: '' }, {
+      kind: 'article',
+      articleId: 'articles:1',
+    })
+    expect(mockRedirect).not.toHaveBeenCalled()
+    expect(toast.error).toHaveBeenCalled()
+  })
+
+  it('redirects with valid amount', () => {
+    const router = { replace: vi.fn() } as unknown as AppRouterInstance
+    mockRedirect.mockClear()
+    vi.mocked(toast.error).mockClear()
+
+    signInToTip(
+      router,
+      '/user/slug',
+      { selectedAmount: 100, customAmount: '', message: 'Thanks' },
+      { kind: 'article', articleId: 'articles:1' }
+    )
+
+    expect(mockRedirect).toHaveBeenCalledWith(router, '/user/slug', {
+      kind: 'article',
+      articleId: 'articles:1',
+      amountCents: 100,
+      message: 'Thanks',
+    })
+  })
+
+  it('rejects message over 500 characters', () => {
+    const result = validateTipAmountForm({
+      selectedAmount: 100,
+      customAmount: '',
+      message: 'x'.repeat(501),
+    })
+    expect(result.ok).toBe(false)
+  })
+})

--- a/lib/tip/signInToTip.test.ts
+++ b/lib/tip/signInToTip.test.ts
@@ -21,10 +21,15 @@ describe('signInToTip', () => {
       customAmount: '',
     })
     expect(result.ok).toBe(false)
-    signInToTip(router, '/article', { selectedAmount: null, customAmount: '' }, {
-      kind: 'article',
-      articleId: 'articles:1',
-    })
+    signInToTip(
+      router,
+      '/article',
+      { selectedAmount: null, customAmount: '' },
+      {
+        kind: 'article',
+        articleId: 'articles:1',
+      }
+    )
     expect(mockRedirect).not.toHaveBeenCalled()
     expect(toast.error).toHaveBeenCalled()
   })

--- a/lib/tip/signInToTip.ts
+++ b/lib/tip/signInToTip.ts
@@ -1,0 +1,57 @@
+import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
+import { toast } from 'sonner'
+import { TIP_MIN_CENTS, TIP_MAX_CENTS, TIP_MAX_USD } from '@/lib/constants'
+import { redirectToLoginForTip } from '@/lib/tip/redirectToLoginForTip'
+import type { PendingTipIntent } from '@/lib/tip/pendingTipIntent'
+
+export type TipAmountFormState = {
+  selectedAmount: number | null
+  customAmount: string
+  message?: string
+}
+
+export type ValidateTipAmountResult =
+  | { ok: true; amountCents: number }
+  | { ok: false }
+
+export function validateTipAmountForm({
+  selectedAmount,
+  customAmount,
+  message,
+}: TipAmountFormState): ValidateTipAmountResult {
+  const amountCents = selectedAmount || parseFloat(customAmount) * 100
+
+  if (!amountCents || amountCents < TIP_MIN_CENTS) {
+    toast.error('Please select or enter a valid amount')
+    return { ok: false }
+  }
+
+  if (amountCents > TIP_MAX_CENTS) {
+    toast.error(`Maximum tip amount is $${TIP_MAX_USD.toFixed(2)}`)
+    return { ok: false }
+  }
+
+  if (message !== undefined && message.length > 500) {
+    toast.error('Message must be 500 characters or less')
+    return { ok: false }
+  }
+
+  return { ok: true, amountCents }
+}
+
+export function signInToTip(
+  router: AppRouterInstance,
+  returnPath: string,
+  form: TipAmountFormState,
+  intent: PendingTipIntent
+): void {
+  const validation = validateTipAmountForm(form)
+  if (!validation.ok) return
+
+  const message = form.message?.trim()
+  redirectToLoginForTip(router, returnPath, {
+    ...intent,
+    amountCents: validation.amountCents,
+    ...(message ? { message } : {}),
+  })
+}


### PR DESCRIPTION
## Summary

Improves post-authentication continuity so users return to the page they were on instead of landing on a generic home route. Signed-out tip attempts are preserved across login, onboarding shortcuts navigate to real destinations after completion, and protected routes redirect to login with a safe `returnTo` path.



## What changed

### Safe return paths (`returnTo`)

- Added `lib/auth/safeReturnPath.ts` to validate same-origin relative paths and block open redirects (`//`, absolute URLs, `javascript:`, etc.).
- Added helpers: `getCurrentReturnPath`, `buildLoginHref`, `buildRegisterHref`.
- Login and register forms read `returnTo` via `useAuthReturnPath` and `router.replace()` to that path after successful auth.
- New `AuthReturnLinks` component (wrapped in `Suspense`) preserves `returnTo` when switching between login/register and provides a Cancel link back to the original page.
- `useRedirectWhenUnauthenticated` now redirects to login with the full current path + query string (e.g. `/profile?tab=wallet`).

### Tip flow resume after login

- Signed-out users who start an article or highlight tip are sent to login with their intent stored in `sessionStorage` (`lib/tip/pendingTipIntent.ts`, Zod-validated).
- After login:
  - **Article tips**: `TipButton` restores amount/message and reopens the tip dialog.
  - **Highlight tips**: `PendingTipResume` on the article page reopens `HighlightTipButton` with the saved selection and amounts.
- Cancel on auth pages clears any pending tip intent.

### Onboarding modal destinations

- Onboarding completion is awaited before navigation (`navigateAfterComplete`).
- Step 2 “Set Up Now” goes to `/guide` after completing onboarding.
- Step 3 shortcuts: Read (`/articles`), Write (`/write`), Guide (`/guide`).
- Close, skip, escape, and overlay dismiss all persist onboarding completion with error toast on failure.
- Added `OnboardingDialog` unit tests for step flow, navigation, skip/close, and error handling.

### Profile / wallet deep link

- New `/profile` route: authenticated users redirect to `/{username}?tab=wallet`; signed-out users go to login with `returnTo=/profile?tab=wallet`.
- Public profile page reads `?tab=` from the URL (including `wallet`) for post-login wallet setup.

### Protected routes

- `/drafts` and `/write` use the updated unauthenticated redirect hook so users return after signing in.

## Security

- `returnTo` is sanitized to relative same-origin paths only; malicious or external URLs fall back to `/`.

