### PR TITLE
feat(auth): accessible login and signup forms with password requirements (ENG-140)

### DIFF
--- a/components/auth/LoginForm.test.tsx
+++ b/components/auth/LoginForm.test.tsx
@@ -79,4 +79,19 @@ describe('LoginForm', () => {
     await user.type(passwordInput, 'new-attempt')
     expect(passwordInput).toHaveValue('new-attempt')
   })
+
+  it('password visibility toggle has accessible name and pressed state', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<LoginForm />)
+
+    const toggle = screen.getByRole('button', { name: /show password/i })
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
+    await user.click(toggle)
+
+    expect(screen.getByRole('button', { name: /hide password/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
 })

--- a/components/auth/LoginForm.test.tsx
+++ b/components/auth/LoginForm.test.tsx
@@ -1,0 +1,84 @@
+/** @vitest-environment jsdom */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import LoginForm from '@/components/auth/LoginForm'
+
+const mockSignIn = vi.hoisted(() => vi.fn())
+const mockReplace = vi.hoisted(() => vi.fn())
+
+vi.mock('@convex-dev/auth/react', () => ({
+  useAuthActions: () => ({
+    signIn: mockSignIn,
+  }),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+  }),
+}))
+
+describe('LoginForm', () => {
+  beforeEach(() => {
+    mockSignIn.mockReset()
+    mockReplace.mockReset()
+  })
+
+  it('shows redirecting message and navigates home on successful sign in', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockSignIn.mockResolvedValue(undefined)
+
+    render(<LoginForm />)
+
+    await user.type(screen.getByLabelText(/email address/i), 'user@example.com')
+    await user.type(screen.getByLabelText(/^password$/i), 'password123')
+    await user.click(screen.getByRole('button', { name: /sign in/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/signed in successfully! redirecting to dashboard/i)
+      ).toBeInTheDocument()
+    })
+
+    expect(mockSignIn).toHaveBeenCalledWith('password', {
+      email: 'user@example.com',
+      password: 'password123',
+      flow: 'signIn',
+    })
+    expect(mockReplace).toHaveBeenCalledWith('/')
+    expect(
+      screen.queryByRole('button', { name: /signing in/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('restores an editable form with retry after failed sign in', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockSignIn.mockRejectedValue(new Error('Invalid credentials'))
+
+    render(<LoginForm />)
+
+    await user.type(screen.getByLabelText(/email address/i), 'user@example.com')
+    await user.type(screen.getByLabelText(/^password$/i), 'wrong-password')
+    await user.click(screen.getByRole('button', { name: /sign in/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/invalid email or password/i)
+      ).toBeInTheDocument()
+    })
+
+    const submitButton = screen.getByRole('button', { name: /sign in/i })
+    expect(submitButton).toBeEnabled()
+    expect(mockReplace).not.toHaveBeenCalled()
+
+    const emailInput = screen.getByLabelText(/email address/i)
+    const passwordInput = screen.getByLabelText(/^password$/i)
+    expect(emailInput).not.toBeDisabled()
+    expect(passwordInput).not.toBeDisabled()
+
+    await user.clear(passwordInput)
+    await user.type(passwordInput, 'new-attempt')
+    expect(passwordInput).toHaveValue('new-attempt')
+  })
+})

--- a/components/auth/LoginForm.test.tsx
+++ b/components/auth/LoginForm.test.tsx
@@ -63,9 +63,7 @@ describe('LoginForm', () => {
     await user.click(screen.getByRole('button', { name: /sign in/i }))
 
     await waitFor(() => {
-      expect(
-        screen.getByText(/invalid email or password/i)
-      ).toBeInTheDocument()
+      expect(screen.getByText(/invalid email or password/i)).toBeInTheDocument()
     })
 
     const submitButton = screen.getByRole('button', { name: /sign in/i })

--- a/components/auth/LoginForm.test.tsx
+++ b/components/auth/LoginForm.test.tsx
@@ -89,9 +89,8 @@ describe('LoginForm', () => {
 
     await user.click(toggle)
 
-    expect(screen.getByRole('button', { name: /hide password/i })).toHaveAttribute(
-      'aria-pressed',
-      'true'
-    )
+    expect(
+      screen.getByRole('button', { name: /hide password/i })
+    ).toHaveAttribute('aria-pressed', 'true')
   })
 })

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -80,9 +80,7 @@ export default function LoginForm() {
               aria-hidden="true"
               className="h-4 w-4 shrink-0 text-success-foreground"
             />
-            <span>
-              Signed in successfully! Redirecting to dashboard...
-            </span>
+            <span>Signed in successfully! Redirecting to dashboard...</span>
           </p>
         </div>
       </div>

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -139,12 +139,14 @@ export default function LoginForm() {
             variant="ghost"
             size="icon"
             onClick={() => setShowPassword(!showPassword)}
+            aria-label={showPassword ? 'Hide password' : 'Show password'}
+            aria-pressed={showPassword}
             className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
           >
             {showPassword ? (
-              <EyeOff className="h-4 w-4" />
+              <EyeOff className="h-4 w-4" aria-hidden="true" />
             ) : (
-              <Eye className="h-4 w-4" />
+              <Eye className="h-4 w-4" aria-hidden="true" />
             )}
           </Button>
         </div>

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -1,17 +1,19 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useAuthActions } from '@convex-dev/auth/react'
 import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { loginSchema, type LoginFormData } from '@/lib/validations/auth'
-import { Eye, EyeOff, Loader2 } from 'lucide-react'
+import { CheckCircle, Eye, EyeOff, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 
 const authInputClassName =
   'rounded-lg bg-background text-foreground focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:border-transparent'
+
+const REDIRECT_TIMEOUT_MS = 15_000
 
 /**
  * Login Form Component
@@ -24,6 +26,7 @@ export default function LoginForm() {
   const [showPassword, setShowPassword] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
 
   const router = useRouter()
   const { signIn } = useAuthActions()
@@ -36,6 +39,18 @@ export default function LoginForm() {
     resolver: zodResolver(loginSchema),
   })
 
+  useEffect(() => {
+    if (!success) return
+
+    const timeout = setTimeout(() => {
+      setSuccess(false)
+      setIsLoading(false)
+      setError('Redirect is taking longer than expected. Try again.')
+    }, REDIRECT_TIMEOUT_MS)
+
+    return () => clearTimeout(timeout)
+  }, [success])
+
   const onSubmit = async (data: LoginFormData) => {
     setIsLoading(true)
     setError(null)
@@ -47,14 +62,31 @@ export default function LoginForm() {
         flow: 'signIn',
       })
 
-      // If we reach here, sign-in was successful
-      // Use replace to prevent back button returning to login
+      setSuccess(true)
       router.replace('/')
     } catch (error) {
       console.error('Login error:', error)
       setError('Invalid email or password. Please try again.')
       setIsLoading(false)
     }
+  }
+
+  if (success) {
+    return (
+      <div className="text-center space-y-4">
+        <div className="p-4 bg-muted border border-border rounded-lg">
+          <p className="inline-flex items-center justify-center gap-2 text-sm text-foreground">
+            <CheckCircle
+              aria-hidden="true"
+              className="h-4 w-4 shrink-0 text-success-foreground"
+            />
+            <span>
+              Signed in successfully! Redirecting to dashboard...
+            </span>
+          </p>
+        </div>
+      </div>
+    )
   }
 
   return (

--- a/components/auth/PasswordRequirements.tsx
+++ b/components/auth/PasswordRequirements.tsx
@@ -1,0 +1,52 @@
+import { Check, Circle } from 'lucide-react'
+import { getPasswordRuleStatuses } from '@/lib/validations/password-rules'
+import { cn } from '@/lib/utils'
+
+export const PASSWORD_REQUIREMENTS_ID = 'password-requirements'
+
+type PasswordRequirementsProps = {
+  password: string
+  highlightFailures?: boolean
+}
+
+export function PasswordRequirements({
+  password,
+  highlightFailures = false,
+}: PasswordRequirementsProps) {
+  const rules = getPasswordRuleStatuses(password)
+
+  return (
+    <ul
+      id={PASSWORD_REQUIREMENTS_ID}
+      aria-live="polite"
+      className="mt-2 space-y-1"
+    >
+      {rules.map((rule) => (
+        <li
+          key={rule.id}
+          className={cn(
+            'flex items-center gap-2 text-sm',
+            rule.met
+              ? 'text-success-foreground'
+              : highlightFailures
+                ? 'text-destructive'
+                : 'text-muted-foreground'
+          )}
+        >
+          {rule.met ? (
+            <Check className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          ) : (
+            <Circle
+              className={cn(
+                'h-3.5 w-3.5 shrink-0',
+                highlightFailures ? 'text-destructive' : 'text-muted-foreground'
+              )}
+              aria-hidden="true"
+            />
+          )}
+          <span>{rule.label}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/components/auth/RegisterForm.test.tsx
+++ b/components/auth/RegisterForm.test.tsx
@@ -114,6 +114,78 @@ describe('RegisterForm accessibility', () => {
     ).toHaveAttribute('aria-pressed', 'true')
   })
 
+  it('shows password requirements before submit', () => {
+    render(<RegisterForm />)
+
+    expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument()
+    expect(screen.getByText(/one uppercase letter/i)).toBeInTheDocument()
+    expect(screen.getByText(/one lowercase letter/i)).toBeInTheDocument()
+    expect(screen.getByText(/one number/i)).toBeInTheDocument()
+  })
+
+  it('updates password requirements as the user types', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<RegisterForm />)
+
+    const passwordInput = screen.getByLabelText(/^password$/i)
+    await user.type(passwordInput, 'Password1')
+
+    const requirements = document.getElementById('password-requirements')
+    expect(requirements).toBeInTheDocument()
+    const items = requirements?.querySelectorAll('li') ?? []
+    expect(items).toHaveLength(4)
+    items.forEach((item) => {
+      expect(item).toHaveClass('text-success-foreground')
+    })
+  })
+
+  it('highlights unmet password rules on failed submit', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<RegisterForm />)
+
+    await user.type(screen.getByLabelText(/email address/i), 'user@example.com')
+    await user.type(screen.getByLabelText(/^username$/i), 'myuser')
+    await user.type(screen.getByLabelText(/^password$/i), 'weak')
+    await user.type(screen.getByLabelText(/^confirm password$/i), 'weak')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(document.getElementById('password-error')).toHaveTextContent(
+        'Password does not meet all requirements'
+      )
+    })
+
+    const requirements = document.getElementById('password-requirements')
+    const unmetItems = requirements?.querySelectorAll('.text-destructive') ?? []
+    expect(unmetItems.length).toBeGreaterThan(0)
+  })
+
+  it('clears password failure highlight when all rules are met', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<RegisterForm />)
+
+    await user.type(screen.getByLabelText(/email address/i), 'user@example.com')
+    await user.type(screen.getByLabelText(/^username$/i), 'myuser')
+    await user.type(screen.getByLabelText(/^password$/i), 'weak')
+    await user.type(screen.getByLabelText(/^confirm password$/i), 'weak')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(document.getElementById('password-error')).toBeInTheDocument()
+    })
+
+    const passwordInput = screen.getByLabelText(/^password$/i)
+    await user.clear(passwordInput)
+    await user.type(passwordInput, 'Password1')
+
+    await waitFor(() => {
+      const requirements = document.getElementById('password-requirements')
+      const unmetItems =
+        requirements?.querySelectorAll('.text-destructive') ?? []
+      expect(unmetItems).toHaveLength(0)
+    })
+  })
+
   it('confirm password visibility toggle has accessible name and pressed state', async () => {
     const user = userEvent.setup({ delay: null })
     render(<RegisterForm />)

--- a/components/auth/RegisterForm.test.tsx
+++ b/components/auth/RegisterForm.test.tsx
@@ -109,17 +109,18 @@ describe('RegisterForm accessibility', () => {
 
     await user.click(toggle)
 
-    expect(screen.getByRole('button', { name: /hide password/i })).toHaveAttribute(
-      'aria-pressed',
-      'true'
-    )
+    expect(
+      screen.getByRole('button', { name: /hide password/i })
+    ).toHaveAttribute('aria-pressed', 'true')
   })
 
   it('confirm password visibility toggle has accessible name and pressed state', async () => {
     const user = userEvent.setup({ delay: null })
     render(<RegisterForm />)
 
-    const toggle = screen.getByRole('button', { name: /show confirm password/i })
+    const toggle = screen.getByRole('button', {
+      name: /show confirm password/i,
+    })
     expect(toggle).toHaveAttribute('aria-pressed', 'false')
 
     await user.click(toggle)

--- a/components/auth/RegisterForm.test.tsx
+++ b/components/auth/RegisterForm.test.tsx
@@ -85,7 +85,7 @@ describe('RegisterForm accessibility', () => {
     await user.type(screen.getByLabelText(/email address/i), 'user@example.com')
     await user.type(screen.getByLabelText(/^username$/i), 'myuser')
     await user.type(screen.getByLabelText(/^password$/i), 'Password1')
-    await user.type(screen.getByLabelText(/confirm password/i), 'Password1')
+    await user.type(screen.getByLabelText(/^confirm password$/i), 'Password1')
     await user.click(screen.getByRole('button', { name: /create account/i }))
 
     await waitFor(() => {
@@ -98,5 +98,34 @@ describe('RegisterForm accessibility', () => {
     expect(emailInput).toHaveAttribute('aria-invalid', 'true')
     expect(emailInput).toHaveAttribute('aria-describedby', 'email-error')
     expect(screen.queryByText(/registration failed/i)).not.toBeInTheDocument()
+  })
+
+  it('password visibility toggle has accessible name and pressed state', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<RegisterForm />)
+
+    const toggle = screen.getByRole('button', { name: /show password/i })
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
+    await user.click(toggle)
+
+    expect(screen.getByRole('button', { name: /hide password/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
+
+  it('confirm password visibility toggle has accessible name and pressed state', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<RegisterForm />)
+
+    const toggle = screen.getByRole('button', { name: /show confirm password/i })
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
+    await user.click(toggle)
+
+    expect(
+      screen.getByRole('button', { name: /hide confirm password/i })
+    ).toHaveAttribute('aria-pressed', 'true')
   })
 })

--- a/components/auth/RegisterForm.test.tsx
+++ b/components/auth/RegisterForm.test.tsx
@@ -1,0 +1,102 @@
+/** @vitest-environment jsdom */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import RegisterForm from '@/components/auth/RegisterForm'
+
+const mockSignIn = vi.hoisted(() => vi.fn())
+const mockReplace = vi.hoisted(() => vi.fn())
+
+vi.mock('@/components/providers/AuthContext', () => ({
+  useAuth: () => ({
+    signIn: mockSignIn,
+    signOut: vi.fn(),
+    user: null,
+    isLoading: false,
+    isAuthenticated: false,
+  }),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+  }),
+}))
+
+describe('RegisterForm accessibility', () => {
+  beforeEach(() => {
+    mockSignIn.mockReset()
+    mockReplace.mockReset()
+  })
+
+  it('marks the first invalid field and associates its error on empty submit', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<RegisterForm />)
+
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(document.getElementById('email-error')).toHaveTextContent(
+        'Email is required'
+      )
+    })
+
+    const emailInput = screen.getByLabelText(/email address/i)
+    expect(emailInput).toHaveAttribute('aria-invalid', 'true')
+    expect(emailInput).toHaveAttribute('aria-describedby', 'email-error')
+
+    const emailError = document.getElementById('email-error')
+    expect(emailError).toHaveTextContent('Email is required')
+
+    expect(screen.getByRole('alert', { hidden: true })).toHaveTextContent(
+      'Email is required'
+    )
+  })
+
+  it('clears email invalid state after the user enters a valid email', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(<RegisterForm />)
+
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(document.getElementById('email-error')).toHaveTextContent(
+        'Email is required'
+      )
+    })
+
+    const emailInput = screen.getByLabelText(/email address/i)
+    await user.type(emailInput, 'user@example.com')
+
+    await waitFor(() => {
+      expect(emailInput).toHaveAttribute('aria-invalid', 'false')
+      expect(emailInput).not.toHaveAttribute('aria-describedby')
+    })
+
+    expect(document.getElementById('email-error')).toBeNull()
+  })
+
+  it('shows a server email conflict on the email field', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockSignIn.mockRejectedValue(new Error('Account already exists'))
+
+    render(<RegisterForm />)
+
+    await user.type(screen.getByLabelText(/email address/i), 'user@example.com')
+    await user.type(screen.getByLabelText(/^username$/i), 'myuser')
+    await user.type(screen.getByLabelText(/^password$/i), 'Password1')
+    await user.type(screen.getByLabelText(/confirm password/i), 'Password1')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(document.getElementById('email-error')).toHaveTextContent(
+        /an account with this email already exists/i
+      )
+    })
+
+    const emailInput = screen.getByLabelText(/email address/i)
+    expect(emailInput).toHaveAttribute('aria-invalid', 'true')
+    expect(emailInput).toHaveAttribute('aria-describedby', 'email-error')
+    expect(screen.queryByText(/registration failed/i)).not.toBeInTheDocument()
+  })
+})

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -175,8 +175,7 @@ export default function RegisterForm() {
         id="name"
         label={
           <>
-            Full Name{' '}
-            <span className="text-muted-foreground">(optional)</span>
+            Full Name <span className="text-muted-foreground">(optional)</span>
           </>
         }
         error={errors.name?.message}

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -2,17 +2,16 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { useForm } from 'react-hook-form'
+import { useForm, type FieldErrors } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { mapRegisterSignInError } from '@/lib/auth/map-register-error'
+import { parseRegisterSignInError } from '@/lib/auth/map-register-error'
+import { getFirstRegisterFieldError } from '@/lib/auth/register-form-a11y'
 import { registerSchema, type RegisterFormData } from '@/lib/validations/auth'
 import { CheckCircle, Eye, EyeOff, Loader2 } from 'lucide-react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-
-const authInputClassName =
-  'rounded-lg bg-background text-foreground focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:border-transparent'
+import { RegisterFormField } from '@/components/auth/RegisterFormField'
 
 /**
  * Register Form Component
@@ -25,7 +24,10 @@ export default function RegisterForm() {
   const [showPassword, setShowPassword] = useState(false)
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [formError, setFormError] = useState<string | null>(null)
+  const [submitAnnouncement, setSubmitAnnouncement] = useState<string | null>(
+    null
+  )
   const [success, setSuccess] = useState(false)
 
   const router = useRouter()
@@ -34,14 +36,36 @@ export default function RegisterForm() {
   const {
     register,
     handleSubmit,
+    setError,
+    clearErrors,
     formState: { errors },
   } = useForm<RegisterFormData>({
     resolver: zodResolver(registerSchema),
+    reValidateMode: 'onChange',
   })
+
+  const clearFieldFeedback = (name: keyof RegisterFormData) => {
+    clearErrors(name)
+    setFormError(null)
+    setSubmitAnnouncement(null)
+  }
+
+  const registerField = (name: keyof RegisterFormData) =>
+    register(name, {
+      onChange: () => clearFieldFeedback(name),
+    })
+
+  const announceFirstError = (formErrors: FieldErrors<RegisterFormData>) => {
+    const first = getFirstRegisterFieldError(formErrors)
+    if (!first) return
+    setSubmitAnnouncement(first.message)
+    document.getElementById(first.field)?.focus()
+  }
 
   const onSubmit = async (data: RegisterFormData) => {
     setIsLoading(true)
-    setError(null)
+    setFormError(null)
+    setSubmitAnnouncement(null)
 
     try {
       await signIn('password', {
@@ -53,12 +77,25 @@ export default function RegisterForm() {
       })
 
       setSuccess(true)
-      // Use replace to prevent back button returning to register
       router.replace('/')
     } catch (error) {
-      setError(mapRegisterSignInError(error))
+      const result = parseRegisterSignInError(error)
+      setSubmitAnnouncement(result.message)
+
+      if (result.field) {
+        setError(result.field, { type: 'server', message: result.message })
+        setFormError(null)
+        document.getElementById(result.field)?.focus()
+      } else {
+        setFormError(result.message)
+      }
+
       setIsLoading(false)
     }
+  }
+
+  const onInvalid = (formErrors: FieldErrors<RegisterFormData>) => {
+    announceFirstError(formErrors)
   }
 
   if (success) {
@@ -80,152 +117,156 @@ export default function RegisterForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-      {/* Error Message */}
-      {error && (
-        <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
-          <p className="text-sm text-red-700">{error}</p>
+    <form onSubmit={handleSubmit(onSubmit, onInvalid)} className="space-y-4">
+      {submitAnnouncement ? (
+        <p role="alert" className="sr-only">
+          {submitAnnouncement}
+        </p>
+      ) : null}
+
+      {formError ? (
+        <div
+          role="alert"
+          className="p-4 bg-red-50 border border-red-200 rounded-lg"
+        >
+          <p className="text-sm text-red-700">{formError}</p>
         </div>
-      )}
+      ) : null}
 
-      {/* Email Field */}
-      <div>
-        <label
-          htmlFor="email"
-          className="block text-sm font-medium text-foreground mb-2"
-        >
-          Email address
-        </label>
-        <Input
-          {...register('email')}
-          type="email"
-          id="email"
-          autoComplete="email"
-          className={authInputClassName}
-          placeholder="you@example.com"
-        />
-        {errors.email && (
-          <p className="mt-1 text-sm text-red-600">{errors.email.message}</p>
-        )}
-      </div>
-
-      {/* Username Field */}
-      <div>
-        <label
-          htmlFor="username"
-          className="block text-sm font-medium text-foreground mb-2"
-        >
-          Username
-        </label>
-        <Input
-          {...register('username')}
-          type="text"
-          id="username"
-          autoComplete="username"
-          className={authInputClassName}
-          placeholder="Choose a unique username"
-        />
-        {errors.username && (
-          <p className="mt-1 text-sm text-red-600">{errors.username.message}</p>
-        )}
-      </div>
-
-      {/* Name Field (Optional) */}
-      <div>
-        <label
-          htmlFor="name"
-          className="block text-sm font-medium text-foreground mb-2"
-        >
-          Full Name <span className="text-muted-foreground">(optional)</span>
-        </label>
-        <Input
-          {...register('name')}
-          type="text"
-          id="name"
-          autoComplete="name"
-          className={authInputClassName}
-          placeholder="Your full name"
-        />
-        {errors.name && (
-          <p className="mt-1 text-sm text-red-600">{errors.name.message}</p>
-        )}
-      </div>
-
-      {/* Password Field */}
-      <div>
-        <label
-          htmlFor="password"
-          className="block text-sm font-medium text-foreground mb-2"
-        >
-          Password
-        </label>
-        <div className="relative">
+      <RegisterFormField
+        id="email"
+        label="Email address"
+        error={errors.email?.message}
+      >
+        {(control) => (
           <Input
-            {...register('password')}
-            type={showPassword ? 'text' : 'password'}
-            id="password"
-            autoComplete="new-password"
-            className={`pr-10 ${authInputClassName}`}
-            placeholder="Create a secure password"
+            {...registerField('email')}
+            type="email"
+            id="email"
+            autoComplete="email"
+            placeholder="you@example.com"
+            aria-invalid={control['aria-invalid']}
+            aria-describedby={control['aria-describedby']}
+            className={control.inputClassName}
           />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={() => setShowPassword(!showPassword)}
-            className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-          >
-            {showPassword ? (
-              <EyeOff className="h-4 w-4" />
-            ) : (
-              <Eye className="h-4 w-4" />
-            )}
-          </Button>
-        </div>
-        {errors.password && (
-          <p className="mt-1 text-sm text-red-600">{errors.password.message}</p>
         )}
-      </div>
+      </RegisterFormField>
 
-      {/* Confirm Password Field */}
-      <div>
-        <label
-          htmlFor="confirmPassword"
-          className="block text-sm font-medium text-foreground mb-2"
-        >
-          Confirm Password
-        </label>
-        <div className="relative">
+      <RegisterFormField
+        id="username"
+        label="Username"
+        error={errors.username?.message}
+      >
+        {(control) => (
           <Input
-            {...register('confirmPassword')}
-            type={showConfirmPassword ? 'text' : 'password'}
-            id="confirmPassword"
-            autoComplete="new-password"
-            className={`pr-10 ${authInputClassName}`}
-            placeholder="Confirm your password"
+            {...registerField('username')}
+            type="text"
+            id="username"
+            autoComplete="username"
+            placeholder="Choose a unique username"
+            aria-invalid={control['aria-invalid']}
+            aria-describedby={control['aria-describedby']}
+            className={control.inputClassName}
           />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-            className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-          >
-            {showConfirmPassword ? (
-              <EyeOff className="h-4 w-4" />
-            ) : (
-              <Eye className="h-4 w-4" />
-            )}
-          </Button>
-        </div>
-        {errors.confirmPassword && (
-          <p className="mt-1 text-sm text-red-600">
-            {errors.confirmPassword.message}
-          </p>
         )}
-      </div>
+      </RegisterFormField>
 
-      {/* Submit Button */}
+      <RegisterFormField
+        id="name"
+        label={
+          <>
+            Full Name{' '}
+            <span className="text-muted-foreground">(optional)</span>
+          </>
+        }
+        error={errors.name?.message}
+      >
+        {(control) => (
+          <Input
+            {...registerField('name')}
+            type="text"
+            id="name"
+            autoComplete="name"
+            placeholder="Your full name"
+            aria-invalid={control['aria-invalid']}
+            aria-describedby={control['aria-describedby']}
+            className={control.inputClassName}
+          />
+        )}
+      </RegisterFormField>
+
+      <RegisterFormField
+        id="password"
+        label="Password"
+        error={errors.password?.message}
+      >
+        {(control) => (
+          <div className="relative">
+            <Input
+              {...registerField('password')}
+              type={showPassword ? 'text' : 'password'}
+              id="password"
+              autoComplete="new-password"
+              placeholder="Create a secure password"
+              aria-invalid={control['aria-invalid']}
+              aria-describedby={control['aria-describedby']}
+              className={`pr-10 ${control.inputClassName}`}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => setShowPassword(!showPassword)}
+              aria-label={showPassword ? 'Hide password' : 'Show password'}
+              className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              {showPassword ? (
+                <EyeOff className="h-4 w-4" aria-hidden="true" />
+              ) : (
+                <Eye className="h-4 w-4" aria-hidden="true" />
+              )}
+            </Button>
+          </div>
+        )}
+      </RegisterFormField>
+
+      <RegisterFormField
+        id="confirmPassword"
+        label="Confirm Password"
+        error={errors.confirmPassword?.message}
+      >
+        {(control) => (
+          <div className="relative">
+            <Input
+              {...registerField('confirmPassword')}
+              type={showConfirmPassword ? 'text' : 'password'}
+              id="confirmPassword"
+              autoComplete="new-password"
+              placeholder="Confirm your password"
+              aria-invalid={control['aria-invalid']}
+              aria-describedby={control['aria-describedby']}
+              className={`pr-10 ${control.inputClassName}`}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+              aria-label={
+                showConfirmPassword ? 'Hide password' : 'Show password'
+              }
+              className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              {showConfirmPassword ? (
+                <EyeOff className="h-4 w-4" aria-hidden="true" />
+              ) : (
+                <Eye className="h-4 w-4" aria-hidden="true" />
+              )}
+            </Button>
+          </div>
+        )}
+      </RegisterFormField>
+
       <Button
         type="submit"
         disabled={isLoading}
@@ -233,7 +274,7 @@ export default function RegisterForm() {
       >
         {isLoading ? (
           <>
-            <Loader2 className="h-4 w-4 animate-spin" />
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
             Creating account...
           </>
         ) : (

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -217,6 +217,7 @@ export default function RegisterForm() {
               size="icon"
               onClick={() => setShowPassword(!showPassword)}
               aria-label={showPassword ? 'Hide password' : 'Show password'}
+              aria-pressed={showPassword}
               className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
             >
               {showPassword ? (
@@ -252,8 +253,11 @@ export default function RegisterForm() {
               size="icon"
               onClick={() => setShowConfirmPassword(!showConfirmPassword)}
               aria-label={
-                showConfirmPassword ? 'Hide password' : 'Show password'
+                showConfirmPassword
+                  ? 'Hide confirm password'
+                  : 'Show confirm password'
               }
+              aria-pressed={showConfirmPassword}
               className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
             >
               {showConfirmPassword ? (

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -1,16 +1,24 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useForm, type FieldErrors } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { parseRegisterSignInError } from '@/lib/auth/map-register-error'
 import { getFirstRegisterFieldError } from '@/lib/auth/register-form-a11y'
 import { registerSchema, type RegisterFormData } from '@/lib/validations/auth'
+import { allPasswordRulesMet } from '@/lib/validations/password-rules'
+
+const PASSWORD_VALIDATION_MESSAGE =
+  'Password does not meet all requirements'
 import { CheckCircle, Eye, EyeOff, Loader2 } from 'lucide-react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import {
+  PasswordRequirements,
+  PASSWORD_REQUIREMENTS_ID,
+} from '@/components/auth/PasswordRequirements'
 import { RegisterFormField } from '@/components/auth/RegisterFormField'
 
 /**
@@ -29,6 +37,8 @@ export default function RegisterForm() {
     null
   )
   const [success, setSuccess] = useState(false)
+  const [highlightPasswordFailures, setHighlightPasswordFailures] =
+    useState(false)
 
   const router = useRouter()
   const { signIn } = useAuth()
@@ -38,11 +48,20 @@ export default function RegisterForm() {
     handleSubmit,
     setError,
     clearErrors,
+    watch,
     formState: { errors },
   } = useForm<RegisterFormData>({
     resolver: zodResolver(registerSchema),
     reValidateMode: 'onChange',
   })
+
+  const password = watch('password') ?? ''
+
+  useEffect(() => {
+    if (highlightPasswordFailures && allPasswordRulesMet(password)) {
+      setHighlightPasswordFailures(false)
+    }
+  }, [password, highlightPasswordFailures])
 
   const clearFieldFeedback = (name: keyof RegisterFormData) => {
     clearErrors(name)
@@ -53,6 +72,13 @@ export default function RegisterForm() {
   const registerField = (name: keyof RegisterFormData) =>
     register(name, {
       onChange: () => clearFieldFeedback(name),
+    })
+
+  const registerPasswordField = () =>
+    register('password', {
+      onChange: () => {
+        clearFieldFeedback('password')
+      },
     })
 
   const announceFirstError = (formErrors: FieldErrors<RegisterFormData>) => {
@@ -95,6 +121,19 @@ export default function RegisterForm() {
   }
 
   const onInvalid = (formErrors: FieldErrors<RegisterFormData>) => {
+    const first = getFirstRegisterFieldError(formErrors)
+
+    if (first?.field === 'password') {
+      setHighlightPasswordFailures(true)
+      setError('password', {
+        type: 'manual',
+        message: PASSWORD_VALIDATION_MESSAGE,
+      })
+      setSubmitAnnouncement(PASSWORD_VALIDATION_MESSAGE)
+      document.getElementById('password')?.focus()
+      return
+    }
+
     announceFirstError(formErrors)
   }
 
@@ -198,35 +237,42 @@ export default function RegisterForm() {
         id="password"
         label="Password"
         error={errors.password?.message}
+        extraDescribedBy={PASSWORD_REQUIREMENTS_ID}
       >
         {(control) => (
-          <div className="relative">
-            <Input
-              {...registerField('password')}
-              type={showPassword ? 'text' : 'password'}
-              id="password"
-              autoComplete="new-password"
-              placeholder="Create a secure password"
-              aria-invalid={control['aria-invalid']}
-              aria-describedby={control['aria-describedby']}
-              className={`pr-10 ${control.inputClassName}`}
+          <>
+            <div className="relative">
+              <Input
+                {...registerPasswordField()}
+                type={showPassword ? 'text' : 'password'}
+                id="password"
+                autoComplete="new-password"
+                placeholder="Create a secure password"
+                aria-invalid={control['aria-invalid']}
+                aria-describedby={control['aria-describedby']}
+                className={`pr-10 ${control.inputClassName}`}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => setShowPassword(!showPassword)}
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+                aria-pressed={showPassword}
+                className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              >
+                {showPassword ? (
+                  <EyeOff className="h-4 w-4" aria-hidden="true" />
+                ) : (
+                  <Eye className="h-4 w-4" aria-hidden="true" />
+                )}
+              </Button>
+            </div>
+            <PasswordRequirements
+              password={password}
+              highlightFailures={highlightPasswordFailures}
             />
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              onClick={() => setShowPassword(!showPassword)}
-              aria-label={showPassword ? 'Hide password' : 'Show password'}
-              aria-pressed={showPassword}
-              className="absolute right-3 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-            >
-              {showPassword ? (
-                <EyeOff className="h-4 w-4" aria-hidden="true" />
-              ) : (
-                <Eye className="h-4 w-4" aria-hidden="true" />
-              )}
-            </Button>
-          </div>
+          </>
         )}
       </RegisterFormField>
 

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -9,8 +9,7 @@ import { getFirstRegisterFieldError } from '@/lib/auth/register-form-a11y'
 import { registerSchema, type RegisterFormData } from '@/lib/validations/auth'
 import { allPasswordRulesMet } from '@/lib/validations/password-rules'
 
-const PASSWORD_VALIDATION_MESSAGE =
-  'Password does not meet all requirements'
+const PASSWORD_VALIDATION_MESSAGE = 'Password does not meet all requirements'
 import { CheckCircle, Eye, EyeOff, Loader2 } from 'lucide-react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { Button } from '@/components/ui/button'

--- a/components/auth/RegisterFormField.tsx
+++ b/components/auth/RegisterFormField.tsx
@@ -15,6 +15,7 @@ type RegisterFormFieldProps = {
   id: string
   label: ReactNode
   error?: string
+  extraDescribedBy?: string
   children: (control: RegisterFieldControlProps) => ReactNode
 }
 
@@ -22,13 +23,17 @@ export function RegisterFormField({
   id,
   label,
   error,
+  extraDescribedBy,
   children,
 }: RegisterFormFieldProps) {
   const errorId = `${id}-error`
   const invalid = !!error
+  const describedBy = [extraDescribedBy, invalid ? errorId : undefined]
+    .filter(Boolean)
+    .join(' ')
   const control: RegisterFieldControlProps = {
     'aria-invalid': invalid,
-    ...(invalid ? { 'aria-describedby': errorId } : {}),
+    ...(describedBy ? { 'aria-describedby': describedBy } : {}),
     inputClassName: cn(
       authInputClassName,
       invalid &&

--- a/components/auth/RegisterFormField.tsx
+++ b/components/auth/RegisterFormField.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+export const authInputClassName =
+  'rounded-lg bg-background text-foreground focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:border-transparent'
+
+export type RegisterFieldControlProps = {
+  'aria-invalid': boolean
+  'aria-describedby'?: string
+  inputClassName: string
+  errorId: string
+}
+
+type RegisterFormFieldProps = {
+  id: string
+  label: ReactNode
+  error?: string
+  children: (control: RegisterFieldControlProps) => ReactNode
+}
+
+export function RegisterFormField({
+  id,
+  label,
+  error,
+  children,
+}: RegisterFormFieldProps) {
+  const errorId = `${id}-error`
+  const invalid = !!error
+  const control: RegisterFieldControlProps = {
+    'aria-invalid': invalid,
+    ...(invalid ? { 'aria-describedby': errorId } : {}),
+    inputClassName: cn(
+      authInputClassName,
+      invalid &&
+        'border-destructive focus-visible:ring-destructive focus-visible:border-destructive'
+    ),
+    errorId,
+  }
+
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className={cn(
+          'block text-sm font-medium text-foreground mb-2',
+          invalid && 'text-destructive'
+        )}
+      >
+        {label}
+      </label>
+      {children(control)}
+      {error ? (
+        <p id={errorId} className="mt-1 text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/lib/auth/map-register-error.test.ts
+++ b/lib/auth/map-register-error.test.ts
@@ -46,13 +46,13 @@ describe('mapRegisterSignInError', () => {
 
 describe('parseRegisterSignInError', () => {
   it('associates duplicate account errors with the email field', () => {
-    expect(parseRegisterSignInError(new Error('Account already exists'))).toEqual(
-      {
-        message:
-          'An account with this email already exists. Try signing in, or use a different email.',
-        field: 'email',
-      }
-    )
+    expect(
+      parseRegisterSignInError(new Error('Account already exists'))
+    ).toEqual({
+      message:
+        'An account with this email already exists. Try signing in, or use a different email.',
+      field: 'email',
+    })
   })
 
   it('associates username conflicts with the username field', () => {

--- a/lib/auth/map-register-error.test.ts
+++ b/lib/auth/map-register-error.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { mapRegisterSignInError } from './map-register-error'
+import {
+  mapRegisterSignInError,
+  parseRegisterSignInError,
+} from './map-register-error'
 
 describe('mapRegisterSignInError', () => {
   it('maps duplicate account messages from Convex-style errors', () => {
@@ -38,5 +41,36 @@ describe('mapRegisterSignInError', () => {
     expect(
       mapRegisterSignInError(new Error('Username "foo" is already taken'))
     ).toBe('This username is not available. Try another one.')
+  })
+})
+
+describe('parseRegisterSignInError', () => {
+  it('associates duplicate account errors with the email field', () => {
+    expect(parseRegisterSignInError(new Error('Account already exists'))).toEqual(
+      {
+        message:
+          'An account with this email already exists. Try signing in, or use a different email.',
+        field: 'email',
+      }
+    )
+  })
+
+  it('associates username conflicts with the username field', () => {
+    expect(
+      parseRegisterSignInError(new Error('Username "foo" is already taken'))
+    ).toEqual({
+      message: 'This username is not available. Try another one.',
+      field: 'username',
+    })
+  })
+
+  it('returns a form-level generic error without a field', () => {
+    expect(
+      parseRegisterSignInError(
+        new Error('[CONVEX A(auth:signIn)] Server Error Something went wrong')
+      )
+    ).toEqual({
+      message: 'Registration failed. Please try again.',
+    })
   })
 })

--- a/lib/auth/map-register-error.ts
+++ b/lib/auth/map-register-error.ts
@@ -5,11 +5,20 @@ const USERNAME_UNAVAILABLE = 'This username is not available. Try another one.'
 
 const GENERIC = 'Registration failed. Please try again.'
 
+export type RegisterSignInErrorField = 'email' | 'username'
+
+export type RegisterSignInErrorResult = {
+  message: string
+  field?: RegisterSignInErrorField
+}
+
 /**
  * Maps Convex Auth / network failures from sign-up into short user-facing copy.
  * Avoids showing raw stack traces or `[CONVEX ...]` payloads in the UI.
  */
-export function mapRegisterSignInError(error: unknown): string {
+export function parseRegisterSignInError(
+  error: unknown
+): RegisterSignInErrorResult {
   const raw = extractMessage(error)
   const lower = raw.toLowerCase()
 
@@ -18,7 +27,7 @@ export function mapRegisterSignInError(error: unknown): string {
     lower.includes('already registered') ||
     /email.+?\b(in use|taken)\b/i.test(raw)
   ) {
-    return DUPLICATE_ACCOUNT
+    return { message: DUPLICATE_ACCOUNT, field: 'email' }
   }
 
   if (
@@ -26,7 +35,7 @@ export function mapRegisterSignInError(error: unknown): string {
     lower.includes('username is not available') ||
     lower.includes('username not available')
   ) {
-    return USERNAME_UNAVAILABLE
+    return { message: USERNAME_UNAVAILABLE, field: 'username' }
   }
 
   if (
@@ -36,14 +45,18 @@ export function mapRegisterSignInError(error: unknown): string {
     lower.includes('request id:') ||
     raw.includes('\n')
   ) {
-    return GENERIC
+    return { message: GENERIC }
   }
 
   if (raw.length > 0 && raw.length <= 200 && !looksLikeStackSnippet(raw)) {
-    return raw
+    return { message: raw }
   }
 
-  return GENERIC
+  return { message: GENERIC }
+}
+
+export function mapRegisterSignInError(error: unknown): string {
+  return parseRegisterSignInError(error).message
 }
 
 function extractMessage(error: unknown): string {

--- a/lib/auth/register-form-a11y.test.ts
+++ b/lib/auth/register-form-a11y.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { getFirstRegisterFieldError } from './register-form-a11y'
+
+describe('getFirstRegisterFieldError', () => {
+  it('returns the first error in registration field order', () => {
+    const result = getFirstRegisterFieldError({
+      confirmPassword: { type: 'custom', message: "Passwords don't match" },
+      email: { type: 'required', message: 'Email is required' },
+      password: { type: 'min', message: 'Password must be at least 8 characters' },
+    })
+
+    expect(result).toEqual({
+      field: 'email',
+      message: 'Email is required',
+    })
+  })
+
+  it('skips fields without messages', () => {
+    const result = getFirstRegisterFieldError({
+      email: { type: 'required', message: '' },
+      username: { type: 'min', message: 'Username must be at least 3 characters' },
+    })
+
+    expect(result).toEqual({
+      field: 'username',
+      message: 'Username must be at least 3 characters',
+    })
+  })
+
+  it('returns null when there are no errors', () => {
+    expect(getFirstRegisterFieldError({})).toBeNull()
+  })
+})

--- a/lib/auth/register-form-a11y.test.ts
+++ b/lib/auth/register-form-a11y.test.ts
@@ -6,7 +6,10 @@ describe('getFirstRegisterFieldError', () => {
     const result = getFirstRegisterFieldError({
       confirmPassword: { type: 'custom', message: "Passwords don't match" },
       email: { type: 'required', message: 'Email is required' },
-      password: { type: 'min', message: 'Password must be at least 8 characters' },
+      password: {
+        type: 'min',
+        message: 'Password must be at least 8 characters',
+      },
     })
 
     expect(result).toEqual({
@@ -18,7 +21,10 @@ describe('getFirstRegisterFieldError', () => {
   it('skips fields without messages', () => {
     const result = getFirstRegisterFieldError({
       email: { type: 'required', message: '' },
-      username: { type: 'min', message: 'Username must be at least 3 characters' },
+      username: {
+        type: 'min',
+        message: 'Username must be at least 3 characters',
+      },
     })
 
     expect(result).toEqual({

--- a/lib/auth/register-form-a11y.ts
+++ b/lib/auth/register-form-a11y.ts
@@ -1,0 +1,24 @@
+import type { FieldErrors } from 'react-hook-form'
+import type { RegisterFormData } from '@/lib/validations/auth'
+
+export const REGISTER_FIELD_ORDER = [
+  'email',
+  'username',
+  'name',
+  'password',
+  'confirmPassword',
+] as const satisfies readonly (keyof RegisterFormData)[]
+
+export type RegisterFieldName = (typeof REGISTER_FIELD_ORDER)[number]
+
+export function getFirstRegisterFieldError(
+  errors: FieldErrors<RegisterFormData>
+): { field: RegisterFieldName; message: string } | null {
+  for (const field of REGISTER_FIELD_ORDER) {
+    const err = errors[field]
+    if (err?.message) {
+      return { field, message: String(err.message) }
+    }
+  }
+  return null
+}

--- a/lib/validations/__tests__/auth.test.ts
+++ b/lib/validations/__tests__/auth.test.ts
@@ -73,6 +73,97 @@ describe('Auth Validation Schemas', () => {
       })
       expect(result.success).toBe(false)
     })
+
+    it('accepts registration with empty name', () => {
+      const result = registerSchema.safeParse({
+        email: 'user@example.com',
+        username: 'validuser',
+        password: 'Password1',
+        confirmPassword: 'Password1',
+        name: '',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts registration with name omitted', () => {
+      const result = registerSchema.safeParse({
+        email: 'user@example.com',
+        username: 'validuser',
+        password: 'Password1',
+        confirmPassword: 'Password1',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts registration with a provided name', () => {
+      const result = registerSchema.safeParse({
+        email: 'user@example.com',
+        username: 'validuser',
+        password: 'Password1',
+        confirmPassword: 'Password1',
+        name: 'Jane Doe',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects name longer than 50 characters', () => {
+      const result = registerSchema.safeParse({
+        email: 'user@example.com',
+        username: 'validuser',
+        password: 'Password1',
+        confirmPassword: 'Password1',
+        name: 'a'.repeat(51),
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          'Name must be at most 50 characters'
+        )
+      }
+    })
+
+    it('rejects empty email with a clear message', () => {
+      const result = registerSchema.safeParse({
+        email: '',
+        username: 'validuser',
+        password: 'Password1',
+        confirmPassword: 'Password1',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe('Email is required')
+      }
+    })
+
+    it('rejects empty username', () => {
+      const result = registerSchema.safeParse({
+        email: 'user@example.com',
+        username: '',
+        password: 'Password1',
+        confirmPassword: 'Password1',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          'Username must be at least 3 characters'
+        )
+      }
+    })
+
+    it('rejects empty password', () => {
+      const result = registerSchema.safeParse({
+        email: 'user@example.com',
+        username: 'validuser',
+        password: '',
+        confirmPassword: '',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          'Password must be at least 8 characters'
+        )
+      }
+    })
   })
 
   describe('profileUpdateSchema', () => {

--- a/lib/validations/__tests__/password-rules.test.ts
+++ b/lib/validations/__tests__/password-rules.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import {
-  allPasswordRulesMet,
-  getPasswordRuleStatuses,
-} from '../password-rules'
+import { allPasswordRulesMet, getPasswordRuleStatuses } from '../password-rules'
 
 describe('password-rules', () => {
   describe('getPasswordRuleStatuses', () => {

--- a/lib/validations/__tests__/password-rules.test.ts
+++ b/lib/validations/__tests__/password-rules.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import {
+  allPasswordRulesMet,
+  getPasswordRuleStatuses,
+} from '../password-rules'
+
+describe('password-rules', () => {
+  describe('getPasswordRuleStatuses', () => {
+    it('returns all rules unmet for an empty password', () => {
+      const statuses = getPasswordRuleStatuses('')
+      expect(statuses).toHaveLength(4)
+      expect(statuses.every((rule) => !rule.met)).toBe(true)
+    })
+
+    it('marks minLength met when password has 8+ characters', () => {
+      const statuses = getPasswordRuleStatuses('12345678')
+      expect(statuses.find((r) => r.id === 'minLength')?.met).toBe(true)
+      expect(statuses.find((r) => r.id === 'uppercase')?.met).toBe(false)
+      expect(statuses.find((r) => r.id === 'lowercase')?.met).toBe(false)
+      expect(statuses.find((r) => r.id === 'digit')?.met).toBe(true)
+    })
+
+    it('marks all rules met for a valid password', () => {
+      const statuses = getPasswordRuleStatuses('Password1')
+      expect(statuses.every((rule) => rule.met)).toBe(true)
+    })
+  })
+
+  describe('allPasswordRulesMet', () => {
+    it('returns false when any rule is unmet', () => {
+      expect(allPasswordRulesMet('password')).toBe(false)
+      expect(allPasswordRulesMet('PASSWORD1')).toBe(false)
+      expect(allPasswordRulesMet('Pass1')).toBe(false)
+    })
+
+    it('returns true when all rules are met', () => {
+      expect(allPasswordRulesMet('Password1')).toBe(true)
+    })
+  })
+})

--- a/lib/validations/auth.ts
+++ b/lib/validations/auth.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { PASSWORD_MIN_LENGTH, PASSWORD_REGEX } from './password-rules'
 
 /**
  * Authentication Validation Schemas
@@ -6,10 +7,6 @@ import { z } from 'zod'
  * Centralized validation schemas for authentication forms using Zod.
  * These schemas ensure consistent validation across the application.
  */
-
-// Password validation regex patterns
-const PASSWORD_MIN_LENGTH = 8
-const PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/
 
 // Username validation regex pattern
 const USERNAME_REGEX = /^[a-zA-Z0-9_-]+$/

--- a/lib/validations/auth.ts
+++ b/lib/validations/auth.ts
@@ -54,9 +54,10 @@ export const registerSchema = z
       ),
     confirmPassword: z.string().min(1, 'Please confirm your password'),
     name: z
-      .string()
-      .min(1, 'Name is required')
-      .max(50, 'Name must be at most 50 characters')
+      .union([
+        z.literal(''),
+        z.string().max(50, 'Name must be at most 50 characters'),
+      ])
       .optional(),
   })
   .refine((data) => data.password === data.confirmPassword, {

--- a/lib/validations/password-rules.ts
+++ b/lib/validations/password-rules.ts
@@ -1,0 +1,54 @@
+export const PASSWORD_MIN_LENGTH = 8
+
+export const PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/
+
+export type PasswordRuleId =
+  | 'minLength'
+  | 'uppercase'
+  | 'lowercase'
+  | 'digit'
+
+export type PasswordRuleStatus = {
+  id: PasswordRuleId
+  label: string
+  met: boolean
+}
+
+const PASSWORD_RULES: {
+  id: PasswordRuleId
+  label: string
+  test: (password: string) => boolean
+}[] = [
+  {
+    id: 'minLength',
+    label: `At least ${PASSWORD_MIN_LENGTH} characters`,
+    test: (password) => password.length >= PASSWORD_MIN_LENGTH,
+  },
+  {
+    id: 'uppercase',
+    label: 'One uppercase letter',
+    test: (password) => /[A-Z]/.test(password),
+  },
+  {
+    id: 'lowercase',
+    label: 'One lowercase letter',
+    test: (password) => /[a-z]/.test(password),
+  },
+  {
+    id: 'digit',
+    label: 'One number',
+    test: (password) => /\d/.test(password),
+  },
+]
+
+export function getPasswordRuleStatuses(password: string): PasswordRuleStatus[] {
+  return PASSWORD_RULES.map(({ id, label, test }) => ({
+    id,
+    label,
+    met: test(password),
+  }))
+}
+
+export function allPasswordRulesMet(password: string): boolean {
+  return getPasswordRuleStatuses(password).every((rule) => rule.met)
+}

--- a/lib/validations/password-rules.ts
+++ b/lib/validations/password-rules.ts
@@ -2,11 +2,7 @@ export const PASSWORD_MIN_LENGTH = 8
 
 export const PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/
 
-export type PasswordRuleId =
-  | 'minLength'
-  | 'uppercase'
-  | 'lowercase'
-  | 'digit'
+export type PasswordRuleId = 'minLength' | 'uppercase' | 'lowercase' | 'digit'
 
 export type PasswordRuleStatus = {
   id: PasswordRuleId
@@ -41,7 +37,9 @@ const PASSWORD_RULES: {
   },
 ]
 
-export function getPasswordRuleStatuses(password: string): PasswordRuleStatus[] {
+export function getPasswordRuleStatuses(
+  password: string
+): PasswordRuleStatus[] {
   return PASSWORD_RULES.map(({ id, label, test }) => ({
     id,
     label,


### PR DESCRIPTION
## Summary

Improves login and registration UX with accessible form patterns, live password requirement feedback, and clearer server-side error handling. Sign-up validation is centralized in shared Zod schemas and password rules so requirements stay consistent across auth flows.



## What changed

### Login form (`LoginForm`)

- Password visibility toggle uses `aria-label` and `aria-pressed` (`Show password` / `Hide password`).
- Successful sign-in shows a success state before redirecting home.
- Failed sign-in keeps the form editable with a generic error message (no raw Convex/stack traces).
- Redirect timeout: if navigation stalls after success, loading clears and a retry message is shown.

### Registration form (`RegisterForm`)

- Rebuilt with `RegisterFormField` for consistent labels, `aria-invalid`, and `aria-describedby` wiring to field errors.
- Live `PasswordRequirements` checklist (min length, uppercase, lowercase, number) with `aria-live="polite"`.
- On invalid submit, first error in field order is announced (`role="alert"`, sr-only) and focus moves to that field.
- Weak password submit highlights unmet rules in destructive styling and sets a clear validation message.
- Separate show/hide toggles for password and confirm password with accessible names and pressed state.
- Optional full name: schema allows empty or omitted `name`; only sent to Convex when provided.
- Server errors mapped via `parseRegisterSignInError` to field-level messages (duplicate email, username taken) or a short generic message (no `[CONVEX ...]` payloads in UI).

### Shared validation and utilities

- `lib/validations/password-rules.ts`: shared rule definitions and `allPasswordRulesMet` / `getPasswordRuleStatuses`.
- `registerSchema` and `passwordChangeSchema` use the same password rules.
- `lib/auth/register-form-a11y.ts`: deterministic first-error field order for focus and screen reader announcements.

## Accessibility highlights

- Invalid fields expose `aria-invalid` and link errors via `aria-describedby`.
- Password field links to the requirements list via `aria-describedby`.
- Submit announcements for validation and server errors without relying on color alone.
- Icon-only controls have explicit accessible names; decorative icons use `aria-hidden`.

