### PR TITLE
fix(profile): align public wallet copy and add in-app tip path (ENG-186)

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation'
 import { useUserByUsername, useUserStats } from '@/hooks/convex'
 import { use, useState, useEffect } from 'react'
 import { useSearchParams } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 import { useAuth } from '@/components/providers/AuthContext'
 import AppNavigation from '@/components/layout/AppNavigation'
 import { SiteFooter } from '@/components/layout/SiteFooter'
@@ -26,6 +27,7 @@ type TabType = 'articles' | 'nfts' | 'earnings' | 'stats' | 'wallet'
 export default function ProfilePage({ params }: ProfilePageProps) {
   const { username } = use(params)
   const searchParams = useSearchParams()
+  const router = useRouter()
   const { user: currentUser } = useAuth()
   const [activeTab, setActiveTab] = useState<TabType>('articles')
   const [localWalletAddress, setLocalWalletAddress] = useState<
@@ -43,8 +45,29 @@ export default function ProfilePage({ params }: ProfilePageProps) {
     searchParams?.get('nftMintedPage') ?? null
   )
 
+  const tabParamRaw = searchParams?.get('tab')
+  const tabParam: TabType | null =
+    tabParamRaw === 'articles' ||
+    tabParamRaw === 'nfts' ||
+    tabParamRaw === 'earnings' ||
+    tabParamRaw === 'stats' ||
+    tabParamRaw === 'wallet'
+      ? tabParamRaw
+      : null
+
   // Fetch user profile
   const user = useUserByUsername(username)
+
+  const updateTabInUrl = (tab: TabType) => {
+    const next = new URLSearchParams(searchParams?.toString())
+    next.set('tab', tab)
+    router.replace(`/${username}?${next.toString()}`, { scroll: false })
+  }
+
+  const handleTabClick = (tab: TabType) => {
+    setActiveTab(tab)
+    updateTabInUrl(tab)
+  }
 
   // Sync local wallet address with user data
   useEffect(() => {
@@ -52,6 +75,13 @@ export default function ProfilePage({ params }: ProfilePageProps) {
       setLocalWalletAddress(user?.stellarAddress)
     }
   }, [user?.stellarAddress, localWalletAddress])
+
+  // Sync active tab from URL param
+  useEffect(() => {
+    if (tabParam && tabParam !== activeTab) {
+      setActiveTab(tabParam)
+    }
+  }, [tabParam, activeTab])
 
   // Fetch user stats
   const userStats = useUserStats(user?._id)
@@ -139,7 +169,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
               <button
                 key={tab.id}
                 data-tab={tab.id}
-                onClick={() => setActiveTab(tab.id)}
+                onClick={() => handleTabClick(tab.id)}
                 className={`
                   flex items-center gap-2 py-3 px-1 border-b-2 font-medium text-sm transition-colors
                   ${
@@ -249,14 +279,26 @@ export default function ProfilePage({ params }: ProfilePageProps) {
                 <p className="text-muted-foreground">
                   {isOwnProfile
                     ? 'Manage your Stellar testnet wallet for sending and receiving practice tips.'
-                    : 'View wallet address for sending tips to this user.'}
+                    : 'View and copy the wallet address, or tip this author from their articles.'}
                 </p>
               </div>
 
               {/* Wallet Settings */}
               <div className="max-w-2xl">
+                {!isOwnProfile ? (
+                  <div className="mb-4">
+                    <button
+                      type="button"
+                      className="focus-ring inline-flex w-full items-center justify-center rounded-lg bg-primary px-4 py-2.5 text-primary-foreground font-medium hover:bg-primary/90 transition-colors"
+                      onClick={() => handleTabClick('articles')}
+                    >
+                      Tip this author from their articles
+                    </button>
+                  </div>
+                ) : null}
                 <WalletSettings
                   walletAddress={localWalletAddress ?? user?.stellarAddress}
+                  profileUsername={username}
                   isOwnProfile={isOwnProfile}
                   onAddressChange={(address) => {
                     // Immediately update local state for instant UI feedback

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -38,6 +38,7 @@ import {
 
 interface WalletSettingsProps {
   walletAddress?: string | null
+  profileUsername?: string
   onAddressChange?: (address: string) => void
   isOwnProfile: boolean
   className?: string
@@ -45,6 +46,7 @@ interface WalletSettingsProps {
 
 export function WalletSettings({
   walletAddress,
+  profileUsername,
   onAddressChange,
   isOwnProfile,
   className = '',
@@ -157,12 +159,42 @@ export function WalletSettings({
 
   if (!isOwnProfile && !walletAddress) {
     return (
-      <Alert className={className}>
-        <AlertCircle className="h-4 w-4" />
-        <AlertDescription>
-          This user hasn&apos;t set up their Stellar wallet yet.
-        </AlertDescription>
-      </Alert>
+      <Card className={className}>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Wallet className="h-5 w-5" />
+            Stellar Wallet
+            <WalletTooltip concept="stellar" />
+            <WalletTooltip concept="testnet" />
+          </CardTitle>
+          <CardDescription>
+            This author hasn&apos;t connected a wallet yet, so in-app tipping
+            isn&apos;t available.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Alert>
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>
+              You can still read their work. Once they connect a wallet, you can
+              tip from any article using &quot;Tip Author&quot;.
+            </AlertDescription>
+          </Alert>
+
+          <div className="flex flex-col gap-2 sm:flex-row">
+            {profileUsername ? (
+              <Button asChild className="flex-1">
+                <Link href={`/${profileUsername}?tab=articles`}>
+                  Browse articles
+                </Link>
+              </Button>
+            ) : null}
+            <Button asChild variant="outline" className="flex-1">
+              <Link href="/guide">Learn how tipping works</Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
     )
   }
 
@@ -179,7 +211,7 @@ export function WalletSettings({
           <CardDescription>
             {isOwnProfile
               ? 'Manage your Stellar testnet wallet for sending and receiving practice tips'
-              : 'Send testnet tips directly to this user&apos;s Stellar wallet'}
+              : 'Copy the wallet address, or tip this author from their articles.'}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -360,8 +392,8 @@ export function WalletSettings({
               <Alert>
                 <DollarSign className="h-4 w-4" />
                 <AlertDescription>
-                  Tips sent to this wallet go directly to the user with minimal
-                  platform fees.
+                  Want to tip in-app? Open any of their articles and click
+                  &quot;Tip Author&quot;.
                 </AlertDescription>
               </Alert>
             </div>


### PR DESCRIPTION
## Summary

Fixes ENG-186: public profile wallet views described sending tips directly to a wallet, but the UI only supported viewing and copying the address.

- Updates public wallet tab copy to match available actions (view/copy address; tip via articles)
- Adds a CTA on the public Wallet tab that switches to the Articles tab, where readers use "Tip Author"
- Improves the empty public wallet state when the author has not connected a wallet, with next-step guidance and links to browse articles or the tipping guide
- Adds `?tab=` URL support on profile pages so tab navigation (including deep links) stays in sync

