### PR TITLE
fix(guide): make wallet guide tabs mobile-friendly

### DIFF
--- a/components/guide/WalletGuide.test.tsx
+++ b/components/guide/WalletGuide.test.tsx
@@ -51,4 +51,3 @@ describe('WalletGuide tabs', () => {
     expect(trigger.className).toContain('whitespace-normal')
   })
 })
-

--- a/components/guide/WalletGuide.test.tsx
+++ b/components/guide/WalletGuide.test.tsx
@@ -1,0 +1,54 @@
+/** @vitest-environment jsdom */
+import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { WalletGuide } from '@/components/guide/WalletGuide'
+
+vi.mock('next/link', () => {
+  return {
+    default: (props: { href: string; children: ReactNode }) => (
+      <a href={props.href}>{props.children}</a>
+    ),
+  }
+})
+
+vi.mock('@/components/stellar/WalletConnectButton', () => {
+  return {
+    WalletConnectButton: () => <button type="button">Mock connect</button>,
+  }
+})
+
+describe('WalletGuide tabs', () => {
+  it('labels the tab list for screen readers', () => {
+    render(<WalletGuide />)
+    expect(screen.getByLabelText('Wallet setup steps')).toBeInTheDocument()
+  })
+
+  it('renders all tab labels in full', () => {
+    render(<WalletGuide />)
+    expect(
+      screen.getByRole('tab', { name: 'What is a Wallet?' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('tab', { name: 'Set Up Freighter' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Connect' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('tab', { name: 'Your First Tip' })
+    ).toBeInTheDocument()
+  })
+
+  it('uses a 2×2 grid on mobile and a single row on larger screens', () => {
+    render(<WalletGuide />)
+    const list = screen.getByLabelText('Wallet setup steps')
+    expect(list.className).toContain('grid-cols-2')
+    expect(list.className).toContain('sm:grid-cols-4')
+  })
+
+  it('allows tab labels to wrap', () => {
+    render(<WalletGuide />)
+    const trigger = screen.getByRole('tab', { name: 'What is a Wallet?' })
+    expect(trigger.className).toContain('whitespace-normal')
+  })
+})
+

--- a/components/guide/WalletGuide.tsx
+++ b/components/guide/WalletGuide.tsx
@@ -18,6 +18,13 @@ import Link from 'next/link'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
 
+const WALLET_GUIDE_TABS = [
+  { value: 'what-is-wallet', label: 'What is a Wallet?' },
+  { value: 'setup', label: 'Set Up Freighter' },
+  { value: 'connect', label: 'Connect' },
+  { value: 'first-tip', label: 'Your First Tip' },
+] as const
+
 export function WalletGuide() {
   return (
     <div className="max-w-3xl mx-auto">
@@ -39,19 +46,19 @@ export function WalletGuide() {
       </Alert>
 
       <Tabs defaultValue="what-is-wallet" className="w-full">
-        <TabsList className="grid w-full grid-cols-4 mb-8">
-          <TabsTrigger value="what-is-wallet" className="text-xs sm:text-sm">
-            What is a Wallet?
-          </TabsTrigger>
-          <TabsTrigger value="setup" className="text-xs sm:text-sm">
-            Set Up Freighter
-          </TabsTrigger>
-          <TabsTrigger value="connect" className="text-xs sm:text-sm">
-            Connect
-          </TabsTrigger>
-          <TabsTrigger value="first-tip" className="text-xs sm:text-sm">
-            Your First Tip
-          </TabsTrigger>
+        <TabsList
+          className="grid w-full grid-cols-2 gap-2 h-auto p-1 mb-8 sm:grid-cols-4 sm:gap-1"
+          aria-label="Wallet setup steps"
+        >
+          {WALLET_GUIDE_TABS.map((tab) => (
+            <TabsTrigger
+              key={tab.value}
+              value={tab.value}
+              className="min-h-11 py-2.5 px-2 text-sm whitespace-normal text-center leading-snug sm:min-h-9 sm:py-1.5 sm:px-3 data-[state=active]:ring-2 data-[state=active]:ring-ring"
+            >
+              {tab.label}
+            </TabsTrigger>
+          ))}
         </TabsList>
 
         {/* Tab 1: What is a Wallet? */}


### PR DESCRIPTION
## Summary
- Switch wallet guide navigation to a mobile 2×2 tab layout (sm+: 1×4) so labels stay readable at 320px/375px and tablet widths.
- Improve tap targets and active-state clarity (larger mobile height + active ring), and allow labels to wrap instead of truncating.
- Add `aria-label` for the tab list and a small unit test to prevent regressions.

<img width="801" height="859" alt="Screenshot 2026-05-27 at 12 13 16 AM" src="https://github.com/user-attachments/assets/40d657c6-eea7-4e67-9b3e-5cfa68e1b506" />
