### PR TITLE
fix(wallet): require explicit disconnect in connected wallet button (ENG-185)

### DIFF
--- a/components/stellar/WalletConnectButton.test.tsx
+++ b/components/stellar/WalletConnectButton.test.tsx
@@ -9,8 +9,7 @@ const mockConnect = vi.fn()
 const mockDisconnect = vi.fn()
 const mockActivateWallet = vi.fn()
 
-const TEST_PUBLIC_KEY =
-  'GBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGB'
+const TEST_PUBLIC_KEY = 'GBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGB'
 
 vi.mock('@/components/providers/WalletProvider', () => ({
   useWallet: vi.fn(),

--- a/components/stellar/WalletConnectButton.test.tsx
+++ b/components/stellar/WalletConnectButton.test.tsx
@@ -1,0 +1,143 @@
+/** @vitest-environment jsdom */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import { WalletConnectButton } from '@/components/stellar/WalletConnectButton'
+
+const mockConnect = vi.fn()
+const mockDisconnect = vi.fn()
+const mockActivateWallet = vi.fn()
+
+const TEST_PUBLIC_KEY =
+  'GBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGB'
+
+vi.mock('@/components/providers/WalletProvider', () => ({
+  useWallet: vi.fn(),
+}))
+
+vi.mock('@/components/providers/WalletActivationContext', () => ({
+  useWalletActivation: () => ({
+    activateWallet: mockActivateWallet,
+    isWalletActive: true,
+  }),
+}))
+
+vi.mock('@/components/stellar/InstallWalletDialog', () => ({
+  InstallWalletDialog: () => null,
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import { useWallet } from '@/components/providers/WalletProvider'
+
+function mockWalletState(
+  overrides: Partial<ReturnType<typeof useWallet>> = {}
+) {
+  vi.mocked(useWallet).mockReturnValue({
+    isInstalled: true,
+    isConnected: false,
+    isLoading: false,
+    publicKey: null,
+    network: null,
+    networkPassphrase: null,
+    error: null,
+    selectedWallet: null,
+    connect: mockConnect,
+    disconnect: mockDisconnect,
+    signTransaction: vi.fn(),
+    refreshConnection: vi.fn(),
+    ...overrides,
+  })
+}
+
+describe('WalletConnectButton', () => {
+  beforeEach(() => {
+    mockConnect.mockReset()
+    mockDisconnect.mockReset()
+    mockActivateWallet.mockReset()
+    vi.mocked(toast.success).mockClear()
+    vi.mocked(toast.error).mockClear()
+  })
+
+  it('does not disconnect when the connected trigger is clicked', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockWalletState({
+      isConnected: true,
+      publicKey: TEST_PUBLIC_KEY,
+      network: 'TESTNET',
+      selectedWallet: { name: 'Freighter', id: 'freighter', type: 'freighter' },
+    })
+
+    render(<WalletConnectButton />)
+
+    await user.click(screen.getByRole('button', { name: 'Open wallet menu' }))
+
+    expect(mockDisconnect).not.toHaveBeenCalled()
+    expect(screen.getByText(TEST_PUBLIC_KEY)).toBeInTheDocument()
+  })
+
+  it('copies the full address when Copy address is chosen', async () => {
+    const user = userEvent.setup({ delay: null })
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+
+    mockWalletState({
+      isConnected: true,
+      publicKey: TEST_PUBLIC_KEY,
+      network: 'TESTNET',
+    })
+
+    render(<WalletConnectButton />)
+
+    await user.click(screen.getByRole('button', { name: 'Open wallet menu' }))
+    await user.click(screen.getByRole('menuitem', { name: 'Copy address' }))
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(TEST_PUBLIC_KEY)
+      expect(toast.success).toHaveBeenCalledWith(
+        'Wallet address copied to clipboard'
+      )
+    })
+    expect(toast.error).not.toHaveBeenCalled()
+    expect(mockDisconnect).not.toHaveBeenCalled()
+  })
+
+  it('disconnects only when Disconnect is chosen', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockWalletState({
+      isConnected: true,
+      publicKey: TEST_PUBLIC_KEY,
+      network: 'TESTNET',
+    })
+
+    render(<WalletConnectButton />)
+
+    await user.click(screen.getByRole('button', { name: 'Open wallet menu' }))
+    await user.click(screen.getByRole('menuitem', { name: 'Disconnect' }))
+
+    expect(mockDisconnect).toHaveBeenCalledTimes(1)
+    expect(toast.success).toHaveBeenCalledWith('Wallet disconnected')
+  })
+
+  it('calls connect when Connect Wallet is clicked', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockConnect.mockResolvedValue(true)
+    mockWalletState({ isConnected: false })
+
+    render(<WalletConnectButton />)
+
+    await user.click(screen.getByRole('button', { name: 'Connect Wallet' }))
+
+    expect(mockConnect).toHaveBeenCalledTimes(1)
+    expect(mockDisconnect).not.toHaveBeenCalled()
+  })
+})

--- a/components/stellar/WalletConnectButton.tsx
+++ b/components/stellar/WalletConnectButton.tsx
@@ -2,9 +2,26 @@
 
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { useWallet } from '@/components/providers/WalletProvider'
 import { useWalletActivation } from '@/components/providers/WalletActivationContext'
-import { Wallet, Loader2, AlertCircle, CheckCircle } from 'lucide-react'
+import {
+  Wallet,
+  Loader2,
+  AlertCircle,
+  CheckCircle,
+  Copy,
+  ExternalLink,
+  Power,
+  ChevronDown,
+} from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import { InstallWalletDialog } from '@/components/stellar/InstallWalletDialog'
@@ -39,11 +56,6 @@ export function WalletConnectButton({
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
 
   const handleConnect = async () => {
-    if (isConnected) {
-      disconnect()
-      return
-    }
-
     activateWallet()
     setIsConnecting(true)
     try {
@@ -71,6 +83,28 @@ export function WalletConnectButton({
     return `${address.slice(0, 6)}...${address.slice(-6)}`
   }
 
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text)
+      toast.success('Wallet address copied to clipboard')
+    } catch {
+      toast.error('Failed to copy address')
+    }
+  }
+
+  const openInExplorer = (address: string) => {
+    const explorerUrl =
+      network === 'TESTNET'
+        ? `https://stellar.expert/explorer/testnet/account/${address}`
+        : `https://stellar.expert/explorer/public/account/${address}`
+    window.open(explorerUrl, '_blank')
+  }
+
+  const handleDisconnect = () => {
+    disconnect()
+    toast.success('Wallet disconnected')
+  }
+
   // Show loading state
   if (isLoading) {
     return (
@@ -86,9 +120,6 @@ export function WalletConnectButton({
       </Button>
     )
   }
-
-  // Wallet selection will happen via modal, no need for install check
-  // The modal will show available wallets
 
   // Show error state
   if (error) {
@@ -111,26 +142,54 @@ export function WalletConnectButton({
   // Show connected state
   if (isConnected && publicKey) {
     return (
-      <Button
-        onClick={handleConnect}
-        size={size}
-        variant="outline"
-        className={cn('gap-2', className)}
-      >
-        <CheckCircle className="w-4 h-4 text-green-800 dark:text-green-300" />
-        <div className="flex flex-col items-start">
-          <span className="text-sm font-medium">
-            {formatAddress(publicKey)}
-          </span>
-          <div className="flex items-center gap-1 text-xs text-muted-foreground">
-            {selectedWallet && <span>{selectedWallet.name}</span>}
-            {network && selectedWallet && <span>•</span>}
-            {network && (
-              <span className="capitalize">{network.toLowerCase()}</span>
-            )}
-          </div>
-        </div>
-      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            size={size}
+            variant="outline"
+            className={cn('gap-2', className)}
+            aria-label="Open wallet menu"
+          >
+            <CheckCircle className="w-4 h-4 text-green-800 dark:text-green-300" />
+            <div className="flex flex-col items-start">
+              <span className="text-sm font-medium">
+                {formatAddress(publicKey)}
+              </span>
+              <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                {selectedWallet && <span>{selectedWallet.name}</span>}
+                {network && selectedWallet && <span>•</span>}
+                {network && (
+                  <span className="capitalize">{network.toLowerCase()}</span>
+                )}
+              </div>
+            </div>
+            <ChevronDown className="w-4 h-4 text-muted-foreground" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-72">
+          <DropdownMenuLabel className="font-normal">
+            <span className="text-xs text-muted-foreground">Address</span>
+            <p className="mt-1 font-mono text-xs break-all">{publicKey}</p>
+          </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => void copyToClipboard(publicKey)}>
+            <Copy className="w-4 h-4" />
+            Copy address
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => openInExplorer(publicKey)}>
+            <ExternalLink className="w-4 h-4" />
+            View on explorer
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={handleDisconnect}
+            className="text-destructive focus:text-destructive"
+          >
+            <Power className="w-4 h-4" />
+            Disconnect
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     )
   }
 


### PR DESCRIPTION
## Summary

- Fixes ENG-185: the connected wallet button on the guide Connect tab no longer disconnects on click.
- Connected state opens a wallet menu with full address inspection, copy, explorer link, and a labeled Disconnect action.
- Adds regression tests for `WalletConnectButton` (tap stability, copy, explicit disconnect, connect flow).

<img width="1218" height="715" alt="1" src="https://github.com/user-attachments/assets/c9da8990-2c27-4496-8f05-ea7f016e302b" />
