### PR TITLE
fix(guide): route wallet guide profile CTA to wallet settings (ENG-205)

### DIFF
--- a/app/profile/page.test.tsx
+++ b/app/profile/page.test.tsx
@@ -1,0 +1,77 @@
+/** @vitest-environment jsdom */
+import { render, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import ProfileHubPage from './page'
+import {
+  WALLET_PROFILE_HUB_PATH,
+  getLoginRedirectPath,
+  getWalletTabPath,
+} from '@/lib/navigation/walletProfileDestination'
+
+const replace = vi.fn()
+const useAuthMock = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace }),
+}))
+
+vi.mock('@/components/providers/AuthContext', () => ({
+  useAuth: () => useAuthMock(),
+}))
+
+vi.mock('@/components/layout/AppNavigation', () => ({
+  default: () => <nav aria-label="App navigation" />,
+}))
+
+vi.mock('@/components/profile/ProfilePageLoadingSkeleton', () => ({
+  ProfilePageLoadingSkeleton: () => <div data-testid="profile-skeleton" />,
+}))
+
+describe('ProfileHubPage', () => {
+  beforeEach(() => {
+    replace.mockClear()
+    useAuthMock.mockReset()
+  })
+
+  it('does not redirect while auth is loading', () => {
+    useAuthMock.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: true,
+    })
+
+    render(<ProfileHubPage />)
+
+    expect(replace).not.toHaveBeenCalled()
+  })
+
+  it('redirects authenticated users to their wallet tab', async () => {
+    useAuthMock.mockReturnValue({
+      user: { username: 'alice' },
+      isAuthenticated: true,
+      isLoading: false,
+    })
+
+    render(<ProfileHubPage />)
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith(getWalletTabPath('alice'))
+    })
+  })
+
+  it('redirects signed-out users to login with hub path preserved', async () => {
+    useAuthMock.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+    })
+
+    render(<ProfileHubPage />)
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith(
+        getLoginRedirectPath(WALLET_PROFILE_HUB_PATH)
+      )
+    })
+  })
+})

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/components/providers/AuthContext'
+import AppNavigation from '@/components/layout/AppNavigation'
+import { ProfilePageLoadingSkeleton } from '@/components/profile/ProfilePageLoadingSkeleton'
+import {
+  WALLET_PROFILE_HUB_PATH,
+  getLoginRedirectPath,
+  getWalletTabPath,
+} from '@/lib/navigation/walletProfileDestination'
+
+export default function ProfileHubPage() {
+  const router = useRouter()
+  const { user, isAuthenticated, isLoading } = useAuth()
+
+  useEffect(() => {
+    if (isLoading) return
+
+    if (isAuthenticated && user?.username) {
+      router.replace(getWalletTabPath(user.username))
+      return
+    }
+
+    if (!isAuthenticated) {
+      router.replace(getLoginRedirectPath(WALLET_PROFILE_HUB_PATH))
+    }
+  }, [isLoading, isAuthenticated, user?.username, router])
+
+  return (
+    <div className="min-h-screen bg-background">
+      <AppNavigation />
+      <ProfilePageLoadingSkeleton />
+    </div>
+  )
+}

--- a/components/auth/LoginForm.test.tsx
+++ b/components/auth/LoginForm.test.tsx
@@ -1,0 +1,76 @@
+/** @vitest-environment jsdom */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import LoginForm from './LoginForm'
+
+const replace = vi.fn()
+const signIn = vi.fn()
+const searchParamsGet = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace }),
+  useSearchParams: () => ({
+    get: (key: string) => searchParamsGet(key),
+  }),
+}))
+
+vi.mock('@convex-dev/auth/react', () => ({
+  useAuthActions: () => ({ signIn }),
+}))
+
+describe('LoginForm', () => {
+  beforeEach(() => {
+    replace.mockClear()
+    signIn.mockReset()
+    searchParamsGet.mockReset()
+    signIn.mockResolvedValue(undefined)
+    searchParamsGet.mockReturnValue(null)
+  })
+
+  it('redirects to home after sign-in when no redirect param', async () => {
+    const user = userEvent.setup()
+    render(<LoginForm />)
+
+    await user.type(screen.getByLabelText(/email address/i), 'you@example.com')
+    await user.type(screen.getByLabelText(/^password$/i), 'password123')
+    await user.click(screen.getByRole('button', { name: 'Sign in' }))
+
+    await waitFor(() => {
+      expect(signIn).toHaveBeenCalled()
+      expect(replace).toHaveBeenCalledWith('/')
+    })
+  })
+
+  it('redirects to safe redirect path after sign-in', async () => {
+    searchParamsGet.mockImplementation((key: string) =>
+      key === 'redirect' ? '/profile?tab=wallet' : null
+    )
+    const user = userEvent.setup()
+    render(<LoginForm />)
+
+    await user.type(screen.getByLabelText(/email address/i), 'you@example.com')
+    await user.type(screen.getByLabelText(/^password$/i), 'password123')
+    await user.click(screen.getByRole('button', { name: 'Sign in' }))
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/profile?tab=wallet')
+    })
+  })
+
+  it('ignores unsafe redirect paths', async () => {
+    searchParamsGet.mockImplementation((key: string) =>
+      key === 'redirect' ? 'https://evil.com' : null
+    )
+    const user = userEvent.setup()
+    render(<LoginForm />)
+
+    await user.type(screen.getByLabelText(/email address/i), 'you@example.com')
+    await user.type(screen.getByLabelText(/^password$/i), 'password123')
+    await user.click(screen.getByRole('button', { name: 'Sign in' }))
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/')
+    })
+  })
+})

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react'
 import { useAuthActions } from '@convex-dev/auth/react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { getSafeRedirectPath } from '@/lib/navigation/walletProfileDestination'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { loginSchema, type LoginFormData } from '@/lib/validations/auth'
@@ -26,6 +27,7 @@ export default function LoginForm() {
   const [error, setError] = useState<string | null>(null)
 
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { signIn } = useAuthActions()
 
   const {
@@ -47,9 +49,8 @@ export default function LoginForm() {
         flow: 'signIn',
       })
 
-      // If we reach here, sign-in was successful
-      // Use replace to prevent back button returning to login
-      router.replace('/')
+      const redirect = getSafeRedirectPath(searchParams.get('redirect'))
+      router.replace(redirect)
     } catch (error) {
       console.error('Login error:', error)
       setError('Invalid email or password. Please try again.')

--- a/components/guide/GuideWalletSettingsLink.tsx
+++ b/components/guide/GuideWalletSettingsLink.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+import { WALLET_PROFILE_HUB_PATH } from '@/lib/navigation/walletProfileDestination'
+
+const linkClassName =
+  'inline-flex items-center gap-2 px-4 py-2 bg-muted text-foreground text-sm rounded-lg border border-border hover:bg-muted/80 transition-colors'
+
+export function GuideWalletSettingsLink() {
+  return (
+    <Link href={WALLET_PROFILE_HUB_PATH} className={linkClassName}>
+      Go to Profile Settings
+    </Link>
+  )
+}

--- a/components/guide/WalletGuide.test.tsx
+++ b/components/guide/WalletGuide.test.tsx
@@ -1,6 +1,7 @@
 /** @vitest-environment jsdom */
 import type { ReactNode } from 'react'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { WalletGuide } from '@/components/guide/WalletGuide'
 
@@ -49,5 +50,14 @@ describe('WalletGuide tabs', () => {
     render(<WalletGuide />)
     const trigger = screen.getByRole('tab', { name: 'What is a Wallet?' })
     expect(trigger.className).toContain('whitespace-normal')
+  })
+
+  it('links profile settings CTA to the wallet profile hub', async () => {
+    const user = userEvent.setup()
+    render(<WalletGuide />)
+    await user.click(screen.getByRole('tab', { name: 'Connect' }))
+    expect(
+      screen.getByRole('link', { name: 'Go to Profile Settings' })
+    ).toHaveAttribute('href', '/profile?tab=wallet')
   })
 })

--- a/components/guide/WalletGuide.tsx
+++ b/components/guide/WalletGuide.tsx
@@ -15,6 +15,7 @@ import {
   ExternalLink,
 } from 'lucide-react'
 import Link from 'next/link'
+import { GuideWalletSettingsLink } from '@/components/guide/GuideWalletSettingsLink'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
 
@@ -180,12 +181,7 @@ export function WalletGuide() {
             description="After connecting, visit your profile to save your wallet address for receiving tips. This is your 'receiving wallet' — when readers tip your articles, payments arrive here."
             isLast
           >
-            <Link
-              href="/profile"
-              className="inline-flex items-center gap-2 px-4 py-2 bg-muted text-foreground text-sm rounded-lg border border-border hover:bg-muted/80 transition-colors"
-            >
-              Go to Profile Settings
-            </Link>
+            <GuideWalletSettingsLink />
           </WalletStepCard>
         </TabsContent>
 

--- a/lib/navigation/walletProfileDestination.test.ts
+++ b/lib/navigation/walletProfileDestination.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import {
+  WALLET_PROFILE_HUB_PATH,
+  getLoginRedirectPath,
+  getSafeRedirectPath,
+  getWalletTabPath,
+} from './walletProfileDestination'
+
+describe('walletProfileDestination', () => {
+  it('defines the wallet profile hub path', () => {
+    expect(WALLET_PROFILE_HUB_PATH).toBe('/profile?tab=wallet')
+  })
+
+  it('builds wallet tab path from username', () => {
+    expect(getWalletTabPath('alice')).toBe('/alice?tab=wallet')
+  })
+
+  it('builds login redirect path with encoded intended path', () => {
+    expect(getLoginRedirectPath('/profile?tab=wallet')).toBe(
+      '/login?redirect=%2Fprofile%3Ftab%3Dwallet'
+    )
+  })
+
+  describe('getSafeRedirectPath', () => {
+    it('returns fallback when raw is empty', () => {
+      expect(getSafeRedirectPath(null)).toBe('/')
+      expect(getSafeRedirectPath(undefined)).toBe('/')
+      expect(getSafeRedirectPath('')).toBe('/')
+    })
+
+    it('allows safe relative paths', () => {
+      expect(getSafeRedirectPath('/profile?tab=wallet')).toBe(
+        '/profile?tab=wallet'
+      )
+      expect(getSafeRedirectPath('/articles')).toBe('/articles')
+    })
+
+    it('rejects open redirects', () => {
+      expect(getSafeRedirectPath('https://evil.com')).toBe('/')
+      expect(getSafeRedirectPath('//evil.com')).toBe('/')
+      expect(getSafeRedirectPath('javascript:alert(1)')).toBe('/')
+    })
+
+    it('uses custom fallback', () => {
+      expect(getSafeRedirectPath(null, '/guide')).toBe('/guide')
+    })
+  })
+})

--- a/lib/navigation/walletProfileDestination.ts
+++ b/lib/navigation/walletProfileDestination.ts
@@ -1,0 +1,20 @@
+export const WALLET_PROFILE_HUB_PATH = '/profile?tab=wallet'
+
+export function getWalletTabPath(username: string): string {
+  return `/${username}?tab=wallet`
+}
+
+export function getLoginRedirectPath(intendedPath: string): string {
+  return `/login?redirect=${encodeURIComponent(intendedPath)}`
+}
+
+export function getSafeRedirectPath(
+  raw: string | null | undefined,
+  fallback = '/'
+): string {
+  if (!raw) return fallback
+  if (!raw.startsWith('/') || raw.startsWith('//') || raw.includes(':')) {
+    return fallback
+  }
+  return raw
+}


### PR DESCRIPTION
## Summary

- Fix the wallet guide "Go to Profile Settings" CTA, which linked to `/profile` and resolved to a 404 because that path was handled as username `profile` on the dynamic route.
- Add an auth-aware `/profile` hub that redirects signed-in users to `/{username}?tab=wallet` and signed-out users to login with redirect intent preserved.
- Update `LoginForm` to honor a safe `redirect` query param after sign-in.
- Extract `GuideWalletSettingsLink` so guide CTAs use the canonical hub path `/profile?tab=wallet`.

## Changes

- `lib/navigation/walletProfileDestination.ts` — shared hub path, wallet tab path, login redirect builder, and open-redirect guard
- `app/profile/page.tsx` — redirect hub for authenticated and unauthenticated users
- `components/auth/LoginForm.tsx` — post-login redirect from `?redirect=`
- `components/guide/GuideWalletSettingsLink.tsx` — reusable guide CTA
- `components/guide/WalletGuide.tsx` — Connect tab uses shared link
- Unit tests for navigation helpers, profile hub, login redirect, and guide CTA

