### PR TITLE
fix(a11y): add labels, focus rings, and pressed state to editor icon buttons

### DIFF
--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -81,12 +81,16 @@ function MoreMenu({
   onDelete?: () => void
   isDeleting?: boolean
 }) {
+  const focusRing =
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
         <button
           type="button"
-          className="p-2 rounded-full border border-border text-muted-foreground hover:bg-muted hover:border-border transition-colors shrink-0"
+          aria-label="More options"
+          className={`p-2 rounded-full border border-border text-muted-foreground hover:bg-muted hover:border-border transition-colors shrink-0 ${focusRing}`}
           title="More options"
         >
           <MoreHorizontal className="h-4 w-4" />
@@ -205,6 +209,9 @@ export function EditorActionBar({
     statusClassName = 'text-muted-foreground opacity-70'
   }
 
+  const focusRing =
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+
   const saveButton = (
     <button
       type="button"
@@ -260,7 +267,8 @@ export function EditorActionBar({
         type="button"
         onClick={() => editor?.chain().focus().undo().run()}
         disabled={!canUndo}
-        className="p-2 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent transition-colors shrink-0"
+        aria-label={`Undo (${shortcuts.undo})`}
+        className={`p-2 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent transition-colors shrink-0 ${focusRing}`}
         title={`Undo (${shortcuts.undo})`}
       >
         <Undo2 className="h-4 w-4" />
@@ -269,7 +277,8 @@ export function EditorActionBar({
         type="button"
         onClick={() => editor?.chain().focus().redo().run()}
         disabled={!canRedo}
-        className="p-2 rounded-md text-muted-foreground opacity-70 hover:bg-muted hover:opacity-100 disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent transition-colors shrink-0"
+        aria-label={`Redo (${shortcuts.redo})`}
+        className={`p-2 rounded-md text-muted-foreground opacity-70 hover:bg-muted hover:opacity-100 disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent transition-colors shrink-0 ${focusRing}`}
         title={`Redo (${shortcuts.redo})`}
       >
         <Redo2 className="h-4 w-4" />

--- a/components/editor/EditorToolbar.tsx
+++ b/components/editor/EditorToolbar.tsx
@@ -99,6 +99,7 @@ const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
         disabled={disabled}
         title={title}
         aria-label={title}
+        aria-pressed={isActive}
         tabIndex={tabIndex}
         onFocus={onFocus}
         data-toolbar-item="true"


### PR DESCRIPTION
## Summary
- Added explicit accessible names (`aria-label`) for icon-only editor action buttons (Undo, Redo, More options).
- Made keyboard focus states clearly visible on editor action bar icon buttons (focus-visible ring + offset).
- Exposed formatting toggle state to assistive tech via `aria-pressed` on editor toolbar buttons.

## Why
Several icon-only editor actions depended on hover tooltips or icons alone, which made the toolbar unclear for keyboard and screen reader users. This change makes controls understandable and stateful without hover.

## Test plan
- Keyboard-only:
  - Tab to the editor action bar (Undo/Redo/More options) and confirm a visible focus ring.
  - Tab into the formatting toolbar; use ArrowLeft/ArrowRight and press Enter/Space to toggle formatting.
- Screen reader (macOS VoiceOver):
  - Cmd+F5 to enable VoiceOver.
  - Navigate toolbar/action buttons and confirm meaningful names are announced.
  - Toggle Bold and confirm it’s announced as pressed/on.
  - Confirm disabled Undo is announced as disabled/dimmed when nothing to undo.

## Files changed
- components/editor/EditorActionBar.tsx
- components/editor/EditorToolbar.tsx