### PR TITLE
feat(stellar): add batch tip transaction builders

### DIFF
--- a/lib/stellar/__tests__/client-batch-transactions.test.ts
+++ b/lib/stellar/__tests__/client-batch-transactions.test.ts
@@ -1,0 +1,301 @@
+import { createHash } from 'crypto'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import type * as StellarSdkModule from '@stellar/stellar-sdk'
+import type { Operation, xdr as StellarXdr } from '@stellar/stellar-sdk'
+
+const TEST_CONTRACT_ID =
+  'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC'
+const TEST_PASSPHRASE = 'Test SDF Network ; September 2015'
+
+vi.mock('@/lib/stellar/config', () => ({
+  STELLAR_CONFIG: {
+    NETWORK: 'TESTNET',
+    NETWORK_PASSPHRASE: TEST_PASSPHRASE,
+    HORIZON_URL: 'https://horizon-testnet.stellar.org',
+    SOROBAN_RPC_URL: 'https://soroban-testnet.stellar.org',
+    TIPPING_CONTRACT_ID: TEST_CONTRACT_ID,
+    PLATFORM_FEE_BPS: 250,
+    MINIMUM_TIP_STROOPS: 100_000,
+    XLM_TO_USD_RATE: 0.25,
+  },
+}))
+
+type StellarSdk = typeof StellarSdkModule
+type InvokeHostFunctionOperation = Extract<
+  Operation,
+  { type: 'invokeHostFunction' }
+>
+
+function shortArticleIdForTest(articleId: string): string {
+  return createHash('sha256').update(articleId).digest('hex').slice(0, 10)
+}
+
+function getInvokeContractCall(StellarSdk: StellarSdk, xdr: string) {
+  const decoded = StellarSdk.TransactionBuilder.fromXDR(xdr, TEST_PASSPHRASE)
+  const operation = decoded.operations[0] as
+    | InvokeHostFunctionOperation
+    | undefined
+
+  expect(operation).toBeDefined()
+  expect(operation?.type).toBe('invokeHostFunction')
+
+  const invocation = operation?.func.invokeContract()
+  expect(invocation).toBeDefined()
+  if (!invocation) throw new Error('Missing invoke contract call')
+
+  return {
+    functionName: Buffer.from(invocation.functionName()).toString(),
+    args: invocation.args(),
+  }
+}
+
+function scMapToNativeEntries(StellarSdk: StellarSdk, scMap: StellarXdr.ScVal) {
+  const entries = scMap.map()
+
+  expect(entries).not.toBeNull()
+  if (!entries) throw new Error('Expected ScVal map entries')
+
+  return Object.fromEntries(
+    entries.map((entry) => {
+      const key = entry.key()
+      const value = entry.val()
+
+      return [
+        StellarSdk.scValToNative(key),
+        {
+          type:
+            typeof value === 'object' &&
+            value !== null &&
+            'switch' in value &&
+            typeof value.switch === 'function'
+              ? value.switch().name
+              : undefined,
+          value: StellarSdk.scValToNative(value),
+        },
+      ]
+    })
+  )
+}
+
+describe('StellarClient batch transaction builders', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('builds article batch_tip XDR with expected argument layout and totals', async () => {
+    const StellarSdk = await import('@stellar/stellar-sdk')
+    const { StellarClient } = await import('@/lib/stellar/client')
+
+    const tipperKeypair = StellarSdk.Keypair.random()
+    const authorOne = StellarSdk.Keypair.random().publicKey()
+    const authorTwo = StellarSdk.Keypair.random().publicKey()
+    const tipperPublicKey = tipperKeypair.publicKey()
+    const fakeAccount = new StellarSdk.Account(tipperPublicKey, '0')
+
+    vi.spyOn(
+      StellarSdk.Horizon.Server.prototype,
+      'loadAccount'
+    ).mockResolvedValue(fakeAccount as unknown as never)
+
+    vi.spyOn(
+      StellarSdk.rpc.Server.prototype,
+      'prepareTransaction'
+    ).mockImplementation(async (tx) => tx as never)
+
+    const client = new StellarClient()
+    vi.spyOn(client, 'convertCentsToStroops').mockImplementation(
+      async (cents) => {
+        if (cents === 100) return 100_000_000
+        if (cents === 250) return 250_000_000
+        throw new Error(`unexpected cents: ${cents}`)
+      }
+    )
+
+    const result = await client.buildArticleBatchTipTransaction(
+      tipperPublicKey,
+      [
+        {
+          articleId: 'article-one',
+          authorAddress: authorOne,
+          amountCents: 100,
+        },
+        {
+          articleId: 'article-two',
+          authorAddress: authorTwo,
+          amountCents: 250,
+        },
+      ]
+    )
+
+    expect(result.stroops).toBe(350_000_000)
+    expect(result.authorReceived).toBe(341_250_000)
+    expect(result.platformFee).toBe(8_750_000)
+    expect(result.items).toEqual([
+      {
+        articleId: 'article-one',
+        authorAddress: authorOne,
+        amountCents: 100,
+        stroops: 100_000_000,
+        authorReceived: 97_500_000,
+        platformFee: 2_500_000,
+      },
+      {
+        articleId: 'article-two',
+        authorAddress: authorTwo,
+        amountCents: 250,
+        stroops: 250_000_000,
+        authorReceived: 243_750_000,
+        platformFee: 6_250_000,
+      },
+    ])
+
+    const call = getInvokeContractCall(StellarSdk, result.xdr)
+    expect(call.functionName).toBe('batch_tip')
+    expect(call.args).toHaveLength(2)
+
+    const tipperArg = call.args[0]
+    const tipsArg = call.args[1]
+    if (!tipperArg || !tipsArg) throw new Error('Missing batch call arguments')
+
+    expect(tipperArg.switch().name).toBe('scvAddress')
+    expect(StellarSdk.scValToNative(tipperArg)).toBe(tipperPublicKey)
+    expect(tipsArg.switch().name).toBe('scvVec')
+
+    const tips = tipsArg.vec()
+    if (!tips) throw new Error('Missing article batch tip vector')
+    expect(tips).toHaveLength(2)
+
+    const firstTip = tips[0]
+    const secondTip = tips[1]
+    if (!firstTip || !secondTip) throw new Error('Missing article batch tips')
+
+    expect(scMapToNativeEntries(StellarSdk, firstTip)).toEqual({
+      amount: { type: 'scvI128', value: BigInt(100_000_000) },
+      article_id: {
+        type: 'scvSymbol',
+        value: shortArticleIdForTest('article-one'),
+      },
+      author: { type: 'scvAddress', value: authorOne },
+    })
+
+    expect(scMapToNativeEntries(StellarSdk, secondTip)).toEqual({
+      amount: { type: 'scvI128', value: BigInt(250_000_000) },
+      article_id: {
+        type: 'scvSymbol',
+        value: shortArticleIdForTest('article-two'),
+      },
+      author: { type: 'scvAddress', value: authorTwo },
+    })
+  }, 15_000)
+
+  it('builds batch_tip_highlights XDR with expected argument layout and totals', async () => {
+    const StellarSdk = await import('@stellar/stellar-sdk')
+    const { StellarClient } = await import('@/lib/stellar/client')
+
+    const tipperKeypair = StellarSdk.Keypair.random()
+    const author = StellarSdk.Keypair.random().publicKey()
+    const tipperPublicKey = tipperKeypair.publicKey()
+    const fakeAccount = new StellarSdk.Account(tipperPublicKey, '0')
+
+    vi.spyOn(
+      StellarSdk.Horizon.Server.prototype,
+      'loadAccount'
+    ).mockResolvedValue(fakeAccount as unknown as never)
+
+    vi.spyOn(
+      StellarSdk.rpc.Server.prototype,
+      'prepareTransaction'
+    ).mockImplementation(async (tx) => tx as never)
+
+    const client = new StellarClient()
+    vi.spyOn(client, 'convertCentsToStroops').mockResolvedValue(125_000_000)
+
+    const result = await client.buildHighlightBatchTipTransaction(
+      tipperPublicKey,
+      [
+        {
+          highlightId: 'highlight-123',
+          articleId: 'article-one',
+          authorAddress: author,
+          amountCents: 125,
+        },
+      ]
+    )
+
+    expect(result.stroops).toBe(125_000_000)
+    expect(result.authorReceived).toBe(121_875_000)
+    expect(result.platformFee).toBe(3_125_000)
+    expect(result.items).toEqual([
+      {
+        highlightId: 'highlight-123',
+        articleId: 'article-one',
+        authorAddress: author,
+        amountCents: 125,
+        stroops: 125_000_000,
+        authorReceived: 121_875_000,
+        platformFee: 3_125_000,
+      },
+    ])
+
+    const call = getInvokeContractCall(StellarSdk, result.xdr)
+    expect(call.functionName).toBe('batch_tip_highlights')
+    expect(call.args).toHaveLength(2)
+
+    const tipperArg = call.args[0]
+    const tipsArg = call.args[1]
+    if (!tipperArg || !tipsArg) throw new Error('Missing batch call arguments')
+
+    expect(tipperArg.switch().name).toBe('scvAddress')
+    expect(StellarSdk.scValToNative(tipperArg)).toBe(tipperPublicKey)
+    expect(tipsArg.switch().name).toBe('scvVec')
+
+    const tips = tipsArg.vec()
+    if (!tips) throw new Error('Missing highlight batch tip vector')
+    expect(tips).toHaveLength(1)
+
+    const firstTip = tips[0]
+    if (!firstTip) throw new Error('Missing highlight batch tip')
+
+    expect(scMapToNativeEntries(StellarSdk, firstTip)).toEqual({
+      amount: { type: 'scvI128', value: BigInt(125_000_000) },
+      article_id: {
+        type: 'scvSymbol',
+        value: shortArticleIdForTest('article-one'),
+      },
+      author: { type: 'scvAddress', value: author },
+      highlight_id: { type: 'scvString', value: 'highlight-123' },
+    })
+  }, 15_000)
+
+  it('rejects invalid batch sizes before loading the source account', async () => {
+    const StellarSdk = await import('@stellar/stellar-sdk')
+    const { StellarClient } = await import('@/lib/stellar/client')
+
+    const loadAccountSpy = vi.spyOn(
+      StellarSdk.Horizon.Server.prototype,
+      'loadAccount'
+    )
+
+    const client = new StellarClient()
+    const tipperPublicKey = StellarSdk.Keypair.random().publicKey()
+    const authorAddress = StellarSdk.Keypair.random().publicKey()
+
+    await expect(
+      client.buildArticleBatchTipTransaction(tipperPublicKey, [])
+    ).rejects.toThrow('Batch must include at least one tip')
+
+    await expect(
+      client.buildHighlightBatchTipTransaction(
+        tipperPublicKey,
+        Array.from({ length: 11 }, (_, index) => ({
+          highlightId: `highlight-${index}`,
+          articleId: `article-${index}`,
+          authorAddress,
+          amountCents: 100,
+        }))
+      )
+    ).rejects.toThrow('Batch cannot include more than 10 tips')
+
+    expect(loadAccountSpy).not.toHaveBeenCalled()
+  })
+})

--- a/lib/stellar/client.ts
+++ b/lib/stellar/client.ts
@@ -13,8 +13,16 @@ import type {
   AuthorBalance,
   TipData,
   XLMPriceData,
+  ArticleBatchTipParams,
+  HighlightBatchTipParams,
+  ArticleBatchTipQuote,
+  HighlightBatchTipQuote,
+  BatchTipQuote,
+  BatchTipTransactionResult,
 } from './types'
 import { stellarFlowEmitter } from './stellar-flow-emitter'
+
+const MAX_BATCH_TIP_ITEMS = 10
 
 /**
  * Generate a deterministic short ID from article ID using SHA256
@@ -22,6 +30,44 @@ import { stellarFlowEmitter } from './stellar-flow-emitter'
  */
 function shortArticleId(articleId: string): string {
   return createHash('sha256').update(articleId).digest('hex').slice(0, 10)
+}
+
+function validateBatchSize(size: number): void {
+  if (size < 1) {
+    throw new Error('Batch must include at least one tip')
+  }
+  if (size > MAX_BATCH_TIP_ITEMS) {
+    throw new Error(
+      `Batch cannot include more than ${MAX_BATCH_TIP_ITEMS} tips`
+    )
+  }
+}
+
+function calculateTipSplit(stroops: number): {
+  authorReceived: number
+  platformFee: number
+} {
+  const platformFee = Math.floor(
+    (stroops * STELLAR_CONFIG.PLATFORM_FEE_BPS) / 10_000
+  )
+  return {
+    authorReceived: stroops - platformFee,
+    platformFee,
+  }
+}
+
+function summarizeBatch<TItem extends BatchTipQuote>(
+  items: TItem[]
+): Pick<
+  BatchTipTransactionResult<TItem>,
+  'stroops' | 'authorReceived' | 'platformFee' | 'items'
+> {
+  return {
+    stroops: items.reduce((sum, item) => sum + item.stroops, 0),
+    authorReceived: items.reduce((sum, item) => sum + item.authorReceived, 0),
+    platformFee: items.reduce((sum, item) => sum + item.platformFee, 0),
+    items,
+  }
 }
 
 // In-tab cache so a single user opening the tip dialog and clicking through
@@ -226,10 +272,7 @@ export class StellarClient {
   }> {
     const { StellarSdk, server, sorobanServer } = await this.getSdkContext()
     const stroops = await this.convertCentsToStroops(params.amountCents)
-    const platformFee = Math.floor(
-      (stroops * STELLAR_CONFIG.PLATFORM_FEE_BPS) / 10_000
-    )
-    const authorReceived = stroops - platformFee
+    const { authorReceived, platformFee } = calculateTipSplit(stroops)
 
     const account = await server.loadAccount(tipperPublicKey)
 
@@ -282,10 +325,7 @@ export class StellarClient {
   }> {
     const { StellarSdk, server, sorobanServer } = await this.getSdkContext()
     const stroops = await this.convertCentsToStroops(params.amountCents)
-    const platformFee = Math.floor(
-      (stroops * STELLAR_CONFIG.PLATFORM_FEE_BPS) / 10_000
-    )
-    const authorReceived = stroops - platformFee
+    const { authorReceived, platformFee } = calculateTipSplit(stroops)
 
     const account = await server.loadAccount(tipperPublicKey)
 
@@ -320,6 +360,126 @@ export class StellarClient {
       stroops,
       authorReceived,
       platformFee,
+    }
+  }
+
+  async buildArticleBatchTipTransaction(
+    tipperPublicKey: string,
+    params: ArticleBatchTipParams[]
+  ): Promise<BatchTipTransactionResult<ArticleBatchTipQuote>> {
+    validateBatchSize(params.length)
+
+    const { StellarSdk, server, sorobanServer } = await this.getSdkContext()
+    const items = await Promise.all(
+      params.map(async (item) => {
+        const stroops = await this.convertCentsToStroops(item.amountCents)
+        const { authorReceived, platformFee } = calculateTipSplit(stroops)
+
+        return {
+          ...item,
+          stroops,
+          authorReceived,
+          platformFee,
+        }
+      })
+    )
+
+    const account = await server.loadAccount(tipperPublicKey)
+    const contract = new StellarSdk.Contract(STELLAR_CONFIG.TIPPING_CONTRACT_ID)
+
+    const tips = items.map((item) => ({
+      article_id: shortArticleId(item.articleId),
+      author: item.authorAddress,
+      amount: BigInt(item.stroops),
+    }))
+
+    const transaction = new StellarSdk.TransactionBuilder(account, {
+      fee: StellarSdk.BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        contract.call(
+          'batch_tip',
+          StellarSdk.nativeToScVal(tipperPublicKey, { type: 'address' }),
+          StellarSdk.nativeToScVal(tips, {
+            type: {
+              article_id: ['symbol', 'symbol'],
+              author: ['symbol', 'address'],
+              amount: ['symbol', 'i128'],
+            },
+          })
+        )
+      )
+      .setTimeout(180)
+      .build()
+
+    const preparedTransaction =
+      await sorobanServer.prepareTransaction(transaction)
+
+    return {
+      xdr: preparedTransaction.toXDR(),
+      ...summarizeBatch(items),
+    }
+  }
+
+  async buildHighlightBatchTipTransaction(
+    tipperPublicKey: string,
+    params: HighlightBatchTipParams[]
+  ): Promise<BatchTipTransactionResult<HighlightBatchTipQuote>> {
+    validateBatchSize(params.length)
+
+    const { StellarSdk, server, sorobanServer } = await this.getSdkContext()
+    const items = await Promise.all(
+      params.map(async (item) => {
+        const stroops = await this.convertCentsToStroops(item.amountCents)
+        const { authorReceived, platformFee } = calculateTipSplit(stroops)
+
+        return {
+          ...item,
+          stroops,
+          authorReceived,
+          platformFee,
+        }
+      })
+    )
+
+    const account = await server.loadAccount(tipperPublicKey)
+    const contract = new StellarSdk.Contract(STELLAR_CONFIG.TIPPING_CONTRACT_ID)
+
+    const tips = items.map((item) => ({
+      highlight_id: item.highlightId,
+      article_id: shortArticleId(item.articleId),
+      author: item.authorAddress,
+      amount: BigInt(item.stroops),
+    }))
+
+    const transaction = new StellarSdk.TransactionBuilder(account, {
+      fee: StellarSdk.BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        contract.call(
+          'batch_tip_highlights',
+          StellarSdk.nativeToScVal(tipperPublicKey, { type: 'address' }),
+          StellarSdk.nativeToScVal(tips, {
+            type: {
+              highlight_id: ['symbol', 'string'],
+              article_id: ['symbol', 'symbol'],
+              author: ['symbol', 'address'],
+              amount: ['symbol', 'i128'],
+            },
+          })
+        )
+      )
+      .setTimeout(180)
+      .build()
+
+    const preparedTransaction =
+      await sorobanServer.prepareTransaction(transaction)
+
+    return {
+      xdr: preparedTransaction.toXDR(),
+      ...summarizeBatch(items),
     }
   }
 

--- a/lib/stellar/types.ts
+++ b/lib/stellar/types.ts
@@ -30,6 +30,37 @@ export interface TipParams {
   signerFn?: (txXDR: string) => Promise<string>
 }
 
+export interface ArticleBatchTipParams {
+  articleId: string
+  authorAddress: string
+  amountCents: number
+}
+
+export interface HighlightBatchTipParams extends ArticleBatchTipParams {
+  highlightId: string
+}
+
+export interface BatchTipQuote {
+  amountCents: number
+  stroops: number
+  authorReceived: number
+  platformFee: number
+}
+
+export interface ArticleBatchTipQuote
+  extends ArticleBatchTipParams, BatchTipQuote {}
+
+export interface HighlightBatchTipQuote
+  extends HighlightBatchTipParams, BatchTipQuote {}
+
+export interface BatchTipTransactionResult<TItem extends BatchTipQuote> {
+  xdr: string
+  stroops: number
+  authorReceived: number
+  platformFee: number
+  items: TItem[]
+}
+
 export interface WithdrawParams {
   authorAddress: string
   signerFn?: (txXDR: string) => Promise<string>


### PR DESCRIPTION
## What

Adds TypeScript builders for article and highlight batch tip Soroban transactions.

## Why

ENG-233 needs client-side batch transaction construction so grouped article/highlight tips can be prepared consistently before wallet signing.

## How

- Adds batch tip parameter/result types for article and highlight tips.
- Reuses existing cent-to-stroop conversion and platform fee splitting.
- Builds `batch_tip` and `batch_tip_highlights` contract calls with prepared Soroban XDR.
- Adds tests that decode generated XDR and verify argument layout, totals, and invalid batch-size handling.

## Checklist

- [x] `bun run lint` and `bun run typecheck` pass
- [x] Tests added/updated (if applicable)
- [x] Tested locally with `bun run dev`
- [x] No secrets or `.env` values committed

## Screenshots

N/A - no UI changes.