### PR TITLE
fix(ENG-187): align money copy with testnet scope and actual tip/withdraw flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Quilltip is a decentralized publishing platform where writers earn money through
 ### For Readers
 
 - **Interactive Reading** — text highlighting with notes, public/private annotations, color-coded highlights, persistent across sessions
-- **Microtipping** — support authors with $0.01–$100, preset amounts, instant Stellar transactions
+- **Microtipping** — support authors with $0.01–$100, preset amounts, fast Stellar confirmations (testnet practice today)
 - **Content Discovery** — full-text search, tag-based filtering, author collections, trending articles
 
 ### For Collectors

--- a/components/dashboard/EarningsDashboard.tsx
+++ b/components/dashboard/EarningsDashboard.tsx
@@ -16,6 +16,7 @@ import { TipHistory } from '@/components/dashboard/TipHistory'
 import { WithdrawalDialog } from '@/components/dashboard/WithdrawalDialog'
 import { EarningsStats } from '@/components/dashboard/EarningsStats'
 import { EarningsDashboardSkeleton } from '@/components/dashboard/EarningsDashboardSkeleton'
+import { withdrawalFlowNote } from '@/lib/copy/network-status'
 
 export function EarningsDashboard() {
   const [showWithdrawModal, setShowWithdrawModal] = useState(false)
@@ -39,7 +40,7 @@ export function EarningsDashboard() {
         stellarAddress: args.stellarAddress,
       })
       toast.success(
-        `Withdrawal initiated! $${args.amountUsd.toFixed(2)} in testnet XLM will be sent to your Stellar wallet, typically within seconds on testnet.`
+        `Withdrawal requested for $${args.amountUsd.toFixed(2)}. ${withdrawalFlowNote()}`
       )
     } catch (error) {
       console.error('Withdrawal error:', error)

--- a/components/dashboard/EarningsStats.tsx
+++ b/components/dashboard/EarningsStats.tsx
@@ -8,7 +8,10 @@ import { TopEarningArticles } from '@/components/dashboard/top-earning-articles'
 import { WalletSetupNotice } from '@/components/dashboard/wallet-setup-notice'
 import { useProfileTabNavigation } from '@/hooks/useProfileTabNavigation'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { networkLabelLowercase, practiceFundsNote } from '@/lib/copy/network-status'
+import {
+  networkLabelLowercase,
+  practiceFundsNote,
+} from '@/lib/copy/network-status'
 
 export type EarningsStatsProps = {
   earnings: Doc<'authorEarnings'>

--- a/components/dashboard/EarningsStats.tsx
+++ b/components/dashboard/EarningsStats.tsx
@@ -8,7 +8,7 @@ import { TopEarningArticles } from '@/components/dashboard/top-earning-articles'
 import { WalletSetupNotice } from '@/components/dashboard/wallet-setup-notice'
 import { useProfileTabNavigation } from '@/hooks/useProfileTabNavigation'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
+import { networkLabelLowercase, practiceFundsNote } from '@/lib/copy/network-status'
 
 export type EarningsStatsProps = {
   earnings: Doc<'authorEarnings'>
@@ -35,7 +35,7 @@ export function EarningsStats({
     <>
       <Alert className="border-border bg-muted/60">
         <AlertDescription className="text-sm text-muted-foreground">
-          {TESTNET_PRACTICE_NOTE}
+          {practiceFundsNote()}
         </AlertDescription>
       </Alert>
 
@@ -51,7 +51,7 @@ export function EarningsStats({
             ${earnings.totalEarnedUsd.toFixed(2)}
           </p>
           <p className="text-sm text-muted-foreground mt-1">
-            {earnings.tipCount} testnet tips received
+            {earnings.tipCount} {networkLabelLowercase()} tips received
           </p>
         </div>
 
@@ -81,8 +81,8 @@ export function EarningsStats({
           </button>
           {showMinimumWithdrawalHelper && (
             <p className="mt-2 text-sm text-muted-foreground">
-              Testnet withdrawals require a minimum available balance of $
-              {minWithdrawalUsd.toFixed(2)}. Add testnet tips until your balance
+              Withdrawals require a minimum available balance of $
+              {minWithdrawalUsd.toFixed(2)}. Add more tips until your balance
               reaches this amount.
             </p>
           )}

--- a/components/dashboard/WithdrawEarningsDialog.tsx
+++ b/components/dashboard/WithdrawEarningsDialog.tsx
@@ -14,7 +14,11 @@ import {
 } from '@/components/ui/dialog'
 import { api } from '@/convex/_generated/api'
 import { MIN_WITHDRAWAL_USD } from '@/lib/constants'
-import { TESTNET_WITHDRAWAL_NOTE } from '@/lib/copy/network-status'
+import {
+  TESTNET_WITHDRAWAL_NOTE,
+  withdrawalAcknowledgementLabel,
+  withdrawalFlowNote,
+} from '@/lib/copy/network-status'
 
 interface WithdrawEarningsDialogProps {
   open: boolean
@@ -35,6 +39,7 @@ export function WithdrawEarningsDialog({
   const [withdrawAmount, setWithdrawAmount] = useState('')
   const [stellarAddress, setStellarAddress] = useState('')
   const [isWithdrawing, setIsWithdrawing] = useState(false)
+  const [acknowledged, setAcknowledged] = useState(false)
 
   const withdrawEarnings = useMutation(api.tips.withdrawEarnings)
 
@@ -42,6 +47,7 @@ export function WithdrawEarningsDialog({
     if (open) {
       setWithdrawAmount('')
       setStellarAddress(savedStellarAddress ?? '')
+      setAcknowledged(false)
     }
   }, [open, savedStellarAddress])
 
@@ -80,7 +86,7 @@ export function WithdrawEarningsDialog({
       })
 
       toast.success(
-        `Withdrawal initiated! $${amount.toFixed(2)} in testnet XLM will be sent to your Stellar wallet, typically within seconds on testnet.`
+        `Withdrawal requested for $${amount.toFixed(2)}. ${withdrawalFlowNote()}`
       )
       onOpenChange(false)
     } catch (error) {
@@ -178,7 +184,21 @@ export function WithdrawEarningsDialog({
               {TESTNET_WITHDRAWAL_NOTE} Transaction fees are covered by
               Quilltip.
             </p>
+            <p className="mt-2 text-sm text-info-foreground">
+              {withdrawalFlowNote()}
+            </p>
           </div>
+
+          <label className="flex items-start gap-2 rounded-lg border border-border bg-card p-3 text-sm text-foreground">
+            <input
+              type="checkbox"
+              checked={acknowledged}
+              onChange={(e) => setAcknowledged(e.target.checked)}
+              disabled={isWithdrawing}
+              className="mt-0.5 h-4 w-4 accent-foreground"
+            />
+            <span>{withdrawalAcknowledgementLabel()}</span>
+          </label>
         </div>
 
         <DialogFooter className="gap-3 sm:gap-0">
@@ -196,7 +216,8 @@ export function WithdrawEarningsDialog({
             disabled={
               isWithdrawing ||
               !withdrawAmount ||
-              !effectiveAddress.startsWith('G')
+              !effectiveAddress.startsWith('G') ||
+              !acknowledged
             }
             className="flex-1 px-4 py-2 bg-brand text-brand-foreground rounded-lg hover:bg-brand-hover disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 sm:flex-none"
           >

--- a/components/dashboard/WithdrawalDialog.test.tsx
+++ b/components/dashboard/WithdrawalDialog.test.tsx
@@ -41,6 +41,7 @@ describe('WithdrawalDialog', () => {
 
     await user.type(screen.getByLabelText(/Amount \(USD\)/i), '10')
     setStellarAddress(VALID_TEST_PUBLIC_KEY)
+    await user.click(screen.getByRole('checkbox'))
     await user.click(screen.getByRole('button', { name: /Withdraw$/i }))
 
     await waitFor(() => {
@@ -69,6 +70,7 @@ describe('WithdrawalDialog', () => {
     )
 
     await user.type(screen.getByLabelText(/Amount \(USD\)/i), '20')
+    await user.click(screen.getByRole('checkbox'))
     await user.click(screen.getByRole('button', { name: /Withdraw$/i }))
 
     expect(onWithdraw).toHaveBeenCalledWith({

--- a/components/dashboard/WithdrawalDialog.tsx
+++ b/components/dashboard/WithdrawalDialog.tsx
@@ -12,7 +12,11 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { isValidStellarAccountId } from '@/lib/stellar/is-valid-stellar-account-id'
-import { TESTNET_WITHDRAWAL_NOTE } from '@/lib/copy/network-status'
+import {
+  TESTNET_WITHDRAWAL_NOTE,
+  withdrawalAcknowledgementLabel,
+  withdrawalFlowNote,
+} from '@/lib/copy/network-status'
 
 export type WithdrawalDialogProps = {
   open: boolean
@@ -39,11 +43,13 @@ export function WithdrawalDialog({
   const [withdrawAmount, setWithdrawAmount] = useState('')
   const [stellarAddress, setStellarAddress] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [acknowledged, setAcknowledged] = useState(false)
 
   useEffect(() => {
     if (open) {
       setWithdrawAmount('')
       setStellarAddress(savedStellarAddress ?? '')
+      setAcknowledged(false)
     }
   }, [open, savedStellarAddress])
 
@@ -187,7 +193,21 @@ export function WithdrawalDialog({
               {TESTNET_WITHDRAWAL_NOTE} Transaction fees are covered by
               Quilltip.
             </p>
+            <p className="mt-2 text-sm text-info-foreground">
+              {withdrawalFlowNote()}
+            </p>
           </div>
+
+          <label className="flex items-start gap-2 rounded-lg border border-border bg-card p-3 text-sm text-foreground">
+            <input
+              type="checkbox"
+              checked={acknowledged}
+              onChange={(e) => setAcknowledged(e.target.checked)}
+              disabled={isSubmitting}
+              className="mt-0.5 h-4 w-4 accent-foreground"
+            />
+            <span>{withdrawalAcknowledgementLabel()}</span>
+          </label>
         </div>
 
         <DialogFooter className="gap-3 sm:gap-0">
@@ -206,7 +226,8 @@ export function WithdrawalDialog({
               isSubmitting ||
               !withdrawAmount ||
               !trimmedAddress ||
-              !isValidStellarAccountId(trimmedAddress)
+              !isValidStellarAccountId(trimmedAddress) ||
+              !acknowledged
             }
             className="flex-1 px-4 py-2 bg-brand text-brand-foreground rounded-lg hover:bg-brand-hover disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 sm:flex-none"
           >

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -40,6 +40,10 @@ import {
 import { InstallWalletDialog } from '@/components/stellar/InstallWalletDialog'
 import { WalletTooltip } from '@/components/guide/WalletTooltip'
 import {
+  networkLabelLowercase,
+  tipFlowShortNote,
+} from '@/lib/copy/network-status'
+import {
   NO_WALLET_AVAILABLE_ERROR_CODE,
   ALBEDO_INSECURE_LOCALHOST_ERROR_CODE,
 } from '@/lib/stellar/wallet-adapter'
@@ -601,8 +605,11 @@ export function HighlightTipButton({
           )}
 
           <p className="text-xs text-muted-foreground text-center mt-2 flex items-center justify-center gap-1 flex-wrap">
-            Powered by Stellar testnet <WalletTooltip concept="testnet" /> •
-            Fast testnet settlement • Low fees
+            Powered by Stellar {networkLabelLowercase()}{' '}
+            {networkLabelLowercase() === 'testnet' ? (
+              <WalletTooltip concept="testnet" />
+            ) : null}{' '}
+            • {tipFlowShortNote()}
           </p>
         </DialogContent>
       </Dialog>

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -35,6 +35,7 @@ import {
   NO_WALLET_AVAILABLE_ERROR_CODE,
   ALBEDO_INSECURE_LOCALHOST_ERROR_CODE,
 } from '@/lib/stellar/wallet-adapter'
+import { networkLabelLowercase, practiceFundsNote } from '@/lib/copy/network-status'
 
 interface WalletSettingsProps {
   walletAddress?: string | null
@@ -174,12 +175,14 @@ export function WalletSettings({
             <Wallet className="h-5 w-5" />
             Stellar Wallet
             <WalletTooltip concept="stellar" />
-            <WalletTooltip concept="testnet" />
+            {networkLabelLowercase() === 'testnet' ? (
+              <WalletTooltip concept="testnet" />
+            ) : null}
           </CardTitle>
           <CardDescription>
             {isOwnProfile
-              ? 'Manage your Stellar testnet wallet for sending and receiving practice tips'
-              : 'Send testnet tips directly to this user&apos;s Stellar wallet'}
+              ? `Manage your Stellar ${networkLabelLowercase()} wallet for sending and receiving tips`
+              : `Send ${networkLabelLowercase()} tips directly to this user&apos;s Stellar wallet`}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -196,14 +199,21 @@ export function WalletSettings({
           )}
 
           {isOwnProfile ? (
+            <Alert>
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{practiceFundsNote()}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          {isOwnProfile ? (
             <>
               {!walletAddress ? (
                 <div className="space-y-4">
                   <Alert>
                     <AlertCircle className="h-4 w-4" />
                     <AlertDescription>
-                      Connect your Stellar testnet wallet to send and receive
-                      practice tips
+                      Connect your Stellar {networkLabelLowercase()} wallet to
+                      send and receive tips
                     </AlertDescription>
                   </Alert>
 
@@ -290,7 +300,11 @@ export function WalletSettings({
                       onClick={() =>
                         walletAddress &&
                         window.open(
-                          `https://stellar.expert/explorer/testnet/account/${walletAddress}`,
+                          `https://stellar.expert/explorer/${
+                            networkLabelLowercase() === 'testnet'
+                              ? 'testnet'
+                              : 'public'
+                          }/account/${walletAddress}`,
                           '_blank'
                         )
                       }
@@ -347,7 +361,9 @@ export function WalletSettings({
                 onClick={() =>
                   walletAddress &&
                   window.open(
-                    `https://stellar.expert/explorer/testnet/account/${walletAddress}`,
+                    `https://stellar.expert/explorer/${
+                      networkLabelLowercase() === 'testnet' ? 'testnet' : 'public'
+                    }/account/${walletAddress}`,
                     '_blank'
                   )
                 }

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -35,7 +35,10 @@ import {
   NO_WALLET_AVAILABLE_ERROR_CODE,
   ALBEDO_INSECURE_LOCALHOST_ERROR_CODE,
 } from '@/lib/stellar/wallet-adapter'
-import { networkLabelLowercase, practiceFundsNote } from '@/lib/copy/network-status'
+import {
+  networkLabelLowercase,
+  practiceFundsNote,
+} from '@/lib/copy/network-status'
 
 interface WalletSettingsProps {
   walletAddress?: string | null
@@ -362,7 +365,9 @@ export function WalletSettings({
                   walletAddress &&
                   window.open(
                     `https://stellar.expert/explorer/${
-                      networkLabelLowercase() === 'testnet' ? 'testnet' : 'public'
+                      networkLabelLowercase() === 'testnet'
+                        ? 'testnet'
+                        : 'public'
                     }/account/${walletAddress}`,
                     '_blank'
                   )

--- a/components/stellar/WalletStatus.tsx
+++ b/components/stellar/WalletStatus.tsx
@@ -19,6 +19,7 @@ import {
   NO_WALLET_AVAILABLE_ERROR_CODE,
   ALBEDO_INSECURE_LOCALHOST_ERROR_CODE,
 } from '@/lib/stellar/wallet-adapter'
+import { networkLabelLowercase } from '@/lib/copy/network-status'
 
 interface WalletStatusProps {
   className?: string
@@ -122,8 +123,8 @@ export function WalletStatus({ className }: WalletStatusProps) {
               <div>
                 <h3 className="font-semibold">Wallet Not Connected</h3>
                 <p className="text-sm text-muted-foreground">
-                  Connect your Stellar testnet wallet to start practice tipping
-                  authors
+                  Connect your Stellar {networkLabelLowercase()} wallet to start
+                  tipping authors
                 </p>
                 <p className="text-xs text-muted-foreground mt-2">
                   Supports Freighter, xBull, Albedo, Rabet, and more

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -49,6 +49,10 @@ import { applyPendingAmountFields } from '@/lib/tip/applyPendingTipFormState'
 import { clearPendingTipIntent } from '@/lib/tip/pendingTipIntent'
 import type { ArticlePendingTipIntent } from '@/lib/tip/pendingTipIntent'
 import { useArticleTipResume } from '@/hooks/useArticleTipResume'
+import {
+  networkLabelLowercase,
+  tipFlowShortNote,
+} from '@/lib/copy/network-status'
 
 interface TipButtonProps {
   articleId: Id<'articles'>
@@ -506,9 +510,12 @@ export function TipButton({
           )}
 
           <p className="text-xs text-muted-foreground text-center flex items-center justify-center gap-1 flex-wrap">
-            Powered by Stellar testnet <WalletTooltip concept="stellar" />{' '}
-            <WalletTooltip concept="testnet" /> • Fast testnet settlement • Low
-            fees
+            Powered by Stellar {networkLabelLowercase()}{' '}
+            <WalletTooltip concept="stellar" />{' '}
+            {networkLabelLowercase() === 'testnet' ? (
+              <WalletTooltip concept="testnet" />
+            ) : null}{' '}
+            • {tipFlowShortNote()}
           </p>
         </DialogContent>
       </Dialog>

--- a/lib/copy/network-status.ts
+++ b/lib/copy/network-status.ts
@@ -1,12 +1,65 @@
 import { MIN_WITHDRAWAL_USD } from '@/lib/constants'
+import { STELLAR_CONFIG } from '@/lib/stellar/config'
 
-export const TESTNET_PRACTICE_NOTE =
-  'Quilltip runs on Stellar testnet. Tips use free test XLM for practice—not real money.'
+type SupportedNetwork = 'TESTNET' | 'MAINNET'
 
-export const TESTNET_TIP_SPEED_NOTE =
-  'Tips settle in about 3 seconds on Stellar testnet with near-zero fees.'
+function getNetwork(): SupportedNetwork {
+  return STELLAR_CONFIG.NETWORK === 'MAINNET' ? 'MAINNET' : 'TESTNET'
+}
 
-export const TESTNET_WITHDRAWAL_NOTE = `Move testnet earnings to your Stellar wallet once your available balance reaches $${MIN_WITHDRAWAL_USD.toFixed(0)}. Test funds only—not withdrawable as real money.`
+export function networkLabelLowercase(): 'testnet' | 'mainnet' {
+  return getNetwork() === 'MAINNET' ? 'mainnet' : 'testnet'
+}
+
+export function practiceFundsNote(): string {
+  if (getNetwork() === 'MAINNET') {
+    return 'Quilltip runs on Stellar mainnet. Tips use real funds.'
+  }
+  return 'Quilltip runs on Stellar testnet. Tips use free test XLM for practice—not real money.'
+}
+
+export function tipSpeedNote(): string {
+  const network = networkLabelLowercase()
+  return `Tips typically confirm in a few seconds on Stellar ${network} with near-zero fees.`
+}
+
+/**
+ * Explains what "withdraw" actually does today vs future mainnet behavior.
+ * Keep this aligned with `convex/tips.ts` withdrawEarnings.
+ */
+export function withdrawalFlowNote(): string {
+  if (getNetwork() === 'MAINNET') {
+    return 'Withdrawals submit an on-chain transfer to your Stellar wallet. Confirmation time depends on the network.'
+  }
+  return 'Withdrawals are testnet-only today and are simulated off-chain. Your dashboard marks them complete after a short delay.'
+}
+
+export function withdrawalNote(): string {
+  if (getNetwork() === 'MAINNET') {
+    return `Move earnings to your Stellar wallet once your available balance reaches $${MIN_WITHDRAWAL_USD.toFixed(0)}.`
+  }
+  return `Move testnet earnings to your Stellar wallet once your available balance reaches $${MIN_WITHDRAWAL_USD.toFixed(0)}. Test funds only—not withdrawable as real money.`
+}
+
+export function tipFlowShortNote(): string {
+  const network = networkLabelLowercase()
+  if (getNetwork() === 'MAINNET') {
+    return `Fast confirmation on Stellar ${network}. You sign in your wallet → the network confirms → your dashboard updates.`
+  }
+  return `Fast testnet confirmation. You sign in your wallet → the network confirms → your dashboard updates.`
+}
+
+export function withdrawalAcknowledgementLabel(): string {
+  if (getNetwork() === 'MAINNET') {
+    return 'I understand this will submit an on-chain transfer and may take time to confirm.'
+  }
+  return 'I understand these are testnet practice funds and withdrawals are simulated off-chain.'
+}
+
+// Backwards-compatible exports (existing imports across the app).
+export const TESTNET_PRACTICE_NOTE = practiceFundsNote()
+export const TESTNET_TIP_SPEED_NOTE = tipSpeedNote()
+export const TESTNET_WITHDRAWAL_NOTE = withdrawalNote()
 
 export const MAINNET_COMING_NOTE =
   'We are working toward a mainnet launch where tips will use real funds. Until then, everything on Quilltip is testnet practice.'


### PR DESCRIPTION
## Summary

- Centralize network-aware money copy in `lib/copy/network-status.ts` (testnet vs mainnet via `NEXT_PUBLIC_STELLAR_NETWORK`).
- Replace misleading withdrawal success copy (“sent within seconds”) with wording that matches the real flow: testnet withdrawals are simulated off-chain; mainnet copy is future-safe.
- Require an acknowledgement checkbox in withdrawal dialogs before submit.
- Update tip dialog footers to keep “fast” claims but explain the flow: sign in wallet → network confirms → dashboard updates.
- Align wallet and earnings surfaces on the same practice-funds / network messaging; fix Stellar Expert links for testnet vs public.
- Update README to remove unqualified “instant Stellar transactions”.

## Context

Earnings and withdrawal UI implied instant, real-money Stellar payouts while the product is testnet-first and withdrawals are simulated in Convex (`withdrawEarnings` → `confirmWithdrawal` after ~2s, no on-chain transfer). Tips are on-chain (wallet sign + Soroban confirm) but copy did not always say that.

<img width="1215" height="715" alt="3" src="https://github.com/user-attachments/assets/eb3e42d7-435e-49de-826a-98dd44d29a04" />


