### PR TITLE
fix(dashboard): mobile card layout for Recent Tips (ENG-223)

### DIFF
--- a/components/dashboard/TipHistory.test.tsx
+++ b/components/dashboard/TipHistory.test.tsx
@@ -59,15 +59,68 @@ describe('TipHistory', () => {
     ]
     render(<TipHistory tips={tips} />)
 
-    expect(screen.getByText('bob')).toBeInTheDocument()
-    expect(screen.getByText('My Article')).toBeInTheDocument()
-    expect(screen.getByText('+$12.50')).toBeInTheDocument()
+    expect(screen.getAllByText('bob').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('My Article').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('+$12.50').length).toBeGreaterThan(0)
   })
 
   it('uses Anonymous when no tipper name', () => {
     const tips = [makeTip({ tipper: null })]
     render(<TipHistory tips={tips} />)
-    expect(screen.getByText('Anonymous')).toBeInTheDocument()
+    expect(screen.getAllByText('Anonymous').length).toBeGreaterThan(0)
+  })
+
+  it('renders a mobile card list alongside the desktop table', () => {
+    const tips = [
+      makeTip({
+        _id: 'a1' as Id<'tips'>,
+        articleTitle: 'Mobile Article',
+        amountUsd: 7,
+        tipper: { username: 'carol' },
+      }),
+    ]
+    render(<TipHistory tips={tips} />)
+
+    const mobileList = screen.getByTestId('tip-history-mobile-list')
+    expect(mobileList).toHaveClass('md:hidden')
+    expect(mobileList).toHaveTextContent('Mobile Article')
+    expect(mobileList).toHaveTextContent('carol')
+    expect(mobileList).toHaveTextContent('+$7.00')
+    expect(screen.getByRole('table')).toBeInTheDocument()
+  })
+
+  it('sorts tips via mobile sort controls', () => {
+    const tips = [
+      makeTip({
+        _id: 'a1' as Id<'tips'>,
+        amountUsd: 3,
+        createdAt: new Date('2024-03-01T00:00:00Z').getTime(),
+        tipper: { username: 'bob' },
+      }),
+      makeTip({
+        _id: 'a2' as Id<'tips'>,
+        amountUsd: 10,
+        createdAt: new Date('2024-03-02T00:00:00Z').getTime(),
+        tipper: { username: 'alice' },
+      }),
+    ]
+
+    render(<TipHistory tips={tips} />)
+
+    const sortSelect = screen.getByLabelText('Sort tips by')
+    fireEvent.change(sortSelect, { target: { value: 'amountUsd' } })
+
+    const mobileList = screen.getByTestId('tip-history-mobile-list')
+    expect(mobileList.textContent?.indexOf('+$3.00')).toBeLessThan(
+      mobileList.textContent?.indexOf('+$10.00') ?? -1
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /sort direction: ascending/i })
+    )
+    expect(mobileList.textContent?.indexOf('+$10.00')).toBeLessThan(
+      mobileList.textContent?.indexOf('+$3.00') ?? -1
+    )
   })
 
   it('shows relative time with absolute date on title and aria-label', () => {
@@ -79,7 +132,7 @@ describe('TipHistory', () => {
 
     render(<TipHistory tips={[makeTip({ createdAt })]} />)
 
-    const timeEl = screen.getByText('2 days ago')
+    const timeEl = screen.getAllByText('2 days ago')[0]
     expect(timeEl.tagName).toBe('TIME')
     expect(timeEl).toHaveAttribute('dateTime', tipDate.toISOString())
     expect(timeEl).toHaveAttribute('title', absolute)

--- a/components/dashboard/TipHistory.test.tsx
+++ b/components/dashboard/TipHistory.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   TipHistory,
@@ -132,7 +132,9 @@ describe('TipHistory', () => {
 
     render(<TipHistory tips={[makeTip({ createdAt })]} />)
 
-    const timeEl = screen.getAllByText('2 days ago')[0]
+    const timeEl = within(
+      screen.getByTestId('tip-history-mobile-list')
+    ).getByText('2 days ago')
     expect(timeEl.tagName).toBe('TIME')
     expect(timeEl).toHaveAttribute('dateTime', tipDate.toISOString())
     expect(timeEl).toHaveAttribute('title', absolute)

--- a/components/dashboard/TipHistory.tsx
+++ b/components/dashboard/TipHistory.tsx
@@ -17,6 +17,39 @@ type PageSize = 10 | 25 | 50 | 'all'
 type SortKey = 'tipper' | 'articleTitle' | 'amountUsd' | 'createdAt'
 type SortDir = 'asc' | 'desc'
 
+const SORT_OPTIONS: { value: SortKey; label: string }[] = [
+  { value: 'tipper', label: 'Tipper' },
+  { value: 'articleTitle', label: 'Article' },
+  { value: 'amountUsd', label: 'Amount' },
+  { value: 'createdAt', label: 'Date' },
+]
+
+function getTipperName(tip: ReceivedTipRow) {
+  return tip.tipper?.name || tip.tipper?.username || 'Anonymous'
+}
+
+function formatTipDate(createdAt: number) {
+  const tipDate = new Date(createdAt)
+  const relative = formatDistanceToNow(tipDate, { addSuffix: true })
+  const absolute = tipDate.toLocaleDateString('en-US', { dateStyle: 'long' })
+  const a11yLabel = `${relative}. ${absolute}.`
+  return { tipDate, relative, absolute, a11yLabel }
+}
+
+function TipDateTime({ createdAt }: { createdAt: number }) {
+  const { tipDate, relative, absolute, a11yLabel } = formatTipDate(createdAt)
+  return (
+    <time
+      dateTime={tipDate.toISOString()}
+      title={absolute}
+      aria-label={a11yLabel}
+      className="text-xs text-muted-foreground"
+    >
+      {relative}
+    </time>
+  )
+}
+
 function csvEscape(value: string) {
   const mustQuote = /[",\n\r]/.test(value)
   if (!mustQuote) return value
@@ -43,9 +76,6 @@ export function TipHistory({ tips }: TipHistoryProps) {
 
   const sortedTips = useMemo(() => {
     if (!list) return null
-
-    const getTipperName = (tip: ReceivedTipRow) =>
-      tip.tipper?.name || tip.tipper?.username || 'Anonymous'
 
     const dir = sortDir === 'asc' ? 1 : -1
 
@@ -105,10 +135,9 @@ export function TipHistory({ tips }: TipHistoryProps) {
 
     const header = ['Tipper', 'Article', 'AmountUsd', 'CreatedAt']
     const rows = visibleTips.map((tip) => {
-      const tipperName = tip.tipper?.name || tip.tipper?.username || 'Anonymous'
       const createdAtIso = new Date(tip.createdAt).toISOString()
       return [
-        tipperName,
+        getTipperName(tip),
         tip.articleTitle,
         tip.amountUsd.toFixed(2),
         createdAtIso,
@@ -127,10 +156,35 @@ export function TipHistory({ tips }: TipHistoryProps) {
   return (
     <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border">
       <div className="p-6 border-b border-border">
-        <div className="flex items-center justify-between gap-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <h3 className="text-lg font-semibold">Recent Tips</h3>
           {list ? (
-            <div className="flex items-center gap-3">
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="flex flex-wrap items-center gap-2 md:hidden">
+                <label className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <span>Sort by</span>
+                  <select
+                    className="h-8 rounded-md border border-border bg-background px-2 text-foreground"
+                    value={sortKey}
+                    onChange={(e) => setSort(e.target.value as SortKey)}
+                    aria-label="Sort tips by"
+                  >
+                    {SORT_OPTIONS.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <button
+                  type="button"
+                  onClick={() => setSort(sortKey)}
+                  className="h-8 rounded-md border border-border bg-background px-3 text-sm text-foreground hover:bg-muted"
+                  aria-label={`Sort direction: ${sortDir === 'asc' ? 'ascending' : 'descending'}`}
+                >
+                  {sortDir === 'asc' ? 'Ascending' : 'Descending'}
+                </button>
+              </div>
               <button
                 type="button"
                 onClick={onDownloadCsv}
@@ -162,81 +216,95 @@ export function TipHistory({ tips }: TipHistoryProps) {
         </div>
       </div>
       {visibleTips ? (
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead className="border-b border-border bg-muted/30">
-              <tr>
-                <th
-                  scope="col"
-                  aria-sort={ariaSort('tipper')}
-                  className="px-4 py-3 text-left font-medium text-foreground"
-                >
-                  <button
-                    type="button"
-                    onClick={() => setSort('tipper')}
-                    className="inline-flex items-center hover:underline"
+        <>
+          <div
+            data-testid="tip-history-mobile-list"
+            className="md:hidden divide-y divide-border"
+          >
+            {visibleTips.map((tip) => (
+              <div key={tip._id} className="p-4 hover:bg-muted/40">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <p className="font-medium text-foreground line-clamp-2">
+                      {tip.articleTitle}
+                    </p>
+                    <p className="mt-1 text-sm text-muted-foreground truncate">
+                      {getTipperName(tip)}
+                    </p>
+                  </div>
+                  <p className="shrink-0 font-semibold text-success-foreground">
+                    +${tip.amountUsd.toFixed(2)}
+                  </p>
+                </div>
+                <div className="mt-2">
+                  <TipDateTime createdAt={tip.createdAt} />
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="hidden md:block overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="border-b border-border bg-muted/30">
+                <tr>
+                  <th
+                    scope="col"
+                    aria-sort={ariaSort('tipper')}
+                    className="px-4 py-3 text-left font-medium text-foreground"
                   >
-                    Tipper{sortIndicator('tipper')}
-                  </button>
-                </th>
-                <th
-                  scope="col"
-                  aria-sort={ariaSort('articleTitle')}
-                  className="px-4 py-3 text-left font-medium text-foreground"
-                >
-                  <button
-                    type="button"
-                    onClick={() => setSort('articleTitle')}
-                    className="inline-flex items-center hover:underline"
+                    <button
+                      type="button"
+                      onClick={() => setSort('tipper')}
+                      className="inline-flex items-center hover:underline"
+                    >
+                      Tipper{sortIndicator('tipper')}
+                    </button>
+                  </th>
+                  <th
+                    scope="col"
+                    aria-sort={ariaSort('articleTitle')}
+                    className="px-4 py-3 text-left font-medium text-foreground"
                   >
-                    Article{sortIndicator('articleTitle')}
-                  </button>
-                </th>
-                <th
-                  scope="col"
-                  aria-sort={ariaSort('amountUsd')}
-                  className="px-4 py-3 text-right font-medium text-foreground"
-                >
-                  <button
-                    type="button"
-                    onClick={() => setSort('amountUsd')}
-                    className="inline-flex items-center hover:underline"
+                    <button
+                      type="button"
+                      onClick={() => setSort('articleTitle')}
+                      className="inline-flex items-center hover:underline"
+                    >
+                      Article{sortIndicator('articleTitle')}
+                    </button>
+                  </th>
+                  <th
+                    scope="col"
+                    aria-sort={ariaSort('amountUsd')}
+                    className="px-4 py-3 text-right font-medium text-foreground"
                   >
-                    Amount{sortIndicator('amountUsd')}
-                  </button>
-                </th>
-                <th
-                  scope="col"
-                  aria-sort={ariaSort('createdAt')}
-                  className="px-4 py-3 text-right font-medium text-foreground"
-                >
-                  <button
-                    type="button"
-                    onClick={() => setSort('createdAt')}
-                    className="inline-flex items-center hover:underline"
+                    <button
+                      type="button"
+                      onClick={() => setSort('amountUsd')}
+                      className="inline-flex items-center hover:underline"
+                    >
+                      Amount{sortIndicator('amountUsd')}
+                    </button>
+                  </th>
+                  <th
+                    scope="col"
+                    aria-sort={ariaSort('createdAt')}
+                    className="px-4 py-3 text-right font-medium text-foreground"
                   >
-                    Date{sortIndicator('createdAt')}
-                  </button>
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {visibleTips.map((tip) => {
-                const tipDate = new Date(tip.createdAt)
-                const relative = formatDistanceToNow(tipDate, {
-                  addSuffix: true,
-                })
-                const absolute = tipDate.toLocaleDateString('en-US', {
-                  dateStyle: 'long',
-                })
-                const a11yLabel = `${relative}. ${absolute}.`
-                const tipperName =
-                  tip.tipper?.name || tip.tipper?.username || 'Anonymous'
-
-                return (
+                    <button
+                      type="button"
+                      onClick={() => setSort('createdAt')}
+                      className="inline-flex items-center hover:underline"
+                    >
+                      Date{sortIndicator('createdAt')}
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {visibleTips.map((tip) => (
                   <tr key={tip._id} className="hover:bg-muted/40">
                     <td className="px-4 py-3 font-medium text-foreground">
-                      {tipperName}
+                      {getTipperName(tip)}
                     </td>
                     <td className="px-4 py-3 text-muted-foreground">
                       {tip.articleTitle}
@@ -245,21 +313,14 @@ export function TipHistory({ tips }: TipHistoryProps) {
                       +${tip.amountUsd.toFixed(2)}
                     </td>
                     <td className="px-4 py-3 text-right">
-                      <time
-                        dateTime={tipDate.toISOString()}
-                        title={absolute}
-                        aria-label={a11yLabel}
-                        className="text-xs text-muted-foreground"
-                      >
-                        {relative}
-                      </time>
+                      <TipDateTime createdAt={tip.createdAt} />
                     </td>
                   </tr>
-                )
-              })}
-            </tbody>
-          </table>
-        </div>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
       ) : (
         <div className="flex min-h-[12rem] flex-col items-center justify-center gap-2 px-6 py-10 text-center">
           <p className="font-medium text-foreground">No tips yet</p>


### PR DESCRIPTION
## Summary

- Add a mobile-friendly card list for Recent Tips on viewports below `md` (768px), so article, tipper, amount, and date are easy to scan without horizontal scrolling.
- Keep the existing sortable table on `md+` with the same sort, row limit, and CSV export behavior.
- Add mobile sort controls (field dropdown + ascending/descending toggle) and stack the header toolbar on narrow screens.
- Extract shared tip row helpers (`getTipperName`, `formatTipDate`, `TipDateTime`) so mobile and desktop layouts stay in sync.
- Extend `TipHistory` tests for the mobile list and mobile sort behavior.
<img width="585" height="718" alt="1" src="https://github.com/user-attachments/assets/cfdddf1c-65e3-4024-a859-4165cdb1c680" />

<img width="585" height="720" alt="2" src="https://github.com/user-attachments/assets/1dc27529-f8e2-4ba4-9740-0c0935eeb2b4" />
