### PR TITLE
fix: improve monthly earnings chart labels and mobile layout

### DIFF
--- a/components/dashboard/EarningsDashboardSkeleton.tsx
+++ b/components/dashboard/EarningsDashboardSkeleton.tsx
@@ -21,7 +21,7 @@ function MonthlyChartSkeleton() {
   return (
     <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
       <Skeleton className="h-6 w-40 mb-4" />
-      <div className="grid grid-cols-6 gap-2">
+      <div className="grid grid-cols-3 sm:grid-cols-6 gap-2">
         {Array.from({ length: 6 }).map((_, i) => (
           <div key={i} className="text-center">
             <Skeleton className="h-3 w-full mb-1 mx-auto" />

--- a/components/dashboard/EarningsStats.test.tsx
+++ b/components/dashboard/EarningsStats.test.tsx
@@ -54,12 +54,12 @@ describe('EarningsStats', () => {
     expect(screen.getByText('5 testnet tips received')).toBeInTheDocument()
   })
 
-  it('renders monthly chart labels in display order', () => {
+  it('renders monthly chart with readable labels for recent months', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2024, 5, 15))
     const earnings = makeEarnings({
       monthlyEarnings: {
-        '2024-01': 10,
-        '2024-02': 20,
-        '2024-03': 30,
+        '2024-06': 30,
       },
     })
     render(
@@ -71,9 +71,12 @@ describe('EarningsStats', () => {
       />
     )
 
-    expect(screen.getByText('2024-01')).toBeInTheDocument()
-    expect(screen.getByText('2024-02')).toBeInTheDocument()
-    expect(screen.getByText('2024-03')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /monthly earnings/i })
+    ).toBeInTheDocument()
+    expect(screen.getByText('$30')).toBeInTheDocument()
+    expect(screen.queryByText('2024-06')).not.toBeInTheDocument()
+    vi.useRealTimers()
   })
 
   it('shows wallet setup notice when profile has no Stellar address', () => {

--- a/components/dashboard/EarningsStats.tsx
+++ b/components/dashboard/EarningsStats.tsx
@@ -107,9 +107,9 @@ export function EarningsStats({
         </div>
       </div>
 
-      {earnings.monthlyEarnings && (
-        <MonthlyEarningsChart monthlyEarnings={earnings.monthlyEarnings} />
-      )}
+      <MonthlyEarningsChart
+        monthlyEarnings={earnings.monthlyEarnings ?? {}}
+      />
 
       {earnings.topArticles && earnings.topArticles.length > 0 && (
         <TopEarningArticles articles={earnings.topArticles} />

--- a/components/dashboard/EarningsStats.tsx
+++ b/components/dashboard/EarningsStats.tsx
@@ -107,9 +107,7 @@ export function EarningsStats({
         </div>
       </div>
 
-      <MonthlyEarningsChart
-        monthlyEarnings={earnings.monthlyEarnings ?? {}}
-      />
+      <MonthlyEarningsChart monthlyEarnings={earnings.monthlyEarnings ?? {}} />
 
       {earnings.topArticles && earnings.topArticles.length > 0 && (
         <TopEarningArticles articles={earnings.topArticles} />

--- a/components/dashboard/monthly-earnings-chart.test.tsx
+++ b/components/dashboard/monthly-earnings-chart.test.tsx
@@ -1,0 +1,69 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MonthlyEarningsChart } from '@/components/dashboard/monthly-earnings-chart'
+
+describe('MonthlyEarningsChart', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2024, 5, 15))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders readable month labels instead of raw keys', () => {
+    render(
+      <MonthlyEarningsChart
+        monthlyEarnings={{
+          '2024-01': 10,
+          '2024-02': 20,
+          '2024-03': 30,
+        }}
+      />
+    )
+
+    expect(screen.getByText('Jan')).toBeInTheDocument()
+    expect(screen.getByText('Feb')).toBeInTheDocument()
+    expect(screen.getByText('Mar')).toBeInTheDocument()
+    expect(screen.queryByText('2024-01')).not.toBeInTheDocument()
+    expect(screen.queryByText('2024-02')).not.toBeInTheDocument()
+    expect(screen.queryByText('2024-03')).not.toBeInTheDocument()
+  })
+
+  it('renders six month slots for sparse data', () => {
+    const { container } = render(
+      <MonthlyEarningsChart monthlyEarnings={{ '2024-06': 30 }} />
+    )
+
+    expect(container.querySelectorAll('.grid > div')).toHaveLength(6)
+    expect(screen.getByText('$30')).toBeInTheDocument()
+    expect(screen.getAllByText('$0')).toHaveLength(5)
+  })
+
+  it('shows helper text when all amounts are zero', () => {
+    render(<MonthlyEarningsChart monthlyEarnings={{}} />)
+
+    expect(
+      screen.getByText(/no earnings in the last 6 months/i)
+    ).toBeInTheDocument()
+    expect(screen.getAllByText('$0')).toHaveLength(6)
+  })
+
+  it('includes year on labels when the window spans two years', () => {
+    vi.setSystemTime(new Date(2025, 0, 15))
+
+    render(
+      <MonthlyEarningsChart
+        monthlyEarnings={{
+          '2024-12': 5,
+          '2025-01': 10,
+        }}
+      />
+    )
+
+    expect(screen.getByText('Dec 2024')).toBeInTheDocument()
+    expect(screen.getByText('Jan 2025')).toBeInTheDocument()
+  })
+})

--- a/components/dashboard/monthly-earnings-chart.tsx
+++ b/components/dashboard/monthly-earnings-chart.tsx
@@ -1,5 +1,11 @@
 'use client'
 
+import {
+  buildLastSixMonthSlots,
+  formatMonthLabel,
+  monthWindowSpansTwoYears,
+} from '@/lib/earnings/monthly-earnings'
+
 type MonthlyEarningsChartProps = {
   monthlyEarnings: Record<string, number>
 }
@@ -7,26 +13,42 @@ type MonthlyEarningsChartProps = {
 export function MonthlyEarningsChart({
   monthlyEarnings,
 }: MonthlyEarningsChartProps) {
-  if (Object.keys(monthlyEarnings).length === 0) {
-    return null
-  }
+  const slots = buildLastSixMonthSlots(monthlyEarnings)
+  const showYear = monthWindowSpansTwoYears(slots.map((slot) => slot.monthKey))
+  const allZero = slots.every((slot) => slot.amountUsd === 0)
 
   return (
     <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
-      <h3 className="text-lg font-semibold mb-4">Monthly Earnings</h3>
-      <div className="grid grid-cols-6 gap-2">
-        {Object.entries(monthlyEarnings)
-          .sort(([a], [b]) => b.localeCompare(a))
-          .slice(0, 6)
-          .reverse()
-          .map(([month, amount]) => (
-            <div key={month} className="text-center">
-              <div className="text-xs text-muted-foreground mb-1">{month}</div>
-              <div className="bg-success text-success-foreground rounded-lg p-2">
-                <p className="text-sm font-semibold">${amount.toFixed(0)}</p>
+      <div className="mb-4">
+        <h3 className="text-lg font-semibold">Monthly Earnings</h3>
+        {allZero && (
+          <p className="text-sm text-muted-foreground mt-1">
+            No earnings in the last 6 months
+          </p>
+        )}
+      </div>
+      <div className="grid grid-cols-3 sm:grid-cols-6 gap-2">
+        {slots.map((slot) => {
+          const hasEarnings = slot.amountUsd > 0
+          return (
+            <div key={slot.monthKey} className="min-w-0 text-center">
+              <div className="text-xs text-muted-foreground mb-1 whitespace-nowrap">
+                {formatMonthLabel(slot.monthKey, { showYear })}
+              </div>
+              <div
+                className={
+                  hasEarnings
+                    ? 'bg-success text-success-foreground rounded-lg p-2'
+                    : 'bg-muted text-muted-foreground rounded-lg border border-border p-2'
+                }
+              >
+                <p className="text-sm font-semibold">
+                  ${slot.amountUsd.toFixed(0)}
+                </p>
               </div>
             </div>
-          ))}
+          )
+        })}
       </div>
     </div>
   )

--- a/lib/earnings/monthly-earnings.test.ts
+++ b/lib/earnings/monthly-earnings.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildLastSixMonthSlots,
+  formatMonthLabel,
+  monthWindowSpansTwoYears,
+  parseMonthKey,
+} from '@/lib/earnings/monthly-earnings'
+
+describe('parseMonthKey', () => {
+  it('parses a valid YYYY-MM key', () => {
+    const date = parseMonthKey('2024-01')
+    expect(date).not.toBeNull()
+    expect(date?.getFullYear()).toBe(2024)
+    expect(date?.getMonth()).toBe(0)
+  })
+
+  it('returns null for invalid keys', () => {
+    expect(parseMonthKey('2024-13')).toBeNull()
+    expect(parseMonthKey('invalid')).toBeNull()
+  })
+})
+
+describe('formatMonthLabel', () => {
+  it('formats as short month without year by default', () => {
+    expect(formatMonthLabel('2024-01', { showYear: false })).toBe('Jan')
+    expect(formatMonthLabel('2024-03', { showYear: false })).toBe('Mar')
+  })
+
+  it('includes year when showYear is true', () => {
+    expect(formatMonthLabel('2024-01', { showYear: true })).toBe('Jan 2024')
+  })
+
+  it('falls back to the raw key for invalid input', () => {
+    expect(formatMonthLabel('not-a-month', { showYear: false })).toBe(
+      'not-a-month'
+    )
+  })
+})
+
+describe('monthWindowSpansTwoYears', () => {
+  it('returns false when all months are in the same year', () => {
+    expect(
+      monthWindowSpansTwoYears([
+        '2024-01',
+        '2024-02',
+        '2024-03',
+        '2024-04',
+        '2024-05',
+        '2024-06',
+      ])
+    ).toBe(false)
+  })
+
+  it('returns true when the window crosses a year boundary', () => {
+    expect(
+      monthWindowSpansTwoYears([
+        '2024-08',
+        '2024-09',
+        '2024-10',
+        '2024-11',
+        '2024-12',
+        '2025-01',
+      ])
+    ).toBe(true)
+  })
+})
+
+describe('buildLastSixMonthSlots', () => {
+  it('returns six chronological slots ending at the current month', () => {
+    const now = new Date(2024, 5, 15)
+    const slots = buildLastSixMonthSlots({ '2024-06': 30 }, now)
+
+    expect(slots).toHaveLength(6)
+    expect(slots.map((slot) => slot.monthKey)).toEqual([
+      '2024-01',
+      '2024-02',
+      '2024-03',
+      '2024-04',
+      '2024-05',
+      '2024-06',
+    ])
+    expect(slots.find((slot) => slot.monthKey === '2024-06')?.amountUsd).toBe(
+      30
+    )
+    expect(slots.filter((slot) => slot.amountUsd > 0)).toHaveLength(1)
+  })
+})

--- a/lib/earnings/monthly-earnings.ts
+++ b/lib/earnings/monthly-earnings.ts
@@ -1,0 +1,87 @@
+const MONTH_KEY_RE = /^(\d{4})-(\d{2})$/
+
+export type MonthlyEarningsSlot = {
+  monthKey: string
+  amountUsd: number
+}
+
+export function parseMonthKey(monthKey: string): Date | null {
+  const match = MONTH_KEY_RE.exec(monthKey)
+  if (!match) {
+    return null
+  }
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  if (month < 1 || month > 12) {
+    return null
+  }
+
+  return new Date(year, month - 1, 1)
+}
+
+export function formatMonthKey(monthKey: string): string {
+  const date = parseMonthKey(monthKey)
+  if (!date) {
+    return monthKey
+  }
+
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`
+}
+
+export function formatMonthLabel(
+  monthKey: string,
+  options: { showYear: boolean }
+): string {
+  const date = parseMonthKey(monthKey)
+  if (!date) {
+    return monthKey
+  }
+
+  if (options.showYear) {
+    return date.toLocaleString(undefined, {
+      month: 'short',
+      year: 'numeric',
+    })
+  }
+
+  return date.toLocaleString(undefined, { month: 'short' })
+}
+
+export function monthWindowSpansTwoYears(monthKeys: string[]): boolean {
+  if (monthKeys.length === 0) {
+    return false
+  }
+
+  const firstKey = monthKeys[0]
+  const lastKey = monthKeys[monthKeys.length - 1]
+  if (!firstKey || !lastKey) {
+    return false
+  }
+
+  const first = parseMonthKey(firstKey)
+  const last = parseMonthKey(lastKey)
+  if (!first || !last) {
+    return false
+  }
+
+  return first.getFullYear() !== last.getFullYear()
+}
+
+export function buildLastSixMonthSlots(
+  monthlyEarnings: Record<string, number>,
+  now: Date = new Date()
+): MonthlyEarningsSlot[] {
+  const slots: MonthlyEarningsSlot[] = []
+
+  for (let offset = 5; offset >= 0; offset -= 1) {
+    const date = new Date(now.getFullYear(), now.getMonth() - offset, 1)
+    const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`
+    slots.push({
+      monthKey,
+      amountUsd: monthlyEarnings[monthKey] ?? 0,
+    })
+  }
+
+  return slots
+}


### PR DESCRIPTION
## Summary
- Render a fixed rolling 6-month monthly earnings view, filling missing months with $0.
- Replace raw `YYYY-MM` labels with readable short month names; include year only when the 6-month window crosses a year boundary.
- Make the chart responsive (3×2 on mobile, 6 columns on larger screens) and prevent label wrapping; clarify empty/low-data states with muted $0 styling and helper text.
<img width="1225" height="720" alt="1" src="https://github.com/user-attachments/assets/1e33d5ff-eda0-4407-a796-a5f8130dca1f" />

<img width="588" height="719" alt="2" src="https://github.com/user-attachments/assets/81c0eb66-c708-4e84-b59d-a1e0416f222a" />
