### PR TITLE
feat: add primary CTA to earnings empty state

### DIFF
--- a/components/dashboard/EarningsDashboard.tsx
+++ b/components/dashboard/EarningsDashboard.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from 'react'
 import { useMutation } from 'convex/react'
 import { api } from '@/convex/_generated/api'
+import { useRouter } from 'next/navigation'
 import {
   useAuthorEarnings,
   useUserByUsername,
@@ -17,10 +18,13 @@ import { WithdrawalDialog } from '@/components/dashboard/WithdrawalDialog'
 import { EarningsStats } from '@/components/dashboard/EarningsStats'
 import { EarningsDashboardSkeleton } from '@/components/dashboard/EarningsDashboardSkeleton'
 import { withdrawalFlowNote } from '@/lib/copy/network-status'
+import { useProfileTabNavigation } from '@/hooks/useProfileTabNavigation'
 
 export function EarningsDashboard() {
   const [showWithdrawModal, setShowWithdrawModal] = useState(false)
   const withdrawTriggerRef = useRef<HTMLButtonElement>(null)
+  const router = useRouter()
+  const navigateToTab = useProfileTabNavigation()
 
   const { user: currentUser } = useAuth()
 
@@ -56,16 +60,37 @@ export function EarningsDashboard() {
   }
 
   if (!earnings) {
+    const hasWallet = Boolean(userProfile?.stellarAddress)
+    const primaryLabel = hasWallet ? 'Write your first post' : 'Set up wallet'
+    const primaryAction = () => {
+      if (hasWallet) {
+        router.push('/write')
+      } else {
+        navigateToTab('wallet')
+      }
+    }
+
     return (
       <div className="space-y-6">
-        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-12 text-center">
+        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-8 sm:p-12 text-center">
           <Coins className="w-16 h-16 text-muted-foreground mx-auto mb-4" />
           <h3 className="text-lg font-semibold text-foreground mb-2">
             No testnet tips yet
           </h3>
-          <p className="text-muted-foreground">
-            Share great content and receive practice tips on Stellar testnet.
+          <p className="text-muted-foreground mx-auto max-w-md">
+            Publish a post, share it with readers, and you’ll start seeing tips
+            here. Set up a Stellar wallet so you can withdraw your earnings when
+            you’re ready.
           </p>
+          <div className="mt-6 flex justify-center">
+            <button
+              type="button"
+              onClick={primaryAction}
+              className="w-full sm:w-auto px-4 py-2 bg-brand text-brand-foreground rounded-lg hover:bg-brand-hover inline-flex items-center justify-center"
+            >
+              {primaryLabel}
+            </button>
+          </div>
         </div>
       </div>
     )


### PR DESCRIPTION
## Summary
- Add a single primary CTA to the Earnings empty state for writers with no tips/earnings.
- CTA is conditional: routes to Wallet setup if no Stellar address, otherwise routes to /write.
- Update empty-state copy to explain how to start earning tips and that wallet setup is needed for withdrawals.
<img width="1219" height="718" alt="1" src="https://github.com/user-attachments/assets/9786dde9-e3a1-4ca2-8a02-7731080eda21" />
<img width="1220" height="713" alt="2" src="https://github.com/user-attachments/assets/8e76c32b-85e3-4d0b-a37d-590d4126b9d8" />
<img width="579" height="719" alt="3" src="https://github.com/user-attachments/assets/2253a69e-797e-4015-8c13-7910125a8a90" />

<img width="591" height="721" alt="4" src="https://github.com/user-attachments/assets/046c9d4c-f5dc-44a8-8f16-150d70d645a5" />
