### PR TITLE
feat(nft): add final confirmation step before NFT ownership transfer (ENG-188)

### DIFF
--- a/app/[username]/[slug]/page.tsx
+++ b/app/[username]/[slug]/page.tsx
@@ -177,7 +177,6 @@ export default function ArticlePage({ params }: ArticlePageProps) {
                       articleSlug={article.slug}
                       authorId={article.author.id}
                       currentUserId={user?._id as Id<'users'> | undefined}
-                      currentUserAddress={user?.stellarAddress}
                     />
                   </div>
 

--- a/components/nft/NFTIntegration.test.tsx
+++ b/components/nft/NFTIntegration.test.tsx
@@ -74,7 +74,6 @@ describe('NFTIntegration transfer actions', () => {
         articleSlug="test-article"
         authorId={authorId}
         currentUserId={newOwnerId}
-        currentUserAddress={sharedStellarAddress}
       />
     )
 
@@ -96,7 +95,6 @@ describe('NFTIntegration transfer actions', () => {
         articleSlug="test-article"
         authorId={authorId}
         currentUserId={oldOwnerId}
-        currentUserAddress={sharedStellarAddress}
       />
     )
 

--- a/components/nft/NFTIntegration.test.tsx
+++ b/components/nft/NFTIntegration.test.tsx
@@ -103,8 +103,6 @@ describe('NFTIntegration transfer actions', () => {
     expect(
       screen.queryByRole('button', { name: /Transfer NFT/i })
     ).not.toBeInTheDocument()
-    expect(
-      screen.getByText(/don.t own this NFT/i)
-    ).toBeInTheDocument()
+    expect(screen.getByText(/don.t own this NFT/i)).toBeInTheDocument()
   })
 })

--- a/components/nft/NFTIntegration.test.tsx
+++ b/components/nft/NFTIntegration.test.tsx
@@ -1,0 +1,112 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NFTIntegration } from '@/components/nft/NFTIntegration'
+import type { Id } from '@/types/convex'
+
+const mockUseNFTByArticle = vi.hoisted(() => vi.fn())
+
+vi.mock('@/hooks/convex', () => ({
+  useNFTByArticle: (articleId: Id<'articles'> | undefined) =>
+    mockUseNFTByArticle(articleId),
+}))
+
+vi.mock('./MintButton', () => ({
+  MintButton: () => <div data-testid="mint-button" />,
+}))
+
+vi.mock('./TransferModal', () => ({
+  TransferModal: () => <div data-testid="transfer-modal" />,
+}))
+
+const articleId = 'jd7aaaaaaaaaaaaaaaa' as Id<'articles'>
+const authorId = 'jd7bbbbbbbbbbbbbbbb' as Id<'users'>
+const oldOwnerId = 'jd7cccccccccccccccc' as Id<'users'>
+const newOwnerId = 'jd7dddddddddddddddd' as Id<'users'>
+const sharedStellarAddress =
+  'GAEV4UC0WEUWGLAQW7NYYPULUA65XMVYYA670GTHL0M705E2ZINYFXPM'
+
+function mintedNftStatus(ownerUserId: Id<'users'>) {
+  return {
+    _id: 'jd7eeeeeeeeeeeeeeee' as Id<'articleNFTs'>,
+    isMinted: true as const,
+    isEligible: true,
+    totalTips: 5000,
+    tipThreshold: 1000,
+    owner: sharedStellarAddress,
+    mintedAt: new Date().toISOString(),
+    transferCount: 1,
+    rarity: 'epic' as const,
+    ownerInfo: {
+      id: ownerUserId,
+      name: 'Owner',
+      username: ownerUserId === newOwnerId ? 'suraj' : 'yash0057',
+      avatar: null,
+      stellarAddress: sharedStellarAddress,
+    },
+    minterInfo: {
+      id: authorId,
+      name: 'Author',
+      username: 'yash0057',
+      avatar: null,
+    },
+  }
+}
+
+async function openActionsTab(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('tab', { name: /^Actions$/i }))
+}
+
+describe('NFTIntegration transfer actions', () => {
+  beforeEach(() => {
+    mockUseNFTByArticle.mockReset()
+  })
+
+  it('shows Transfer NFT when the signed-in user owns the NFT by user id', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockUseNFTByArticle.mockReturnValue(mintedNftStatus(newOwnerId))
+
+    render(
+      <NFTIntegration
+        articleId={articleId}
+        articleTitle="Test Article"
+        articleSlug="test-article"
+        authorId={authorId}
+        currentUserId={newOwnerId}
+        currentUserAddress={sharedStellarAddress}
+      />
+    )
+
+    await openActionsTab(user)
+
+    expect(
+      screen.getByRole('button', { name: /Transfer NFT/i })
+    ).toBeInTheDocument()
+  })
+
+  it('hides Transfer NFT for a former owner who shares the same stellar address', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockUseNFTByArticle.mockReturnValue(mintedNftStatus(newOwnerId))
+
+    render(
+      <NFTIntegration
+        articleId={articleId}
+        articleTitle="Test Article"
+        articleSlug="test-article"
+        authorId={authorId}
+        currentUserId={oldOwnerId}
+        currentUserAddress={sharedStellarAddress}
+      />
+    )
+
+    await openActionsTab(user)
+
+    expect(
+      screen.queryByRole('button', { name: /Transfer NFT/i })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByText(/don.t own this NFT/i)
+    ).toBeInTheDocument()
+  })
+})

--- a/components/nft/NFTIntegration.tsx
+++ b/components/nft/NFTIntegration.tsx
@@ -55,9 +55,10 @@ export function NFTIntegration({
   const isOwner =
     nftStatus != null &&
     nftStatus.isMinted === true &&
-    currentUserAddress === nftStatus.owner
+    currentUserId != null &&
+    nftStatus.ownerInfo?.id === currentUserId
   const canMint = isAuthor && !nftStatus?.isMinted && nftStatus?.isEligible
-  const canTransfer = isOwner && nftStatus?.isMinted === true
+  const canTransfer = isOwner
 
   const progressPercentage = nftStatus
     ? (nftStatus.totalTips / nftStatus.tipThreshold) * 100
@@ -277,6 +278,7 @@ export function NFTIntegration({
           articleId={articleId}
           articleTitle={articleTitle}
           currentOwner={nftStatus.owner}
+          currentOwnerUsername={nftStatus.ownerInfo?.username}
           nftId={nftStatus._id}
           onTransferComplete={handleTransferComplete}
           triggerRef={transferTriggerRef}

--- a/components/nft/NFTIntegration.tsx
+++ b/components/nft/NFTIntegration.tsx
@@ -25,7 +25,6 @@ interface NFTIntegrationProps {
   articleSlug: string
   authorId: Id<'users'>
   currentUserId?: Id<'users'>
-  currentUserAddress?: string | null
 }
 
 export function NFTIntegration({
@@ -34,7 +33,6 @@ export function NFTIntegration({
   articleSlug,
   authorId,
   currentUserId,
-  currentUserAddress,
 }: NFTIntegrationProps) {
   const [showTransferModal, setShowTransferModal] = useState(false)
   const transferTriggerRef = useRef<HTMLButtonElement>(null)

--- a/components/nft/TransferModal.test.tsx
+++ b/components/nft/TransferModal.test.tsx
@@ -37,6 +37,7 @@ function ControlledTransferModal() {
         articleId={articleId}
         articleTitle="Test Article"
         currentOwner="seller"
+        currentOwnerUsername="seller"
         nftId={nftId}
       />
       <button type="button" onClick={() => setOpen(true)}>
@@ -46,10 +47,176 @@ function ControlledTransferModal() {
   )
 }
 
+async function reviewAndConfirmTransfer(
+  user: ReturnType<typeof userEvent.setup>
+) {
+  await user.type(
+    screen.getByLabelText(/Transfer To \(Username\)/i),
+    'buyername'
+  )
+  await user.click(screen.getByRole('button', { name: /^Review transfer$/i }))
+  await screen.findByTestId('transfer-confirm-recipient')
+  await user.click(screen.getByRole('button', { name: /^Confirm transfer$/i }))
+}
+
 describe('TransferModal', () => {
   beforeEach(() => {
     mockTransfer.mockReset()
     vi.mocked(toast.error).mockClear()
+  })
+
+  it('blocks transfer to the current owner on review', async () => {
+    const user = userEvent.setup({ delay: null })
+
+    render(
+      <TransferModal
+        isOpen
+        onClose={() => {}}
+        articleId={articleId}
+        articleTitle="Test Article"
+        currentOwner="GAEV4UC0WEUWGLAQW7NYYPULUA65XMVYYA670GTHL0M705E2ZINYFXPM"
+        currentOwnerUsername="seller"
+        nftId={nftId}
+      />
+    )
+
+    await user.type(
+      screen.getByLabelText(/Transfer To \(Username\)/i),
+      'seller'
+    )
+    await user.click(screen.getByRole('button', { name: /^Review transfer$/i }))
+
+    expect(screen.getByTestId('transfer-modal-message')).toHaveTextContent(
+      'Cannot transfer to the current owner'
+    )
+    expect(
+      screen.queryByRole('button', { name: /^Confirm transfer$/i })
+    ).not.toBeInTheDocument()
+    expect(mockTransfer).not.toHaveBeenCalled()
+  })
+
+  it('does not call transferNFT when only reviewing', async () => {
+    const user = userEvent.setup({ delay: null })
+
+    render(
+      <TransferModal
+        isOpen
+        onClose={() => {}}
+        articleId={articleId}
+        articleTitle="Test Article"
+        currentOwner="seller"
+        currentOwnerUsername="seller"
+        nftId={nftId}
+      />
+    )
+
+    await user.type(
+      screen.getByLabelText(/Transfer To \(Username\)/i),
+      'buyername'
+    )
+    await user.click(screen.getByRole('button', { name: /^Review transfer$/i }))
+
+    expect(screen.getByTestId('transfer-confirm-recipient')).toHaveTextContent(
+      '@buyername'
+    )
+    expect(mockTransfer).not.toHaveBeenCalled()
+  })
+
+  it('shows recipient and asset details on the confirmation step', async () => {
+    const user = userEvent.setup({ delay: null })
+
+    render(
+      <TransferModal
+        isOpen
+        onClose={() => {}}
+        articleId={articleId}
+        articleTitle="Test Article"
+        currentOwner="seller"
+        currentOwnerUsername="seller"
+        nftId={nftId}
+      />
+    )
+
+    await user.type(
+      screen.getByLabelText(/Transfer To \(Username\)/i),
+      'buyername'
+    )
+    await user.click(screen.getByRole('button', { name: /^Review transfer$/i }))
+
+    expect(screen.getByTestId('transfer-confirm-recipient')).toHaveTextContent(
+      '@buyername'
+    )
+    expect(screen.getByTestId('transfer-confirm-asset')).toHaveTextContent(
+      'Test Article'
+    )
+    expect(
+      screen.getByTestId('transfer-confirm-current-owner')
+    ).toHaveTextContent('@seller')
+    expect(screen.getByTestId('transfer-confirm-nft-id')).toHaveTextContent(
+      nftId
+    )
+    expect(screen.getByTestId('transfer-confirm-warning')).toHaveTextContent(
+      'Test Article'
+    )
+    expect(screen.getByTestId('transfer-confirm-warning')).toHaveTextContent(
+      '@buyername'
+    )
+    expect(screen.getByTestId('transfer-confirm-warning')).toHaveTextContent(
+      'cannot be undone'
+    )
+  })
+
+  it('does not transfer when cancel is clicked on the confirmation step', async () => {
+    const user = userEvent.setup({ delay: null })
+
+    render(
+      <TransferModal
+        isOpen
+        onClose={() => {}}
+        articleId={articleId}
+        articleTitle="Test Article"
+        currentOwner="seller"
+        currentOwnerUsername="seller"
+        nftId={nftId}
+      />
+    )
+
+    await user.type(
+      screen.getByLabelText(/Transfer To \(Username\)/i),
+      'buyername'
+    )
+    await user.click(screen.getByRole('button', { name: /^Review transfer$/i }))
+    await user.click(screen.getByRole('button', { name: /^Cancel$/i }))
+
+    expect(mockTransfer).not.toHaveBeenCalled()
+  })
+
+  it('does not transfer when back is clicked on the confirmation step', async () => {
+    const user = userEvent.setup({ delay: null })
+
+    render(
+      <TransferModal
+        isOpen
+        onClose={() => {}}
+        articleId={articleId}
+        articleTitle="Test Article"
+        currentOwner="seller"
+        currentOwnerUsername="seller"
+        nftId={nftId}
+      />
+    )
+
+    await user.type(
+      screen.getByLabelText(/Transfer To \(Username\)/i),
+      'buyername'
+    )
+    await user.click(screen.getByRole('button', { name: /^Review transfer$/i }))
+    await user.click(screen.getByRole('button', { name: /^Back$/i }))
+
+    expect(mockTransfer).not.toHaveBeenCalled()
+    expect(
+      screen.getByLabelText(/Transfer To \(Username\)/i)
+    ).toBeInTheDocument()
   })
 
   it('shows a single success message in the message slot after transfer', async () => {
@@ -63,15 +230,12 @@ describe('TransferModal', () => {
         articleId={articleId}
         articleTitle="Test Article"
         currentOwner="seller"
+        currentOwnerUsername="seller"
         nftId={nftId}
       />
     )
 
-    await user.type(
-      screen.getByLabelText(/Transfer To \(Username\)/i),
-      'buyername'
-    )
-    await user.click(screen.getByRole('button', { name: /^Transfer NFT$/i }))
+    await reviewAndConfirmTransfer(user)
 
     await waitFor(() => {
       expect(screen.getByTestId('transfer-modal-message')).toHaveTextContent(
@@ -97,15 +261,12 @@ describe('TransferModal', () => {
         articleId={articleId}
         articleTitle="Test Article"
         currentOwner="seller"
+        currentOwnerUsername="seller"
         nftId={nftId}
       />
     )
 
-    await user.type(
-      screen.getByLabelText(/Transfer To \(Username\)/i),
-      'buyername'
-    )
-    await user.click(screen.getByRole('button', { name: /^Transfer NFT$/i }))
+    await reviewAndConfirmTransfer(user)
 
     await waitFor(() => {
       expect(screen.getByTestId('transfer-modal-message')).toHaveTextContent(
@@ -125,7 +286,7 @@ describe('TransferModal', () => {
     )
   })
 
-  it('shows progress only in the message slot while the button stays Transfer NFT', async () => {
+  it('shows progress only in the message slot while the button stays Confirm transfer', async () => {
     const user = userEvent.setup({ delay: null })
     let resolveTransfer!: (value: string) => void
     const transferPromise = new Promise<string>((resolve) => {
@@ -140,22 +301,19 @@ describe('TransferModal', () => {
         articleId={articleId}
         articleTitle="Test Article"
         currentOwner="seller"
+        currentOwnerUsername="seller"
         nftId={nftId}
       />
     )
 
-    await user.type(
-      screen.getByLabelText(/Transfer To \(Username\)/i),
-      'buyername'
-    )
-    await user.click(screen.getByRole('button', { name: /^Transfer NFT$/i }))
+    await reviewAndConfirmTransfer(user)
 
     const slot = screen.getByTestId('transfer-modal-message')
     await waitFor(() => {
       expect(slot).toHaveTextContent('Processing transfer...')
     })
 
-    const submit = screen.getByRole('button', { name: /^Transfer NFT$/i })
+    const submit = screen.getByRole('button', { name: /^Confirm transfer$/i })
     expect(submit.textContent).not.toMatch(/Processing transfer/i)
 
     resolveTransfer!('transfer_id')
@@ -170,7 +328,7 @@ describe('TransferModal', () => {
     render(<ControlledTransferModal />)
 
     await user.type(screen.getByLabelText(/Transfer To \(Username\)/i), 'ab')
-    await user.click(screen.getByRole('button', { name: /^Transfer NFT$/i }))
+    await user.click(screen.getByRole('button', { name: /^Review transfer$/i }))
     await waitFor(() => {
       expect(screen.getByTestId('transfer-modal-message')).toHaveTextContent(
         'Invalid username format'

--- a/components/nft/TransferModal.tsx
+++ b/components/nft/TransferModal.tsx
@@ -76,9 +76,7 @@ export function TransferModal({
     nftId || (nftData && nftData.isMinted ? nftData._id : null)
 
   const nftTokenId =
-    nftData && nftData.isMinted && 'tokenId' in nftData
-      ? nftData.tokenId
-      : null
+    nftData && nftData.isMinted && 'tokenId' in nftData ? nftData.tokenId : null
 
   const nftIdentifier = nftTokenId ?? actualNftId ?? 'Unknown'
 
@@ -240,9 +238,7 @@ export function TransferModal({
       >
         <DialogHeader>
           <DialogTitle>
-            {step === 'details'
-              ? 'Transfer NFT Ownership'
-              : 'Confirm transfer'}
+            {step === 'details' ? 'Transfer NFT Ownership' : 'Confirm transfer'}
           </DialogTitle>
           <DialogDescription>
             {step === 'details'
@@ -356,7 +352,11 @@ export function TransferModal({
           </div>
         </div>
 
-        <DialogFooter className={step === 'confirm' ? 'sm:flex-row sm:justify-between' : undefined}>
+        <DialogFooter
+          className={
+            step === 'confirm' ? 'sm:flex-row sm:justify-between' : undefined
+          }
+        >
           {step === 'confirm' ? (
             <Button
               type="button"
@@ -396,7 +396,10 @@ export function TransferModal({
               >
                 {isBusy ? (
                   <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+                    <Loader2
+                      className="mr-2 h-4 w-4 animate-spin"
+                      aria-hidden
+                    />
                     Confirm transfer
                   </>
                 ) : (

--- a/components/nft/TransferModal.tsx
+++ b/components/nft/TransferModal.tsx
@@ -20,6 +20,8 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { userFacingTransferNftError } from '@/lib/convex/userFacingTransferNftError'
 
+type TransferStep = 'details' | 'confirm'
+
 type TransferMessage =
   | { kind: 'none' }
   | { kind: 'progress'; text: string }
@@ -34,10 +36,17 @@ interface TransferModalProps {
   onClose: () => void
   articleId: string
   articleTitle: string
+  /** Stellar address (or fallback label) shown in the UI */
   currentOwner: string
+  /** Username of the current owner; used to block self-transfer on review */
+  currentOwnerUsername?: string
   nftId?: Id<'articleNFTs'>
   onTransferComplete?: (newOwner: string) => void
   triggerRef?: RefObject<HTMLElement | null>
+}
+
+function validateRecipientUsername(username: string): boolean {
+  return /^[a-zA-Z0-9_-]{3,30}$/.test(username)
 }
 
 export function TransferModal({
@@ -46,11 +55,13 @@ export function TransferModal({
   articleId,
   articleTitle,
   currentOwner,
+  currentOwnerUsername,
   nftId,
   onTransferComplete,
   triggerRef,
 }: TransferModalProps) {
   const [recipientUsername, setRecipientUsername] = useState('')
+  const [step, setStep] = useState<TransferStep>('details')
   const [transferMessage, setTransferMessage] = useState<TransferMessage>({
     kind: 'none',
   })
@@ -64,11 +75,19 @@ export function TransferModal({
   const actualNftId =
     nftId || (nftData && nftData.isMinted ? nftData._id : null)
 
+  const nftTokenId =
+    nftData && nftData.isMinted && 'tokenId' in nftData
+      ? nftData.tokenId
+      : null
+
+  const nftIdentifier = nftTokenId ?? actualNftId ?? 'Unknown'
+
   const prevOpenRef = useRef(false)
 
   useEffect(() => {
     if (isOpen && !prevOpenRef.current) {
       setRecipientUsername('')
+      setStep('details')
       setTransferMessage({ kind: 'none' })
     }
     prevOpenRef.current = isOpen
@@ -76,42 +95,64 @@ export function TransferModal({
 
   const isBusy = transferMessage.kind === 'progress'
 
-  const validateUsername = (username: string): boolean => {
-    return /^[a-zA-Z0-9_-]{3,30}$/.test(username)
+  const validateTransferInput = (): string | null => {
+    if (!recipientUsername.trim()) {
+      return 'Please enter a recipient username'
+    }
+
+    if (!validateRecipientUsername(recipientUsername)) {
+      return 'Invalid username format. Use only letters, numbers, underscores, and hyphens (3-30 characters).'
+    }
+
+    const ownerUsername =
+      currentOwnerUsername ??
+      (nftData && nftData.isMinted ? nftData.ownerInfo?.username : undefined)
+
+    if (
+      ownerUsername &&
+      recipientUsername.toLowerCase() === ownerUsername.toLowerCase()
+    ) {
+      return 'Cannot transfer to the current owner'
+    }
+
+    if (!actualNftId) {
+      return 'NFT not found for this article'
+    }
+
+    return null
+  }
+
+  const handleReview = () => {
+    setTransferMessage({ kind: 'none' })
+
+    const validationError = validateTransferInput()
+    if (validationError) {
+      setTransferMessage({ kind: 'error', text: validationError })
+      return
+    }
+
+    setStep('confirm')
+  }
+
+  const handleBack = () => {
+    if (isBusy) return
+    setTransferMessage({ kind: 'none' })
+    setStep('details')
   }
 
   const handleTransfer = async () => {
     setTransferMessage({ kind: 'none' })
 
-    if (!recipientUsername.trim()) {
-      setTransferMessage({
-        kind: 'error',
-        text: 'Please enter a recipient username',
-      })
-      return
-    }
-
-    if (!validateUsername(recipientUsername)) {
-      setTransferMessage({
-        kind: 'error',
-        text: 'Invalid username format. Use only letters, numbers, underscores, and hyphens (3-30 characters).',
-      })
-      return
-    }
-
-    if (recipientUsername.toLowerCase() === currentOwner.toLowerCase()) {
-      setTransferMessage({
-        kind: 'error',
-        text: 'Cannot transfer to the current owner',
-      })
+    const validationError = validateTransferInput()
+    if (validationError) {
+      setTransferMessage({ kind: 'error', text: validationError })
+      if (step === 'confirm') {
+        setStep('details')
+      }
       return
     }
 
     if (!actualNftId) {
-      setTransferMessage({
-        kind: 'error',
-        text: 'NFT not found for this article',
-      })
       return
     }
 
@@ -150,6 +191,7 @@ export function TransferModal({
   const handleClose = () => {
     if (isBusy) return
     setRecipientUsername('')
+    setStep('details')
     setTransferMessage({ kind: 'none' })
     onClose()
   }
@@ -172,6 +214,8 @@ export function TransferModal({
       <AlertCircle className="h-4 w-4 shrink-0 text-red-500" />
     ) : null
 
+  const irreversibleWarning = `You are transferring ownership of the NFT for "${articleTitle}" to @${recipientUsername}. This cannot be undone.`
+
   return (
     <Dialog
       open={isOpen}
@@ -180,7 +224,7 @@ export function TransferModal({
       }}
     >
       <DialogContent
-        className="w-[calc(100vw-2rem)] sm:max-w-md"
+        className="w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] overflow-x-hidden sm:max-w-md"
         onCloseAutoFocus={(e) => {
           if (triggerRef?.current) {
             e.preventDefault()
@@ -195,37 +239,102 @@ export function TransferModal({
         }}
       >
         <DialogHeader>
-          <DialogTitle>Transfer NFT Ownership</DialogTitle>
+          <DialogTitle>
+            {step === 'details'
+              ? 'Transfer NFT Ownership'
+              : 'Confirm transfer'}
+          </DialogTitle>
           <DialogDescription>
-            Transfer ownership of &quot;{articleTitle}&quot; to another user.
-            This action cannot be undone.
+            {step === 'details'
+              ? `Transfer ownership of "${articleTitle}" to another user.`
+              : 'Review the details below before completing this transfer.'}
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Label className="text-sm text-muted-foreground">
-              Current Owner
-            </Label>
-            <div className="max-w-full overflow-hidden px-3 py-2 bg-muted rounded-lg text-sm font-mono break-all">
-              @{currentOwner}
-            </div>
-          </div>
+        <div className="min-w-0 space-y-4">
+          {step === 'details' ? (
+            <>
+              <div className="space-y-2">
+                <Label className="text-sm text-muted-foreground">
+                  Current Owner
+                </Label>
+                <div className="max-w-full overflow-hidden rounded-lg bg-muted px-3 py-2 font-mono text-sm break-all">
+                  @{currentOwner}
+                </div>
+              </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="recipient">Transfer To (Username)</Label>
-            <Input
-              id="recipient"
-              placeholder="Enter recipient username"
-              value={recipientUsername}
-              onChange={(e) => setRecipientUsername(e.target.value)}
-              disabled={isBusy || transferMessage.kind === 'success'}
-              className="font-mono"
-            />
-            <p className="text-xs text-muted-foreground">
-              Enter the username of the recipient (e.g., johndoe)
-            </p>
-          </div>
+              <div className="space-y-2">
+                <Label htmlFor="recipient">Transfer To (Username)</Label>
+                <Input
+                  id="recipient"
+                  placeholder="Enter recipient username"
+                  value={recipientUsername}
+                  onChange={(e) => setRecipientUsername(e.target.value)}
+                  disabled={isBusy || transferMessage.kind === 'success'}
+                  className="font-mono"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Enter the username of the recipient (e.g., johndoe)
+                </p>
+              </div>
+            </>
+          ) : (
+            <>
+              <p
+                className="min-w-0 break-words rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+                data-testid="transfer-confirm-warning"
+              >
+                {irreversibleWarning}
+              </p>
+
+              <div className="min-w-0 space-y-2 overflow-hidden rounded-md border border-border bg-muted/40 p-3 text-sm">
+                <div className="min-w-0">
+                  <div className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                    Recipient
+                  </div>
+                  <p
+                    className="mt-0.5 font-mono font-medium break-all"
+                    data-testid="transfer-confirm-recipient"
+                  >
+                    @{recipientUsername}
+                  </p>
+                </div>
+                <div className="min-w-0">
+                  <div className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                    Asset
+                  </div>
+                  <p
+                    className="mt-0.5 break-words font-medium"
+                    data-testid="transfer-confirm-asset"
+                  >
+                    {articleTitle}
+                  </p>
+                </div>
+                <div className="min-w-0">
+                  <div className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                    NFT identifier
+                  </div>
+                  <p
+                    className="mt-0.5 font-mono text-xs break-all"
+                    data-testid="transfer-confirm-nft-id"
+                  >
+                    {nftIdentifier}
+                  </p>
+                </div>
+                <div className="min-w-0">
+                  <div className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                    Current owner
+                  </div>
+                  <p
+                    className="mt-0.5 font-mono text-xs break-all"
+                    data-testid="transfer-confirm-current-owner"
+                  >
+                    @{currentOwner}
+                  </p>
+                </div>
+              </div>
+            </>
+          )}
 
           <div
             className="flex min-h-[3.75rem] items-center rounded-lg"
@@ -247,32 +356,58 @@ export function TransferModal({
           </div>
         </div>
 
-        <DialogFooter>
-          <Button variant="outline" onClick={handleClose} disabled={isBusy}>
-            Cancel
-          </Button>
-          <Button
-            onClick={handleTransfer}
-            disabled={
-              isBusy ||
-              transferMessage.kind === 'success' ||
-              !recipientUsername.trim()
-            }
-            aria-busy={isBusy}
-            className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600"
-          >
-            {isBusy ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
-                Transfer NFT
-              </>
-            ) : (
-              <>
+        <DialogFooter className={step === 'confirm' ? 'sm:flex-row sm:justify-between' : undefined}>
+          {step === 'confirm' ? (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={handleBack}
+              disabled={isBusy || transferMessage.kind === 'success'}
+              className="sm:mr-auto"
+            >
+              Back
+            </Button>
+          ) : null}
+          <div className="flex w-full flex-col-reverse gap-2 sm:w-auto sm:flex-row sm:justify-end">
+            <Button variant="outline" onClick={handleClose} disabled={isBusy}>
+              Cancel
+            </Button>
+            {step === 'details' ? (
+              <Button
+                type="button"
+                onClick={handleReview}
+                disabled={
+                  isBusy ||
+                  transferMessage.kind === 'success' ||
+                  !recipientUsername.trim()
+                }
+                className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600"
+              >
                 <Send className="mr-2 h-4 w-4" aria-hidden />
-                Transfer NFT
-              </>
+                Review transfer
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                onClick={() => void handleTransfer()}
+                disabled={isBusy || transferMessage.kind === 'success'}
+                aria-busy={isBusy}
+                className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600"
+              >
+                {isBusy ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+                    Confirm transfer
+                  </>
+                ) : (
+                  <>
+                    <Send className="mr-2 h-4 w-4" aria-hidden />
+                    Confirm transfer
+                  </>
+                )}
+              </Button>
             )}
-          </Button>
+          </div>
         </DialogFooter>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary

Adds a deliberate two-step confirmation flow to the NFT transfer modal so ownership cannot change from a single misclick. Users enter a recipient, review a summary (recipient, asset, NFT identifier, current owner), and must explicitly confirm before the transfer mutation runs.

Also fixes transfer button visibility in `NFTIntegration` by comparing ownership via Convex user id instead of Stellar address, so former owners who share a wallet address no longer see Transfer NFT after a transfer.


## Changes

- **TransferModal**: two-step flow (`details` → `confirm`)
  - Step 1: enter recipient → **Review transfer** (no mutation)
  - Step 2: read-only summary + specific irreversible warning → **Confirm transfer** (calls `transferNFT`)
  - **Back** returns to step 1 without transferring
  - **Cancel** closes the modal without transferring
  - Busy state still blocks escape/outside-click during processing
- **TransferModal tests**: regression coverage for review-only, summary fields, cancel/back not calling mutation, and existing success/error/progress behavior
- **NFTIntegration**: `isOwner` / `canTransfer` use `ownerInfo.id === currentUserId`
- **NFTIntegration tests**: transfer button shown for current owner, hidden for former owner with same Stellar address
<img width="1216" height="717" alt="1" src="https://github.com/user-attachments/assets/7ed3d6cd-644f-494a-8002-6239832f9454" />

<img width="1220" height="718" alt="2" src="https://github.com/user-attachments/assets/8832494f-7a44-4002-87df-d2a892a7ccd5" />

<img width="1220" height="715" alt="3" src="https://github.com/user-attachments/assets/410e0794-edfe-4bde-aad2-47f6af2e6f59" />

<img width="1220" height="718" alt="2" src="https://github.com/user-attachments/assets/ceae3a39-5df7-4567-ad65-f23f7d53f525" />
