### PR TITLE
feat(profile): show real article identity on NFT cards (ENG-209)

### DIFF
--- a/components/nft/NftCard.test.tsx
+++ b/components/nft/NftCard.test.tsx
@@ -10,7 +10,7 @@ vi.mock('next/image', () => ({
   }: {
     src: string
     alt: string
-  // eslint-disable-next-line @next/next/no-img-element -- mock for next/image
+    // eslint-disable-next-line @next/next/no-img-element -- mock for next/image
   }) => <img src={src} alt={alt} />,
 }))
 
@@ -36,10 +36,7 @@ const baseProps = {
 describe('NftCard', () => {
   it('renders cover image when coverImage is set', () => {
     render(
-      <NftCard
-        {...baseProps}
-        coverImage="https://example.com/cover.jpg"
-      />
+      <NftCard {...baseProps} coverImage="https://example.com/cover.jpg" />
     )
 
     const img = screen.getByRole('img', { name: 'Test Article' })
@@ -62,12 +59,7 @@ describe('NftCard', () => {
   })
 
   it('shows excerpt and footer when provided', () => {
-    render(
-      <NftCard
-        {...baseProps}
-        excerpt="A short summary of the article."
-      />
-    )
+    render(<NftCard {...baseProps} excerpt="A short summary of the article." />)
 
     expect(
       screen.getByText('A short summary of the article.')

--- a/components/nft/NftCard.test.tsx
+++ b/components/nft/NftCard.test.tsx
@@ -1,0 +1,78 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { NftCard } from '@/components/nft/NftCard'
+
+vi.mock('next/image', () => ({
+  default: ({
+    src,
+    alt,
+  }: {
+    src: string
+    alt: string
+  // eslint-disable-next-line @next/next/no-img-element -- mock for next/image
+  }) => <img src={src} alt={alt} />,
+}))
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+  }: {
+    href: string
+    children: React.ReactNode
+  }) => <a href={href}>{children}</a>,
+}))
+
+const baseProps = {
+  title: 'Test Article',
+  slug: 'test-article',
+  authorUsername: 'writer',
+  tokenId: 'abc123def456',
+  footerLabel: 'Minted by',
+  footerUsername: 'minter',
+}
+
+describe('NftCard', () => {
+  it('renders cover image when coverImage is set', () => {
+    render(
+      <NftCard
+        {...baseProps}
+        coverImage="https://example.com/cover.jpg"
+      />
+    )
+
+    const img = screen.getByRole('img', { name: 'Test Article' })
+    expect(img).toHaveAttribute('src', 'https://example.com/cover.jpg')
+  })
+
+  it('renders fallback without img when coverImage is missing', () => {
+    render(<NftCard {...baseProps} />)
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(screen.getByText('No cover image')).toBeInTheDocument()
+  })
+
+  it('links to the article page', () => {
+    render(<NftCard {...baseProps} />)
+
+    const links = screen.getAllByRole('link', { name: /Test Article/i })
+    expect(links.length).toBeGreaterThan(0)
+    expect(links[0]).toHaveAttribute('href', '/writer/test-article')
+  })
+
+  it('shows excerpt and footer when provided', () => {
+    render(
+      <NftCard
+        {...baseProps}
+        excerpt="A short summary of the article."
+      />
+    )
+
+    expect(
+      screen.getByText('A short summary of the article.')
+    ).toBeInTheDocument()
+    expect(screen.getByText(/Minted by @minter/)).toBeInTheDocument()
+    expect(screen.getByText(/Token ID: abc123de/)).toBeInTheDocument()
+  })
+})

--- a/components/nft/NftCard.tsx
+++ b/components/nft/NftCard.tsx
@@ -96,7 +96,9 @@ export function NftCard({
         )}
 
         {excerpt && (
-          <p className="text-sm text-muted-foreground line-clamp-2">{excerpt}</p>
+          <p className="text-sm text-muted-foreground line-clamp-2">
+            {excerpt}
+          </p>
         )}
 
         <p className="text-sm text-muted-foreground pt-1">

--- a/components/nft/NftCard.tsx
+++ b/components/nft/NftCard.tsx
@@ -1,0 +1,118 @@
+import Link from 'next/link'
+import Image from 'next/image'
+import { FileText } from 'lucide-react'
+
+export interface NftCardProps {
+  title: string
+  slug?: string
+  authorUsername?: string
+  coverImage?: string
+  excerpt?: string
+  tokenId: string
+  footerLabel: string
+  footerUsername?: string
+  href?: string
+}
+
+function buildArticleHref(
+  authorUsername: string | undefined,
+  slug: string | undefined
+): string | undefined {
+  if (!authorUsername || !slug) return undefined
+  return `/${authorUsername}/${slug}`
+}
+
+export function NftCard({
+  title,
+  slug,
+  authorUsername,
+  coverImage,
+  excerpt,
+  tokenId,
+  footerLabel,
+  footerUsername,
+  href,
+}: NftCardProps) {
+  const articleHref = href ?? buildArticleHref(authorUsername, slug)
+  const displayTitle = title || 'Untitled'
+  const truncatedTokenId =
+    tokenId.length > 8 ? `${tokenId.slice(0, 8)}...` : tokenId
+
+  const media = coverImage ? (
+    <div className="relative aspect-video w-full overflow-hidden rounded-lg">
+      <Image
+        src={coverImage}
+        alt={displayTitle}
+        fill
+        sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+        className="object-cover"
+      />
+    </div>
+  ) : (
+    <div
+      className="aspect-video w-full rounded-lg border border-border bg-muted flex flex-col items-center justify-center gap-2 px-4"
+      aria-hidden
+    >
+      <FileText className="h-10 w-10 text-muted-foreground/60" />
+      <span className="sr-only">No cover image</span>
+    </div>
+  )
+
+  const cardBody = (
+    <>
+      {articleHref ? (
+        <Link
+          href={articleHref}
+          className="focus-ring block rounded-lg"
+          scroll={false}
+        >
+          {media}
+        </Link>
+      ) : (
+        media
+      )}
+
+      <div className="mt-4 min-w-0 space-y-1">
+        {articleHref ? (
+          <Link
+            href={articleHref}
+            className="focus-ring block rounded-md"
+            scroll={false}
+          >
+            <h4 className="font-semibold text-foreground truncate hover:text-brand-blue transition-colors">
+              {displayTitle}
+            </h4>
+          </Link>
+        ) : (
+          <h4 className="font-semibold text-foreground truncate">
+            {displayTitle}
+          </h4>
+        )}
+
+        {authorUsername && (
+          <p className="text-sm text-muted-foreground truncate">
+            @{authorUsername}
+          </p>
+        )}
+
+        {excerpt && (
+          <p className="text-sm text-muted-foreground line-clamp-2">{excerpt}</p>
+        )}
+
+        <p className="text-sm text-muted-foreground pt-1">
+          Token ID: {truncatedTokenId}
+        </p>
+
+        <p className="text-xs text-muted-foreground/80">
+          {footerLabel} @{footerUsername || 'unknown'}
+        </p>
+      </div>
+    </>
+  )
+
+  return (
+    <article className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-3 sm:p-4 min-w-0">
+      {cardBody}
+    </article>
+  )
+}

--- a/components/nft/index.ts
+++ b/components/nft/index.ts
@@ -1,5 +1,7 @@
 // NFT Component Exports
 export { MintButton } from './MintButton'
+export { NftCard } from './NftCard'
+export type { NftCardProps } from './NftCard'
 export { NFTBadge } from './NFTBadge'
 export { TransferModal } from './TransferModal'
 export { NFTIntegration } from './NFTIntegration'

--- a/components/profile/ProfileNftsTabContent.tsx
+++ b/components/profile/ProfileNftsTabContent.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import Link from 'next/link'
 import { usePathname, useSearchParams } from 'next/navigation'
 import {
   useNFTsByOwnerPaginated,
@@ -12,7 +13,8 @@ import { ProfileNftsTabSkeleton } from '@/components/profile/ProfileNftsTabSkele
 import { PaginationTransition } from '@/components/profile/PaginationTransition'
 import Pagination from '@/components/articles/Pagination'
 import { buildProfileNftPaginationHref } from '@/lib/profile/buildProfileNftPaginationHref'
-import { Image, Trophy } from 'lucide-react'
+import { NftCard } from '@/components/nft/NftCard'
+import { ImageIcon, Trophy } from 'lucide-react'
 
 const NFT_PAGE_LIMIT = 9
 
@@ -102,23 +104,17 @@ export function ProfileNftsTabContent({
           <PaginationTransition isPaginating={owned.isPaginating}>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {ownedNfts.map((nft) => (
-                <div
+                <NftCard
                   key={nft._id}
-                  className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-4"
-                >
-                  <div className="aspect-video bg-gradient-to-br from-purple-400 to-pink-400 rounded-lg mb-4 flex items-center justify-center">
-                    <Image className="w-12 h-12 text-white" aria-label="NFT" />
-                  </div>
-                  <h4 className="font-semibold text-foreground truncate">
-                    {nft.article?.title || 'Untitled'}
-                  </h4>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Token ID: {nft.tokenId.slice(0, 8)}...
-                  </p>
-                  <p className="text-xs text-muted-foreground/80 mt-2">
-                    Minted by @{nft.minter?.username || 'unknown'}
-                  </p>
-                </div>
+                  title={nft.article?.title || 'Untitled'}
+                  slug={nft.article?.slug}
+                  authorUsername={nft.article?.authorUsername}
+                  coverImage={nft.article?.coverImage}
+                  excerpt={nft.article?.excerpt}
+                  tokenId={nft.tokenId}
+                  footerLabel="Minted by"
+                  footerUsername={nft.minter?.username}
+                />
               ))}
             </div>
           </PaginationTransition>
@@ -149,23 +145,17 @@ export function ProfileNftsTabContent({
           <PaginationTransition isPaginating={minted.isPaginating}>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {mintedNfts.map((nft) => (
-                <div
+                <NftCard
                   key={nft._id}
-                  className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-4"
-                >
-                  <div className="aspect-video bg-gradient-to-br from-blue-400 to-green-400 rounded-lg mb-4 flex items-center justify-center">
-                    <Image className="w-12 h-12 text-white" aria-label="NFT" />
-                  </div>
-                  <h4 className="font-semibold text-foreground truncate">
-                    {nft.article?.title || 'Untitled'}
-                  </h4>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Token ID: {nft.tokenId.slice(0, 8)}...
-                  </p>
-                  <p className="text-xs text-muted-foreground/80 mt-2">
-                    Owner: @{nft.currentOwnerInfo?.username || 'unknown'}
-                  </p>
-                </div>
+                  title={nft.article?.title || 'Untitled'}
+                  slug={nft.article?.slug}
+                  authorUsername={nft.article?.authorUsername}
+                  coverImage={nft.article?.coverImage}
+                  excerpt={nft.article?.excerpt}
+                  tokenId={nft.tokenId}
+                  footerLabel="Owner"
+                  footerUsername={nft.currentOwnerInfo?.username}
+                />
               ))}
             </div>
           </PaginationTransition>
@@ -191,15 +181,27 @@ export function ProfileNftsTabContent({
       )}
 
       {bothEmpty && (
-        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-12 text-center">
-          <Image
+        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-8 sm:p-12 text-center">
+          <ImageIcon
             className="w-12 h-12 text-muted-foreground/50 mx-auto mb-4"
-            aria-label="No NFTs"
+            aria-hidden
           />
-          <p className="text-muted-foreground text-lg">
-            {isOwnProfile ? "You don't" : `${displayName} doesn't`} have any
-            NFTs yet.
+          <h3 className="text-lg font-semibold text-foreground mb-2">
+            No NFTs yet
+          </h3>
+          <p className="text-muted-foreground max-w-md mx-auto">
+            {isOwnProfile
+              ? 'Articles earn NFTs when they reach the tip threshold. Mint or collect one to see it here.'
+              : `${displayName} doesn't have any NFTs yet.`}
           </p>
+          {isOwnProfile && (
+            <Link
+              href="/articles"
+              className="focus-ring inline-block mt-6 text-sm font-medium text-brand-blue hover:underline"
+            >
+              Browse articles
+            </Link>
+          )}
         </div>
       )}
     </div>

--- a/components/profile/ProfileNftsTabSkeleton.tsx
+++ b/components/profile/ProfileNftsTabSkeleton.tsx
@@ -1,19 +1,28 @@
 import { Skeleton } from '@/components/ui/skeleton'
 
+function NftCardSkeleton() {
+  return (
+    <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-3 sm:p-4 min-w-0">
+      <Skeleton className="aspect-video w-full rounded-lg" />
+      <Skeleton className="h-5 w-3/4 mt-4" />
+      <Skeleton className="h-4 w-1/3 mt-2" />
+      <Skeleton className="h-4 w-full mt-2" />
+      <Skeleton className="h-4 w-1/2 mt-3" />
+      <Skeleton className="h-3 w-2/5 mt-2" />
+    </div>
+  )
+}
+
 export function ProfileNftsTabSkeleton() {
   return (
     <div className="space-y-8">
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <div
-            key={i}
-            className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-4"
-          >
-            <Skeleton className="aspect-video w-full rounded-lg mb-4" />
-            <Skeleton className="h-5 w-3/4 mb-2" />
-            <Skeleton className="h-4 w-1/2" />
-          </div>
-        ))}
+      <div>
+        <Skeleton className="h-7 w-40 mb-4" />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <NftCardSkeleton key={i} />
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/convex/nfts.ts
+++ b/convex/nfts.ts
@@ -501,6 +501,8 @@ export const getUserMintedNFTsPaginated = query({
                 id: article._id,
                 title: article.title,
                 slug: article.slug,
+                excerpt: article.excerpt,
+                coverImage: article.coverImage,
                 authorUsername: article.authorUsername,
               }
             : null,


### PR DESCRIPTION
## Summary

Profile NFT cards no longer use abstract gradient placeholders. They show real article identity—cover image, title, author, excerpt—and link to the article. Minted NFT queries now return the same article fields as owned NFTs. Loading and empty states are updated for dark mode and mobile.



## Changes

- Add shared `NftCard` component with article cover (`next/image`), metadata (title, @author, excerpt, token ID), and links to `/{author}/{slug}`
- Replace purple/blue gradient placeholders with an intentional muted fallback when an article has no cover
- Wire `ProfileNftsTabContent` owned and minted grids to `NftCard`
- Extend `getUserMintedNFTsPaginated` to include `coverImage` and `excerpt` on the article object
- Polish `ProfileNftsTabSkeleton` to match card layout
- Improve empty state: heading, contextual copy, and “Browse articles” CTA on own profile
- Add `NftCard` unit tests
<img width="1222" height="718" alt="1" src="https://github.com/user-attachments/assets/03bc6606-aa99-4c01-a42d-bad1dc29f385" />

<img width="1220" height="720" alt="2" src="https://github.com/user-attachments/assets/4ab93dab-0741-4b39-9ff9-ce881c95096a" />
<img width="587" height="718" alt="3" src="https://github.com/user-attachments/assets/023d5752-0832-4656-96a1-785a6a445bb7" />
<img width="1222" height="719" alt="4" src="https://github.com/user-attachments/assets/d3b19ba4-05ed-4c51-93e6-a09cefe73a7e" />
