### PR TITLE
fix: persist critical outcomes for save/publish/wallet/tip/withdrawal flows

### DIFF
--- a/components/dashboard/EarningsDashboard.tsx
+++ b/components/dashboard/EarningsDashboard.tsx
@@ -8,8 +8,9 @@ import {
   useUserByUsername,
   useUserReceivedTips,
 } from '@/hooks/convex'
-import { Coins } from 'lucide-react'
+import { AlertCircle, CheckCircle2, Coins, X } from 'lucide-react'
 import { toast } from 'sonner'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { useAuth } from '@/components/providers/AuthContext'
 import { MIN_WITHDRAWAL_USD } from '@/lib/constants'
 import { TipHistory } from '@/components/dashboard/TipHistory'
@@ -17,8 +18,17 @@ import { WithdrawalDialog } from '@/components/dashboard/WithdrawalDialog'
 import { EarningsStats } from '@/components/dashboard/EarningsStats'
 import { EarningsDashboardSkeleton } from '@/components/dashboard/EarningsDashboardSkeleton'
 
+type WithdrawalOutcome =
+  | { kind: 'success'; message: string }
+  | { kind: 'error'; message: string }
+
 export function EarningsDashboard() {
   const [showWithdrawModal, setShowWithdrawModal] = useState(false)
+  const [withdrawalOutcome, setWithdrawalOutcome] =
+    useState<WithdrawalOutcome | null>(null)
+  const [withdrawalDialogError, setWithdrawalDialogError] = useState<
+    string | null
+  >(null)
   const withdrawTriggerRef = useRef<HTMLButtonElement>(null)
 
   const { user: currentUser } = useAuth()
@@ -38,14 +48,17 @@ export function EarningsDashboard() {
         amountUsd: args.amountUsd,
         stellarAddress: args.stellarAddress,
       })
-      toast.success(
-        `Withdrawal initiated! $${args.amountUsd.toFixed(2)} in testnet XLM will be sent to your Stellar wallet, typically within seconds on testnet.`
-      )
+      const successMessage = `Withdrawal initiated! $${args.amountUsd.toFixed(2)} in testnet XLM will be sent to your Stellar wallet, typically within seconds on testnet.`
+      setWithdrawalDialogError(null)
+      setWithdrawalOutcome({ kind: 'success', message: successMessage })
+      toast.success(successMessage)
     } catch (error) {
       console.error('Withdrawal error:', error)
-      toast.error(
+      const message =
         error instanceof Error ? error.message : 'Failed to process withdrawal'
-      )
+      setWithdrawalOutcome({ kind: 'error', message })
+      setWithdrawalDialogError(message)
+      toast.error(message)
       throw error
     }
   }
@@ -72,11 +85,48 @@ export function EarningsDashboard() {
 
   return (
     <div className="space-y-6">
+      {withdrawalOutcome && (
+        <div className="flex items-start gap-2">
+          <Alert
+            variant={
+              withdrawalOutcome.kind === 'error' ? 'destructive' : 'default'
+            }
+            className={
+              withdrawalOutcome.kind === 'success'
+                ? 'flex-1 border-success/50 bg-success/10'
+                : 'flex-1'
+            }
+          >
+            {withdrawalOutcome.kind === 'success' ? (
+              <CheckCircle2 className="h-4 w-4 text-success-foreground" />
+            ) : (
+              <AlertCircle className="h-4 w-4" />
+            )}
+            <AlertTitle>
+              {withdrawalOutcome.kind === 'success'
+                ? 'Withdrawal initiated'
+                : 'Withdrawal failed'}
+            </AlertTitle>
+            <AlertDescription>{withdrawalOutcome.message}</AlertDescription>
+          </Alert>
+          <button
+            type="button"
+            onClick={() => setWithdrawalOutcome(null)}
+            className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Dismiss withdrawal message"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      )}
       <EarningsStats
         earnings={earnings}
         userProfile={userProfile}
         minWithdrawalUsd={MIN_WITHDRAWAL_USD}
-        onOpenWithdrawModal={() => setShowWithdrawModal(true)}
+        onOpenWithdrawModal={() => {
+          setWithdrawalDialogError(null)
+          setShowWithdrawModal(true)
+        }}
         withdrawTriggerRef={withdrawTriggerRef}
       />
 
@@ -90,6 +140,7 @@ export function EarningsDashboard() {
         savedStellarAddress={userProfile?.stellarAddress}
         onWithdraw={handleWithdrawFromDialog}
         triggerRef={withdrawTriggerRef}
+        externalError={withdrawalDialogError}
       />
     </div>
   )

--- a/components/dashboard/WithdrawalDialog.test.tsx
+++ b/components/dashboard/WithdrawalDialog.test.tsx
@@ -127,6 +127,9 @@ describe('WithdrawalDialog', () => {
     await user.click(screen.getByRole('button', { name: /Withdraw$/i }))
 
     expect(onWithdraw).not.toHaveBeenCalled()
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Minimum withdrawal amount is $5.00'
+    )
   })
 
   it('renders nothing when closed', () => {

--- a/components/dashboard/WithdrawalDialog.tsx
+++ b/components/dashboard/WithdrawalDialog.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useEffect, useState, type RefObject } from 'react'
-import { Loader2, Wallet } from 'lucide-react'
-import { toast } from 'sonner'
+import { AlertCircle, Loader2, Wallet } from 'lucide-react'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import {
   Dialog,
   DialogContent,
@@ -25,6 +25,7 @@ export type WithdrawalDialogProps = {
     stellarAddress: string
   }) => Promise<void>
   triggerRef: RefObject<HTMLButtonElement | null>
+  externalError?: string | null
 }
 
 export function WithdrawalDialog({
@@ -35,15 +36,18 @@ export function WithdrawalDialog({
   savedStellarAddress,
   onWithdraw,
   triggerRef,
+  externalError = null,
 }: WithdrawalDialogProps) {
   const [withdrawAmount, setWithdrawAmount] = useState('')
   const [stellarAddress, setStellarAddress] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
 
   useEffect(() => {
     if (open) {
       setWithdrawAmount('')
       setStellarAddress(savedStellarAddress ?? '')
+      setSubmitError(null)
     }
   }, [open, savedStellarAddress])
 
@@ -60,22 +64,23 @@ export function WithdrawalDialog({
     const amount = parseFloat(withdrawAmount)
 
     if (!amount || amount < minWithdrawalUsd) {
-      toast.error(
+      setSubmitError(
         `Minimum withdrawal amount is $${minWithdrawalUsd.toFixed(2)}`
       )
       return
     }
 
     if (!isValidStellarAccountId(trimmedAddress)) {
-      toast.error('Please enter a valid Stellar address')
+      setSubmitError('Please enter a valid Stellar address')
       return
     }
 
     if (amount > availableBalanceUsd) {
-      toast.error('Insufficient balance')
+      setSubmitError('Insufficient balance')
       return
     }
 
+    setSubmitError(null)
     setIsSubmitting(true)
     try {
       await onWithdraw({
@@ -83,12 +88,16 @@ export function WithdrawalDialog({
         stellarAddress: trimmedAddress,
       })
       onOpenChange(false)
-    } catch {
-      // Parent shows toast for mutation errors
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to process withdrawal'
+      setSubmitError(message)
     } finally {
       setIsSubmitting(false)
     }
   }
+
+  const displayError = submitError ?? externalError
 
   if (!open) {
     return null
@@ -135,7 +144,10 @@ export function WithdrawalDialog({
                 max={availableBalanceUsd}
                 step="0.01"
                 value={withdrawAmount}
-                onChange={(e) => setWithdrawAmount(e.target.value)}
+                onChange={(e) => {
+                  setWithdrawAmount(e.target.value)
+                  setSubmitError(null)
+                }}
                 disabled={isSubmitting}
                 className="w-full pl-8 pr-3 py-2 border border-input bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-ring"
                 placeholder={`${minWithdrawalUsd.toFixed(2)}`}
@@ -158,7 +170,10 @@ export function WithdrawalDialog({
               id="stellar-address"
               type="text"
               value={stellarAddress || savedStellarAddress || ''}
-              onChange={(e) => setStellarAddress(e.target.value)}
+              onChange={(e) => {
+                setStellarAddress(e.target.value)
+                setSubmitError(null)
+              }}
               aria-invalid={showAddressError}
               className={`w-full px-3 py-2 border bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-ring read-only:bg-muted/50 ${
                 showAddressError
@@ -189,6 +204,14 @@ export function WithdrawalDialog({
             </p>
           </div>
         </div>
+
+        {displayError && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Withdrawal failed</AlertTitle>
+            <AlertDescription>{displayError}</AlertDescription>
+          </Alert>
+        )}
 
         <DialogFooter className="gap-3 sm:gap-0">
           <button

--- a/components/editor/EditorActionBar.test.tsx
+++ b/components/editor/EditorActionBar.test.tsx
@@ -67,10 +67,10 @@ describe('EditorActionBar autosave status', () => {
     )
     const statuses = screen.getAllByRole('status')
     for (const status of statuses) {
-      expect(status).toHaveTextContent("Couldn't save")
+      expect(status).toHaveTextContent(/Couldn't save:?\s*Network error/)
     }
     expect(container.querySelector('.bg-destructive\\/15')).not.toBeNull()
-    expect(screen.getByText('Save failed')).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent('Network error')
   })
 
   it('shows relative saved label when lastSavedAt is set and not dirty', () => {
@@ -117,7 +117,7 @@ describe('EditorActionBar autosave status', () => {
     )
     const statuses = screen.getAllByRole('status')
     for (const status of statuses) {
-      expect(status).toHaveTextContent("Couldn't save")
+      expect(status).toHaveTextContent(/Couldn't save:?\s*Network error/)
       expect(status).toHaveAttribute(
         'title',
         `Network error · ${AUTO_SAVE_GUIDANCE}`

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { AUTO_SAVE_GUIDANCE } from '@/lib/autosave'
+import { truncateFeedbackMessage } from '@/lib/feedback/flow-feedback'
 import { estimateReadingMinutes } from '@/lib/reading-time'
 
 function draftStatusTitle(
@@ -193,7 +194,12 @@ export function EditorActionBar({
       </>
     )
   } else if (error) {
-    statusText = "Couldn't save"
+    statusText = (
+      <>
+        <span className="shrink-0">Couldn&apos;t save:</span>
+        <span className="truncate">{truncateFeedbackMessage(error, 80)}</span>
+      </>
+    )
     statusClassName = 'text-destructive'
   } else if (hasUnsavedChanges) {
     statusText = 'Unsaved changes'
@@ -378,12 +384,12 @@ export function EditorActionBar({
       </div>
 
       {error && (
-        <div
-          className="border-t border-border bg-destructive/10 px-4 py-2 text-xs text-destructive"
-          title={error}
+        <p
+          role="alert"
+          className="border-t border-border bg-destructive/10 px-4 py-2 text-xs text-destructive break-words"
         >
-          Save failed
-        </div>
+          {error}
+        </p>
       )}
     </div>
   )

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -32,7 +32,8 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
 import { Textarea } from '@/components/ui/textarea'
-import { ChevronDown, Loader2 } from 'lucide-react'
+import { AlertCircle, ChevronDown, Loader2, X } from 'lucide-react'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -44,6 +45,11 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { cn } from '@/lib/utils'
+import type { FlowFeedback } from '@/lib/feedback/flow-feedback'
+import {
+  PUBLISH_EMPTY_CONTENT_FEEDBACK,
+  publishErrorFeedback,
+} from '@/lib/editor/publish-feedback'
 import {
   compressImage,
   uploadFile,
@@ -155,6 +161,13 @@ export function WriteEditorWorkspace() {
   const [backupRecoveryStatus, setBackupRecoveryStatus] = useState<
     'pending' | 'resolved'
   >('pending')
+  const [saveErrorDismissed, setSaveErrorDismissed] = useState(false)
+  const [publishFeedback, setPublishFeedback] = useState<FlowFeedback | null>(
+    null
+  )
+  const [deleteFeedback, setDeleteFeedback] = useState<FlowFeedback | null>(
+    null
+  )
 
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -252,6 +265,7 @@ export function WriteEditorWorkspace() {
       const json = editor.getJSON()
       setEditorContent(json)
       setHasUnsavedChanges(true)
+      setPublishFeedback(null)
     },
   })
 
@@ -272,6 +286,7 @@ export function WriteEditorWorkspace() {
       setArticleId(response.id)
       syncDraftIdInUrl(response.id)
       setHasUnsavedChanges(false)
+      setSaveErrorDismissed(false)
       if (!recoveryDeferredRef.current) {
         clearDraftBackup()
       }
@@ -279,6 +294,7 @@ export function WriteEditorWorkspace() {
     onSaveError: (error) => {
       console.error('Auto-save error:', error)
       setHasUnsavedChanges(true)
+      setSaveErrorDismissed(false)
     },
   })
 
@@ -523,24 +539,29 @@ export function WriteEditorWorkspace() {
 
   const requestPublish = useCallback(() => {
     if (!editor || editor.isEmpty) {
+      setPublishFeedback(PUBLISH_EMPTY_CONTENT_FEEDBACK)
       toast.warning('Please add content before publishing')
       return
     }
+    setPublishFeedback(null)
     setPublishConfirmOpen(true)
   }, [editor])
 
   const handlePublish = useCallback(async () => {
     if (!editor || editor.isEmpty) {
       setPublishConfirmOpen(false)
+      setPublishFeedback(PUBLISH_EMPTY_CONTENT_FEEDBACK)
       toast.warning('Please add content before publishing')
       return
     }
     if (!editorContent) {
       setPublishConfirmOpen(false)
+      setPublishFeedback(PUBLISH_EMPTY_CONTENT_FEEDBACK)
       toast.warning('Please add content before publishing')
       return
     }
 
+    setPublishFeedback(null)
     setIsPublishing(true)
     try {
       await saveNow()
@@ -575,12 +596,17 @@ export function WriteEditorWorkspace() {
         published: true,
         publishedAt: new Date(),
       })
+      setPublishFeedback(null)
 
       toast.success('Article published successfully!')
     } catch (error) {
       console.error('Publish error:', error)
+      const feedback = publishErrorFeedback(error)
+      setPublishFeedback(feedback)
       toast.error(
-        `Failed to publish: ${error instanceof Error ? error.message : 'Unknown error'}`
+        feedback.detail
+          ? `${feedback.title}: ${feedback.detail}`
+          : feedback.title
       )
     } finally {
       setIsPublishing(false)
@@ -601,6 +627,7 @@ export function WriteEditorWorkspace() {
 
   const handleRequestDelete = useCallback(() => {
     if (!articleId || isDeleting) return
+    setDeleteFeedback(null)
     setDeleteDialogOpen(true)
   }, [articleId, isDeleting])
 
@@ -616,6 +643,13 @@ export function WriteEditorWorkspace() {
       router.push('/')
     } catch (error) {
       console.error('Delete error:', error)
+      const message =
+        error instanceof Error ? error.message : 'Please try again.'
+      setDeleteFeedback({
+        variant: 'destructive',
+        title: 'Failed to delete draft',
+        detail: message,
+      })
       toast.error('Failed to delete draft. Please try again.')
       setIsDeleting(false)
     }
@@ -939,6 +973,63 @@ export function WriteEditorWorkspace() {
         isDeleting={isDeleting}
         hasUnsavedChanges={hasUnsavedChanges}
       />
+      {publishFeedback && (
+        <div className="border-b border-border bg-background">
+          <div className="mx-auto flex max-w-4xl items-start gap-2 px-4 py-3 sm:px-6">
+            <Alert
+              variant={
+                publishFeedback.variant === 'destructive'
+                  ? 'destructive'
+                  : 'default'
+              }
+              className="flex-1"
+            >
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>{publishFeedback.title}</AlertTitle>
+              {publishFeedback.detail ? (
+                <AlertDescription>{publishFeedback.detail}</AlertDescription>
+              ) : null}
+            </Alert>
+            <button
+              type="button"
+              onClick={() => setPublishFeedback(null)}
+              className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+              aria-label="Dismiss publish message"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      )}
+      {error && !saveErrorDismissed && (
+        <div className="border-b border-border bg-background">
+          <div className="mx-auto flex max-w-4xl items-start gap-2 px-4 py-3 sm:px-6">
+            <Alert variant="destructive" className="flex-1">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>Couldn&apos;t save draft</AlertTitle>
+              <AlertDescription className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <span>{error.message}</span>
+                <button
+                  type="button"
+                  onClick={() => void saveNow()}
+                  disabled={isSaving}
+                  className="shrink-0 rounded-md border border-destructive/50 px-3 py-1.5 text-sm font-medium hover:bg-destructive/10 disabled:opacity-50"
+                >
+                  {isSaving ? 'Saving...' : 'Retry save'}
+                </button>
+              </AlertDescription>
+            </Alert>
+            <button
+              type="button"
+              onClick={() => setSaveErrorDismissed(true)}
+              className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+              aria-label="Dismiss save error"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      )}
       <div className="flex min-w-0 flex-1 flex-col pb-8">
         <div className="sticky top-16 z-40 mb-6 w-full bg-background">
           <div className="mx-auto w-full max-w-4xl px-4 sm:px-6">
@@ -1521,6 +1612,15 @@ export function WriteEditorWorkspace() {
               deleted.
             </AlertDialogDescription>
           </AlertDialogHeader>
+          {deleteFeedback && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>{deleteFeedback.title}</AlertTitle>
+              {deleteFeedback.detail ? (
+                <AlertDescription>{deleteFeedback.detail}</AlertDescription>
+              ) : null}
+            </Alert>
+          )}
           <AlertDialogFooter>
             <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
             <AlertDialogAction

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -114,6 +114,10 @@ export function HighlightTipButton({
   const [isLoading, setIsLoading] = useState(false)
   const [tipFlowStep, setTipFlowStep] = useState<TipFlowStep | null>(null)
   const [tipFailure, setTipFailure] = useState<TipFailureMessage | null>(null)
+  const [tipFormError, setTipFormError] = useState<TipFailureMessage | null>(
+    null
+  )
+  const [tipSuccess, setTipSuccess] = useState<string | null>(null)
 
   const convex = useConvex()
   const createHighlightTip = useMutation(api.highlightTips.create)
@@ -205,7 +209,9 @@ export function HighlightTipButton({
     setIsOpen(open)
     onResumeOpenChange?.(open)
     setTipFailure(null)
+    setTipFormError(null)
     if (!open) {
+      setTipSuccess(null)
       setSelectedAmount(null)
       setCustomAmount('')
     }
@@ -242,16 +248,24 @@ export function HighlightTipButton({
       selectedAmount,
       customAmount,
     })
-    if (!validation.ok) return
+    if (!validation.ok) {
+      setTipFormError({ title: validation.message })
+      toast.error(validation.message)
+      return
+    }
     const amountCents = validation.amountCents
 
     if (!isConnected || !publicKey) {
-      toast.error('Please connect your Stellar wallet to send tips')
+      const message = 'Please connect your Stellar wallet to send tips'
+      setTipFormError({ title: message })
+      toast.error(message)
       return
     }
 
     if (!authorStellarAddress) {
-      toast.error('Author has not set up their Stellar wallet yet')
+      const message = 'Author has not set up their Stellar wallet yet'
+      setTipFormError({ title: message })
+      toast.error(message)
       return
     }
 
@@ -263,9 +277,9 @@ export function HighlightTipButton({
     try {
       const cooldown = await convex.query(api.tips.canTip, {})
       if (!cooldown.allowed) {
-        toast.error('Slow down', {
-          description: `Please wait ${cooldown.waitSec}s before tipping again.`,
-        })
+        const detail = `Please wait ${cooldown.waitSec}s before tipping again.`
+        setTipFormError({ title: 'Slow down', detail })
+        toast.error('Slow down', { description: detail })
         return
       }
     } catch (err) {
@@ -276,6 +290,8 @@ export function HighlightTipButton({
     }
 
     setTipFailure(null)
+    setTipFormError(null)
+    setTipSuccess(null)
     setIsLoading(true)
 
     try {
@@ -325,32 +341,35 @@ export function HighlightTipButton({
 
       clearPendingTipIntent()
       setTipFailure(null)
-      setIsOpen(false)
-      setSelectedAmount(null)
-      setCustomAmount('')
+      setTipFormError(null)
+      const successMessage = `Successfully tipped ${authorName} ${formatTipAmount(amountCents)} for this highlight!`
+      setTipSuccess(successMessage)
 
-      toast.success(
-        `Successfully tipped ${authorName} ${formatTipAmount(amountCents)} for this highlight!`,
-        {
-          description: receipt.transactionHash
-            ? `Transaction: ${receipt.transactionHash.slice(0, 8)}...`
-            : undefined,
-          action: receipt.transactionHash
-            ? {
-                label: 'View',
-                onClick: () =>
-                  window.open(
-                    `https://stellar.expert/explorer/testnet/tx/${receipt.transactionHash}`,
-                    '_blank'
-                  ),
-              }
-            : undefined,
+      toast.success(successMessage, {
+        description: receipt.transactionHash
+          ? `Transaction: ${receipt.transactionHash.slice(0, 8)}...`
+          : undefined,
+        action: receipt.transactionHash
+          ? {
+              label: 'View',
+              onClick: () =>
+                window.open(
+                  `https://stellar.expert/explorer/testnet/tx/${receipt.transactionHash}`,
+                  '_blank'
+                ),
+            }
+          : undefined,
+      })
+
+      window.setTimeout(() => {
+        setIsOpen(false)
+        setTipSuccess(null)
+        setSelectedAmount(null)
+        setCustomAmount('')
+        if (onSuccess) {
+          onSuccess()
         }
-      )
-
-      if (onSuccess) {
-        onSuccess()
-      }
+      }, 3000)
     } catch (error) {
       console.error('Highlight tip error:', error)
       setTipFailure(formatTipFailureMessage(error))
@@ -364,6 +383,7 @@ export function HighlightTipButton({
     try {
       const connected = await connect()
       if (connected) {
+        setTipFormError(null)
         toast.success('Wallet connected successfully!')
       }
     } catch (error) {
@@ -379,9 +399,33 @@ export function HighlightTipButton({
         return
       }
 
+      setTipFormError({ title: message })
       toast.error(message)
     }
   }
+
+  const inlineTipAlert = tipSuccess ? (
+    <Alert className="border-success/50 bg-success/10 text-success-foreground">
+      <AlertTitle>Tip sent</AlertTitle>
+      <AlertDescription>{tipSuccess}</AlertDescription>
+    </Alert>
+  ) : tipFailure ? (
+    <Alert variant="destructive">
+      <AlertCircle className="h-4 w-4" />
+      <AlertTitle>{tipFailure.title}</AlertTitle>
+      {tipFailure.detail ? (
+        <AlertDescription>{tipFailure.detail}</AlertDescription>
+      ) : null}
+    </Alert>
+  ) : tipFormError ? (
+    <Alert variant="destructive">
+      <AlertCircle className="h-4 w-4" />
+      <AlertTitle>{tipFormError.title}</AlertTitle>
+      {tipFormError.detail ? (
+        <AlertDescription>{tipFormError.detail}</AlertDescription>
+      ) : null}
+    </Alert>
+  ) : null
 
   const displayText =
     highlightText.length > 60
@@ -424,15 +468,7 @@ export function HighlightTipButton({
             </DialogDescription>
           </DialogHeader>
 
-          {tipFailure && (
-            <Alert variant="destructive">
-              <AlertCircle className="h-4 w-4" />
-              <AlertTitle>{tipFailure.title}</AlertTitle>
-              {tipFailure.detail ? (
-                <AlertDescription>{tipFailure.detail}</AlertDescription>
-              ) : null}
-            </Alert>
-          )}
+          {inlineTipAlert}
 
           <div className="mb-4 p-3 bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800 rounded-lg">
             <p className="text-sm text-foreground italic">
@@ -569,7 +605,11 @@ export function HighlightTipButton({
               <button
                 type="button"
                 onClick={() => void handleTip()}
-                disabled={isLoading || (!selectedAmount && !customAmount)}
+                disabled={
+                  isLoading ||
+                  !!tipSuccess ||
+                  (!selectedAmount && !customAmount)
+                }
                 className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
               >
                 {isLoading ? (

--- a/components/stellar/WalletSettings.test.tsx
+++ b/components/stellar/WalletSettings.test.tsx
@@ -1,0 +1,58 @@
+/** @vitest-environment jsdom */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { WalletSettings } from '@/components/stellar/WalletSettings'
+
+const mockConnect = vi.fn()
+const mockDisconnect = vi.fn()
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('convex/react', () => ({
+  useMutation: () => vi.fn(),
+}))
+
+vi.mock('@/components/providers/WalletProvider', () => ({
+  useWallet: () => ({
+    isLoading: false,
+    connect: mockConnect,
+    disconnect: mockDisconnect,
+  }),
+}))
+
+vi.mock('@/components/stellar/InstallWalletDialog', () => ({
+  InstallWalletDialog: () => null,
+}))
+
+vi.mock('@/components/legal/LegalLinks', () => ({
+  LegalLinks: () => null,
+}))
+
+vi.mock('@/components/guide/WalletTooltip', () => ({
+  WalletTooltip: () => null,
+}))
+
+describe('WalletSettings', () => {
+  beforeEach(() => {
+    mockConnect.mockReset()
+    mockDisconnect.mockReset()
+  })
+
+  it('shows persistent alert when connect fails', async () => {
+    mockConnect.mockRejectedValue(new Error('User rejected'))
+    const user = userEvent.setup({ delay: null })
+
+    render(<WalletSettings isOwnProfile walletAddress={null} />)
+
+    await user.click(
+      screen.getByRole('button', { name: /Connect Stellar Wallet/i })
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('User rejected')).toBeInTheDocument()
+    })
+  })
+})

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -14,7 +14,8 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import type { FlowFeedback } from '@/lib/feedback/flow-feedback'
 import {
   Wallet,
   Copy,
@@ -56,6 +57,9 @@ export function WalletSettings({
   const [isCopied, setIsCopied] = useState(false)
   const [isConnecting, setIsConnecting] = useState(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
+  const [walletFeedback, setWalletFeedback] = useState<FlowFeedback | null>(
+    null
+  )
 
   const handleCopy = async () => {
     if (!walletAddress) return
@@ -63,15 +67,22 @@ export function WalletSettings({
     try {
       await navigator.clipboard.writeText(walletAddress)
       setIsCopied(true)
+      setWalletFeedback(null)
       toast.success('Wallet address copied to clipboard')
       setTimeout(() => setIsCopied(false), 2000)
     } catch {
+      setWalletFeedback({
+        variant: 'destructive',
+        title: 'Failed to copy address',
+        detail: 'Copy the address manually or try again.',
+      })
       toast.error('Failed to copy address')
     }
   }
 
   const handleConnectWallet = async () => {
     setIsConnecting(true)
+    setWalletFeedback(null)
     try {
       const success = await connect()
       if (success) {
@@ -84,9 +95,15 @@ export function WalletSettings({
             stellarAddress: connectedKey,
           })
           onAddressChange?.(connectedKey)
+          setWalletFeedback(null)
           toast.success('Wallet connected and saved successfully!')
         }
       } else {
+        setWalletFeedback({
+          variant: 'destructive',
+          title: 'Failed to connect wallet',
+          detail: 'Try again or choose a different wallet extension.',
+        })
         toast.error('Failed to connect wallet')
       }
     } catch (error) {
@@ -104,6 +121,11 @@ export function WalletSettings({
         return
       }
 
+      setWalletFeedback({
+        variant: 'destructive',
+        title: 'Failed to connect wallet',
+        detail: message,
+      })
       toast.error(message)
     } finally {
       setIsConnecting(false)
@@ -115,6 +137,7 @@ export function WalletSettings({
     if (isConnecting) return
 
     setIsConnecting(true)
+    setWalletFeedback(null)
 
     try {
       // Step 1: Update database FIRST (ensures source of truth is updated)
@@ -127,6 +150,7 @@ export function WalletSettings({
 
       // Step 3: Notify parent component for immediate UI update
       onAddressChange?.('')
+      setWalletFeedback(null)
 
       toast.success('Wallet disconnected successfully')
     } catch (error) {
@@ -135,16 +159,36 @@ export function WalletSettings({
       // Provide specific error messages
       if (error instanceof Error) {
         if (error.message.includes('Not authenticated')) {
+          setWalletFeedback({
+            variant: 'destructive',
+            title: 'Session expired',
+            detail: 'Please refresh and try again.',
+          })
           toast.error('Session expired. Please refresh and try again.')
         } else if (
           error.message.includes('network') ||
           error.message.includes('fetch')
         ) {
+          setWalletFeedback({
+            variant: 'destructive',
+            title: 'Network error',
+            detail: 'Check your connection and try again.',
+          })
           toast.error('Network error. Check your connection and try again.')
         } else {
+          setWalletFeedback({
+            variant: 'destructive',
+            title: 'Disconnect failed',
+            detail: error.message,
+          })
           toast.error(`Disconnect failed: ${error.message}`)
         }
       } else {
+        setWalletFeedback({
+          variant: 'destructive',
+          title: 'Failed to disconnect wallet',
+          detail: 'Please try again.',
+        })
         toast.error('Failed to disconnect wallet. Please try again.')
       }
 
@@ -183,6 +227,21 @@ export function WalletSettings({
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
+          {walletFeedback && (
+            <Alert
+              variant={
+                walletFeedback.variant === 'destructive'
+                  ? 'destructive'
+                  : 'default'
+              }
+            >
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>{walletFeedback.title}</AlertTitle>
+              {walletFeedback.detail ? (
+                <AlertDescription>{walletFeedback.detail}</AlertDescription>
+              ) : null}
+            </Alert>
+          )}
           {isOwnProfile && (
             <Alert className="border-info/50 bg-info">
               <AlertCircle className="h-4 w-4 text-info-foreground" />

--- a/components/tipping/TipButton.test.tsx
+++ b/components/tipping/TipButton.test.tsx
@@ -141,4 +141,24 @@ describe('TipButton auth-first CTA', () => {
     await user.click(screen.getByRole('button', { name: /Tip Author/i }))
     expect(screen.getByRole('button', { name: 'Send Tip' })).toBeInTheDocument()
   })
+
+  it('shows inline alert for invalid tip amount when wallet is connected', async () => {
+    mockIsAuthenticated.mockReturnValue(true)
+    mockIsConnected.mockReturnValue(true)
+    const user = userEvent.setup({ delay: null })
+    render(
+      <TipButton
+        articleId={'articles:abc' as never}
+        authorName="Author"
+        authorStellarAddress="GABC"
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /Tip Author/i }))
+    const customInput = screen.getByPlaceholderText('0.00')
+    await user.type(customInput, '0')
+    await user.click(screen.getByRole('button', { name: 'Send Tip' }))
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/valid amount/i)
+  })
 })

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -81,6 +81,10 @@ export function TipButton({
   const [isLoading, setIsLoading] = useState(false)
   const [tipFlowStep, setTipFlowStep] = useState<TipFlowStep | null>(null)
   const [tipFailure, setTipFailure] = useState<TipFailureMessage | null>(null)
+  const [tipFormError, setTipFormError] = useState<TipFailureMessage | null>(
+    null
+  )
+  const [tipSuccess, setTipSuccess] = useState<string | null>(null)
   const [tipMessage, setTipMessage] = useState('')
 
   const convex = useConvex()
@@ -119,6 +123,8 @@ export function TipButton({
     }
     setIsOpen(open)
     setTipFailure(null)
+    setTipFormError(null)
+    if (!open) setTipSuccess(null)
   }
 
   const handleSignInToTip = () => {
@@ -146,18 +152,25 @@ export function TipButton({
       customAmount,
       message: tipMessage,
     })
-    if (!validation.ok) return
+    if (!validation.ok) {
+      setTipFormError({ title: validation.message })
+      toast.error(validation.message)
+      return
+    }
     const amountCents = validation.amountCents
 
     if (!isConnected || !publicKey) {
-      toast.error('Please connect your Stellar wallet to send tips')
+      const message = 'Please connect your Stellar wallet to send tips'
+      setTipFormError({ title: message })
+      toast.error(message)
       return
     }
 
     if (!authorStellarAddress) {
-      toast.error(
+      const message =
         'Author has not set up their Stellar wallet for receiving tips'
-      )
+      setTipFormError({ title: message })
+      toast.error(message)
       return
     }
 
@@ -169,9 +182,9 @@ export function TipButton({
     try {
       const cooldown = await convex.query(api.tips.canTip, {})
       if (!cooldown.allowed) {
-        toast.error('Slow down', {
-          description: `Please wait ${cooldown.waitSec}s before tipping again.`,
-        })
+        const detail = `Please wait ${cooldown.waitSec}s before tipping again.`
+        setTipFormError({ title: 'Slow down', detail })
+        toast.error('Slow down', { description: detail })
         return
       }
     } catch (err) {
@@ -182,6 +195,8 @@ export function TipButton({
     }
 
     setTipFailure(null)
+    setTipFormError(null)
+    setTipSuccess(null)
     setIsLoading(true)
 
     try {
@@ -217,29 +232,33 @@ export function TipButton({
 
       clearPendingTipIntent()
       setTipFailure(null)
-      setIsOpen(false)
-      setSelectedAmount(null)
-      setCustomAmount('')
-      setTipMessage('')
+      setTipFormError(null)
+      const successMessage = `Successfully tipped ${authorName} $${(amountCents / 100).toFixed(2)} via Stellar!`
+      setTipSuccess(successMessage)
 
-      toast.success(
-        `Successfully tipped ${authorName} $${(amountCents / 100).toFixed(2)} via Stellar!`,
-        {
-          description: receipt.transactionHash
-            ? `Transaction: ${receipt.transactionHash.slice(0, 8)}...`
-            : undefined,
-          action: receipt.transactionHash
-            ? {
-                label: 'View',
-                onClick: () =>
-                  window.open(
-                    `https://stellar.expert/explorer/testnet/tx/${receipt.transactionHash}`,
-                    '_blank'
-                  ),
-              }
-            : undefined,
-        }
-      )
+      toast.success(successMessage, {
+        description: receipt.transactionHash
+          ? `Transaction: ${receipt.transactionHash.slice(0, 8)}...`
+          : undefined,
+        action: receipt.transactionHash
+          ? {
+              label: 'View',
+              onClick: () =>
+                window.open(
+                  `https://stellar.expert/explorer/testnet/tx/${receipt.transactionHash}`,
+                  '_blank'
+                ),
+            }
+          : undefined,
+      })
+
+      window.setTimeout(() => {
+        setIsOpen(false)
+        setTipSuccess(null)
+        setSelectedAmount(null)
+        setCustomAmount('')
+        setTipMessage('')
+      }, 3000)
     } catch (error) {
       console.error('Stellar tip error:', error)
       setTipFailure(formatTipFailureMessage(error))
@@ -259,6 +278,7 @@ export function TipButton({
     try {
       const connected = await connect()
       if (connected) {
+        setTipFormError(null)
         toast.success('Wallet connected successfully!')
       }
     } catch (error) {
@@ -274,9 +294,33 @@ export function TipButton({
         return
       }
 
+      setTipFormError({ title: message })
       toast.error(message)
     }
   }
+
+  const inlineTipAlert = tipSuccess ? (
+    <Alert className="border-success/50 bg-success/10 text-success-foreground">
+      <AlertTitle>Tip sent</AlertTitle>
+      <AlertDescription>{tipSuccess}</AlertDescription>
+    </Alert>
+  ) : tipFailure ? (
+    <Alert variant="destructive">
+      <AlertCircle className="h-4 w-4" />
+      <AlertTitle>{tipFailure.title}</AlertTitle>
+      {tipFailure.detail ? (
+        <AlertDescription>{tipFailure.detail}</AlertDescription>
+      ) : null}
+    </Alert>
+  ) : tipFormError ? (
+    <Alert variant="destructive">
+      <AlertCircle className="h-4 w-4" />
+      <AlertTitle>{tipFormError.title}</AlertTitle>
+      {tipFormError.detail ? (
+        <AlertDescription>{tipFormError.detail}</AlertDescription>
+      ) : null}
+    </Alert>
+  ) : null
 
   return (
     <>
@@ -309,15 +353,7 @@ export function TipButton({
             </DialogDescription>
           </DialogHeader>
 
-          {tipFailure && (
-            <Alert variant="destructive">
-              <AlertCircle className="h-4 w-4" />
-              <AlertTitle>{tipFailure.title}</AlertTitle>
-              {tipFailure.detail ? (
-                <AlertDescription>{tipFailure.detail}</AlertDescription>
-              ) : null}
-            </Alert>
-          )}
+          {inlineTipAlert}
 
           {!isAuthenticated ? (
             <div className="p-3 bg-muted border border-border rounded-lg text-sm text-muted-foreground">
@@ -474,7 +510,11 @@ export function TipButton({
               <button
                 type="button"
                 onClick={handleTip}
-                disabled={isLoading || (!selectedAmount && !customAmount)}
+                disabled={
+                  isLoading ||
+                  !!tipSuccess ||
+                  (!selectedAmount && !customAmount)
+                }
                 className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
               >
                 {isLoading ? (

--- a/lib/editor/publish-feedback.test.ts
+++ b/lib/editor/publish-feedback.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PUBLISH_EMPTY_CONTENT_FEEDBACK,
+  publishErrorFeedback,
+} from './publish-feedback'
+
+describe('publish-feedback', () => {
+  it('defines empty content feedback', () => {
+    expect(PUBLISH_EMPTY_CONTENT_FEEDBACK.title).toMatch(/content/i)
+  })
+
+  it('maps errors to destructive feedback', () => {
+    expect(publishErrorFeedback(new Error('Offline')).detail).toBe('Offline')
+    expect(publishErrorFeedback('x').detail).toBe('Unknown error')
+  })
+})

--- a/lib/editor/publish-feedback.ts
+++ b/lib/editor/publish-feedback.ts
@@ -1,0 +1,17 @@
+import type { FlowFeedback } from '@/lib/feedback/flow-feedback'
+
+export const PUBLISH_EMPTY_CONTENT_FEEDBACK: FlowFeedback = {
+  variant: 'default',
+  title: 'Add content before publishing',
+  detail: 'Write something in the editor, then try again.',
+}
+
+export function publishErrorFeedback(error: unknown): FlowFeedback {
+  const message =
+    error instanceof Error ? error.message : 'Unknown error'
+  return {
+    variant: 'destructive',
+    title: 'Failed to publish',
+    detail: message,
+  }
+}

--- a/lib/editor/publish-feedback.ts
+++ b/lib/editor/publish-feedback.ts
@@ -7,8 +7,7 @@ export const PUBLISH_EMPTY_CONTENT_FEEDBACK: FlowFeedback = {
 }
 
 export function publishErrorFeedback(error: unknown): FlowFeedback {
-  const message =
-    error instanceof Error ? error.message : 'Unknown error'
+  const message = error instanceof Error ? error.message : 'Unknown error'
   return {
     variant: 'destructive',
     title: 'Failed to publish',

--- a/lib/feedback/flow-feedback.ts
+++ b/lib/feedback/flow-feedback.ts
@@ -6,7 +6,10 @@ export type FlowFeedback = {
   detail?: string
 }
 
-export function truncateFeedbackMessage(message: string, maxLength = 120): string {
+export function truncateFeedbackMessage(
+  message: string,
+  maxLength = 120
+): string {
   if (message.length <= maxLength) return message
   return `${message.slice(0, maxLength - 1)}…`
 }

--- a/lib/feedback/flow-feedback.ts
+++ b/lib/feedback/flow-feedback.ts
@@ -1,0 +1,12 @@
+export type FlowFeedbackVariant = 'destructive' | 'default'
+
+export type FlowFeedback = {
+  variant: FlowFeedbackVariant
+  title: string
+  detail?: string
+}
+
+export function truncateFeedbackMessage(message: string, maxLength = 120): string {
+  if (message.length <= maxLength) return message
+  return `${message.slice(0, maxLength - 1)}…`
+}

--- a/lib/tip/signInToTip.test.ts
+++ b/lib/tip/signInToTip.test.ts
@@ -1,11 +1,6 @@
 import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
 import { describe, expect, it, vi } from 'vitest'
-import { toast } from 'sonner'
 import { validateTipAmountForm, signInToTip } from './signInToTip'
-
-vi.mock('sonner', () => ({
-  toast: { error: vi.fn() },
-}))
 
 const mockRedirect = vi.hoisted(() => vi.fn())
 
@@ -21,6 +16,9 @@ describe('signInToTip', () => {
       customAmount: '',
     })
     expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.message).toMatch(/valid amount/i)
+    }
     signInToTip(
       router,
       '/article',
@@ -31,13 +29,11 @@ describe('signInToTip', () => {
       }
     )
     expect(mockRedirect).not.toHaveBeenCalled()
-    expect(toast.error).toHaveBeenCalled()
   })
 
   it('redirects with valid amount', () => {
     const router = { replace: vi.fn() } as unknown as AppRouterInstance
     mockRedirect.mockClear()
-    vi.mocked(toast.error).mockClear()
 
     signInToTip(
       router,
@@ -61,5 +57,8 @@ describe('signInToTip', () => {
       message: 'x'.repeat(501),
     })
     expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.message).toMatch(/500 characters/)
+    }
   })
 })

--- a/lib/tip/signInToTip.ts
+++ b/lib/tip/signInToTip.ts
@@ -1,5 +1,4 @@
 import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
-import { toast } from 'sonner'
 import { TIP_MIN_CENTS, TIP_MAX_CENTS, TIP_MAX_USD } from '@/lib/constants'
 import { redirectToLoginForTip } from '@/lib/tip/redirectToLoginForTip'
 import type { PendingTipIntent } from '@/lib/tip/pendingTipIntent'
@@ -12,7 +11,7 @@ export type TipAmountFormState = {
 
 export type ValidateTipAmountResult =
   | { ok: true; amountCents: number }
-  | { ok: false }
+  | { ok: false; message: string }
 
 export function validateTipAmountForm({
   selectedAmount,
@@ -22,18 +21,24 @@ export function validateTipAmountForm({
   const amountCents = selectedAmount || parseFloat(customAmount) * 100
 
   if (!amountCents || amountCents < TIP_MIN_CENTS) {
-    toast.error('Please select or enter a valid amount')
-    return { ok: false }
+    return {
+      ok: false,
+      message: 'Please select or enter a valid amount',
+    }
   }
 
   if (amountCents > TIP_MAX_CENTS) {
-    toast.error(`Maximum tip amount is $${TIP_MAX_USD.toFixed(2)}`)
-    return { ok: false }
+    return {
+      ok: false,
+      message: `Maximum tip amount is $${TIP_MAX_USD.toFixed(2)}`,
+    }
   }
 
   if (message !== undefined && message.length > 500) {
-    toast.error('Message must be 500 characters or less')
-    return { ok: false }
+    return {
+      ok: false,
+      message: 'Message must be 500 characters or less',
+    }
   }
 
   return { ok: true, amountCents }


### PR DESCRIPTION
## Summary
- Added persistent inline feedback (alerts/banners) for critical outcomes across save, publish, wallet, tip, and withdrawal flows; toasts remain supplemental.
- Save/publish: editor surfaces autosave and publish errors persistently (with retry/dismiss), plus persistent delete-draft failure in the dialog.
- Wallet/tip/withdrawal: persistent errors shown in relevant UI (wallet settings, tip dialogs, withdrawal dialog) and a dashboard banner for withdrawal outcomes.

<img width="1227" height="761" alt="6" src="https://github.com/user-attachments/assets/42db3855-a490-4344-a9e3-822a0cf9be14" />
<img width="1219" height="718" alt="1" src="https://github.com/user-attachments/assets/185c5426-35f2-4aa4-a7b7-fb20370600bf" />
