### PR TITLE
fix(a11y): announce loading and add stale-load retry states

### DIFF
--- a/app/[username]/[slug]/page.tsx
+++ b/app/[username]/[slug]/page.tsx
@@ -46,6 +46,9 @@ import {
 import { ReadingProgressBar } from '@/components/articles/ReadingProgressBar'
 import { extractH2HeadingsFromTiptapJson } from '@/lib/tiptap/headings'
 import { ArticleTableOfContents } from '@/components/articles/ArticleTableOfContents'
+import { LoadingRegion } from '@/components/a11y/LoadingRegion'
+import { useStaleLoading } from '@/hooks/useStaleLoading'
+import { useRouter } from 'next/navigation'
 
 interface ArticlePageProps {
   params: Promise<{
@@ -58,8 +61,10 @@ export default function ArticlePage({ params }: ArticlePageProps) {
   const { username, slug } = use(params)
   const [showHighlightsPanel, setShowHighlightsPanel] = useState(false)
   const { user } = useAuth()
+  const router = useRouter()
 
   const article = useArticleBySlug(username, slug)
+  const { isStale, reset: resetStale } = useStaleLoading(article === undefined)
 
   const highlights = useArticleHighlightsQuery(article?._id)
 
@@ -87,11 +92,22 @@ export default function ArticlePage({ params }: ArticlePageProps) {
   }
 
   // Show loading while article is being fetched
-  if (!article) {
+  if (article === undefined) {
     return (
       <div className="min-h-screen bg-background">
         <AppNavigation />
-        <ArticlePageLoadingSkeleton />
+        <LoadingRegion
+          label="article"
+          isLoading
+          isStale={isStale}
+          onRetry={() => {
+            resetStale()
+            router.refresh()
+          }}
+          fallback={<ArticlePageLoadingSkeleton />}
+        >
+          <div />
+        </LoadingRegion>
       </div>
     )
   }

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -4,6 +4,8 @@ import { notFound } from 'next/navigation'
 import { useUserByUsername, useUserStats } from '@/hooks/convex'
 import { use, useState, useEffect } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { LoadingRegion } from '@/components/a11y/LoadingRegion'
+import { useStaleLoading } from '@/hooks/useStaleLoading'
 import {
   buildProfileTabHref,
   parseProfileTab,
@@ -51,6 +53,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
 
   // Fetch user profile
   const user = useUserByUsername(username)
+  const { isStale, reset: resetStale } = useStaleLoading(user === undefined)
 
   // Sync local wallet address with user data
   useEffect(() => {
@@ -85,11 +88,22 @@ export default function ProfilePage({ params }: ProfilePageProps) {
   }
 
   // Show loading while data is being fetched
-  if (!user) {
+  if (user === undefined) {
     return (
       <div className="min-h-screen bg-background">
         <AppNavigation />
-        <ProfilePageLoadingSkeleton />
+        <LoadingRegion
+          label="profile"
+          isLoading
+          isStale={isStale}
+          onRetry={() => {
+            resetStale()
+            router.refresh()
+          }}
+          fallback={<ProfilePageLoadingSkeleton />}
+        >
+          <div />
+        </LoadingRegion>
       </div>
     )
   }

--- a/app/write/page.tsx
+++ b/app/write/page.tsx
@@ -7,9 +7,14 @@ import { EditorChromeSkeleton } from '@/components/editor/EditorChromeSkeleton'
 import { ErrorBoundary } from '@/components/error/ErrorBoundary'
 import { EditorWorkspaceErrorFallback } from '@/components/error/SectionErrorFallback'
 import { WriteEditorWorkspace } from '@/components/editor/WriteEditorWorkspace'
+import { LoadingRegion } from '@/components/a11y/LoadingRegion'
+import { useStaleLoading } from '@/hooks/useStaleLoading'
+import { useRouter } from 'next/navigation'
 
 export default function WritePage() {
   const { isAuthenticated, isLoading } = useAuth()
+  const router = useRouter()
+  const { isStale, reset: resetStale } = useStaleLoading(isLoading)
 
   useRedirectWhenUnauthenticated(isLoading, isAuthenticated)
 
@@ -17,7 +22,18 @@ export default function WritePage() {
     return (
       <div className="min-h-screen bg-background">
         <AppNavigation />
-        <EditorChromeSkeleton />
+        <LoadingRegion
+          label="editor"
+          isLoading
+          isStale={isStale}
+          onRetry={() => {
+            resetStale()
+            router.refresh()
+          }}
+          fallback={<EditorChromeSkeleton />}
+        >
+          <div />
+        </LoadingRegion>
       </div>
     )
   }

--- a/components/a11y/LoadingRegion.tsx
+++ b/components/a11y/LoadingRegion.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+type LoadingRegionProps = {
+  label: string
+  isLoading: boolean
+  isStale: boolean
+  onRetry: () => void
+  fallback: ReactNode
+  children: ReactNode
+  className?: string
+}
+
+export function LoadingRegion({
+  label,
+  isLoading,
+  isStale,
+  onRetry,
+  fallback,
+  children,
+  className,
+}: LoadingRegionProps) {
+  const prevIsLoadingRef = useRef<boolean>(false)
+  const [announcement, setAnnouncement] = useState<string>('')
+
+  const liveText = useMemo(() => {
+    if (!announcement) return ''
+    return announcement
+  }, [announcement])
+
+  useEffect(() => {
+    const prevIsLoading = prevIsLoadingRef.current
+    prevIsLoadingRef.current = isLoading
+
+    if (isLoading && !prevIsLoading) {
+      setAnnouncement(`Loading ${label}.`)
+      return
+    }
+
+    if (!isLoading && prevIsLoading) {
+      setAnnouncement(`${label} loaded.`)
+    }
+  }, [isLoading, label])
+
+  return (
+    <div
+      className={className}
+      aria-busy={isLoading && !isStale ? true : undefined}
+    >
+      <p className="sr-only" role="status" aria-live="polite">
+        {liveText}
+      </p>
+
+      {isLoading ? (
+        isStale ? (
+          <div
+            role="alert"
+            className={cn(
+              'mx-auto max-w-2xl rounded-lg border border-border bg-muted p-6 text-center',
+              className
+            )}
+          >
+            <p className="font-medium text-foreground">
+              Still loading {label}.
+            </p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              This is taking longer than expected. Try again, or reload the
+              page.
+            </p>
+            <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+              <Button
+                type="button"
+                onClick={onRetry}
+                className="min-w-[9.5rem]"
+              >
+                Try again
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => window.location.reload()}
+              >
+                Reload page
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div aria-hidden>{fallback}</div>
+        )
+      ) : (
+        children
+      )}
+    </div>
+  )
+}
+

--- a/components/a11y/LoadingRegion.tsx
+++ b/components/a11y/LoadingRegion.tsx
@@ -96,4 +96,3 @@ export function LoadingRegion({
     </div>
   )
 }
-

--- a/components/articles/ArticleCardSkeleton.tsx
+++ b/components/articles/ArticleCardSkeleton.tsx
@@ -2,7 +2,10 @@ import { Skeleton } from '@/components/ui/skeleton'
 
 export function ArticleCardSkeleton() {
   return (
-    <div className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border overflow-hidden">
+    <div
+      className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border overflow-hidden"
+      aria-hidden
+    >
       {/* Cover image placeholder */}
       <Skeleton className="h-48 w-full rounded-none" />
 

--- a/components/articles/ArticleEngagementSkeleton.tsx
+++ b/components/articles/ArticleEngagementSkeleton.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 
 export function TipButtonSkeleton() {
   return (
-    <div className="space-y-3">
+    <div className="space-y-3" aria-hidden>
       <Skeleton className="h-10 w-full" />
       <Skeleton className="h-4 w-3/4" />
     </div>
@@ -11,7 +11,7 @@ export function TipButtonSkeleton() {
 
 export function NftSidebarSkeleton() {
   return (
-    <div className="space-y-3">
+    <div className="space-y-3" aria-hidden>
       <Skeleton className="h-4 w-full" />
       <Skeleton className="h-4 w-5/6" />
       <Skeleton className="h-10 w-full" />

--- a/components/articles/ArticlePageLoadingSkeleton.tsx
+++ b/components/articles/ArticlePageLoadingSkeleton.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 
 export function ArticlePageLoadingSkeleton() {
   return (
-    <main className="pt-20">
+    <main className="pt-20" aria-hidden>
       <div className="max-w-4xl mx-auto px-4 py-8">
         <Skeleton className="h-96 w-full rounded-lg mb-8" />
         <Skeleton className="h-8 w-3/4 mb-4" />

--- a/components/editor/EditorChromeSkeleton.tsx
+++ b/components/editor/EditorChromeSkeleton.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 
 export function EditorChromeSkeleton() {
   return (
-    <div className="flex flex-col pt-16">
+    <div className="flex flex-col pt-16" aria-hidden>
       <div className="sticky top-16 z-40 bg-background border-b border-border w-full mb-6 px-4 py-3">
         <div className="max-w-5xl mx-auto flex gap-2">
           <Skeleton className="h-9 w-20" />

--- a/components/profile/ProfilePageLoadingSkeleton.tsx
+++ b/components/profile/ProfilePageLoadingSkeleton.tsx
@@ -3,7 +3,10 @@ import { ArticleGridSkeleton } from '@/components/articles/ArticleCardSkeleton'
 
 export function ProfilePageLoadingSkeleton() {
   return (
-    <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12">
+    <main
+      className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12"
+      aria-hidden
+    >
       <div className="mb-8">
         <div className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-8">
           <div className="flex flex-col sm:flex-row gap-6">

--- a/hooks/useStaleLoading.ts
+++ b/hooks/useStaleLoading.ts
@@ -1,0 +1,46 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+type UseStaleLoadingOptions = {
+  timeoutMs?: number
+}
+
+export function useStaleLoading(
+  isLoading: boolean,
+  { timeoutMs = 10_000 }: UseStaleLoadingOptions = {}
+) {
+  const [isStale, setIsStale] = useState(false)
+  const timeoutIdRef = useRef<number | null>(null)
+
+  const reset = useCallback(() => {
+    setIsStale(false)
+  }, [])
+
+  useEffect(() => {
+    if (!isLoading) {
+      if (timeoutIdRef.current !== null) {
+        window.clearTimeout(timeoutIdRef.current)
+        timeoutIdRef.current = null
+      }
+      setIsStale(false)
+      return
+    }
+
+    if (isStale) return
+
+    timeoutIdRef.current = window.setTimeout(() => {
+      setIsStale(true)
+    }, timeoutMs)
+
+    return () => {
+      if (timeoutIdRef.current !== null) {
+        window.clearTimeout(timeoutIdRef.current)
+        timeoutIdRef.current = null
+      }
+    }
+  }, [isLoading, isStale, timeoutMs])
+
+  return { isStale, reset }
+}
+

--- a/hooks/useStaleLoading.ts
+++ b/hooks/useStaleLoading.ts
@@ -43,4 +43,3 @@ export function useStaleLoading(
 
   return { isStale, reset }
 }
-


### PR DESCRIPTION
## Summary
- Added an accessible `LoadingRegion` wrapper that announces loading/completion and marks regions `aria-busy`.
- Added `useStaleLoading` (10s default) to transition long-running loads from skeletons to a retryable alert state.
- Wired the pattern into article, profile, and /write auth-loading surfaces.

## Changes
- New: `components/a11y/LoadingRegion.tsx`
- New: `hooks/useStaleLoading.ts`
- Updated loading branches:
  - `app/[username]/[slug]/page.tsx`
  - `app/[username]/page.tsx`
  - `app/write/page.tsx`
- Skeleton a11y: marked key skeleton fallbacks `aria-hidden` to avoid screen reader noise:
  - `components/articles/ArticlePageLoadingSkeleton.tsx`
  - `components/profile/ProfilePageLoadingSkeleton.tsx`
  - `components/editor/EditorChromeSkeleton.tsx`
  - `components/articles/ArticleCardSkeleton.tsx`
  - `components/articles/ArticleEngagementSkeleton.tsx`

