### PR TITLE
fix(articles): drive reading progress from scroll and layout events (ENG-203)

### DIFF
--- a/components/articles/ReadingProgressBar.tsx
+++ b/components/articles/ReadingProgressBar.tsx
@@ -91,45 +91,79 @@ function getScrollProgress(nested: HTMLElement | null): number {
 export function ReadingProgressBar() {
   const [progress, setProgress] = useState(0)
   const nestedRef = useRef<HTMLElement | null>(null)
-  const frameRef = useRef(0)
+  const nestedScrollCleanupRef = useRef<(() => void) | null>(null)
+  const rafPendingRef = useRef(false)
+  const frameRef = useRef<number | null>(null)
 
   useEffect(() => {
+    const updateProgressNow = () => {
+      const next = getScrollProgress(nestedRef.current)
+      setProgress((prev) => (Object.is(prev, next) ? prev : next))
+    }
+
+    const scheduleUpdate = () => {
+      if (rafPendingRef.current) return
+      rafPendingRef.current = true
+      frameRef.current = window.requestAnimationFrame(() => {
+        rafPendingRef.current = false
+        updateProgressNow()
+      })
+    }
+
     const refreshNested = () => {
-      nestedRef.current = findLikelyNestedScrollRoot()
+      const nextNested = findLikelyNestedScrollRoot()
+      if (nestedRef.current === nextNested) return
+
+      nestedScrollCleanupRef.current?.()
+      nestedScrollCleanupRef.current = null
+      nestedRef.current = nextNested
+
+      if (nextNested) {
+        const onNestedScroll = () => scheduleUpdate()
+        nextNested.addEventListener('scroll', onNestedScroll, { passive: true })
+        nestedScrollCleanupRef.current = () => {
+          nextNested.removeEventListener('scroll', onNestedScroll)
+        }
+      }
+
+      scheduleUpdate()
     }
 
     refreshNested()
+    scheduleUpdate()
 
     const ro =
       typeof ResizeObserver !== 'undefined'
         ? new ResizeObserver(() => {
             refreshNested()
+            scheduleUpdate()
           })
         : null
     ro?.observe(document.documentElement)
     if (document.body) ro?.observe(document.body)
 
-    const onLayout = () => refreshNested()
+    const onLayout = () => {
+      refreshNested()
+      scheduleUpdate()
+    }
+    const onScroll = () => scheduleUpdate()
+
     window.addEventListener('load', onLayout)
     window.addEventListener('resize', onLayout)
+    window.addEventListener('scroll', onScroll, { passive: true })
     visualViewport?.addEventListener('resize', onLayout)
 
-    let frameCount = 0
-    const tick = () => {
-      frameCount += 1
-      if (frameCount % 45 === 0) refreshNested()
-
-      const next = getScrollProgress(nestedRef.current)
-      setProgress((prev) => (Object.is(prev, next) ? prev : next))
-
-      frameRef.current = requestAnimationFrame(tick)
-    }
-    frameRef.current = requestAnimationFrame(tick)
-
     return () => {
-      cancelAnimationFrame(frameRef.current)
+      nestedScrollCleanupRef.current?.()
+      nestedScrollCleanupRef.current = null
+
+      if (frameRef.current != null) cancelAnimationFrame(frameRef.current)
+      frameRef.current = null
+      rafPendingRef.current = false
+
       window.removeEventListener('load', onLayout)
       window.removeEventListener('resize', onLayout)
+      window.removeEventListener('scroll', onScroll)
       visualViewport?.removeEventListener('resize', onLayout)
       ro?.disconnect()
     }


### PR DESCRIPTION
## Summary

Fixes ENG-203 by removing the perpetual `requestAnimationFrame` loop in `ReadingProgressBar`. Progress now updates only on meaningful scroll or layout changes, reducing idle main-thread work on long article pages.

## Problem

The reading progress bar ran a continuous rAF loop for the entire session, calling `setProgress` every frame even when the user was not scrolling. On long articles and lower-end devices, this wasted battery and could hurt scroll smoothness.

## Solution

- Replace the idle rAF loop with a coalesced `scheduleUpdate()` that runs at most once per frame when triggered
- Listen for `window` scroll (passive), resize, and `visualViewport` resize
- Recompute on document size changes via `ResizeObserver` on `documentElement` and `body`
- Detect nested scroll containers on layout changes only; attach/detach passive scroll listeners when the root changes
- Keep the existing `Object.is` guard to skip redundant React state updates

