### PR TITLE
fix(a11y): expose current section in article table of contents (ENG-202)

### DIFF
--- a/components/articles/ArticleTableOfContents.tsx
+++ b/components/articles/ArticleTableOfContents.tsx
@@ -1,11 +1,14 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { pickActiveId } from '@/lib/articles/tocActiveSection'
 import type { TocHeading } from '@/lib/tiptap/headings'
 
 const ARTICLE_ROOT_SELECTOR = '.article-content'
-/** Below fixed nav (h-16) + thin progress strip; aligns with prose scroll-margin. */
-const ACTIVE_HEADING_TOP_OFFSET_PX = 96
+const TOC_HEADING_ID = 'article-toc-heading'
+
+const TOC_LINK_CLASS =
+  'block w-full text-left text-sm rounded px-2 py-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
 
 interface ArticleTableOfContentsProps {
   headings: TocHeading[]
@@ -17,22 +20,6 @@ function getHeadingElements(ids: string[]): HTMLElement[] {
     .filter((el): el is HTMLElement => el instanceof HTMLElement)
 }
 
-function pickActiveId(ids: string[]): string | null {
-  let active: string | null = null
-  let firstFound: string | null = null
-
-  for (const id of ids) {
-    const el = document.getElementById(id)
-    if (!el) continue
-    if (firstFound == null) firstFound = id
-    if (el.getBoundingClientRect().top <= ACTIVE_HEADING_TOP_OFFSET_PX) {
-      active = id
-    }
-  }
-
-  return active ?? firstFound
-}
-
 export function ArticleTableOfContents({
   headings,
 }: ArticleTableOfContentsProps) {
@@ -41,6 +28,13 @@ export function ArticleTableOfContents({
 
   const ids = useMemo(() => headings.map((h) => h.id), [headings])
 
+  const syncActiveFromScroll = useCallback(() => {
+    setActiveId((prev) => {
+      const next = pickActiveId(ids)
+      return prev === next ? prev : next
+    })
+  }, [ids])
+
   useEffect(() => {
     if (!enabled) return
 
@@ -48,18 +42,27 @@ export function ArticleTableOfContents({
 
     let scrollCleanup: (() => void) | null = null
     let mo: MutationObserver | null = null
+    let raf: number | null = null
 
-    const updateActive = () => {
-      setActiveId(pickActiveId(ids))
+    const scheduleSyncActive = () => {
+      if (raf != null) return
+      raf = requestAnimationFrame(() => {
+        raf = null
+        syncActiveFromScroll()
+      })
     }
 
     const attachScrollListeners = () => {
-      updateActive()
-      window.addEventListener('scroll', updateActive, { passive: true })
-      window.addEventListener('resize', updateActive)
+      syncActiveFromScroll()
+      window.addEventListener('scroll', scheduleSyncActive, { passive: true })
+      window.addEventListener('resize', scheduleSyncActive)
       return () => {
-        window.removeEventListener('scroll', updateActive)
-        window.removeEventListener('resize', updateActive)
+        window.removeEventListener('scroll', scheduleSyncActive)
+        window.removeEventListener('resize', scheduleSyncActive)
+        if (raf != null) {
+          cancelAnimationFrame(raf)
+          raf = null
+        }
       }
     }
 
@@ -83,37 +86,47 @@ export function ArticleTableOfContents({
     return () => {
       mo?.disconnect()
       scrollCleanup?.()
+      if (raf != null) cancelAnimationFrame(raf)
     }
-  }, [enabled, ids])
+  }, [enabled, ids, syncActiveFromScroll])
+
+  const scrollToHeading = useCallback((id: string) => {
+    setActiveId(id)
+    document.getElementById(id)?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'start',
+    })
+  }, [])
 
   if (!enabled) return null
 
   return (
     <div className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-[var(--card-padding)]">
-      <h3 className="text-lg font-semibold mb-3">On this page</h3>
-      <nav aria-label="Table of contents">
+      <h3 id={TOC_HEADING_ID} className="text-lg font-semibold mb-3">
+        On this page
+      </h3>
+      <nav aria-labelledby={TOC_HEADING_ID}>
         <ul className="space-y-1">
           {headings.map((h) => {
             const isActive = activeId === h.id
             return (
               <li key={h.id}>
-                <button
-                  type="button"
-                  onClick={() => {
-                    document.getElementById(h.id)?.scrollIntoView({
-                      behavior: 'smooth',
-                      block: 'start',
-                    })
+                <a
+                  href={`#${h.id}`}
+                  aria-current={isActive ? 'location' : undefined}
+                  onClick={(e) => {
+                    e.preventDefault()
+                    scrollToHeading(h.id)
                   }}
                   className={[
-                    'w-full text-left text-sm rounded px-2 py-1.5 transition-colors',
+                    TOC_LINK_CLASS,
                     isActive
                       ? 'bg-primary/10 text-foreground'
                       : 'text-muted-foreground hover:bg-muted hover:text-foreground',
                   ].join(' ')}
                 >
                   {h.text}
-                </button>
+                </a>
               </li>
             )
           })}

--- a/lib/articles/tocActiveSection.test.ts
+++ b/lib/articles/tocActiveSection.test.ts
@@ -1,9 +1,6 @@
 /** @vitest-environment jsdom */
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import {
-  ACTIVE_HEADING_TOP_OFFSET_PX,
-  pickActiveId,
-} from './tocActiveSection'
+import { ACTIVE_HEADING_TOP_OFFSET_PX, pickActiveId } from './tocActiveSection'
 
 function mockHeading(id: string, top: number) {
   const el = document.createElement('h2')

--- a/lib/articles/tocActiveSection.test.ts
+++ b/lib/articles/tocActiveSection.test.ts
@@ -1,0 +1,90 @@
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  ACTIVE_HEADING_TOP_OFFSET_PX,
+  pickActiveId,
+} from './tocActiveSection'
+
+function mockHeading(id: string, top: number) {
+  const el = document.createElement('h2')
+  el.id = id
+  vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+    top,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    width: 0,
+    height: 0,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect)
+  return el
+}
+
+describe('pickActiveId', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns null when ids is empty', () => {
+    expect(pickActiveId([])).toBeNull()
+  })
+
+  it('returns null when no heading elements exist in the DOM', () => {
+    vi.spyOn(document, 'getElementById').mockReturnValue(null)
+    expect(pickActiveId(['a', 'b'])).toBeNull()
+  })
+
+  it('returns the first heading when all are below the offset', () => {
+    const a = mockHeading('intro', 200)
+    const b = mockHeading('body', 400)
+    vi.spyOn(document, 'getElementById').mockImplementation((id) => {
+      if (id === 'intro') return a
+      if (id === 'body') return b
+      return null
+    })
+
+    expect(pickActiveId(['intro', 'body'])).toBe('intro')
+  })
+
+  it('returns the last heading at or above the offset threshold', () => {
+    const a = mockHeading('intro', 40)
+    const b = mockHeading('middle', 80)
+    const c = mockHeading('deep', 120)
+    vi.spyOn(document, 'getElementById').mockImplementation((id) => {
+      if (id === 'intro') return a
+      if (id === 'middle') return b
+      if (id === 'deep') return c
+      return null
+    })
+
+    expect(pickActiveId(['intro', 'middle', 'deep'])).toBe('middle')
+  })
+
+  it('skips missing DOM nodes and still resolves active section', () => {
+    const b = mockHeading('middle', 50)
+    vi.spyOn(document, 'getElementById').mockImplementation((id) => {
+      if (id === 'missing') return null
+      if (id === 'middle') return b
+      return null
+    })
+
+    expect(pickActiveId(['missing', 'middle'])).toBe('middle')
+  })
+
+  it('respects a custom offset', () => {
+    const a = mockHeading('intro', 150)
+    vi.spyOn(document, 'getElementById').mockReturnValue(a)
+
+    expect(pickActiveId(['intro'], 100)).toBe('intro')
+    expect(pickActiveId(['intro'], 200)).toBe('intro')
+  })
+
+  it('uses the default offset constant', () => {
+    const atThreshold = mockHeading('section', ACTIVE_HEADING_TOP_OFFSET_PX)
+    vi.spyOn(document, 'getElementById').mockReturnValue(atThreshold)
+
+    expect(pickActiveId(['section'])).toBe('section')
+  })
+})

--- a/lib/articles/tocActiveSection.ts
+++ b/lib/articles/tocActiveSection.ts
@@ -1,0 +1,26 @@
+/** Below fixed nav (h-16) + thin progress strip; aligns with prose scroll-margin. */
+export const ACTIVE_HEADING_TOP_OFFSET_PX = 96
+
+/**
+ * Returns the id of the heading that is currently "active" for TOC highlighting:
+ * the last heading whose top edge is at or above the scroll offset threshold,
+ * or the first heading found if none have crossed the threshold yet.
+ */
+export function pickActiveId(
+  ids: string[],
+  offsetPx = ACTIVE_HEADING_TOP_OFFSET_PX
+): string | null {
+  let active: string | null = null
+  let firstFound: string | null = null
+
+  for (const id of ids) {
+    const el = document.getElementById(id)
+    if (!el) continue
+    if (firstFound == null) firstFound = id
+    if (el.getBoundingClientRect().top <= offsetPx) {
+      active = id
+    }
+  }
+
+  return active ?? firstFound
+}


### PR DESCRIPTION
## Summary

Fixes ENG-202. The article table of contents now exposes the active section to assistive technology and keeps keyboard focus styling aligned with scroll-driven state.

- Mark the active TOC entry with `aria-current="location"` and wire the nav landmark to the visible "On this page" heading via `aria-labelledby`
- Replace TOC buttons with in-page anchor links (`href="#section-id"`) for standard section navigation semantics
- Add `focus-visible` rings on TOC links; set `activeId` optimistically on link activation so highlight matches intent during smooth scroll
- Coalesce scroll/resize updates with `requestAnimationFrame` and skip `setActiveId` when the active section id is unchanged
- Extract scroll-spy logic to `lib/articles/tocActiveSection.ts` with unit tests

<img width="1222" height="720" alt="1" src="https://github.com/user-attachments/assets/e3d0b553-9ef0-43f6-b38a-e63d1cd5a756" />
