### PR TITLE
feat(articles): article discovery polish, listing filters, and author 404 (ENG-148)

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { notFound } from 'next/navigation'
 import { useUserByUsername, useUserStats } from '@/hooks/convex'
 import { use, useState, useEffect } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
@@ -17,6 +16,7 @@ import ProfileHeader from '@/components/profile/ProfileHeader'
 import { ProfileTabBar } from '@/components/profile/ProfileTabBar'
 import { ProfileArticlesTabContent } from '@/components/profile/ProfileArticlesTabContent'
 import { ProfileNftsTabContent } from '@/components/profile/ProfileNftsTabContent'
+import { AuthorNotFoundPage } from '@/components/profile/AuthorNotFoundPage'
 import { ProfilePageLoadingSkeleton } from '@/components/profile/ProfilePageLoadingSkeleton'
 import { EarningsDashboard } from '@/components/dashboard/EarningsDashboard'
 import { WalletSettings } from '@/components/stellar'
@@ -79,9 +79,8 @@ export default function ProfilePage({ params }: ProfilePageProps) {
     )
   }, [authLoading, isOwnProfile, pathname, rawTab, router, searchParams])
 
-  // Check if user exists
   if (user === null) {
-    notFound()
+    return <AuthorNotFoundPage username={username} />
   }
 
   // Show loading while data is being fetched

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -93,6 +93,8 @@ export default function ProfilePage({ params }: ProfilePageProps) {
     )
   }
 
+  const profileDisplayName = user.name || user.username
+
   // Prepare user data with stats
   const userWithStats = {
     id: user._id,
@@ -178,7 +180,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
                 page={page}
                 basePath={`/${username}`}
                 isOwnProfile={isOwnProfile}
-                displayName={user.name || user.username}
+                displayName={profileDisplayName}
               />
             </div>
           )}
@@ -191,7 +193,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
               nftOwnedPage={nftOwnedPage}
               nftMintedPage={nftMintedPage}
               isOwnProfile={isOwnProfile}
-              displayName={user.name || user.username}
+              displayName={profileDisplayName}
             />
           )}
 
@@ -251,7 +253,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
                 <h2 className="text-2xl font-bold text-foreground mb-2">
                   {isOwnProfile
                     ? 'Wallet Management'
-                    : `${user?.name}'s Wallet`}
+                    : `${profileDisplayName}'s Wallet`}
                 </h2>
                 <p className="text-muted-foreground">
                   {isOwnProfile
@@ -263,8 +265,9 @@ export default function ProfilePage({ params }: ProfilePageProps) {
               {/* Wallet Settings */}
               <div className="max-w-2xl">
                 <WalletSettings
-                  walletAddress={localWalletAddress ?? user?.stellarAddress}
+                  walletAddress={localWalletAddress ?? user.stellarAddress}
                   isOwnProfile={isOwnProfile}
+                  profileDisplayName={profileDisplayName}
                   onAddressChange={(address) => {
                     // Immediately update local state for instant UI feedback
                     setLocalWalletAddress(address || undefined)

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -6,6 +6,7 @@ import AppNavigation from '@/components/layout/AppNavigation'
 import { SiteFooter } from '@/components/layout/SiteFooter'
 import SearchInput from '@/components/articles/SearchInput'
 import { ArticlesBrowseContent } from '@/components/articles/ArticlesBrowseContent'
+import { buildArticlesBrowseHref } from '@/lib/articles/buildArticlesBrowseHref'
 import {
   buildArticlesBrowseScrollStorageKey,
   writeBrowseScrollY,
@@ -61,14 +62,13 @@ export default function ArticlesPage() {
   }, [urlSearch])
 
   const handleSearchChange = (search: string) => {
-    const params = new URLSearchParams(searchParams?.toString() || '')
-    if (search.trim()) {
-      params.set('search', search.trim())
-    } else {
-      params.delete('search')
-    }
-    params.set('page', '1') // Reset to first page when searching
-    router.push(`/articles?${params.toString()}`)
+    router.push(
+      buildArticlesBrowseHref({
+        search,
+        page: 1,
+        sourceParams: searchParams,
+      })
+    )
   }
 
   const clearFilters = () => {
@@ -115,12 +115,13 @@ export default function ArticlesPage() {
                 Tag: {tag}
                 <button
                   onClick={() => {
-                    const params = new URLSearchParams(
-                      searchParams?.toString() || ''
+                    router.push(
+                      buildArticlesBrowseHref({
+                        tag: '',
+                        page: 1,
+                        sourceParams: searchParams,
+                      })
                     )
-                    params.delete('tag')
-                    params.set('page', '1')
-                    router.push(`/articles?${params.toString()}`)
                   }}
                   className="ml-2 hover:text-primary-foreground/80"
                   aria-label="Remove tag filter"
@@ -134,12 +135,13 @@ export default function ArticlesPage() {
                 Author: @{author}
                 <button
                   onClick={() => {
-                    const params = new URLSearchParams(
-                      searchParams?.toString() || ''
+                    router.push(
+                      buildArticlesBrowseHref({
+                        author: '',
+                        page: 1,
+                        sourceParams: searchParams,
+                      })
                     )
-                    params.delete('author')
-                    params.set('page', '1')
-                    router.push(`/articles?${params.toString()}`)
                   }}
                   className="ml-2 hover:text-primary-foreground/80"
                   aria-label="Remove author filter"
@@ -153,12 +155,13 @@ export default function ArticlesPage() {
                 Search: &ldquo;{urlSearch}&rdquo;
                 <button
                   onClick={() => {
-                    const params = new URLSearchParams(
-                      searchParams?.toString() || ''
+                    router.push(
+                      buildArticlesBrowseHref({
+                        search: '',
+                        page: 1,
+                        sourceParams: searchParams,
+                      })
                     )
-                    params.delete('search')
-                    params.set('page', '1')
-                    router.push(`/articles?${params.toString()}`)
                   }}
                   className="ml-2 hover:text-primary-foreground/80"
                   aria-label="Remove search filter"

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -91,12 +91,18 @@ export default function ArticlesPage() {
         </div>
 
         {/* Search Input */}
-        <div className="mb-6">
+        <div className="mb-6 max-w-md">
+          <label
+            htmlFor="articles-browse-search"
+            className="mb-2 block text-sm font-medium text-foreground"
+          >
+            Search articles
+          </label>
           <SearchInput
+            id="articles-browse-search"
             value={searchTerm}
             onChange={handleSearchChange}
             placeholder="Search articles by title or excerpt..."
-            className="max-w-md"
           />
         </div>
 

--- a/components/articles/ArticleAuthorByline.test.tsx
+++ b/components/articles/ArticleAuthorByline.test.tsx
@@ -1,0 +1,70 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import {
+  ArticleAuthorByline,
+  canLinkAuthorProfile,
+} from '@/components/articles/ArticleAuthorByline'
+import type { ArticleAuthorBylineAuthor } from '@/components/articles/ArticleAuthorByline'
+
+const linkableAuthor: ArticleAuthorBylineAuthor = {
+  id: 'user-1',
+  name: 'Jane Writer',
+  username: 'janewriter',
+  avatar: null,
+}
+
+const missingAuthor: ArticleAuthorBylineAuthor = {
+  id: '',
+  name: 'Former Author',
+  username: 'unknown',
+  avatar: null,
+}
+
+describe('canLinkAuthorProfile', () => {
+  it('returns true when id and username are valid', () => {
+    expect(canLinkAuthorProfile(linkableAuthor)).toBe(true)
+  })
+
+  it('returns false when username is unknown or empty', () => {
+    expect(canLinkAuthorProfile(missingAuthor)).toBe(false)
+    expect(canLinkAuthorProfile({ id: 'x', username: '' })).toBe(false)
+    expect(canLinkAuthorProfile({ id: '', username: 'janewriter' })).toBe(false)
+  })
+})
+
+describe('ArticleAuthorByline', () => {
+  it('renders profile link with accessible label and href', () => {
+    render(<ArticleAuthorByline author={linkableAuthor} />)
+
+    const link = screen.getByRole('link', {
+      name: "View Jane Writer's profile",
+    })
+    expect(link).toHaveAttribute('href', '/janewriter')
+    expect(screen.getByText('Jane Writer')).toBeInTheDocument()
+  })
+
+  it('renders non-link fallback when profile is unavailable', () => {
+    render(<ArticleAuthorByline author={missingAuthor} showHandle />)
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(screen.getByText('Former Author')).toBeInTheDocument()
+    expect(screen.getByText('Author profile unavailable')).toBeInTheDocument()
+    expect(screen.getByText('@unknown')).toBeInTheDocument()
+  })
+
+  it('renders metadata children outside the profile link', () => {
+    render(
+      <ArticleAuthorByline author={linkableAuthor}>
+        <p>3 min read</p>
+      </ArticleAuthorByline>
+    )
+
+    const link = screen.getByRole('link', {
+      name: "View Jane Writer's profile",
+    })
+    expect(link).not.toHaveTextContent('3 min read')
+    expect(screen.getByText('3 min read')).toBeInTheDocument()
+  })
+})

--- a/components/articles/ArticleAuthorByline.tsx
+++ b/components/articles/ArticleAuthorByline.tsx
@@ -41,7 +41,9 @@ export function ArticleAuthorByline({
       ? 'text-sm font-medium text-foreground'
       : 'font-medium text-foreground'
   const handleClassName =
-    size === 'sm' ? 'text-xs text-muted-foreground' : 'text-sm text-muted-foreground'
+    size === 'sm'
+      ? 'text-xs text-muted-foreground'
+      : 'text-sm text-muted-foreground'
 
   const identityBlock = (
     <>
@@ -54,11 +56,11 @@ export function ArticleAuthorByline({
       />
       <div>
         <p className={nameClassName}>{displayName}</p>
-        {showHandle && (
-          <p className={handleClassName}>@{author.username}</p>
-        )}
+        {showHandle && <p className={handleClassName}>@{author.username}</p>}
         {!linkable && (
-          <p className="text-xs text-muted-foreground">Author profile unavailable</p>
+          <p className="text-xs text-muted-foreground">
+            Author profile unavailable
+          </p>
         )}
       </div>
     </>

--- a/components/articles/ArticleAuthorByline.tsx
+++ b/components/articles/ArticleAuthorByline.tsx
@@ -1,0 +1,90 @@
+import Link from 'next/link'
+import { UserAvatar } from '@/components/ui/user-avatar'
+import type { ArticleForDisplay } from '@/types/index'
+import { cn } from '@/lib/utils'
+
+export type ArticleAuthorBylineAuthor = ArticleForDisplay['author']
+
+export function canLinkAuthorProfile(author: {
+  id: string
+  username: string
+}): boolean {
+  const u = author.username?.trim()
+  return Boolean(author.id && u && u !== 'unknown')
+}
+
+function profileAriaLabel(displayName: string): string {
+  return `View ${displayName}'s profile`
+}
+
+type ArticleAuthorBylineProps = {
+  author: ArticleAuthorBylineAuthor
+  size?: 'sm' | 'md'
+  showHandle?: boolean
+  className?: string
+  children?: React.ReactNode
+}
+
+export function ArticleAuthorByline({
+  author,
+  size = 'md',
+  showHandle = false,
+  className,
+  children,
+}: ArticleAuthorBylineProps) {
+  const displayName = author.name || author.username
+  const linkable = canLinkAuthorProfile(author)
+  const avatarClassName = size === 'sm' ? 'h-9 w-9' : 'h-12 w-12'
+  const fallbackClassName = size === 'sm' ? undefined : 'text-base'
+  const nameClassName =
+    size === 'sm'
+      ? 'text-sm font-medium text-foreground'
+      : 'font-medium text-foreground'
+  const handleClassName =
+    size === 'sm' ? 'text-xs text-muted-foreground' : 'text-sm text-muted-foreground'
+
+  const identityBlock = (
+    <>
+      <UserAvatar
+        src={author.avatar}
+        alt={displayName}
+        name={displayName}
+        className={avatarClassName}
+        fallbackClassName={fallbackClassName}
+      />
+      <div>
+        <p className={nameClassName}>{displayName}</p>
+        {showHandle && (
+          <p className={handleClassName}>@{author.username}</p>
+        )}
+        {!linkable && (
+          <p className="text-xs text-muted-foreground">Author profile unavailable</p>
+        )}
+      </div>
+    </>
+  )
+
+  const wrapperClassName = cn('flex flex-col gap-1', className)
+
+  if (linkable) {
+    return (
+      <div className={wrapperClassName}>
+        <Link
+          href={`/${author.username}`}
+          aria-label={profileAriaLabel(displayName)}
+          className="focus-ring flex items-center gap-3 rounded-md hover:opacity-80 transition-opacity w-fit"
+        >
+          {identityBlock}
+        </Link>
+        {children}
+      </div>
+    )
+  }
+
+  return (
+    <div className={wrapperClassName} aria-label={`Author: ${displayName}`}>
+      <div className="flex items-center gap-3">{identityBlock}</div>
+      {children}
+    </div>
+  )
+}

--- a/components/articles/ArticleCard.tsx
+++ b/components/articles/ArticleCard.tsx
@@ -9,12 +9,14 @@ interface ArticleCardProps {
   article: ArticleForDisplay
   priority?: boolean
   onArticleNavigate?: () => void
+  tagLinkAuthor?: string
 }
 
 export default function ArticleCard({
   article,
   priority,
   onArticleNavigate,
+  tagLinkAuthor,
 }: ArticleCardProps) {
   const publishedDate = article.publishedAt
     ? formatDistanceToNow(new Date(article.publishedAt), { addSuffix: true })
@@ -69,7 +71,11 @@ export default function ArticleCard({
         {article.tags.length > 0 && (
           <div className="flex flex-wrap gap-2 mb-4">
             {article.tags.slice(0, 3).map((tag) => (
-              <TagFilterLink key={tag.id} tag={tag.name}>
+              <TagFilterLink
+                key={tag.id}
+                tag={tag.name}
+                author={tagLinkAuthor}
+              >
                 {tag.name}
               </TagFilterLink>
             ))}

--- a/components/articles/ArticleCard.tsx
+++ b/components/articles/ArticleCard.tsx
@@ -83,11 +83,7 @@ export default function ArticleCard({
 
         {/* Author Info */}
         <div className="flex items-center justify-between pt-4 border-t border-border">
-          <ArticleAuthorByline
-            author={article.author}
-            size="sm"
-            showHandle
-          />
+          <ArticleAuthorByline author={article.author} size="sm" showHandle />
 
           {/* Published Date */}
           {publishedDate && (

--- a/components/articles/ArticleCard.tsx
+++ b/components/articles/ArticleCard.tsx
@@ -71,11 +71,7 @@ export default function ArticleCard({
         {article.tags.length > 0 && (
           <div className="flex flex-wrap gap-2 mb-4">
             {article.tags.slice(0, 3).map((tag) => (
-              <TagFilterLink
-                key={tag.id}
-                tag={tag.name}
-                author={tagLinkAuthor}
-              >
+              <TagFilterLink key={tag.id} tag={tag.name} author={tagLinkAuthor}>
                 {tag.name}
               </TagFilterLink>
             ))}

--- a/components/articles/ArticleCard.tsx
+++ b/components/articles/ArticleCard.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link'
 import Image from 'next/image'
-import { UserAvatar } from '@/components/ui/user-avatar'
 import { formatDistanceToNow } from 'date-fns'
 import { ArticleForDisplay } from '@/types/index'
+import { ArticleAuthorByline } from '@/components/articles/ArticleAuthorByline'
 import { TagFilterLink } from '@/components/articles/TagFilterLink'
 
 interface ArticleCardProps {
@@ -83,25 +83,11 @@ export default function ArticleCard({
 
         {/* Author Info */}
         <div className="flex items-center justify-between pt-4 border-t border-border">
-          <Link
-            href={`/${article.author.username}`}
-            className="focus-ring flex items-center gap-3 rounded-md hover:opacity-80 transition-opacity"
-          >
-            <UserAvatar
-              src={article.author.avatar}
-              alt={article.author.name || article.author.username}
-              name={article.author.name || article.author.username}
-              className="h-9 w-9"
-            />
-            <div>
-              <p className="text-sm font-medium text-foreground">
-                {article.author.name || article.author.username}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                @{article.author.username}
-              </p>
-            </div>
-          </Link>
+          <ArticleAuthorByline
+            author={article.author}
+            size="sm"
+            showHandle
+          />
 
           {/* Published Date */}
           {publishedDate && (

--- a/components/articles/ArticleDisplay.tsx
+++ b/components/articles/ArticleDisplay.tsx
@@ -5,7 +5,7 @@ import { type JSONContent } from '@tiptap/core'
 import { useEffect, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import Image from 'next/image'
-import { UserAvatar } from '@/components/ui/user-avatar'
+import { ArticleAuthorByline } from '@/components/articles/ArticleAuthorByline'
 import ShareButtons from './ShareButtons'
 import { ArticleReadOnlyBody } from '@/components/articles/ArticleReadOnlyBody'
 import { ArticleBodySkeleton } from '@/components/articles/ArticleBodySkeleton'
@@ -63,31 +63,19 @@ export default function ArticleDisplay({
         </h1>
 
         <div className="flex items-center gap-4 mb-6">
-          <div className="flex items-center gap-3">
-            <UserAvatar
-              src={article.author.avatar}
-              alt={article.author.name || article.author.username}
-              name={article.author.name || article.author.username}
-              className="h-12 w-12"
-              fallbackClassName="text-base"
-            />
-            <div>
-              <p className="font-medium text-foreground">
-                {article.author.name || article.author.username}
-              </p>
-              <p className="text-sm text-muted-foreground">
-                @{article.author.username}
-                <span className="mx-1">•</span>
-                {publishedDate && (
-                  <>
-                    {publishedDate}
-                    <span className="mx-1">•</span>
-                  </>
-                )}
-                {readingMinutes} min read
-              </p>
-            </div>
-          </div>
+          <ArticleAuthorByline author={article.author} size="md">
+            <p className="text-sm text-muted-foreground">
+              @{article.author.username}
+              <span className="mx-1">•</span>
+              {publishedDate && (
+                <>
+                  {publishedDate}
+                  <span className="mx-1">•</span>
+                </>
+              )}
+              {readingMinutes} min read
+            </p>
+          </ArticleAuthorByline>
         </div>
 
         {article.coverImage && (

--- a/components/articles/ArticleGrid.tsx
+++ b/components/articles/ArticleGrid.tsx
@@ -7,12 +7,14 @@ interface ArticleGridProps {
   articles: ArticleForDisplay[]
   variant?: 'home' | 'articles'
   onArticleNavigate?: () => void
+  tagLinkAuthor?: string
 }
 
 export default function ArticleGrid({
   articles,
   variant = 'articles',
   onArticleNavigate,
+  tagLinkAuthor,
 }: ArticleGridProps) {
   if (articles.length === 0) {
     if (variant === 'home') {
@@ -81,6 +83,7 @@ export default function ArticleGrid({
           article={article}
           priority={index === 0}
           onArticleNavigate={onArticleNavigate}
+          tagLinkAuthor={tagLinkAuthor}
         />
       ))}
     </div>

--- a/components/articles/ArticlesBrowseContent.tsx
+++ b/components/articles/ArticlesBrowseContent.tsx
@@ -7,6 +7,7 @@ import { mapListArticlesToDisplay } from '@/lib/articles/mapListArticleToDisplay
 import ArticleGrid from '@/components/articles/ArticleGrid'
 import Pagination from '@/components/articles/Pagination'
 import { ArticleGridSkeleton } from '@/components/articles/ArticleCardSkeleton'
+import { buildArticlesBrowseHref } from '@/lib/articles/buildArticlesBrowseHref'
 import { readBrowseScrollY } from '@/lib/articles/browseListScrollStorage'
 
 function buildPagination(result: {
@@ -69,9 +70,12 @@ export function ArticlesBrowseContent({
   const pagination = buildPagination(result)
 
   const handlePageChange = (page: number) => {
-    const params = new URLSearchParams(searchParams?.toString() || '')
-    params.set('page', page.toString())
-    router.push(`/articles?${params.toString()}`)
+    router.push(
+      buildArticlesBrowseHref({
+        page,
+        sourceParams: searchParams,
+      })
+    )
   }
 
   return (

--- a/components/articles/SearchInput.test.tsx
+++ b/components/articles/SearchInput.test.tsx
@@ -1,7 +1,22 @@
 /** @vitest-environment jsdom */
 import { render, screen, fireEvent, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import SearchInput from '@/components/articles/SearchInput'
+
+function renderWithLabel() {
+  return render(
+    <>
+      <label htmlFor="articles-browse-search">Search articles</label>
+      <SearchInput
+        id="articles-browse-search"
+        value=""
+        onChange={vi.fn()}
+        debounceMs={300}
+      />
+    </>
+  )
+}
 
 describe('SearchInput debounce', () => {
   beforeEach(() => {
@@ -111,5 +126,65 @@ describe('SearchInput controlled value sync', () => {
 
     rerender(<SearchInput value="bar" onChange={vi.fn()} />)
     expect(screen.getByRole('textbox')).toHaveValue('bar')
+  })
+})
+
+describe('SearchInput accessibility', () => {
+  it('keeps the visible label when the user types', () => {
+    renderWithLabel()
+    const input = screen.getByLabelText('Search articles')
+
+    expect(screen.getByText('Search articles')).toBeVisible()
+    fireEvent.change(input, { target: { value: 'stellar' } })
+    expect(screen.getByText('Search articles')).toBeVisible()
+    expect(input).toHaveValue('stellar')
+  })
+
+  it('associates the input with an external label via id', () => {
+    renderWithLabel()
+    expect(screen.getByLabelText('Search articles')).toHaveAttribute(
+      'id',
+      'articles-browse-search'
+    )
+  })
+
+  it('renders decorative icons as aria-hidden', () => {
+    const { container } = render(
+      <SearchInput value="query" onChange={vi.fn()} />
+    )
+    const icons = container.querySelectorAll('svg[aria-hidden="true"]')
+    expect(icons.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('exposes the clear button as type button with an accessible name', () => {
+    render(<SearchInput value="test" onChange={vi.fn()} />)
+    const clearButton = screen.getByRole('button', { name: /clear search/i })
+    expect(clearButton).toHaveAttribute('type', 'button')
+  })
+
+  it('clears search when the clear button is activated with Enter', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<SearchInput value="test" onChange={onChange} debounceMs={300} />)
+
+    const clearButton = screen.getByRole('button', { name: /clear search/i })
+    clearButton.focus()
+    await user.keyboard('{Enter}')
+
+    expect(onChange).toHaveBeenCalledWith('')
+    expect(screen.getByRole('textbox')).toHaveValue('')
+  })
+
+  it('clears search when the clear button is activated with Space', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<SearchInput value="test" onChange={onChange} debounceMs={300} />)
+
+    const clearButton = screen.getByRole('button', { name: /clear search/i })
+    clearButton.focus()
+    await user.keyboard(' ')
+
+    expect(onChange).toHaveBeenCalledWith('')
+    expect(screen.getByRole('textbox')).toHaveValue('')
   })
 })

--- a/components/articles/SearchInput.tsx
+++ b/components/articles/SearchInput.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useId } from 'react'
 import { Search, X } from 'lucide-react'
 
 interface SearchInputProps {
@@ -18,8 +18,10 @@ export default function SearchInput({
   placeholder = 'Search articles...',
   className = '',
   debounceMs = 300,
-  id,
+  id: idProp,
 }: SearchInputProps) {
+  const generatedId = useId()
+  const inputId = idProp ?? generatedId
   const [localValue, setLocalValue] = useState(value)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const onChangeRef = useRef(onChange)
@@ -64,22 +66,26 @@ export default function SearchInput({
   return (
     <div className={`relative ${className}`}>
       <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-quill-500" />
+        <Search
+          className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-quill-500"
+          aria-hidden
+        />
         <input
-          id={id}
+          id={inputId}
           type="text"
           value={localValue}
           onChange={handleInputChange}
           placeholder={placeholder}
-          className="w-full pl-10 pr-10 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue focus:border-transparent text-foreground placeholder:text-muted-foreground"
+          className="w-full pl-10 pr-10 py-2 border border-input rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:border-transparent text-foreground placeholder:text-muted-foreground"
         />
         {localValue && (
           <button
+            type="button"
             onClick={clearSearch}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-quill-500 hover:text-quill-700 transition-colors"
+            className="absolute right-3 top-1/2 -translate-y-1/2 rounded-sm text-quill-500 transition-colors hover:text-quill-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue"
             aria-label="Clear search"
           >
-            <X className="h-4 w-4" />
+            <X className="h-4 w-4" aria-hidden />
           </button>
         )}
       </div>

--- a/components/articles/SearchInput.tsx
+++ b/components/articles/SearchInput.tsx
@@ -9,6 +9,7 @@ interface SearchInputProps {
   placeholder?: string
   className?: string
   debounceMs?: number
+  id?: string
 }
 
 export default function SearchInput({
@@ -17,6 +18,7 @@ export default function SearchInput({
   placeholder = 'Search articles...',
   className = '',
   debounceMs = 300,
+  id,
 }: SearchInputProps) {
   const [localValue, setLocalValue] = useState(value)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -64,6 +66,7 @@ export default function SearchInput({
       <div className="relative">
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-quill-500" />
         <input
+          id={id}
           type="text"
           value={localValue}
           onChange={handleInputChange}

--- a/components/articles/TagFilterLink.test.tsx
+++ b/components/articles/TagFilterLink.test.tsx
@@ -1,0 +1,64 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { TagFilterLink } from './TagFilterLink'
+
+const useSearchParams = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => useSearchParams(),
+}))
+
+function hrefParams(href: string) {
+  const qs = href.split('?')[1] ?? ''
+  return new URLSearchParams(qs)
+}
+
+describe('TagFilterLink', () => {
+  beforeEach(() => {
+    useSearchParams.mockReset()
+  })
+
+  it('strips profile-only params from the articles browse href', () => {
+    useSearchParams.mockReturnValue(
+      new URLSearchParams('page=2&nftOwnedPage=3&nftMintedPage=1')
+    )
+    render(<TagFilterLink tag="rust">rust</TagFilterLink>)
+    const href = screen.getByRole('link', { name: 'Filter by tag rust' }).getAttribute(
+      'href'
+    )
+    expect(href).toBeTruthy()
+    const params = hrefParams(href!)
+    expect(params.get('tag')).toBe('rust')
+    expect(params.has('page')).toBe(false)
+    expect(params.has('nftOwnedPage')).toBe(false)
+    expect(params.has('nftMintedPage')).toBe(false)
+  })
+
+  it('includes author when the prop is provided', () => {
+    useSearchParams.mockReturnValue(new URLSearchParams('page=2&nftOwnedPage=3'))
+    render(
+      <TagFilterLink tag="rust" author="alice">
+        rust
+      </TagFilterLink>
+    )
+    const params = hrefParams(
+      screen.getByRole('link', { name: 'Filter by tag rust' }).getAttribute('href')!
+    )
+    expect(params.get('author')).toBe('alice')
+    expect(params.get('tag')).toBe('rust')
+  })
+
+  it('preserves search from the current articles browse URL', () => {
+    useSearchParams.mockReturnValue(
+      new URLSearchParams('search=stellar&tag=old&page=3')
+    )
+    render(<TagFilterLink tag="rust">rust</TagFilterLink>)
+    const params = hrefParams(
+      screen.getByRole('link', { name: 'Filter by tag rust' }).getAttribute('href')!
+    )
+    expect(params.get('search')).toBe('stellar')
+    expect(params.get('tag')).toBe('rust')
+    expect(params.has('page')).toBe(false)
+  })
+})

--- a/components/articles/TagFilterLink.test.tsx
+++ b/components/articles/TagFilterLink.test.tsx
@@ -24,9 +24,9 @@ describe('TagFilterLink', () => {
       new URLSearchParams('page=2&nftOwnedPage=3&nftMintedPage=1')
     )
     render(<TagFilterLink tag="rust">rust</TagFilterLink>)
-    const href = screen.getByRole('link', { name: 'Filter by tag rust' }).getAttribute(
-      'href'
-    )
+    const href = screen
+      .getByRole('link', { name: 'Filter by tag rust' })
+      .getAttribute('href')
     expect(href).toBeTruthy()
     const params = hrefParams(href!)
     expect(params.get('tag')).toBe('rust')
@@ -36,14 +36,18 @@ describe('TagFilterLink', () => {
   })
 
   it('includes author when the prop is provided', () => {
-    useSearchParams.mockReturnValue(new URLSearchParams('page=2&nftOwnedPage=3'))
+    useSearchParams.mockReturnValue(
+      new URLSearchParams('page=2&nftOwnedPage=3')
+    )
     render(
       <TagFilterLink tag="rust" author="alice">
         rust
       </TagFilterLink>
     )
     const params = hrefParams(
-      screen.getByRole('link', { name: 'Filter by tag rust' }).getAttribute('href')!
+      screen
+        .getByRole('link', { name: 'Filter by tag rust' })
+        .getAttribute('href')!
     )
     expect(params.get('author')).toBe('alice')
     expect(params.get('tag')).toBe('rust')
@@ -55,7 +59,9 @@ describe('TagFilterLink', () => {
     )
     render(<TagFilterLink tag="rust">rust</TagFilterLink>)
     const params = hrefParams(
-      screen.getByRole('link', { name: 'Filter by tag rust' }).getAttribute('href')!
+      screen
+        .getByRole('link', { name: 'Filter by tag rust' })
+        .getAttribute('href')!
     )
     expect(params.get('search')).toBe('stellar')
     expect(params.get('tag')).toBe('rust')

--- a/components/articles/TagFilterLink.tsx
+++ b/components/articles/TagFilterLink.tsx
@@ -2,23 +2,27 @@
 
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
+import { buildArticlesBrowseHref } from '@/lib/articles/buildArticlesBrowseHref'
 
 export function TagFilterLink({
   tag,
+  author,
   className = '',
   children,
 }: {
   tag: string
+  author?: string
   className?: string
   children?: React.ReactNode
 }) {
   const searchParams = useSearchParams()
 
-  const params = new URLSearchParams(searchParams?.toString() || '')
-  params.set('tag', tag)
-  params.set('page', '1')
-
-  const href = `/articles?${params.toString()}`
+  const href = buildArticlesBrowseHref({
+    tag,
+    page: 1,
+    author,
+    sourceParams: searchParams,
+  })
 
   return (
     <Link

--- a/components/editor/EditorActionBar.test.tsx
+++ b/components/editor/EditorActionBar.test.tsx
@@ -147,23 +147,16 @@ describe('EditorActionBar publish requirements', () => {
     const reason =
       'Please add an excerpt of at least 10 characters before publishing'
     render(
-      <EditorActionBar
-        {...baseProps}
-        canPublish
-        publishBlockReason={reason}
-      />
+      <EditorActionBar {...baseProps} canPublish publishBlockReason={reason} />
     )
     expect(screen.getByText(reason)).toBeVisible()
   })
 
   it('associates Publish with the block reason via aria-describedby', () => {
-    const reason = 'Please replace "Untitled" with a real title before publishing'
+    const reason =
+      'Please replace "Untitled" with a real title before publishing'
     render(
-      <EditorActionBar
-        {...baseProps}
-        canPublish
-        publishBlockReason={reason}
-      />
+      <EditorActionBar {...baseProps} canPublish publishBlockReason={reason} />
     )
     const publishButtons = screen.getAllByRole('button', { name: 'Publish' })
     const describedBy = publishButtons[0]!.getAttribute('aria-describedby')

--- a/components/editor/EditorActionBar.test.tsx
+++ b/components/editor/EditorActionBar.test.tsx
@@ -141,3 +141,46 @@ describe('EditorActionBar autosave status', () => {
     }
   })
 })
+
+describe('EditorActionBar publish requirements', () => {
+  it('shows a visible banner when publishBlockReason is set', () => {
+    const reason =
+      'Please add an excerpt of at least 10 characters before publishing'
+    render(
+      <EditorActionBar
+        {...baseProps}
+        canPublish
+        publishBlockReason={reason}
+      />
+    )
+    expect(screen.getByText(reason)).toBeVisible()
+  })
+
+  it('associates Publish with the block reason via aria-describedby', () => {
+    const reason = 'Please replace "Untitled" with a real title before publishing'
+    render(
+      <EditorActionBar
+        {...baseProps}
+        canPublish
+        publishBlockReason={reason}
+      />
+    )
+    const publishButtons = screen.getAllByRole('button', { name: 'Publish' })
+    const describedBy = publishButtons[0]!.getAttribute('aria-describedby')
+    expect(describedBy).toBeTruthy()
+    const banner = document.getElementById(describedBy!)
+    expect(banner).toHaveTextContent(reason)
+  })
+
+  it('does not show publish block banner when already published', () => {
+    render(
+      <EditorActionBar
+        {...baseProps}
+        isPublished
+        publishBlockReason="Please add an excerpt of at least 10 characters before publishing"
+      />
+    )
+    expect(screen.queryByText(/excerpt of at least/)).not.toBeInTheDocument()
+    expect(screen.getAllByText('Published').length).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useId, useState, type ReactNode } from 'react'
 import { Editor } from '@tiptap/react'
 import { formatDistanceToNow } from 'date-fns'
 import {
@@ -64,6 +64,7 @@ interface EditorActionBarProps {
   isPublished: boolean
   isPublishing: boolean
   canPublish: boolean
+  publishBlockReason?: string | null
   lastSavedAt?: Date | null
   onDelete?: () => void
   isDeleting?: boolean
@@ -157,11 +158,13 @@ export function EditorActionBar({
   isPublished,
   isPublishing,
   canPublish,
+  publishBlockReason = null,
   lastSavedAt,
   onDelete,
   isDeleting = false,
   hasUnsavedChanges = false,
 }: EditorActionBarProps) {
+  const publishBlockReasonId = useId()
   const [relativeTick, setRelativeTick] = useState(0)
   const shortcuts = useUndoRedoShortcuts()
 
@@ -227,8 +230,17 @@ export function EditorActionBar({
       type="button"
       onClick={onPublish}
       disabled={isPublishing || !canPublish}
+      aria-describedby={
+        publishBlockReason ? publishBlockReasonId : undefined
+      }
       className="px-5 py-2 text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed rounded-full transition-colors shrink-0"
-      title="Publish article"
+      title={
+        publishBlockReason
+          ? publishBlockReason
+          : canPublish
+            ? 'Publish article'
+            : 'Add content before publishing'
+      }
     >
       {isPublishing ? 'Publishing...' : 'Publish'}
     </button>
@@ -383,6 +395,16 @@ export function EditorActionBar({
           title={error}
         >
           Save failed
+        </div>
+      )}
+
+      {publishBlockReason && !isPublished && (
+        <div
+          id={publishBlockReasonId}
+          role="status"
+          className="border-t border-border bg-muted/50 px-4 py-2 text-xs text-muted-foreground"
+        >
+          {publishBlockReason}
         </div>
       )}
     </div>

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -230,9 +230,7 @@ export function EditorActionBar({
       type="button"
       onClick={onPublish}
       disabled={isPublishing || !canPublish}
-      aria-describedby={
-        publishBlockReason ? publishBlockReasonId : undefined
-      }
+      aria-describedby={publishBlockReason ? publishBlockReasonId : undefined}
       className="px-5 py-2 text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed rounded-full transition-colors shrink-0"
       title={
         publishBlockReason

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -950,7 +950,8 @@ export function WriteEditorWorkspace() {
         error={error?.message ?? null}
         isPublished={publishStatus.published}
         isPublishing={isPublishing}
-        canPublish={!!editor && !editor.isEmpty && publishListingError === null}
+        canPublish={!!editor && !editor.isEmpty && !isPublishing}
+        publishBlockReason={publishListingError}
         lastSavedAt={lastSavedAt ?? undefined}
         onDelete={handleRequestDelete}
         isDeleting={isDeleting}

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -59,6 +59,7 @@ import {
   shouldPersistDraftBackup,
   writeDraftBackup,
 } from '@/lib/draftBackup'
+import { getListingReadyPublishError } from '@/convex/lib/articleListingReady'
 import { getWriteUrlWithDraftId } from '@/lib/writeDraftUrl'
 
 const PUBLISH_EXCERPT_PREVIEW_MAX = 280
@@ -521,13 +522,23 @@ export function WriteEditorWorkspace() {
     return () => window.removeEventListener('keydown', handler)
   }, [saveNow])
 
+  const publishListingError = getListingReadyPublishError({
+    title,
+    excerpt,
+  })
+
   const requestPublish = useCallback(() => {
     if (!editor || editor.isEmpty) {
       toast.warning('Please add content before publishing')
       return
     }
+    const listingError = getListingReadyPublishError({ title, excerpt })
+    if (listingError) {
+      toast.warning(listingError)
+      return
+    }
     setPublishConfirmOpen(true)
-  }, [editor])
+  }, [editor, title, excerpt])
 
   const handlePublish = useCallback(async () => {
     if (!editor || editor.isEmpty) {
@@ -538,6 +549,12 @@ export function WriteEditorWorkspace() {
     if (!editorContent) {
       setPublishConfirmOpen(false)
       toast.warning('Please add content before publishing')
+      return
+    }
+    const listingError = getListingReadyPublishError({ title, excerpt })
+    if (listingError) {
+      setPublishConfirmOpen(false)
+      toast.warning(listingError)
       return
     }
 
@@ -554,9 +571,9 @@ export function WriteEditorWorkspace() {
         resultId = published.id
       } else {
         resultId = await createArticleMutation({
-          title: title || 'Untitled',
+          title: title.trim(),
           content: editorContent,
-          excerpt: excerpt || undefined,
+          excerpt: excerpt.trim(),
           coverImage: coverImage || undefined,
           tags: tags
             .split(',')
@@ -933,7 +950,7 @@ export function WriteEditorWorkspace() {
         error={error?.message ?? null}
         isPublished={publishStatus.published}
         isPublishing={isPublishing}
-        canPublish={!!editor}
+        canPublish={!!editor && !editor.isEmpty && publishListingError === null}
         lastSavedAt={lastSavedAt ?? undefined}
         onDelete={handleRequestDelete}
         isDeleting={isDeleting}
@@ -1202,7 +1219,8 @@ export function WriteEditorWorkspace() {
                     </span>
                   </div>
                   <p className="mt-0.5 text-xs text-muted-foreground">
-                    Optional. Shown on article cards and in the publish preview.
+                    Required for publishing. Shown on article cards and in the
+                    publish preview (at least 10 characters).
                   </p>
                   {!excerptOpen && excerpt.trim().length > 0 && (
                     <p className="mt-2 line-clamp-2 whitespace-pre-wrap break-words text-sm text-foreground/80">

--- a/components/profile/AuthorNotFoundPage.test.tsx
+++ b/components/profile/AuthorNotFoundPage.test.tsx
@@ -1,0 +1,88 @@
+/** @vitest-environment jsdom */
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+import { AuthorNotFoundPage } from '@/components/profile/AuthorNotFoundPage'
+
+const push = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => '/badhandle',
+}))
+
+vi.mock('@/components/layout/AppNavigation', () => ({
+  default: () => <nav data-testid="app-nav" />,
+}))
+
+vi.mock('@/components/layout/SiteFooter', () => ({
+  SiteFooter: () => <footer data-testid="site-footer" />,
+}))
+
+vi.mock('@/components/providers/AuthContext', () => ({
+  useAuth: () => ({ user: null, isAuthenticated: false, signOut: vi.fn() }),
+}))
+
+describe('AuthorNotFoundPage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    push.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders profile unavailable heading and username', () => {
+    render(<AuthorNotFoundPage username="badhandle" />)
+
+    expect(screen.getByText('Profile unavailable')).toBeInTheDocument()
+    expect(screen.getByText('@badhandle')).toBeInTheDocument()
+    expect(
+      screen.getByText(/No writer profile exists for/i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders search input with accessible label', () => {
+    render(<AuthorNotFoundPage username="badhandle" />)
+
+    expect(screen.getByLabelText('Search for articles')).toBeInTheDocument()
+    expect(
+      screen.getByPlaceholderText('Search articles and writers...')
+    ).toBeInTheDocument()
+  })
+
+  it('links Browse articles to /articles and Go home to /', () => {
+    render(<AuthorNotFoundPage username="badhandle" />)
+
+    expect(screen.getByRole('link', { name: 'Browse articles' })).toHaveAttribute(
+      'href',
+      '/articles'
+    )
+    expect(screen.getByRole('link', { name: 'Go home' })).toHaveAttribute(
+      'href',
+      '/'
+    )
+  })
+
+  it('navigates to articles search after debounced input', () => {
+    render(<AuthorNotFoundPage username="badhandle" />)
+    const input = screen.getByRole('textbox')
+
+    fireEvent.change(input, { target: { value: 'stellar' } })
+    act(() => vi.advanceTimersByTime(300))
+
+    expect(push).toHaveBeenCalledTimes(1)
+    expect(push).toHaveBeenCalledWith('/articles?search=stellar&page=1')
+  })
+
+  it('does not navigate when search is empty or whitespace', () => {
+    render(<AuthorNotFoundPage username="badhandle" />)
+    const input = screen.getByRole('textbox')
+
+    fireEvent.change(input, { target: { value: '   ' } })
+    act(() => vi.advanceTimersByTime(300))
+
+    expect(push).not.toHaveBeenCalled()
+  })
+})

--- a/components/profile/AuthorNotFoundPage.test.tsx
+++ b/components/profile/AuthorNotFoundPage.test.tsx
@@ -55,10 +55,9 @@ describe('AuthorNotFoundPage', () => {
   it('links Browse articles to /articles and Go home to /', () => {
     render(<AuthorNotFoundPage username="badhandle" />)
 
-    expect(screen.getByRole('link', { name: 'Browse articles' })).toHaveAttribute(
-      'href',
-      '/articles'
-    )
+    expect(
+      screen.getByRole('link', { name: 'Browse articles' })
+    ).toHaveAttribute('href', '/articles')
     expect(screen.getByRole('link', { name: 'Go home' })).toHaveAttribute(
       'href',
       '/'

--- a/components/profile/AuthorNotFoundPage.tsx
+++ b/components/profile/AuthorNotFoundPage.tsx
@@ -72,9 +72,7 @@ export function AuthorNotFoundPage({ username }: AuthorNotFoundPageProps) {
     (search: string) => {
       const trimmed = search.trim()
       if (!trimmed) return
-      router.push(
-        `/articles?search=${encodeURIComponent(trimmed)}&page=1`
-      )
+      router.push(`/articles?search=${encodeURIComponent(trimmed)}&page=1`)
     },
     [router]
   )

--- a/components/profile/AuthorNotFoundPage.tsx
+++ b/components/profile/AuthorNotFoundPage.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useCallback } from 'react'
+
+import SearchInput from '@/components/articles/SearchInput'
+import { FailurePageShell } from '@/components/error/FailurePageShell'
+import AppNavigation from '@/components/layout/AppNavigation'
+import { SiteFooter } from '@/components/layout/SiteFooter'
+import { Button } from '@/components/ui/button'
+
+type AuthorNotFoundPageProps = {
+  username: string
+}
+
+function AuthorNotFoundIllustration() {
+  return (
+    <div className="mx-auto mb-6 w-full max-w-[220px]">
+      <svg
+        viewBox="0 0 200 168"
+        className="h-auto w-full"
+        aria-hidden
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="100"
+          cy="52"
+          r="28"
+          className="fill-card stroke-border"
+          strokeWidth="2"
+        />
+        <path
+          d="M56 120c8-22 28-34 44-34s36 12 44 34"
+          className="fill-none stroke-border"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <line
+          x1="88"
+          y1="48"
+          x2="112"
+          y2="56"
+          className="stroke-muted-foreground/70"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        />
+        <line
+          x1="112"
+          y1="48"
+          x2="88"
+          y2="56"
+          className="stroke-muted-foreground/70"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        />
+        <path
+          d="M158 36l18 18M176 36l-18 18"
+          className="stroke-brand-accent"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        />
+      </svg>
+    </div>
+  )
+}
+
+export function AuthorNotFoundPage({ username }: AuthorNotFoundPageProps) {
+  const router = useRouter()
+
+  const handleSearchChange = useCallback(
+    (search: string) => {
+      const trimmed = search.trim()
+      if (!trimmed) return
+      router.push(
+        `/articles?search=${encodeURIComponent(trimmed)}&page=1`
+      )
+    },
+    [router]
+  )
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <AppNavigation />
+      <main className="flex flex-1 flex-col">
+        <FailurePageShell
+          className="flex-1 py-12"
+          illustration={<AuthorNotFoundIllustration />}
+          heading={
+            <h1 className="font-display text-2xl font-medium tracking-[-0.01em] text-foreground sm:text-3xl">
+              Profile unavailable
+            </h1>
+          }
+          description={
+            <>
+              <p>
+                No writer profile exists for{' '}
+                <span className="font-medium text-foreground">@{username}</span>
+                .
+              </p>
+              <p className="mt-2">
+                Check the spelling or search for their articles.
+              </p>
+            </>
+          }
+          actionsClassName="flex w-full flex-col items-stretch gap-4 sm:flex-col"
+          actions={
+            <>
+              <div className="w-full text-left">
+                <label
+                  id="author-not-found-search-label"
+                  htmlFor="author-not-found-search"
+                  className="mb-2 block text-sm font-medium text-foreground"
+                >
+                  Search for articles
+                </label>
+                <SearchInput
+                  id="author-not-found-search"
+                  value=""
+                  onChange={handleSearchChange}
+                  placeholder="Search articles and writers..."
+                  className="w-full"
+                />
+              </div>
+              <Button asChild size="lg" className="w-full sm:w-auto sm:mx-auto">
+                <Link href="/articles">Browse articles</Link>
+              </Button>
+              <Link
+                href="/"
+                className="text-center text-sm font-medium text-primary underline-offset-4 transition-colors hover:underline sm:mx-auto"
+              >
+                Go home
+              </Link>
+            </>
+          }
+        />
+      </main>
+      <SiteFooter variant="default" />
+    </div>
+  )
+}

--- a/components/profile/ProfileArticlesTabContent.tsx
+++ b/components/profile/ProfileArticlesTabContent.tsx
@@ -62,7 +62,7 @@ export function ProfileArticlesTabContent({
   return (
     <>
       <PaginationTransition isPaginating={isPaginating}>
-        <ArticleGrid articles={articles} />
+        <ArticleGrid articles={articles} tagLinkAuthor={username} />
       </PaginationTransition>
 
       {totalPages > 1 && (

--- a/components/stellar/WalletSettings.test.tsx
+++ b/components/stellar/WalletSettings.test.tsx
@@ -1,0 +1,75 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { WalletSettings } from '@/components/stellar/WalletSettings'
+
+vi.mock('convex/react', () => ({
+  useMutation: () => vi.fn(),
+}))
+
+vi.mock('@/components/providers/WalletProvider', () => ({
+  useWallet: () => ({
+    isLoading: false,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('@/components/guide/WalletTooltip', () => ({
+  WalletTooltip: () => null,
+}))
+
+vi.mock('@/components/stellar/InstallWalletDialog', () => ({
+  InstallWalletDialog: () => null,
+}))
+
+vi.mock('@/components/legal/LegalLinks', () => ({
+  LegalLinks: () => null,
+}))
+
+describe('WalletSettings', () => {
+  it('shows visitor empty alert with profile display name', () => {
+    render(
+      <WalletSettings
+        isOwnProfile={false}
+        walletAddress={null}
+        profileDisplayName="alice"
+      />
+    )
+
+    expect(
+      screen.getByText("alice hasn't set up their Stellar wallet yet.")
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/undefined/i)).not.toBeInTheDocument()
+  })
+
+  it('falls back to generic visitor empty alert without profile display name', () => {
+    render(<WalletSettings isOwnProfile={false} walletAddress={null} />)
+
+    expect(
+      screen.getByText("This user hasn't set up their Stellar wallet yet.")
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/undefined/i)).not.toBeInTheDocument()
+  })
+
+  it('shows owner connect CTA when wallet address is missing', () => {
+    render(<WalletSettings isOwnProfile walletAddress={null} />)
+
+    expect(
+      screen.getByRole('button', { name: /Connect Stellar Wallet/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        /Connect your Stellar testnet wallet to send and receive practice tips/i
+      )
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/undefined/i)).not.toBeInTheDocument()
+  })
+})

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -40,6 +40,7 @@ interface WalletSettingsProps {
   walletAddress?: string | null
   onAddressChange?: (address: string) => void
   isOwnProfile: boolean
+  profileDisplayName?: string
   className?: string
 }
 
@@ -47,6 +48,7 @@ export function WalletSettings({
   walletAddress,
   onAddressChange,
   isOwnProfile,
+  profileDisplayName,
   className = '',
 }: WalletSettingsProps) {
   const updateProfile = useMutation(api.users.updateProfile)
@@ -160,7 +162,9 @@ export function WalletSettings({
       <Alert className={className}>
         <AlertCircle className="h-4 w-4" />
         <AlertDescription>
-          This user hasn&apos;t set up their Stellar wallet yet.
+          {profileDisplayName
+            ? `${profileDisplayName} hasn't set up their Stellar wallet yet.`
+            : "This user hasn't set up their Stellar wallet yet."}
         </AlertDescription>
       </Alert>
     )

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as highlightTips from "../highlightTips.js";
 import type * as highlights from "../highlights.js";
 import type * as http from "../http.js";
 import type * as lib_articleListing from "../lib/articleListing.js";
+import type * as lib_articleListingReady from "../lib/articleListingReady.js";
 import type * as lib_articleSlug from "../lib/articleSlug.js";
 import type * as lib_constants from "../lib/constants.js";
 import type * as lib_enrich from "../lib/enrich.js";
@@ -53,6 +54,7 @@ declare const fullApi: ApiFromModules<{
   highlights: typeof highlights;
   http: typeof http;
   "lib/articleListing": typeof lib_articleListing;
+  "lib/articleListingReady": typeof lib_articleListingReady;
   "lib/articleSlug": typeof lib_articleSlug;
   "lib/constants": typeof lib_constants;
   "lib/enrich": typeof lib_enrich;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -18,6 +18,7 @@ import type * as highlights from "../highlights.js";
 import type * as http from "../http.js";
 import type * as lib_articleListing from "../lib/articleListing.js";
 import type * as lib_articleListingReady from "../lib/articleListingReady.js";
+import type * as lib_articleSearch from "../lib/articleSearch.js";
 import type * as lib_articleSlug from "../lib/articleSlug.js";
 import type * as lib_constants from "../lib/constants.js";
 import type * as lib_enrich from "../lib/enrich.js";
@@ -55,6 +56,7 @@ declare const fullApi: ApiFromModules<{
   http: typeof http;
   "lib/articleListing": typeof lib_articleListing;
   "lib/articleListingReady": typeof lib_articleListingReady;
+  "lib/articleSearch": typeof lib_articleSearch;
   "lib/articleSlug": typeof lib_articleSlug;
   "lib/constants": typeof lib_constants;
   "lib/enrich": typeof lib_enrich;

--- a/convex/articles.listArticles.test.ts
+++ b/convex/articles.listArticles.test.ts
@@ -353,4 +353,134 @@ describe('listArticles', () => {
       expect(res.articles[0]!.title).toBe('Complete Article')
     })
   })
+
+  it('finds articles by tag via search when searchContent is stale', async () => {
+    const t = convexTest(schema, modules)
+    await t.run(async (ctx) => {
+      const now = Date.now()
+      const u = await ctx.db.insert('users', {
+        email: 'stale@x.test',
+        username: 'stalewriter',
+        createdAt: now,
+        updatedAt: now,
+      })
+      const id = await ctx.db.insert('articles', {
+        slug: 'stale-tag',
+        title: 'Stale Tag Article',
+        excerpt: listingExcerpt,
+        content: emptyDoc,
+        published: true,
+        publishedAt: now,
+        authorId: u,
+        authorUsername: 'stalewriter',
+        tags: ['visibleTag'],
+        searchContent: 'Stale Tag Article',
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      const doc = await ctx.db.get(id)
+      if (doc) await replaceTagLinksForArticle(ctx, doc)
+
+      const res = await ctx.runQuery(api.articles.listArticles, {
+        search: 'visibleTag',
+        page: 1,
+        limit: 10,
+      })
+      expect(res.total).toBe(1)
+      expect(res.articles[0]!._id).toBe(id)
+    })
+  })
+
+  it('finds articles by full title when searchContent matches title only', async () => {
+    const t = convexTest(schema, modules)
+    await t.run(async (ctx) => {
+      const now = Date.now()
+      const u = await ctx.db.insert('users', {
+        email: 'title@x.test',
+        username: 'titlewriter',
+        createdAt: now,
+        updatedAt: now,
+      })
+      const fullTitle = 'My Complete Guide Title'
+      await ctx.db.insert('articles', {
+        slug: 'full-title',
+        title: fullTitle,
+        excerpt: listingExcerpt,
+        content: emptyDoc,
+        published: true,
+        publishedAt: now,
+        authorId: u,
+        authorUsername: 'titlewriter',
+        tags: [],
+        searchContent: fullTitle,
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      const res = await ctx.runQuery(api.articles.listArticles, {
+        search: fullTitle,
+        page: 1,
+        limit: 10,
+      })
+      expect(res.total).toBe(1)
+      expect(res.articles[0]!.title).toBe(fullTitle)
+    })
+  })
+
+  it('falls back to computed search content when FTS misses', async () => {
+    const t = convexTest(schema, modules)
+    await t.run(async (ctx) => {
+      const now = Date.now()
+      const u = await ctx.db.insert('users', {
+        email: 'fallback@x.test',
+        username: 'fallbackwriter',
+        createdAt: now,
+        updatedAt: now,
+      })
+      const uniqueToken = 'fallbackUniqueBodyToken'
+      const title = 'Fallback Search Article'
+      await ctx.db.insert('articles', {
+        slug: 'fallback',
+        title,
+        excerpt: listingExcerpt,
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: uniqueToken }],
+            },
+          ],
+        },
+        published: true,
+        publishedAt: now,
+        authorId: u,
+        authorUsername: 'fallbackwriter',
+        tags: [],
+        searchContent: undefined,
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      const res = await ctx.runQuery(api.articles.listArticles, {
+        search: uniqueToken,
+        page: 1,
+        limit: 10,
+      })
+      expect(res.total).toBe(1)
+      expect(res.articles[0]!.title).toBe(title)
+    })
+  })
 })

--- a/convex/articles.listArticles.test.ts
+++ b/convex/articles.listArticles.test.ts
@@ -10,6 +10,9 @@ import {
 
 const emptyDoc = { type: 'doc', content: [] }
 
+/** Meets MIN_LISTING_EXCERPT_CHARS for public discovery lists */
+const listingExcerpt = 'A valid excerpt for public listing.'
+
 const modules = import.meta.glob(['./**/*.ts', '!./**/*.test.ts'])
 
 describe('listArticles', () => {
@@ -26,6 +29,7 @@ describe('listArticles', () => {
       const a1 = await ctx.db.insert('articles', {
         slug: 'one',
         title: 'One',
+        excerpt: listingExcerpt,
         content: emptyDoc,
         published: true,
         publishedAt: now,
@@ -87,6 +91,7 @@ describe('listArticles', () => {
         const id = await ctx.db.insert('articles', {
           slug: `p-${i}`,
           title: `P${i}`,
+          excerpt: listingExcerpt,
           content: emptyDoc,
           published: true,
           publishedAt: now + i * 1000,
@@ -137,6 +142,7 @@ describe('listArticles', () => {
       await ctx.db.insert('articles', {
         slug: 'old',
         title: 'Banana guide',
+        excerpt: listingExcerpt,
         content: emptyDoc,
         published: true,
         publishedAt: now,
@@ -154,6 +160,7 @@ describe('listArticles', () => {
       await ctx.db.insert('articles', {
         slug: 'new',
         title: 'Fresh banana',
+        excerpt: listingExcerpt,
         content: emptyDoc,
         published: true,
         publishedAt: now + 99999,
@@ -196,6 +203,7 @@ describe('listArticles', () => {
       await ctx.db.insert('articles', {
         slug: 'tagged',
         title: 'Only Title',
+        excerpt: listingExcerpt,
         content: emptyDoc,
         published: true,
         publishedAt: now,
@@ -240,6 +248,7 @@ describe('listArticles', () => {
       const id = await ctx.db.insert('articles', {
         slug: 'at',
         title: 'T',
+        excerpt: listingExcerpt,
         content: emptyDoc,
         published: true,
         publishedAt: now,
@@ -257,6 +266,7 @@ describe('listArticles', () => {
       const idB = await ctx.db.insert('articles', {
         slug: 'bt',
         title: 'T2',
+        excerpt: listingExcerpt,
         content: emptyDoc,
         published: true,
         publishedAt: now,
@@ -284,6 +294,63 @@ describe('listArticles', () => {
       })
       expect(res.total).toBe(1)
       expect(res.articles[0]!.authorUsername).toBe('alice')
+    })
+  })
+
+  it('excludes incomplete published articles from default listing', async () => {
+    const t = convexTest(schema, modules)
+    await t.run(async (ctx) => {
+      const now = Date.now()
+      const u = await ctx.db.insert('users', {
+        email: 'ready@x.test',
+        username: 'readywriter',
+        createdAt: now,
+        updatedAt: now,
+      })
+      await ctx.db.insert('articles', {
+        slug: 'untitled',
+        title: 'Untitled',
+        content: emptyDoc,
+        published: true,
+        publishedAt: now,
+        authorId: u,
+        authorUsername: 'readywriter',
+        tags: [],
+        searchContent: 'Untitled',
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      const readyId = await ctx.db.insert('articles', {
+        slug: 'complete',
+        title: 'Complete Article',
+        excerpt: listingExcerpt,
+        content: emptyDoc,
+        published: true,
+        publishedAt: now + 1,
+        authorId: u,
+        authorUsername: 'readywriter',
+        tags: [],
+        searchContent: 'Complete Article',
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      const res = await ctx.runQuery(api.articles.listArticles, {
+        page: 1,
+        limit: 10,
+      })
+      expect(res.total).toBe(1)
+      expect(res.articles).toHaveLength(1)
+      expect(res.articles[0]!._id).toBe(readyId)
+      expect(res.articles[0]!.title).toBe('Complete Article')
     })
   })
 })

--- a/convex/articles.publishListingReady.test.ts
+++ b/convex/articles.publishListingReady.test.ts
@@ -1,0 +1,173 @@
+/// <reference types="vite/client" />
+import { convexTest } from 'convex-test'
+import { describe, expect, it } from 'vitest'
+import { api } from './_generated/api'
+import schema from './schema'
+import type { Id } from './_generated/dataModel'
+import { MIN_LISTING_EXCERPT_CHARS } from './lib/articleListingReady'
+
+const docWithBody = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'Hello body' }],
+    },
+  ],
+}
+
+const listingExcerpt = 'a'.repeat(MIN_LISTING_EXCERPT_CHARS)
+
+const modules = import.meta.glob(['./**/*.ts', '!./**/*.test.ts'])
+
+async function seedAuthor(t: ReturnType<typeof convexTest>) {
+  return await t.run(async (ctx) => {
+    const now = Date.now()
+    const userId = await ctx.db.insert('users', {
+      email: 'pub@x.test',
+      username: 'pubwriter',
+      createdAt: now,
+      updatedAt: now,
+    })
+    return { userId, now }
+  })
+}
+
+describe('publish listing readiness', () => {
+  it('rejects publishArticle when title is Untitled', async () => {
+    const t = convexTest(schema, modules)
+    const { userId, now } = await seedAuthor(t)
+    const asAuthor = t.withIdentity({ subject: userId })
+
+    const articleId = await t.run(async (ctx) => {
+      return await ctx.db.insert('articles', {
+        slug: 'untitled-draft',
+        title: 'Untitled',
+        excerpt: listingExcerpt,
+        content: docWithBody,
+        published: false,
+        authorId: userId,
+        authorUsername: 'pubwriter',
+        tags: [],
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+    })
+
+    await expect(
+      asAuthor.mutation(api.articles.publishArticle, {
+        id: articleId as Id<'articles'>,
+      })
+    ).rejects.toThrow(/real title/)
+  })
+
+  it('rejects publishArticle when excerpt is too short', async () => {
+    const t = convexTest(schema, modules)
+    const { userId, now } = await seedAuthor(t)
+    const asAuthor = t.withIdentity({ subject: userId })
+
+    const articleId = await t.run(async (ctx) => {
+      return await ctx.db.insert('articles', {
+        slug: 'short-excerpt',
+        title: 'Real Title',
+        excerpt: 'short',
+        content: docWithBody,
+        published: false,
+        authorId: userId,
+        authorUsername: 'pubwriter',
+        tags: [],
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+    })
+
+    await expect(
+      asAuthor.mutation(api.articles.publishArticle, {
+        id: articleId as Id<'articles'>,
+      })
+    ).rejects.toThrow(/excerpt/)
+  })
+
+  it('publishes when title and excerpt are listing-ready', async () => {
+    const t = convexTest(schema, modules)
+    const { userId, now } = await seedAuthor(t)
+    const asAuthor = t.withIdentity({ subject: userId })
+
+    const articleId = await t.run(async (ctx) => {
+      return await ctx.db.insert('articles', {
+        slug: 'ready-draft',
+        title: 'Real Title',
+        excerpt: listingExcerpt,
+        content: docWithBody,
+        published: false,
+        authorId: userId,
+        authorUsername: 'pubwriter',
+        tags: [],
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+    })
+
+    await asAuthor.mutation(api.articles.publishArticle, {
+      id: articleId as Id<'articles'>,
+    })
+    await new Promise((r) => setTimeout(r, 0))
+    await t.finishAllScheduledFunctions(() => {})
+
+    const row = await t.run(async (ctx) => ctx.db.get(articleId as Id<'articles'>))
+    expect(row?.published).toBe(true)
+  })
+
+  it('rejects createArticle with published when not listing-ready', async () => {
+    const t = convexTest(schema, modules)
+    const { userId } = await seedAuthor(t)
+    const asAuthor = t.withIdentity({ subject: userId })
+
+    await expect(
+      asAuthor.mutation(api.articles.createArticle, {
+        title: 'Untitled',
+        content: docWithBody,
+        excerpt: listingExcerpt,
+        published: true,
+      })
+    ).rejects.toThrow(/real title/)
+
+    await expect(
+      asAuthor.mutation(api.articles.createArticle, {
+        title: 'Good Title',
+        content: docWithBody,
+        published: true,
+      })
+    ).rejects.toThrow(/excerpt/)
+  })
+
+  it('allows createArticle published when listing-ready', async () => {
+    const t = convexTest(schema, modules)
+    const { userId } = await seedAuthor(t)
+    const asAuthor = t.withIdentity({ subject: userId })
+
+    const id = await asAuthor.mutation(api.articles.createArticle, {
+      title: 'Good Title',
+      content: docWithBody,
+      excerpt: listingExcerpt,
+      published: true,
+    })
+    await new Promise((r) => setTimeout(r, 0))
+    await t.finishAllScheduledFunctions(() => {})
+
+    const row = await t.run(async (ctx) => ctx.db.get(id as Id<'articles'>))
+    expect(row?.published).toBe(true)
+  })
+})

--- a/convex/articles.publishListingReady.test.ts
+++ b/convex/articles.publishListingReady.test.ts
@@ -126,7 +126,9 @@ describe('publish listing readiness', () => {
     await new Promise((r) => setTimeout(r, 0))
     await t.finishAllScheduledFunctions(() => {})
 
-    const row = await t.run(async (ctx) => ctx.db.get(articleId as Id<'articles'>))
+    const row = await t.run(async (ctx) =>
+      ctx.db.get(articleId as Id<'articles'>)
+    )
     expect(row?.published).toBe(true)
   })
 

--- a/convex/articles.ts
+++ b/convex/articles.ts
@@ -14,6 +14,10 @@ import {
   replaceTagLinksForArticle,
 } from './lib/articleListing'
 import {
+  assertArticleListingReady,
+  isArticleListingReady,
+} from './lib/articleListingReady'
+import {
   extractTextFromTiptapJson,
   tiptapJsonHasNonEmptyText,
 } from './lib/tiptapContent'
@@ -117,6 +121,7 @@ export const listArticles = query({
       if (tag) {
         rows = rows.filter((a) => a.tags?.includes(tag))
       }
+      rows = rows.filter(isArticleListingReady)
       rows.sort((a, b) => (b.publishedAt ?? 0) - (a.publishedAt ?? 0))
       const total = rows.length
       const slice = rows.slice(offset, offset + limit)
@@ -149,16 +154,17 @@ export const listArticles = query({
             .withIndex('by_tag_publishedAt', (q) => q.eq('tag', tag))
             .order('desc')
             .collect()
-      const total = linkRows.length
-      const pageLinks = linkRows.slice(offset, offset + limit)
       const fetched = await Promise.all(
-        pageLinks.map((row) => ctx.db.get(row.articleId))
+        linkRows.map((row) => ctx.db.get(row.articleId))
       )
       const articles = fetched.filter(
-        (a): a is NonNullable<typeof a> => a?.published === true
+        (a): a is NonNullable<typeof a> =>
+          a?.published === true && isArticleListingReady(a)
       )
+      const total = articles.length
+      const pageSlice = articles.slice(offset, offset + limit)
       const enrichedArticles = await Promise.all(
-        articles.map(async (article) => ({
+        pageSlice.map(async (article) => ({
           ...stripWriterNotes(article),
           author: await enrichWithUser(ctx, article.authorId),
         }))
@@ -181,7 +187,8 @@ export const listArticles = query({
       rowsQuery = rowsQuery.filter((q) => q.eq(q.field('authorId'), authorId!))
     }
 
-    const rows = await rowsQuery.collect()
+    let rows = await rowsQuery.collect()
+    rows = rows.filter(isArticleListingReady)
     const total = rows.length
     const slice = rows.slice(offset, offset + limit)
     const enrichedArticles = await Promise.all(
@@ -330,6 +337,14 @@ export const createArticle = mutation({
     const user = await ctx.db.get(userId)
     if (!user) throw new Error('User not found')
 
+    if (args.published) {
+      assertArticleListingReady({
+        title: args.title,
+        excerpt: args.excerpt,
+        authorUsername: user.username,
+      })
+    }
+
     const finalSlug = await generateUniqueArticleSlugForAuthor(ctx, {
       title: args.title,
       authorId: userId,
@@ -450,6 +465,19 @@ export const updateArticle = mutation({
       )
     }
 
+    if (article.published) {
+      const merged = {
+        title: updates.title ?? article.title,
+        excerpt: updates.excerpt !== undefined ? updates.excerpt : article.excerpt,
+        authorUsername: article.authorUsername,
+      }
+      if (!isArticleListingReady(merged)) {
+        throw new Error(
+          'Cannot update: published articles must keep a real title and excerpt for public discovery'
+        )
+      }
+    }
+
     await ctx.db.patch(args.id, updates)
 
     const updated = await ctx.db.get(args.id)
@@ -485,6 +513,12 @@ export const publishArticle = mutation({
     if (!tiptapJsonHasNonEmptyText(article.content)) {
       throw new Error('Cannot publish: article body is empty')
     }
+
+    assertArticleListingReady({
+      title: article.title,
+      excerpt: article.excerpt,
+      authorUsername: article.authorUsername,
+    })
 
     const now = Date.now()
 

--- a/convex/articles.ts
+++ b/convex/articles.ts
@@ -17,6 +17,7 @@ import {
   assertArticleListingReady,
   isArticleListingReady,
 } from './lib/articleListingReady'
+import { searchListingArticles } from './lib/articleSearch'
 import {
   extractTextFromTiptapJson,
   tiptapJsonHasNonEmptyText,
@@ -103,26 +104,12 @@ export const listArticles = query({
     }
 
     if (search) {
-      // FTS: tokenized (whitespace/punctuation, terms up to 32 chars, lowercased), not raw
-      // substring matches; prefix on the last term per Convex text search. Results are then
-      // sorted by publishedAt desc so newest-first matches the by_published_date listing.
-      const matches = await ctx.db
-        .query('articles')
-        .withSearchIndex('search_listing', (q) => {
-          let s = q.search('searchContent', search).eq('published', true)
-          if (args.author) {
-            s = s.eq('authorUsername', args.author!)
-          }
-          return s
-        })
-        .collect()
-
-      let rows = matches
-      if (tag) {
-        rows = rows.filter((a) => a.tags?.includes(tag))
-      }
-      rows = rows.filter(isArticleListingReady)
-      rows.sort((a, b) => (b.publishedAt ?? 0) - (a.publishedAt ?? 0))
+      const rows = await searchListingArticles(ctx, {
+        search,
+        authorUsername: args.author,
+        authorId,
+        filterTag: tag,
+      })
       const total = rows.length
       const slice = rows.slice(offset, offset + limit)
       const enrichedArticles = await Promise.all(
@@ -737,7 +724,7 @@ export const saveDraft = mutation({
   },
 })
 
-// One-off after deploy: bunx convex run internal/articles:backfillArticleTagsAndSearchContent
+// One-off after deploy: bunx convex run articles:backfillArticleTagsAndSearchContent
 export const backfillArticleTagsAndSearchContent = internalMutation({
   args: {},
   handler: async (ctx) => {

--- a/convex/articles.ts
+++ b/convex/articles.ts
@@ -468,7 +468,8 @@ export const updateArticle = mutation({
     if (article.published) {
       const merged = {
         title: updates.title ?? article.title,
-        excerpt: updates.excerpt !== undefined ? updates.excerpt : article.excerpt,
+        excerpt:
+          updates.excerpt !== undefined ? updates.excerpt : article.excerpt,
         authorUsername: article.authorUsername,
       }
       if (!isArticleListingReady(merged)) {

--- a/convex/lib/articleListingReady.test.ts
+++ b/convex/lib/articleListingReady.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getListingReadyPublishError,
+  isArticleListingReady,
+  isPlaceholderListingTitle,
+  MIN_LISTING_EXCERPT_CHARS,
+} from './articleListingReady'
+
+describe('isPlaceholderListingTitle', () => {
+  it('treats Untitled as placeholder', () => {
+    expect(isPlaceholderListingTitle('Untitled')).toBe(true)
+    expect(isPlaceholderListingTitle('  untitled  ')).toBe(true)
+  })
+
+  it('does not treat real titles as placeholder', () => {
+    expect(isPlaceholderListingTitle('My Article')).toBe(false)
+    expect(isPlaceholderListingTitle('Untitled Adventures')).toBe(false)
+  })
+})
+
+describe('getListingReadyPublishError', () => {
+  it('returns null when title and excerpt meet requirements', () => {
+    expect(
+      getListingReadyPublishError({
+        title: 'My Post',
+        excerpt: 'a'.repeat(MIN_LISTING_EXCERPT_CHARS),
+      })
+    ).toBeNull()
+  })
+
+  it('returns messages for invalid title or excerpt', () => {
+    expect(
+      getListingReadyPublishError({ title: 'Untitled', excerpt: 'abcdefghij' })
+    ).toMatch(/real title/)
+    expect(
+      getListingReadyPublishError({ title: 'OK', excerpt: 'short' })
+    ).toMatch(/excerpt/)
+  })
+})
+
+describe('isArticleListingReady', () => {
+  const ready = {
+    title: 'Real Title',
+    excerpt: 'a'.repeat(MIN_LISTING_EXCERPT_CHARS),
+    authorUsername: 'writer',
+  }
+
+  it('accepts a listing-ready article', () => {
+    expect(isArticleListingReady(ready)).toBe(true)
+  })
+
+  it('rejects Untitled', () => {
+    expect(
+      isArticleListingReady({ ...ready, title: 'Untitled' })
+    ).toBe(false)
+  })
+
+  it('rejects whitespace-only title', () => {
+    expect(isArticleListingReady({ ...ready, title: '   ' })).toBe(false)
+  })
+
+  it('rejects short or missing excerpt', () => {
+    expect(isArticleListingReady({ ...ready, excerpt: '' })).toBe(false)
+    expect(
+      isArticleListingReady({
+        ...ready,
+        excerpt: 'a'.repeat(MIN_LISTING_EXCERPT_CHARS - 1),
+      })
+    ).toBe(false)
+  })
+
+  it('rejects missing author username', () => {
+    expect(
+      isArticleListingReady({ ...ready, authorUsername: undefined })
+    ).toBe(false)
+    expect(
+      isArticleListingReady({ ...ready, authorUsername: '  ' })
+    ).toBe(false)
+  })
+})

--- a/convex/lib/articleListingReady.test.ts
+++ b/convex/lib/articleListingReady.test.ts
@@ -50,9 +50,7 @@ describe('isArticleListingReady', () => {
   })
 
   it('rejects Untitled', () => {
-    expect(
-      isArticleListingReady({ ...ready, title: 'Untitled' })
-    ).toBe(false)
+    expect(isArticleListingReady({ ...ready, title: 'Untitled' })).toBe(false)
   })
 
   it('rejects whitespace-only title', () => {
@@ -70,11 +68,11 @@ describe('isArticleListingReady', () => {
   })
 
   it('rejects missing author username', () => {
-    expect(
-      isArticleListingReady({ ...ready, authorUsername: undefined })
-    ).toBe(false)
-    expect(
-      isArticleListingReady({ ...ready, authorUsername: '  ' })
-    ).toBe(false)
+    expect(isArticleListingReady({ ...ready, authorUsername: undefined })).toBe(
+      false
+    )
+    expect(isArticleListingReady({ ...ready, authorUsername: '  ' })).toBe(
+      false
+    )
   })
 })

--- a/convex/lib/articleListingReady.ts
+++ b/convex/lib/articleListingReady.ts
@@ -1,0 +1,58 @@
+export const MIN_LISTING_EXCERPT_CHARS = 10
+
+export function isPlaceholderListingTitle(title: string): boolean {
+  return title.trim().toLowerCase() === 'untitled'
+}
+
+export function isArticleListingReady(article: {
+  title: string
+  excerpt?: string
+  authorUsername?: string
+}): boolean {
+  const title = article.title.trim()
+  const excerpt = (article.excerpt ?? '').trim()
+  return (
+    title.length > 0 &&
+    !isPlaceholderListingTitle(title) &&
+    excerpt.length >= MIN_LISTING_EXCERPT_CHARS &&
+    Boolean(article.authorUsername?.trim())
+  )
+}
+
+export function getListingReadyPublishError(input: {
+  title: string
+  excerpt: string
+}): string | null {
+  const title = input.title.trim()
+  if (title.length === 0) {
+    return 'Please add a title before publishing'
+  }
+  if (isPlaceholderListingTitle(title)) {
+    return 'Please replace "Untitled" with a real title before publishing'
+  }
+  const excerpt = input.excerpt.trim()
+  if (excerpt.length < MIN_LISTING_EXCERPT_CHARS) {
+    return `Please add an excerpt of at least ${MIN_LISTING_EXCERPT_CHARS} characters before publishing`
+  }
+  return null
+}
+
+export function assertArticleListingReady(article: {
+  title: string
+  excerpt?: string
+  authorUsername?: string
+}): void {
+  const title = article.title.trim()
+  if (title.length === 0 || isPlaceholderListingTitle(title)) {
+    throw new Error('Cannot publish: add a real title (not "Untitled")')
+  }
+  const excerpt = (article.excerpt ?? '').trim()
+  if (excerpt.length < MIN_LISTING_EXCERPT_CHARS) {
+    throw new Error(
+      `Cannot publish: add an excerpt of at least ${MIN_LISTING_EXCERPT_CHARS} characters`
+    )
+  }
+  if (!article.authorUsername?.trim()) {
+    throw new Error('Cannot publish: author username is required')
+  }
+}

--- a/convex/lib/articleSearch.test.ts
+++ b/convex/lib/articleSearch.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import type { Doc, Id } from '../_generated/dataModel'
+import {
+  articleMatchesSearchTerms,
+  dedupeArticlesById,
+  isSingleTokenSearch,
+} from './articleSearch'
+
+function stubArticle(
+  overrides: Partial<Doc<'articles'>> & Pick<Doc<'articles'>, '_id'>
+): Doc<'articles'> {
+  return {
+    _creationTime: 0,
+    slug: 's',
+    title: 'Title',
+    content: { type: 'doc', content: [] },
+    published: true,
+    authorId: 'user1' as Id<'users'>,
+    authorUsername: 'writer',
+    viewCount: 0,
+    highlightCount: 0,
+    tipCount: 0,
+    totalTipsUsd: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  }
+}
+
+describe('articleSearch helpers', () => {
+  it('dedupeArticlesById keeps first occurrence per id', () => {
+    const a = stubArticle({ _id: 'a1' as Id<'articles'>, title: 'First' })
+    const b = stubArticle({ _id: 'a1' as Id<'articles'>, title: 'Second' })
+    const c = stubArticle({ _id: 'a2' as Id<'articles'> })
+    expect(dedupeArticlesById([a, b, c])).toEqual([a, c])
+  })
+
+  it('isSingleTokenSearch is false for multi-word queries', () => {
+    expect(isSingleTokenSearch('one two')).toBe(false)
+    expect(isSingleTokenSearch('tag')).toBe(true)
+  })
+
+  it('articleMatchesSearchTerms requires all terms in built content', () => {
+    const article = stubArticle({
+      _id: 'a1' as Id<'articles'>,
+      title: 'Banana Guide',
+      excerpt: 'A valid excerpt for public listing.',
+      tags: ['rust'],
+    })
+    expect(articleMatchesSearchTerms(article, 'banana guide')).toBe(true)
+    expect(articleMatchesSearchTerms(article, 'banana mango')).toBe(false)
+    expect(articleMatchesSearchTerms(article, 'rust')).toBe(true)
+  })
+})

--- a/convex/lib/articleSearch.ts
+++ b/convex/lib/articleSearch.ts
@@ -1,0 +1,140 @@
+import type { Doc, Id } from '../_generated/dataModel'
+import type { QueryCtx } from '../_generated/server'
+import { buildSearchContent } from './articleListing'
+import { isArticleListingReady } from './articleListingReady'
+
+export function dedupeArticlesById(
+  articles: Doc<'articles'>[]
+): Doc<'articles'>[] {
+  const seen = new Set<Id<'articles'>>()
+  const result: Doc<'articles'>[] = []
+  for (const article of articles) {
+    if (seen.has(article._id)) continue
+    seen.add(article._id)
+    result.push(article)
+  }
+  return result
+}
+
+export function isSingleTokenSearch(search: string): boolean {
+  const trimmed = search.trim()
+  return trimmed.length > 0 && !/\s/.test(trimmed)
+}
+
+export function articleMatchesSearchTerms(
+  article: Doc<'articles'>,
+  search: string
+): boolean {
+  const terms = search
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+  if (terms.length === 0) return false
+
+  const content = buildSearchContent(article.title, article.excerpt, {
+    tags: article.tags,
+    content: article.content,
+  }).toLowerCase()
+
+  return terms.every((term) => content.includes(term.toLowerCase()))
+}
+
+export async function fetchArticlesByTagSearch(
+  ctx: QueryCtx,
+  tag: string,
+  authorId?: Id<'users'>
+): Promise<Doc<'articles'>[]> {
+  const linkRows = authorId
+    ? await ctx.db
+        .query('articleTagLinks')
+        .withIndex('by_author_tag_publishedAt', (q) =>
+          q.eq('authorId', authorId).eq('tag', tag)
+        )
+        .order('desc')
+        .collect()
+    : await ctx.db
+        .query('articleTagLinks')
+        .withIndex('by_tag_publishedAt', (q) => q.eq('tag', tag))
+        .order('desc')
+        .collect()
+
+  const fetched = await Promise.all(
+    linkRows.map((row) => ctx.db.get(row.articleId))
+  )
+  return fetched.filter(
+    (a): a is Doc<'articles'> => a !== null && a.published === true
+  )
+}
+
+export async function fetchListingSearchFallback(
+  ctx: QueryCtx,
+  search: string,
+  authorId?: Id<'users'>
+): Promise<Doc<'articles'>[]> {
+  let rowsQuery = ctx.db
+    .query('articles')
+    .withIndex('by_published_date', (q) => q.eq('published', true))
+    .order('desc')
+
+  if (authorId) {
+    rowsQuery = rowsQuery.filter((q) => q.eq(q.field('authorId'), authorId))
+  }
+
+  const rows = await rowsQuery.collect()
+  return rows.filter(
+    (a) => isArticleListingReady(a) && articleMatchesSearchTerms(a, search)
+  )
+}
+
+export async function searchListingArticles(
+  ctx: QueryCtx,
+  options: {
+    search: string
+    authorUsername?: string
+    authorId?: Id<'users'>
+    filterTag?: string
+  }
+): Promise<Doc<'articles'>[]> {
+  const { search, authorUsername, authorId, filterTag } = options
+
+  let ftsMatches: Doc<'articles'>[] = []
+  try {
+    ftsMatches = await ctx.db
+      .query('articles')
+      .withSearchIndex('search_listing', (q) => {
+        let s = q.search('searchContent', search).eq('published', true)
+        if (authorUsername) {
+          s = s.eq('authorUsername', authorUsername)
+        }
+        return s
+      })
+      .collect()
+  } catch {
+    ftsMatches = []
+  }
+
+  let rows = ftsMatches
+
+  if (!filterTag && isSingleTokenSearch(search)) {
+    const tagMatches = await fetchArticlesByTagSearch(
+      ctx,
+      search.trim(),
+      authorId
+    )
+    rows = dedupeArticlesById([...rows, ...tagMatches])
+  } else {
+    rows = dedupeArticlesById(rows)
+  }
+
+  if (rows.length === 0) {
+    rows = await fetchListingSearchFallback(ctx, search, authorId)
+  }
+
+  if (filterTag) {
+    rows = rows.filter((a) => a.tags?.includes(filterTag))
+  }
+
+  rows = rows.filter(isArticleListingReady)
+  rows.sort((a, b) => (b.publishedAt ?? 0) - (a.publishedAt ?? 0))
+  return rows
+}

--- a/convex/lib/articleSearch.ts
+++ b/convex/lib/articleSearch.ts
@@ -25,10 +25,7 @@ export function articleMatchesSearchTerms(
   article: Doc<'articles'>,
   search: string
 ): boolean {
-  const terms = search
-    .trim()
-    .split(/\s+/)
-    .filter(Boolean)
+  const terms = search.trim().split(/\s+/).filter(Boolean)
   if (terms.length === 0) return false
 
   const content = buildSearchContent(article.title, article.excerpt, {

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,6 +1,7 @@
 import { v } from 'convex/values'
 import { query, mutation } from './_generated/server'
 import { getAuthUserId } from '@convex-dev/auth/server'
+import { isArticleListingReady } from './lib/articleListingReady'
 
 /**
  * Validate Stellar address format
@@ -156,6 +157,7 @@ export const getUserStats = query({
       .withIndex('by_author', (q) => q.eq('authorId', userId))
       .filter((q) => q.eq(q.field('published'), true))
       .collect()
+    const listingReadyCount = articles.filter(isArticleListingReady).length
 
     // Get total tips received
     const tipsReceived = await ctx.db
@@ -170,7 +172,7 @@ export const getUserStats = query({
     )
 
     return {
-      articleCount: articles.length,
+      articleCount: listingReadyCount,
       totalEarnings,
       tipsReceivedCount: tipsReceived.length,
     }

--- a/lib/articles/buildArticlesBrowseHref.test.ts
+++ b/lib/articles/buildArticlesBrowseHref.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildArticlesBrowseHref,
+  pickArticlesBrowseParams,
+} from './buildArticlesBrowseHref'
+
+describe('pickArticlesBrowseParams', () => {
+  it('keeps only tag, page, search, and author', () => {
+    const source = new URLSearchParams(
+      'page=2&tag=rust&search=foo&author=alice&nftOwnedPage=3&tab=earnings'
+    )
+    const picked = pickArticlesBrowseParams(source)
+    expect(Object.fromEntries(picked)).toEqual({
+      tag: 'rust',
+      page: '2',
+      search: 'foo',
+      author: 'alice',
+    })
+  })
+
+  it('returns empty when no browse keys are present', () => {
+    const source = new URLSearchParams('nftOwnedPage=3&nftMintedPage=1')
+    expect(pickArticlesBrowseParams(source).toString()).toBe('')
+  })
+})
+
+describe('buildArticlesBrowseHref', () => {
+  it('strips profile params and sets tag with page 1', () => {
+    const source = new URLSearchParams(
+      'page=2&nftOwnedPage=3&nftMintedPage=1'
+    )
+    expect(
+      buildArticlesBrowseHref({
+        tag: 'rust',
+        page: 1,
+        sourceParams: source,
+      })
+    ).toBe('/articles?tag=rust')
+  })
+
+  it('preserves search and replaces tag when building from articles browse', () => {
+    const source = new URLSearchParams('search=foo&tag=old&page=3')
+    expect(
+      buildArticlesBrowseHref({
+        tag: 'new',
+        page: 1,
+        sourceParams: source,
+      })
+    ).toBe('/articles?tag=new&search=foo')
+  })
+
+  it('sets author and overrides picked author from source', () => {
+    const source = new URLSearchParams('author=other&page=2')
+    expect(
+      buildArticlesBrowseHref({
+        tag: 'rust',
+        page: 1,
+        author: 'alice',
+        sourceParams: source,
+      })
+    ).toBe('/articles?author=alice&tag=rust')
+  })
+
+  it('returns /articles when clearing all filters', () => {
+    expect(
+      buildArticlesBrowseHref({
+        tag: '',
+        search: '',
+        author: '',
+        page: 1,
+        sourceParams: new URLSearchParams('tag=old&search=x'),
+      })
+    ).toBe('/articles')
+  })
+
+  it('sets page greater than 1', () => {
+    expect(
+      buildArticlesBrowseHref({
+        tag: 'rust',
+        page: 2,
+      })
+    ).toBe('/articles?tag=rust&page=2')
+  })
+})

--- a/lib/articles/buildArticlesBrowseHref.test.ts
+++ b/lib/articles/buildArticlesBrowseHref.test.ts
@@ -26,9 +26,7 @@ describe('pickArticlesBrowseParams', () => {
 
 describe('buildArticlesBrowseHref', () => {
   it('strips profile params and sets tag with page 1', () => {
-    const source = new URLSearchParams(
-      'page=2&nftOwnedPage=3&nftMintedPage=1'
-    )
+    const source = new URLSearchParams('page=2&nftOwnedPage=3&nftMintedPage=1')
     expect(
       buildArticlesBrowseHref({
         tag: 'rust',

--- a/lib/articles/buildArticlesBrowseHref.ts
+++ b/lib/articles/buildArticlesBrowseHref.ts
@@ -1,0 +1,58 @@
+export const ARTICLES_BROWSE_QUERY_KEYS = [
+  'tag',
+  'page',
+  'search',
+  'author',
+] as const
+
+export type ArticlesBrowseQueryKey =
+  (typeof ARTICLES_BROWSE_QUERY_KEYS)[number]
+
+export function pickArticlesBrowseParams(
+  searchParams: URLSearchParams
+): URLSearchParams {
+  const picked = new URLSearchParams()
+  for (const key of ARTICLES_BROWSE_QUERY_KEYS) {
+    const value = searchParams.get(key)
+    if (value) picked.set(key, value)
+  }
+  return picked
+}
+
+export function buildArticlesBrowseHref(options: {
+  tag?: string
+  page?: number
+  search?: string
+  author?: string
+  sourceParams?: URLSearchParams | null
+}): string {
+  const params = options.sourceParams
+    ? pickArticlesBrowseParams(options.sourceParams)
+    : new URLSearchParams()
+
+  if (options.tag !== undefined) {
+    const trimmed = options.tag.trim()
+    if (trimmed) params.set('tag', trimmed)
+    else params.delete('tag')
+  }
+
+  if (options.search !== undefined) {
+    const trimmed = options.search.trim()
+    if (trimmed) params.set('search', trimmed)
+    else params.delete('search')
+  }
+
+  if (options.author !== undefined) {
+    const trimmed = options.author.trim()
+    if (trimmed) params.set('author', trimmed)
+    else params.delete('author')
+  }
+
+  if (options.page !== undefined) {
+    if (options.page <= 1) params.delete('page')
+    else params.set('page', String(options.page))
+  }
+
+  const qs = params.toString()
+  return qs ? `/articles?${qs}` : '/articles'
+}

--- a/lib/articles/buildArticlesBrowseHref.ts
+++ b/lib/articles/buildArticlesBrowseHref.ts
@@ -5,8 +5,7 @@ export const ARTICLES_BROWSE_QUERY_KEYS = [
   'author',
 ] as const
 
-export type ArticlesBrowseQueryKey =
-  (typeof ARTICLES_BROWSE_QUERY_KEYS)[number]
+export type ArticlesBrowseQueryKey = (typeof ARTICLES_BROWSE_QUERY_KEYS)[number]
 
 export function pickArticlesBrowseParams(
   searchParams: URLSearchParams

--- a/lib/articles/mapListArticleToDisplay.ts
+++ b/lib/articles/mapListArticleToDisplay.ts
@@ -20,9 +20,9 @@ export function mapListArticleRowToDisplay(
         }
       : {
           id: '',
-          name: null,
-          username: 'unknown',
-          avatar: null,
+          name: article.authorName ?? null,
+          username: article.authorUsername?.trim() || 'unknown',
+          avatar: article.authorAvatar ?? null,
         },
     tags: (article.tags ?? []).map((tagName, index) => ({
       id: `tag-${index}`,


### PR DESCRIPTION
## Summary

Closes ENG-148. Improves article discovery and profile UX by hiding incomplete listings, guiding writers before publish, and replacing a bare profile 404 with a helpful recovery page.

### Article listing quality

- Adds shared listing-readiness rules in `convex/lib/articleListingReady.ts`:
  - Real title required (not blank or placeholder `"Untitled"`)
  - Excerpt at least 10 characters
  - Author username present
- Applies those rules when listing published articles (browse, search, tag filters) and when counting articles on profiles, so drafts and placeholder posts no longer appear in discovery surfaces.
- Enforces the same rules server-side on publish so incomplete articles cannot be published into public lists.

### Writer publish flow

- `WriteEditorWorkspace` validates title and excerpt before publish and surfaces clear, actionable error messages via `getListingReadyPublishError`.
- Regression tests cover publish rejection and list filtering for untitled / short-excerpt / missing-author cases.

### Article discovery polish

- New `ArticleAuthorByline` component used on article cards and article pages: avatar, display name, optional handle, profile link when the author is linkable, and a fallback when the profile is unavailable.
- `SearchInput` accepts an optional `id` for accessible labeling; articles browse page wires a visible label.
- `buildArticlesBrowseHref` centralizes `/articles` URL construction (tag, page, search, author) so pagination, tag chips, and browse controls keep query params consistent.
- `TagFilterLink` supports an optional `author` filter for scoped browsing.

### Profile: author not found

- New `AuthorNotFoundPage` replaces `notFound()` on `/{username}` when no writer exists.
- Shows a clear “Profile unavailable” message, inline article search (routes to `/articles?search=…`), and links to browse articles and home.
- Uses the shared `FailurePageShell` layout for consistency with other error pages.

### Profile display

- `WalletSettings` uses a consistent `profileDisplayName` on profile pages for personalized copy.
- Profile article counts reflect listing-ready published articles only.


https://github.com/user-attachments/assets/7e1f3a80-e96b-4cb6-a4ff-59822d83304c
<img width="1437" height="859" alt="2" src="https://github.com/user-attachments/assets/197094e9-2624-485d-bf8a-a8729b368f03" />
<img width="1437" height="860" alt="3" src="https://github.com/user-attachments/assets/fddfac2a-3cfd-4b6b-8fce-bf721de913f5" />
<img width="1220" height="719" alt="4" src="https://github.com/user-attachments/assets/271d0bb2-6b09-487d-b03a-ec1e5a9e4e49" />
<img width="1440" height="900" alt="6" src="https://github.com/user-attachments/assets/c45fb9c1-f364-49ee-a938-a39233162099" />
<img width="1440" height="900" alt="7" src="https://github.com/user-attachments/assets/ff5f29f4-b6ed-4a29-b566-df26d84eb42b" />
<img width="1219" height="734" alt="8" src="https://github.com/user-attachments/assets/79f48dea-eb24-44b2-84ab-22970720ac0e" />


