### PR TITLE
feat(wallet): wallet UX copy, guide tabs, safe disconnect, and profile settings link (ENG-143)

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -258,7 +258,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
                 <p className="text-muted-foreground">
                   {isOwnProfile
                     ? 'Manage your Stellar testnet wallet for sending and receiving practice tips.'
-                    : 'View wallet address for sending tips to this user.'}
+                    : 'View and copy the wallet address, or tip this author from their articles.'}
                 </p>
               </div>
 
@@ -266,6 +266,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
               <div className="max-w-2xl">
                 <WalletSettings
                   walletAddress={localWalletAddress ?? user.stellarAddress}
+                  profileUsername={username}
                   isOwnProfile={isOwnProfile}
                   profileDisplayName={profileDisplayName}
                   onAddressChange={(address) => {

--- a/app/profile/page.test.tsx
+++ b/app/profile/page.test.tsx
@@ -1,0 +1,79 @@
+/** @vitest-environment jsdom */
+import { render, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import ProfileRedirectPage from './page'
+import { buildLoginHref } from '@/lib/auth/safeReturnPath'
+import {
+  WALLET_PROFILE_HUB_PATH,
+  getWalletTabPath,
+} from '@/lib/navigation/walletProfileDestination'
+
+const replace = vi.fn()
+const useAuthMock = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace }),
+  usePathname: () => '/profile',
+  useSearchParams: () => new URLSearchParams('tab=wallet'),
+}))
+
+vi.mock('@/components/providers/AuthContext', () => ({
+  useAuth: () => useAuthMock(),
+}))
+
+vi.mock('@/components/layout/AppNavigation', () => ({
+  default: () => <nav aria-label="App navigation" />,
+}))
+
+vi.mock('@/components/profile/ProfilePageLoadingSkeleton', () => ({
+  ProfilePageLoadingSkeleton: () => <div data-testid="profile-skeleton" />,
+}))
+
+describe('ProfileRedirectPage', () => {
+  beforeEach(() => {
+    replace.mockClear()
+    useAuthMock.mockReset()
+  })
+
+  it('does not redirect while auth is loading', () => {
+    useAuthMock.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: true,
+    })
+
+    render(<ProfileRedirectPage />)
+
+    expect(replace).not.toHaveBeenCalled()
+  })
+
+  it('redirects authenticated users to their wallet tab', async () => {
+    useAuthMock.mockReturnValue({
+      user: { username: 'alice' },
+      isAuthenticated: true,
+      isLoading: false,
+    })
+
+    render(<ProfileRedirectPage />)
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith(getWalletTabPath('alice'))
+    })
+  })
+
+  it('redirects signed-out users to login with hub path preserved', async () => {
+    useAuthMock.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+    })
+
+    render(<ProfileRedirectPage />)
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith(
+        buildLoginHref(WALLET_PROFILE_HUB_PATH)
+      )
+    })
+  })
+})

--- a/components/auth/LoginForm.test.tsx
+++ b/components/auth/LoginForm.test.tsx
@@ -7,6 +7,7 @@ import LoginForm from '@/components/auth/LoginForm'
 const mockSignIn = vi.hoisted(() => vi.fn())
 const mockReplace = vi.hoisted(() => vi.fn())
 const mockUseAuthReturnPath = vi.hoisted(() => vi.fn())
+const mockSearchParamsGet = vi.hoisted(() => vi.fn())
 
 vi.mock('@convex-dev/auth/react', () => ({
   useAuthActions: () => ({
@@ -17,6 +18,9 @@ vi.mock('@convex-dev/auth/react', () => ({
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     replace: mockReplace,
+  }),
+  useSearchParams: () => ({
+    get: (key: string) => mockSearchParamsGet(key),
   }),
 }))
 
@@ -33,12 +37,14 @@ describe('LoginForm', () => {
     mockSignIn.mockReset()
     mockReplace.mockReset()
     mockUseAuthReturnPath.mockReset()
+    mockSearchParamsGet.mockReset()
     mockUseAuthReturnPath.mockReturnValue('/articles?tag=writing')
+    mockSearchParamsGet.mockReturnValue(null)
+    mockSignIn.mockResolvedValue(undefined)
   })
 
   it('shows redirecting message and navigates to the return path on successful sign in', async () => {
     const user = userEvent.setup({ delay: null })
-    mockSignIn.mockResolvedValue(undefined)
 
     render(<LoginForm />)
 
@@ -61,6 +67,40 @@ describe('LoginForm', () => {
     expect(
       screen.queryByRole('button', { name: /signing in/i })
     ).not.toBeInTheDocument()
+  })
+
+  it('redirects to safe redirect query param when present', async () => {
+    mockSearchParamsGet.mockImplementation((key: string) =>
+      key === 'redirect' ? '/profile?tab=wallet' : null
+    )
+    const user = userEvent.setup({ delay: null })
+
+    render(<LoginForm />)
+
+    await user.type(screen.getByLabelText(/email address/i), 'you@example.com')
+    await user.type(screen.getByLabelText(/^password$/i), 'password123')
+    await user.click(screen.getByRole('button', { name: /sign in/i }))
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/profile?tab=wallet')
+    })
+  })
+
+  it('ignores unsafe redirect query params', async () => {
+    mockSearchParamsGet.mockImplementation((key: string) =>
+      key === 'redirect' ? 'https://evil.com' : null
+    )
+    const user = userEvent.setup({ delay: null })
+
+    render(<LoginForm />)
+
+    await user.type(screen.getByLabelText(/email address/i), 'you@example.com')
+    await user.type(screen.getByLabelText(/^password$/i), 'password123')
+    await user.click(screen.getByRole('button', { name: /sign in/i }))
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/articles?tag=writing')
+    })
   })
 
   it('restores an editable form with retry after failed sign in', async () => {

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -2,9 +2,10 @@
 
 import { useEffect, useState } from 'react'
 import { useAuthActions } from '@convex-dev/auth/react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useAuthReturnPath } from '@/components/auth/useAuthReturnPath'
 import { readPendingTipIntent } from '@/lib/tip/pendingTipIntent'
+import { getSafeRedirectPath } from '@/lib/navigation/walletProfileDestination'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { loginSchema, type LoginFormData } from '@/lib/validations/auth'
@@ -31,7 +32,13 @@ export default function LoginForm() {
   const [success, setSuccess] = useState(false)
 
   const router = useRouter()
-  const returnPath = useAuthReturnPath()
+  const searchParams = useSearchParams()
+  const returnToPath = useAuthReturnPath()
+  const redirectParam = searchParams.get('redirect')
+  const postLoginPath =
+    redirectParam != null && redirectParam !== ''
+      ? getSafeRedirectPath(redirectParam, returnToPath)
+      : returnToPath
   const { signIn } = useAuthActions()
 
   const {
@@ -70,14 +77,14 @@ export default function LoginForm() {
       // before the article page mounts (avoids inconsistent client-side resume).
       const pendingTipIntent = readPendingTipIntent()
       if (
-        returnPath.includes('resumeArticleTip=1') ||
+        postLoginPath.includes('resumeArticleTip=1') ||
         pendingTipIntent?.kind === 'highlight'
       ) {
-        window.location.assign(returnPath)
+        window.location.assign(postLoginPath)
         return
       }
 
-      router.replace(returnPath)
+      router.replace(postLoginPath)
     } catch (error) {
       console.error('Login error:', error)
       setError('Invalid email or password. Please try again.')

--- a/components/guide/GuideWalletSettingsLink.tsx
+++ b/components/guide/GuideWalletSettingsLink.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+import { WALLET_PROFILE_HUB_PATH } from '@/lib/navigation/walletProfileDestination'
+
+const linkClassName =
+  'inline-flex items-center gap-2 px-4 py-2 bg-muted text-foreground text-sm rounded-lg border border-border hover:bg-muted/80 transition-colors'
+
+export function GuideWalletSettingsLink() {
+  return (
+    <Link href={WALLET_PROFILE_HUB_PATH} className={linkClassName}>
+      Go to Profile Settings
+    </Link>
+  )
+}

--- a/components/guide/WalletGuide.test.tsx
+++ b/components/guide/WalletGuide.test.tsx
@@ -51,4 +51,3 @@ describe('WalletGuide tabs', () => {
     expect(trigger.className).toContain('whitespace-normal')
   })
 })
-

--- a/components/guide/WalletGuide.test.tsx
+++ b/components/guide/WalletGuide.test.tsx
@@ -1,6 +1,7 @@
 /** @vitest-environment jsdom */
 import type { ReactNode } from 'react'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { WalletGuide } from '@/components/guide/WalletGuide'
 
@@ -49,5 +50,14 @@ describe('WalletGuide tabs', () => {
     render(<WalletGuide />)
     const trigger = screen.getByRole('tab', { name: 'What is a Wallet?' })
     expect(trigger.className).toContain('whitespace-normal')
+  })
+
+  it('links profile settings CTA to the wallet profile hub', async () => {
+    const user = userEvent.setup()
+    render(<WalletGuide />)
+    await user.click(screen.getByRole('tab', { name: 'Connect' }))
+    expect(
+      screen.getByRole('link', { name: 'Go to Profile Settings' })
+    ).toHaveAttribute('href', '/profile?tab=wallet')
   })
 })

--- a/components/guide/WalletGuide.test.tsx
+++ b/components/guide/WalletGuide.test.tsx
@@ -1,0 +1,54 @@
+/** @vitest-environment jsdom */
+import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { WalletGuide } from '@/components/guide/WalletGuide'
+
+vi.mock('next/link', () => {
+  return {
+    default: (props: { href: string; children: ReactNode }) => (
+      <a href={props.href}>{props.children}</a>
+    ),
+  }
+})
+
+vi.mock('@/components/stellar/WalletConnectButton', () => {
+  return {
+    WalletConnectButton: () => <button type="button">Mock connect</button>,
+  }
+})
+
+describe('WalletGuide tabs', () => {
+  it('labels the tab list for screen readers', () => {
+    render(<WalletGuide />)
+    expect(screen.getByLabelText('Wallet setup steps')).toBeInTheDocument()
+  })
+
+  it('renders all tab labels in full', () => {
+    render(<WalletGuide />)
+    expect(
+      screen.getByRole('tab', { name: 'What is a Wallet?' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('tab', { name: 'Set Up Freighter' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Connect' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('tab', { name: 'Your First Tip' })
+    ).toBeInTheDocument()
+  })
+
+  it('uses a 2×2 grid on mobile and a single row on larger screens', () => {
+    render(<WalletGuide />)
+    const list = screen.getByLabelText('Wallet setup steps')
+    expect(list.className).toContain('grid-cols-2')
+    expect(list.className).toContain('sm:grid-cols-4')
+  })
+
+  it('allows tab labels to wrap', () => {
+    render(<WalletGuide />)
+    const trigger = screen.getByRole('tab', { name: 'What is a Wallet?' })
+    expect(trigger.className).toContain('whitespace-normal')
+  })
+})
+

--- a/components/guide/WalletGuide.tsx
+++ b/components/guide/WalletGuide.tsx
@@ -15,6 +15,7 @@ import {
   ExternalLink,
 } from 'lucide-react'
 import Link from 'next/link'
+import { GuideWalletSettingsLink } from '@/components/guide/GuideWalletSettingsLink'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
 
@@ -180,12 +181,7 @@ export function WalletGuide() {
             description="After connecting, visit your profile to save your wallet address for receiving tips. This is your 'receiving wallet' — when readers tip your articles, payments arrive here."
             isLast
           >
-            <Link
-              href="/profile?tab=wallet"
-              className="inline-flex items-center gap-2 px-4 py-2 bg-muted text-foreground text-sm rounded-lg border border-border hover:bg-muted/80 transition-colors"
-            >
-              Go to Profile Settings
-            </Link>
+            <GuideWalletSettingsLink />
           </WalletStepCard>
         </TabsContent>
 

--- a/components/guide/WalletGuide.tsx
+++ b/components/guide/WalletGuide.tsx
@@ -18,6 +18,13 @@ import Link from 'next/link'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
 
+const WALLET_GUIDE_TABS = [
+  { value: 'what-is-wallet', label: 'What is a Wallet?' },
+  { value: 'setup', label: 'Set Up Freighter' },
+  { value: 'connect', label: 'Connect' },
+  { value: 'first-tip', label: 'Your First Tip' },
+] as const
+
 export function WalletGuide() {
   return (
     <div className="max-w-3xl mx-auto">
@@ -39,19 +46,19 @@ export function WalletGuide() {
       </Alert>
 
       <Tabs defaultValue="what-is-wallet" className="w-full">
-        <TabsList className="grid w-full grid-cols-4 mb-8">
-          <TabsTrigger value="what-is-wallet" className="text-xs sm:text-sm">
-            What is a Wallet?
-          </TabsTrigger>
-          <TabsTrigger value="setup" className="text-xs sm:text-sm">
-            Set Up Freighter
-          </TabsTrigger>
-          <TabsTrigger value="connect" className="text-xs sm:text-sm">
-            Connect
-          </TabsTrigger>
-          <TabsTrigger value="first-tip" className="text-xs sm:text-sm">
-            Your First Tip
-          </TabsTrigger>
+        <TabsList
+          className="grid w-full grid-cols-2 gap-2 h-auto p-1 mb-8 sm:grid-cols-4 sm:gap-1"
+          aria-label="Wallet setup steps"
+        >
+          {WALLET_GUIDE_TABS.map((tab) => (
+            <TabsTrigger
+              key={tab.value}
+              value={tab.value}
+              className="min-h-11 py-2.5 px-2 text-sm whitespace-normal text-center leading-snug sm:min-h-9 sm:py-1.5 sm:px-3 data-[state=active]:ring-2 data-[state=active]:ring-ring"
+            >
+              {tab.label}
+            </TabsTrigger>
+          ))}
         </TabsList>
 
         {/* Tab 1: What is a Wallet? */}

--- a/components/stellar/WalletConnectButton.test.tsx
+++ b/components/stellar/WalletConnectButton.test.tsx
@@ -9,8 +9,7 @@ const mockConnect = vi.fn()
 const mockDisconnect = vi.fn()
 const mockActivateWallet = vi.fn()
 
-const TEST_PUBLIC_KEY =
-  'GBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGB'
+const TEST_PUBLIC_KEY = 'GBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGB'
 
 vi.mock('@/components/providers/WalletProvider', () => ({
   useWallet: vi.fn(),

--- a/components/stellar/WalletConnectButton.test.tsx
+++ b/components/stellar/WalletConnectButton.test.tsx
@@ -1,0 +1,143 @@
+/** @vitest-environment jsdom */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import { WalletConnectButton } from '@/components/stellar/WalletConnectButton'
+
+const mockConnect = vi.fn()
+const mockDisconnect = vi.fn()
+const mockActivateWallet = vi.fn()
+
+const TEST_PUBLIC_KEY =
+  'GBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGBGB'
+
+vi.mock('@/components/providers/WalletProvider', () => ({
+  useWallet: vi.fn(),
+}))
+
+vi.mock('@/components/providers/WalletActivationContext', () => ({
+  useWalletActivation: () => ({
+    activateWallet: mockActivateWallet,
+    isWalletActive: true,
+  }),
+}))
+
+vi.mock('@/components/stellar/InstallWalletDialog', () => ({
+  InstallWalletDialog: () => null,
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import { useWallet } from '@/components/providers/WalletProvider'
+
+function mockWalletState(
+  overrides: Partial<ReturnType<typeof useWallet>> = {}
+) {
+  vi.mocked(useWallet).mockReturnValue({
+    isInstalled: true,
+    isConnected: false,
+    isLoading: false,
+    publicKey: null,
+    network: null,
+    networkPassphrase: null,
+    error: null,
+    selectedWallet: null,
+    connect: mockConnect,
+    disconnect: mockDisconnect,
+    signTransaction: vi.fn(),
+    refreshConnection: vi.fn(),
+    ...overrides,
+  })
+}
+
+describe('WalletConnectButton', () => {
+  beforeEach(() => {
+    mockConnect.mockReset()
+    mockDisconnect.mockReset()
+    mockActivateWallet.mockReset()
+    vi.mocked(toast.success).mockClear()
+    vi.mocked(toast.error).mockClear()
+  })
+
+  it('does not disconnect when the connected trigger is clicked', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockWalletState({
+      isConnected: true,
+      publicKey: TEST_PUBLIC_KEY,
+      network: 'TESTNET',
+      selectedWallet: { name: 'Freighter', id: 'freighter', type: 'freighter' },
+    })
+
+    render(<WalletConnectButton />)
+
+    await user.click(screen.getByRole('button', { name: 'Open wallet menu' }))
+
+    expect(mockDisconnect).not.toHaveBeenCalled()
+    expect(screen.getByText(TEST_PUBLIC_KEY)).toBeInTheDocument()
+  })
+
+  it('copies the full address when Copy address is chosen', async () => {
+    const user = userEvent.setup({ delay: null })
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+
+    mockWalletState({
+      isConnected: true,
+      publicKey: TEST_PUBLIC_KEY,
+      network: 'TESTNET',
+    })
+
+    render(<WalletConnectButton />)
+
+    await user.click(screen.getByRole('button', { name: 'Open wallet menu' }))
+    await user.click(screen.getByRole('menuitem', { name: 'Copy address' }))
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(TEST_PUBLIC_KEY)
+      expect(toast.success).toHaveBeenCalledWith(
+        'Wallet address copied to clipboard'
+      )
+    })
+    expect(toast.error).not.toHaveBeenCalled()
+    expect(mockDisconnect).not.toHaveBeenCalled()
+  })
+
+  it('disconnects only when Disconnect is chosen', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockWalletState({
+      isConnected: true,
+      publicKey: TEST_PUBLIC_KEY,
+      network: 'TESTNET',
+    })
+
+    render(<WalletConnectButton />)
+
+    await user.click(screen.getByRole('button', { name: 'Open wallet menu' }))
+    await user.click(screen.getByRole('menuitem', { name: 'Disconnect' }))
+
+    expect(mockDisconnect).toHaveBeenCalledTimes(1)
+    expect(toast.success).toHaveBeenCalledWith('Wallet disconnected')
+  })
+
+  it('calls connect when Connect Wallet is clicked', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockConnect.mockResolvedValue(true)
+    mockWalletState({ isConnected: false })
+
+    render(<WalletConnectButton />)
+
+    await user.click(screen.getByRole('button', { name: 'Connect Wallet' }))
+
+    expect(mockConnect).toHaveBeenCalledTimes(1)
+    expect(mockDisconnect).not.toHaveBeenCalled()
+  })
+})

--- a/components/stellar/WalletConnectButton.tsx
+++ b/components/stellar/WalletConnectButton.tsx
@@ -2,9 +2,26 @@
 
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { useWallet } from '@/components/providers/WalletProvider'
 import { useWalletActivation } from '@/components/providers/WalletActivationContext'
-import { Wallet, Loader2, AlertCircle, CheckCircle } from 'lucide-react'
+import {
+  Wallet,
+  Loader2,
+  AlertCircle,
+  CheckCircle,
+  Copy,
+  ExternalLink,
+  Power,
+  ChevronDown,
+} from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import { InstallWalletDialog } from '@/components/stellar/InstallWalletDialog'
@@ -39,11 +56,6 @@ export function WalletConnectButton({
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
 
   const handleConnect = async () => {
-    if (isConnected) {
-      disconnect()
-      return
-    }
-
     activateWallet()
     setIsConnecting(true)
     try {
@@ -71,6 +83,28 @@ export function WalletConnectButton({
     return `${address.slice(0, 6)}...${address.slice(-6)}`
   }
 
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text)
+      toast.success('Wallet address copied to clipboard')
+    } catch {
+      toast.error('Failed to copy address')
+    }
+  }
+
+  const openInExplorer = (address: string) => {
+    const explorerUrl =
+      network === 'TESTNET'
+        ? `https://stellar.expert/explorer/testnet/account/${address}`
+        : `https://stellar.expert/explorer/public/account/${address}`
+    window.open(explorerUrl, '_blank')
+  }
+
+  const handleDisconnect = () => {
+    disconnect()
+    toast.success('Wallet disconnected')
+  }
+
   // Show loading state
   if (isLoading) {
     return (
@@ -86,9 +120,6 @@ export function WalletConnectButton({
       </Button>
     )
   }
-
-  // Wallet selection will happen via modal, no need for install check
-  // The modal will show available wallets
 
   // Show error state
   if (error) {
@@ -111,26 +142,54 @@ export function WalletConnectButton({
   // Show connected state
   if (isConnected && publicKey) {
     return (
-      <Button
-        onClick={handleConnect}
-        size={size}
-        variant="outline"
-        className={cn('gap-2', className)}
-      >
-        <CheckCircle className="w-4 h-4 text-green-800 dark:text-green-300" />
-        <div className="flex flex-col items-start">
-          <span className="text-sm font-medium">
-            {formatAddress(publicKey)}
-          </span>
-          <div className="flex items-center gap-1 text-xs text-muted-foreground">
-            {selectedWallet && <span>{selectedWallet.name}</span>}
-            {network && selectedWallet && <span>•</span>}
-            {network && (
-              <span className="capitalize">{network.toLowerCase()}</span>
-            )}
-          </div>
-        </div>
-      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            size={size}
+            variant="outline"
+            className={cn('gap-2', className)}
+            aria-label="Open wallet menu"
+          >
+            <CheckCircle className="w-4 h-4 text-green-800 dark:text-green-300" />
+            <div className="flex flex-col items-start">
+              <span className="text-sm font-medium">
+                {formatAddress(publicKey)}
+              </span>
+              <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                {selectedWallet && <span>{selectedWallet.name}</span>}
+                {network && selectedWallet && <span>•</span>}
+                {network && (
+                  <span className="capitalize">{network.toLowerCase()}</span>
+                )}
+              </div>
+            </div>
+            <ChevronDown className="w-4 h-4 text-muted-foreground" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-72">
+          <DropdownMenuLabel className="font-normal">
+            <span className="text-xs text-muted-foreground">Address</span>
+            <p className="mt-1 font-mono text-xs break-all">{publicKey}</p>
+          </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => void copyToClipboard(publicKey)}>
+            <Copy className="w-4 h-4" />
+            Copy address
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => openInExplorer(publicKey)}>
+            <ExternalLink className="w-4 h-4" />
+            View on explorer
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={handleDisconnect}
+            className="text-destructive focus:text-destructive"
+          >
+            <Power className="w-4 h-4" />
+            Disconnect
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     )
   }
 

--- a/components/stellar/WalletSettings.test.tsx
+++ b/components/stellar/WalletSettings.test.tsx
@@ -45,7 +45,9 @@ describe('WalletSettings', () => {
     )
 
     expect(
-      screen.getByText("alice hasn't set up their Stellar wallet yet.")
+      screen.getByText(
+        "alice hasn't connected a wallet yet, so in-app tipping isn't available."
+      )
     ).toBeInTheDocument()
     expect(screen.queryByText(/undefined/i)).not.toBeInTheDocument()
   })
@@ -54,9 +56,25 @@ describe('WalletSettings', () => {
     render(<WalletSettings isOwnProfile={false} walletAddress={null} />)
 
     expect(
-      screen.getByText("This user hasn't set up their Stellar wallet yet.")
+      screen.getByText(
+        "This author hasn't connected a wallet yet, so in-app tipping isn't available."
+      )
     ).toBeInTheDocument()
     expect(screen.queryByText(/undefined/i)).not.toBeInTheDocument()
+  })
+
+  it('shows browse articles link when profile username is provided', () => {
+    render(
+      <WalletSettings
+        isOwnProfile={false}
+        walletAddress={null}
+        profileUsername="alice"
+      />
+    )
+
+    expect(
+      screen.getByRole('link', { name: /Browse articles/i })
+    ).toHaveAttribute('href', '/alice?tab=articles')
   })
 
   it('shows owner connect CTA when wallet address is missing', () => {

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -38,6 +38,7 @@ import {
 
 interface WalletSettingsProps {
   walletAddress?: string | null
+  profileUsername?: string
   onAddressChange?: (address: string) => void
   isOwnProfile: boolean
   profileDisplayName?: string
@@ -46,6 +47,7 @@ interface WalletSettingsProps {
 
 export function WalletSettings({
   walletAddress,
+  profileUsername,
   onAddressChange,
   isOwnProfile,
   profileDisplayName,
@@ -159,14 +161,43 @@ export function WalletSettings({
 
   if (!isOwnProfile && !walletAddress) {
     return (
-      <Alert className={className}>
-        <AlertCircle className="h-4 w-4" />
-        <AlertDescription>
-          {profileDisplayName
-            ? `${profileDisplayName} hasn't set up their Stellar wallet yet.`
-            : "This user hasn't set up their Stellar wallet yet."}
-        </AlertDescription>
-      </Alert>
+      <Card className={className}>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Wallet className="h-5 w-5" />
+            Stellar Wallet
+            <WalletTooltip concept="stellar" />
+            <WalletTooltip concept="testnet" />
+          </CardTitle>
+          <CardDescription>
+            {profileDisplayName
+              ? `${profileDisplayName} hasn't connected a wallet yet, so in-app tipping isn't available.`
+              : "This author hasn't connected a wallet yet, so in-app tipping isn't available."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Alert>
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>
+              You can still read their work. Once they connect a wallet, you can
+              tip from any article using &quot;Tip Author&quot;.
+            </AlertDescription>
+          </Alert>
+
+          <div className="flex flex-col gap-2 sm:flex-row">
+            {profileUsername ? (
+              <Button asChild className="flex-1">
+                <Link href={`/${profileUsername}?tab=articles`}>
+                  Browse articles
+                </Link>
+              </Button>
+            ) : null}
+            <Button asChild variant="outline" className="flex-1">
+              <Link href="/guide">Learn how tipping works</Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
     )
   }
 
@@ -183,7 +214,7 @@ export function WalletSettings({
           <CardDescription>
             {isOwnProfile
               ? 'Manage your Stellar testnet wallet for sending and receiving practice tips'
-              : 'Send testnet tips directly to this user&apos;s Stellar wallet'}
+              : 'Copy the wallet address, or tip this author from their articles.'}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -364,8 +395,8 @@ export function WalletSettings({
               <Alert>
                 <DollarSign className="h-4 w-4" />
                 <AlertDescription>
-                  Tips sent to this wallet go directly to the user with minimal
-                  platform fees.
+                  Want to tip in-app? Open any of their articles and click
+                  &quot;Tip Author&quot;.
                 </AlertDescription>
               </Alert>
             </div>

--- a/lib/navigation/walletProfileDestination.test.ts
+++ b/lib/navigation/walletProfileDestination.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import {
+  WALLET_PROFILE_HUB_PATH,
+  getLoginRedirectPath,
+  getSafeRedirectPath,
+  getWalletTabPath,
+} from './walletProfileDestination'
+
+describe('walletProfileDestination', () => {
+  it('defines the wallet profile hub path', () => {
+    expect(WALLET_PROFILE_HUB_PATH).toBe('/profile?tab=wallet')
+  })
+
+  it('builds wallet tab path from username', () => {
+    expect(getWalletTabPath('alice')).toBe('/alice?tab=wallet')
+  })
+
+  it('builds login redirect path with encoded intended path', () => {
+    expect(getLoginRedirectPath('/profile?tab=wallet')).toBe(
+      '/login?redirect=%2Fprofile%3Ftab%3Dwallet'
+    )
+  })
+
+  describe('getSafeRedirectPath', () => {
+    it('returns fallback when raw is empty', () => {
+      expect(getSafeRedirectPath(null)).toBe('/')
+      expect(getSafeRedirectPath(undefined)).toBe('/')
+      expect(getSafeRedirectPath('')).toBe('/')
+    })
+
+    it('allows safe relative paths', () => {
+      expect(getSafeRedirectPath('/profile?tab=wallet')).toBe(
+        '/profile?tab=wallet'
+      )
+      expect(getSafeRedirectPath('/articles')).toBe('/articles')
+    })
+
+    it('rejects open redirects', () => {
+      expect(getSafeRedirectPath('https://evil.com')).toBe('/')
+      expect(getSafeRedirectPath('//evil.com')).toBe('/')
+      expect(getSafeRedirectPath('javascript:alert(1)')).toBe('/')
+    })
+
+    it('uses custom fallback', () => {
+      expect(getSafeRedirectPath(null, '/guide')).toBe('/guide')
+    })
+  })
+})

--- a/lib/navigation/walletProfileDestination.ts
+++ b/lib/navigation/walletProfileDestination.ts
@@ -1,0 +1,20 @@
+export const WALLET_PROFILE_HUB_PATH = '/profile?tab=wallet'
+
+export function getWalletTabPath(username: string): string {
+  return `/${username}?tab=wallet`
+}
+
+export function getLoginRedirectPath(intendedPath: string): string {
+  return `/login?redirect=${encodeURIComponent(intendedPath)}`
+}
+
+export function getSafeRedirectPath(
+  raw: string | null | undefined,
+  fallback = '/'
+): string {
+  if (!raw) return fallback
+  if (!raw.startsWith('/') || raw.startsWith('//') || raw.includes(':')) {
+    return fallback
+  }
+  return raw
+}


### PR DESCRIPTION
## Summary

Improves wallet onboarding and profile wallet management for ENG-143: clearer wallet copy, mobile-friendly guide tabs, explicit disconnect safety, and a reliable route from the guide to profile wallet settings.

## Changes

- Replaces the connected wallet button toggle with a dropdown menu for copy address, Stellar Expert, and explicit Disconnect.
- Updates wallet guide tabs to use full labels, mobile 2x2 layout, wrapping labels, larger touch targets, and visible active state.
- Adds a guide profile-settings CTA that targets `/profile?tab=wallet` and uses the generic profile redirect path.
- Updates login redirect handling so safe redirect paths are honored after sign-in.
- Updates wallet settings copy for own profile vs other authors and points tipping users to article-level Tip Author actions.
- Adds focused tests for wallet guide tabs, wallet connect menu behavior, wallet settings copy, login redirect handling, and profile wallet redirect behavior.

## Testing

- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run test:once`
- `bun run build`
- GitHub checks: Build, Dependency Audit, Lint/Typecheck/Test, Vercel, and Vercel Preview Comments.
- Preview QA completed for ENG-143 wallet guide, wallet menu, profile wallet redirect, wallet settings copy, signed-in/signed-out flows, and mobile guide tab behavior.

## Notes

- QA evidence is recorded locally in the ignored internal evidence doc.
- No contract, fee math, Stellar transaction verification, storage key, or Arweave behavior changes are included.
