### PR TITLE
feat(editor): mobile toolbar polish, writer notes drawer, and destructive highlight delete (ENG-154)

### DIFF
--- a/components/articles/HighlightableArticle.tsx
+++ b/components/articles/HighlightableArticle.tsx
@@ -522,6 +522,24 @@ export function HighlightableArticle({
     editor?.commands.focus()
   }, [editor])
 
+  const handleHighlightDeleted = useCallback(
+    (highlightId: Id<'highlights'>) => {
+      const remainingHighlights = (highlightsRef.current ?? []).filter(
+        (highlight) => highlight._id !== highlightId
+      )
+
+      highlightsRef.current = remainingHighlights
+      setHighlightTooltip((current) =>
+        current?.highlight._id === highlightId ? null : current
+      )
+
+      if (editor && highlightsActive) {
+        HighlightConverter.applyHighlightsToEditor(editor, remainingHighlights)
+      }
+    },
+    [editor, highlightsActive]
+  )
+
   const handleSignInPromptClose = useCallback(() => {
     if (editor) {
       const { from, to } = editor.state.selection
@@ -599,6 +617,7 @@ export function HighlightableArticle({
             highlight={highlightTooltip.highlight}
             position={highlightTooltip.position}
             onClose={handleTooltipClose}
+            onDeleted={handleHighlightDeleted}
             currentUserId={user?._id as Id<'users'> | undefined}
             articleId={articleId}
             articleSlug={article.slug}

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -82,12 +82,16 @@ function MoreMenu({
   onDelete?: () => void
   isDeleting?: boolean
 }) {
+  const focusRing =
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
         <button
           type="button"
-          className="p-2 rounded-full border border-border text-muted-foreground hover:bg-muted hover:border-border transition-colors shrink-0"
+          aria-label="More options"
+          className={`p-2 rounded-full border border-border text-muted-foreground hover:bg-muted hover:border-border transition-colors shrink-0 ${focusRing}`}
           title="More options"
         >
           <MoreHorizontal className="h-4 w-4" />
@@ -208,6 +212,9 @@ export function EditorActionBar({
     statusClassName = 'text-muted-foreground opacity-70'
   }
 
+  const focusRing =
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+
   const saveButton = (
     <button
       type="button"
@@ -270,7 +277,8 @@ export function EditorActionBar({
         type="button"
         onClick={() => editor?.chain().focus().undo().run()}
         disabled={!canUndo}
-        className="p-2 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent transition-colors shrink-0"
+        aria-label={`Undo (${shortcuts.undo})`}
+        className={`p-2 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent transition-colors shrink-0 ${focusRing}`}
         title={`Undo (${shortcuts.undo})`}
       >
         <Undo2 className="h-4 w-4" />
@@ -279,7 +287,8 @@ export function EditorActionBar({
         type="button"
         onClick={() => editor?.chain().focus().redo().run()}
         disabled={!canRedo}
-        className="p-2 rounded-md text-muted-foreground opacity-70 hover:bg-muted hover:opacity-100 disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent transition-colors shrink-0"
+        aria-label={`Redo (${shortcuts.redo})`}
+        className={`p-2 rounded-md text-muted-foreground opacity-70 hover:bg-muted hover:opacity-100 disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent transition-colors shrink-0 ${focusRing}`}
         title={`Redo (${shortcuts.redo})`}
       >
         <Redo2 className="h-4 w-4" />

--- a/components/editor/EditorToolbar.test.tsx
+++ b/components/editor/EditorToolbar.test.tsx
@@ -1,0 +1,94 @@
+/** @vitest-environment jsdom */
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { Editor } from '@tiptap/react'
+import { EditorToolbar } from '@/components/editor/EditorToolbar'
+
+const useIsMobileMock = vi.hoisted(() => vi.fn(() => false))
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => useIsMobileMock(),
+}))
+
+function makeStubEditor(): Editor {
+  return {
+    isActive: () => false,
+    chain: () => ({
+      focus: () => ({
+        toggleBold: () => ({ run: () => true }),
+        toggleItalic: () => ({ run: () => true }),
+        toggleUnderline: () => ({ run: () => true }),
+        toggleStrike: () => ({ run: () => true }),
+        toggleBlockquote: () => ({ run: () => true }),
+        toggleCodeBlock: () => ({ run: () => true }),
+        toggleOrderedList: () => ({ run: () => true }),
+        toggleBulletList: () => ({ run: () => true }),
+        setParagraph: () => ({ run: () => true }),
+        toggleHeading: () => ({ run: () => true }),
+      }),
+    }),
+  } as unknown as Editor
+}
+
+describe('EditorToolbar notes', () => {
+  beforeEach(() => {
+    useIsMobileMock.mockReturnValue(false)
+  })
+
+  it('opens desktop notes popover when Notes is clicked', async () => {
+    const user = userEvent.setup()
+    render(
+      <EditorToolbar
+        editor={makeStubEditor()}
+        notes=""
+        onNotesChange={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Notes' }))
+
+    expect(screen.getByRole('dialog', { name: 'Personal notes' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Done' })).not.toBeInTheDocument()
+  })
+
+  it('opens mobile notes drawer with Done control', async () => {
+    useIsMobileMock.mockReturnValue(true)
+    const user = userEvent.setup()
+    render(
+      <EditorToolbar
+        editor={makeStubEditor()}
+        notes=""
+        onNotesChange={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Notes' }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument()
+    expect(
+      screen.queryByLabelText('Personal notes', { selector: 'div[role="dialog"]' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('calls onNotesChange when editing notes in mobile drawer', async () => {
+    useIsMobileMock.mockReturnValue(true)
+    const onNotesChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <EditorToolbar
+        editor={makeStubEditor()}
+        notes=""
+        onNotesChange={onNotesChange}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Notes' }))
+    fireEvent.change(screen.getByLabelText('Personal notes'), {
+      target: { value: 'Plan chapter 2' },
+    })
+
+    expect(onNotesChange).toHaveBeenCalledWith('Plan chapter 2')
+  })
+})

--- a/components/editor/EditorToolbar.test.tsx
+++ b/components/editor/EditorToolbar.test.tsx
@@ -48,8 +48,12 @@ describe('EditorToolbar notes', () => {
 
     await user.click(screen.getByRole('button', { name: 'Notes' }))
 
-    expect(screen.getByRole('dialog', { name: 'Personal notes' })).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Done' })).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('dialog', { name: 'Personal notes' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Done' })
+    ).not.toBeInTheDocument()
   })
 
   it('opens mobile notes drawer with Done control', async () => {
@@ -68,7 +72,9 @@ describe('EditorToolbar notes', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument()
     expect(
-      screen.queryByLabelText('Personal notes', { selector: 'div[role="dialog"]' })
+      screen.queryByLabelText('Personal notes', {
+        selector: 'div[role="dialog"]',
+      })
     ).not.toBeInTheDocument()
   })
 

--- a/components/editor/EditorToolbar.tsx
+++ b/components/editor/EditorToolbar.tsx
@@ -28,6 +28,7 @@ import { useEffect, useState, useRef, useLayoutEffect, forwardRef } from 'react'
 import { createPortal } from 'react-dom'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { cn } from '@/lib/utils'
 import { ImageUploadDialog } from './ImageUploadDialog'
 import { YouTubeEmbedDialog } from './YouTubeEmbedDialog'
 import {
@@ -122,6 +123,13 @@ function ToolbarDivider({ className = '' }: { className?: string }) {
       className={`w-px h-5 bg-border mx-0.5 shrink-0 ${className}`}
       aria-hidden
     />
+  )
+}
+
+function moreMenuItemClass(isActive: boolean) {
+  return cn(
+    'px-4 py-2 text-sm hover:bg-muted cursor-pointer outline-none flex items-center gap-2',
+    isActive && 'bg-muted font-medium text-primary'
   )
 }
 
@@ -372,7 +380,6 @@ export function EditorToolbar({
     const isActivation = e.key === 'Enter' || e.key === ' '
     if (!isActivation) return
 
-    // Native <button> handles Enter/Space. For non-button elements we click defensively.
     if (target instanceof HTMLButtonElement) return
     e.preventDefault()
     target.click()
@@ -381,8 +388,409 @@ export function EditorToolbar({
   const focusRing =
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
 
+  const currentHeading = getCurrentHeading()
+
+  const headingDropdown = (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button
+          type="button"
+          onMouseDown={(e) => e.preventDefault()}
+          data-toolbar-item="true"
+          data-toolbar-key="heading"
+          tabIndex={tabIndexFor('heading')}
+          aria-label={currentHeading}
+          title={currentHeading}
+          className={`flex items-center gap-1.5 px-2.5 py-2 rounded hover:bg-muted text-foreground text-sm shrink-0 ${focusRing}`}
+        >
+          <Type className="w-4 h-4 shrink-0" />
+          <span className="hidden md:inline">{currentHeading}</span>
+          <ChevronDown className="w-3.5 h-3.5 opacity-70 shrink-0" />
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content className="bg-popover text-popover-foreground rounded-lg shadow-lg border border-border py-1 z-50">
+          {headingOptions.map((option) => (
+            <DropdownMenu.Item
+              key={option.level}
+              onSelect={option.command}
+              className="px-4 py-2 text-sm hover:bg-muted cursor-pointer outline-none"
+            >
+              {option.label}
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+
+  const addMenu = (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button
+          type="button"
+          onMouseDown={(e) => e.preventDefault()}
+          data-toolbar-item="true"
+          data-toolbar-key="add"
+          tabIndex={tabIndexFor('add')}
+          className={`p-2 rounded hover:bg-muted text-foreground transition-colors cursor-pointer shrink-0 ${focusRing}`}
+          title="Add"
+          aria-label="Add"
+        >
+          <Plus className="w-4 h-4" />
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          className="bg-popover text-popover-foreground rounded-lg shadow-lg border border-border py-1 z-50 min-w-[200px]"
+          sideOffset={4}
+          align="start"
+        >
+          <DropdownMenu.Item
+            onSelect={() => onFocusCoverImage?.()}
+            className="px-4 py-2.5 text-sm hover:bg-muted cursor-pointer outline-none flex items-center gap-2"
+          >
+            <Image className="w-4 h-4 shrink-0" />
+            Cover Image
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            onSelect={() => onFocusTitle?.()}
+            className="px-4 py-2.5 text-sm hover:bg-muted cursor-pointer outline-none flex items-center gap-2"
+          >
+            <Type className="w-4 h-4 shrink-0" />
+            Article Title
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            onSelect={() => onFocusExcerpt?.()}
+            className="px-4 py-2.5 text-sm hover:bg-muted cursor-pointer outline-none flex items-center gap-2"
+          >
+            <FileText className="w-4 h-4 shrink-0" />
+            Article Excerpt
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            onSelect={() => onFocusTags?.()}
+            className="px-4 py-2.5 text-sm hover:bg-muted cursor-pointer outline-none flex items-center gap-2"
+          >
+            <Tag className="w-4 h-4 shrink-0" />
+            Tags
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+
+  const linkControl = (
+    <div ref={linkAnchorRef} className="relative shrink-0">
+      {editor.isActive('link') ? (
+        <ToolbarButton
+          onClick={removeLink}
+          isActive
+          title={`Remove link (${shortcut('K')})`}
+          tabIndex={tabIndexFor('linkRemove')}
+          onFocus={() => setActiveItemKey('linkRemove')}
+          toolbarKey="linkRemove"
+        >
+          <Link2 className="w-4 h-4" />
+        </ToolbarButton>
+      ) : (
+        <ToolbarButton
+          onClick={() => setShowLinkInput(!showLinkInput)}
+          title={`Insert link (${shortcut('K')})`}
+          tabIndex={tabIndexFor('linkInsert')}
+          onFocus={() => setActiveItemKey('linkInsert')}
+          toolbarKey="linkInsert"
+        >
+          <Link2 className="w-4 h-4" />
+        </ToolbarButton>
+      )}
+    </div>
+  )
+
+  const moreMenu = (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button
+          type="button"
+          onMouseDown={(e) => e.preventDefault()}
+          data-toolbar-item="true"
+          data-toolbar-key="more"
+          tabIndex={tabIndexFor('more')}
+          className={`p-2 rounded hover:bg-muted text-foreground transition-colors cursor-pointer shrink-0 ${focusRing}`}
+          title="More formatting"
+          aria-label="More formatting"
+        >
+          <MoreHorizontal className="w-4 h-4" />
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          className="bg-popover text-popover-foreground rounded-lg shadow-lg border border-border py-1 z-50 min-w-[200px]"
+          sideOffset={4}
+          align="end"
+        >
+          <DropdownMenu.Label className="px-3 py-1.5 text-xs font-medium text-muted-foreground">
+            Alignment
+          </DropdownMenu.Label>
+          <DropdownMenu.Item
+            onSelect={() => setTextAlign('left')}
+            className={moreMenuItemClass(
+              editor.isActive({ textAlign: 'left' })
+            )}
+          >
+            <AlignLeft className="w-4 h-4 shrink-0" />
+            Align left
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            onSelect={() => setTextAlign('center')}
+            className={moreMenuItemClass(
+              editor.isActive({ textAlign: 'center' })
+            )}
+          >
+            <AlignCenter className="w-4 h-4 shrink-0" />
+            Align center
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            onSelect={() => setTextAlign('right')}
+            className={moreMenuItemClass(
+              editor.isActive({ textAlign: 'right' })
+            )}
+          >
+            <AlignRight className="w-4 h-4 shrink-0" />
+            Align right
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            onSelect={() => setTextAlign('justify')}
+            className={moreMenuItemClass(
+              editor.isActive({ textAlign: 'justify' })
+            )}
+          >
+            <AlignJustify className="w-4 h-4 shrink-0" />
+            Justify
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator className="h-px bg-border my-1" />
+          <DropdownMenu.Item
+            onSelect={() => setShowImageDialog(true)}
+            className="px-4 py-2 text-sm hover:bg-muted cursor-pointer outline-none flex items-center gap-2"
+          >
+            <Image className="w-4 h-4 shrink-0" />
+            Insert image
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            onSelect={() => setShowYouTubeDialog(true)}
+            className="px-4 py-2 text-sm hover:bg-muted cursor-pointer outline-none flex items-center gap-2"
+          >
+            <Youtube className="w-4 h-4 shrink-0" />
+            Embed YouTube
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+
+  const notesControl = (
+    <div className="relative">
+      <button
+        type="button"
+        onMouseDown={(e) => e.preventDefault()}
+        data-toolbar-item="true"
+        data-toolbar-key="notes"
+        tabIndex={tabIndexFor('notes')}
+        className={`flex items-center gap-1.5 rounded px-2 py-2 text-sm font-medium hover:bg-muted md:gap-2 md:pl-3 md:pr-2 ${focusRing} ${showNotes ? 'bg-muted text-primary' : 'text-foreground'}`}
+        title="Notes"
+        aria-label="Notes"
+        onClick={() => setShowNotes(!showNotes)}
+        onFocus={() => setActiveItemKey('notes')}
+      >
+        <FileText className="h-4 w-4 shrink-0" />
+        <span className="hidden min-[360px]:inline md:inline">Notes</span>
+      </button>
+      {showNotes && (
+        <div className="absolute top-full right-0 z-50 mt-1 w-72 max-w-[min(18rem,calc(100vw-2rem))] rounded-lg border border-border bg-popover shadow-lg">
+          <div className="border-b border-border px-3 py-2">
+            <p className="text-xs font-medium text-muted-foreground">
+              Personal Notes
+            </p>
+            <p className="mt-1 text-xs leading-snug text-muted-foreground/80">
+              Private planning notes for you only. They are saved with this draft
+              and are not published with your article.
+            </p>
+          </div>
+          <textarea
+            value={notes}
+            onChange={(e) => onNotesChange?.(e.target.value)}
+            placeholder="Jot down ideas, reminders, or notes..."
+            className="w-full resize-none rounded-b-lg bg-popover p-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
+            rows={6}
+          />
+        </div>
+      )}
+    </div>
+  )
+
+  const formattingControls = (
+    <>
+      {headingDropdown}
+      <ToolbarDivider />
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleBold().run()}
+        isActive={editor.isActive('bold')}
+        title={`Bold (${shortcut('B')})`}
+        tabIndex={tabIndexFor('bold')}
+        onFocus={() => setActiveItemKey('bold')}
+        toolbarKey="bold"
+      >
+        <Bold className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleItalic().run()}
+        isActive={editor.isActive('italic')}
+        title={`Italic (${shortcut('I')})`}
+        tabIndex={tabIndexFor('italic')}
+        onFocus={() => setActiveItemKey('italic')}
+        toolbarKey="italic"
+      >
+        <Italic className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleUnderline().run()}
+        isActive={editor.isActive('underline')}
+        title="Underline"
+        tabIndex={tabIndexFor('underline')}
+        onFocus={() => setActiveItemKey('underline')}
+        toolbarKey="underline"
+      >
+        <Underline className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleStrike().run()}
+        isActive={editor.isActive('strike')}
+        title="Strikethrough"
+        tabIndex={tabIndexFor('strike')}
+        onFocus={() => setActiveItemKey('strike')}
+        toolbarKey="strike"
+      >
+        <Strikethrough className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleBlockquote().run()}
+        isActive={editor.isActive('blockquote')}
+        title="Blockquote"
+        tabIndex={tabIndexFor('blockquote')}
+        onFocus={() => setActiveItemKey('blockquote')}
+        toolbarKey="blockquote"
+      >
+        <Quote className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarDivider />
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleCodeBlock().run()}
+        isActive={editor.isActive('codeBlock')}
+        title="Code block"
+        tabIndex={tabIndexFor('codeBlock')}
+        onFocus={() => setActiveItemKey('codeBlock')}
+        toolbarKey="codeBlock"
+      >
+        <Code className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleOrderedList().run()}
+        isActive={editor.isActive('orderedList')}
+        title="Numbered list"
+        tabIndex={tabIndexFor('orderedList')}
+        onFocus={() => setActiveItemKey('orderedList')}
+        toolbarKey="orderedList"
+      >
+        <ListOrdered className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => editor.chain().focus().toggleBulletList().run()}
+        isActive={editor.isActive('bulletList')}
+        title="Bullet list"
+        tabIndex={tabIndexFor('bulletList')}
+        onFocus={() => setActiveItemKey('bulletList')}
+        toolbarKey="bulletList"
+      >
+        <List className="w-4 h-4" />
+      </ToolbarButton>
+    </>
+  )
+
+  const desktopAlignmentControls = (
+    <div className="hidden md:contents">
+      <ToolbarDivider />
+      <ToolbarButton
+        onClick={() => setTextAlign('left')}
+        isActive={editor.isActive({ textAlign: 'left' })}
+        title="Align left"
+        tabIndex={tabIndexFor('alignLeft')}
+        onFocus={() => setActiveItemKey('alignLeft')}
+        toolbarKey="alignLeft"
+      >
+        <AlignLeft className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => setTextAlign('center')}
+        isActive={editor.isActive({ textAlign: 'center' })}
+        title="Align center"
+        tabIndex={tabIndexFor('alignCenter')}
+        onFocus={() => setActiveItemKey('alignCenter')}
+        toolbarKey="alignCenter"
+      >
+        <AlignCenter className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => setTextAlign('right')}
+        isActive={editor.isActive({ textAlign: 'right' })}
+        title="Align right"
+        tabIndex={tabIndexFor('alignRight')}
+        onFocus={() => setActiveItemKey('alignRight')}
+        toolbarKey="alignRight"
+      >
+        <AlignRight className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => setTextAlign('justify')}
+        isActive={editor.isActive({ textAlign: 'justify' })}
+        title="Justify"
+        tabIndex={tabIndexFor('alignJustify')}
+        onFocus={() => setActiveItemKey('alignJustify')}
+        toolbarKey="alignJustify"
+      >
+        <AlignJustify className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarDivider />
+    </div>
+  )
+
+  const desktopMediaControls = (
+    <>
+      <ToolbarButton
+        ref={imageDialogTriggerRef}
+        onClick={() => setShowImageDialog(true)}
+        title="Insert image"
+        className="hidden md:inline-flex"
+        tabIndex={tabIndexFor('image')}
+        onFocus={() => setActiveItemKey('image')}
+        toolbarKey="image"
+      >
+        <Image className="w-4 h-4" />
+      </ToolbarButton>
+      <ToolbarButton
+        ref={youtubeDialogTriggerRef}
+        onClick={() => setShowYouTubeDialog(true)}
+        title="Embed YouTube video"
+        className="hidden md:inline-flex"
+        tabIndex={tabIndexFor('youtube')}
+        onFocus={() => setActiveItemKey('youtube')}
+        toolbarKey="youtube"
+      >
+        <Youtube className="w-4 h-4" />
+      </ToolbarButton>
+    </>
+  )
+
   return (
-    <div className="bg-background w-full min-w-0 flex items-stretch min-h-[44px] py-2 gap-2">
+    <div className="flex min-h-[44px] w-full min-w-0 items-stretch gap-2 overflow-x-hidden bg-background py-2 md:overflow-x-visible">
       <div
         ref={toolbarRef}
         role="toolbar"
@@ -391,395 +799,19 @@ export function EditorToolbar({
         onFocusCapture={handleToolbarFocusCapture}
         className="flex min-w-0 flex-1 items-stretch gap-2"
       >
-        <div className="min-w-0 flex-1 overflow-x-auto overflow-y-hidden overscroll-x-contain [scrollbar-width:thin]">
-          <div className="inline-flex min-h-[44px] flex-nowrap items-center gap-0.5 justify-start">
-            {/* Paragraph / style dropdown */}
-            <DropdownMenu.Root>
-              <DropdownMenu.Trigger asChild>
-                <button
-                  onMouseDown={(e) => e.preventDefault()}
-                  data-toolbar-item="true"
-                  data-toolbar-key="heading"
-                  tabIndex={tabIndexFor('heading')}
-                  className={`flex items-center gap-1.5 px-2.5 py-2 rounded hover:bg-muted text-foreground text-sm shrink-0 ${focusRing}`}
-                >
-                  <Type className="w-4 h-4 shrink-0" />
-                  <span>{getCurrentHeading()}</span>
-                  <ChevronDown className="w-3.5 h-3.5 opacity-70 shrink-0" />
-                </button>
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content className="bg-popover text-popover-foreground rounded-lg shadow-lg border border-border py-1 z-50">
-                  {headingOptions.map((option) => (
-                    <DropdownMenu.Item
-                      key={option.level}
-                      onSelect={option.command}
-                      className="px-4 py-2 text-sm hover:bg-muted cursor-pointer outline-none"
-                    >
-                      {option.label}
-                    </DropdownMenu.Item>
-                  ))}
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
-            </DropdownMenu.Root>
-
-            <ToolbarDivider />
-
-            {/* B I U */}
-            <ToolbarButton
-              onClick={() => editor.chain().focus().toggleBold().run()}
-              isActive={editor.isActive('bold')}
-              title={`Bold (${shortcut('B')})`}
-              tabIndex={tabIndexFor('bold')}
-              onFocus={() => setActiveItemKey('bold')}
-              toolbarKey="bold"
-            >
-              <Bold className="w-4 h-4" />
-            </ToolbarButton>
-            <ToolbarButton
-              onClick={() => editor.chain().focus().toggleItalic().run()}
-              isActive={editor.isActive('italic')}
-              title={`Italic (${shortcut('I')})`}
-              tabIndex={tabIndexFor('italic')}
-              onFocus={() => setActiveItemKey('italic')}
-              toolbarKey="italic"
-            >
-              <Italic className="w-4 h-4" />
-            </ToolbarButton>
-            <ToolbarButton
-              onClick={() => editor.chain().focus().toggleUnderline().run()}
-              isActive={editor.isActive('underline')}
-              title="Underline"
-              tabIndex={tabIndexFor('underline')}
-              onFocus={() => setActiveItemKey('underline')}
-              toolbarKey="underline"
-            >
-              <Underline className="w-4 h-4" />
-            </ToolbarButton>
-            <ToolbarButton
-              onClick={() => editor.chain().focus().toggleStrike().run()}
-              isActive={editor.isActive('strike')}
-              title="Strikethrough"
-              tabIndex={tabIndexFor('strike')}
-              onFocus={() => setActiveItemKey('strike')}
-              toolbarKey="strike"
-            >
-              <Strikethrough className="w-4 h-4" />
-            </ToolbarButton>
-
-            {/* Quote */}
-            <ToolbarButton
-              onClick={() => editor.chain().focus().toggleBlockquote().run()}
-              isActive={editor.isActive('blockquote')}
-              title="Blockquote"
-              tabIndex={tabIndexFor('blockquote')}
-              onFocus={() => setActiveItemKey('blockquote')}
-              toolbarKey="blockquote"
-            >
-              <Quote className="w-4 h-4" />
-            </ToolbarButton>
-
-            <ToolbarDivider />
-
-            {/* Code block, lists */}
-            <ToolbarButton
-              onClick={() => editor.chain().focus().toggleCodeBlock().run()}
-              isActive={editor.isActive('codeBlock')}
-              title="Code block"
-              tabIndex={tabIndexFor('codeBlock')}
-              onFocus={() => setActiveItemKey('codeBlock')}
-              toolbarKey="codeBlock"
-            >
-              <Code className="w-4 h-4" />
-            </ToolbarButton>
-            <ToolbarButton
-              onClick={() => editor.chain().focus().toggleOrderedList().run()}
-              isActive={editor.isActive('orderedList')}
-              title="Numbered list"
-              tabIndex={tabIndexFor('orderedList')}
-              onFocus={() => setActiveItemKey('orderedList')}
-              toolbarKey="orderedList"
-            >
-              <ListOrdered className="w-4 h-4" />
-            </ToolbarButton>
-            <ToolbarButton
-              onClick={() => editor.chain().focus().toggleBulletList().run()}
-              isActive={editor.isActive('bulletList')}
-              title="Bullet list"
-              tabIndex={tabIndexFor('bulletList')}
-              onFocus={() => setActiveItemKey('bulletList')}
-              toolbarKey="bulletList"
-            >
-              <List className="w-4 h-4" />
-            </ToolbarButton>
-
-            <ToolbarDivider className="hidden md:block" />
-
-            {/* Alignment — md+ only */}
-            <div className="hidden md:contents">
-              <ToolbarButton
-                onClick={() => setTextAlign('left')}
-                isActive={editor.isActive({ textAlign: 'left' })}
-                title="Align left"
-                tabIndex={tabIndexFor('alignLeft')}
-                onFocus={() => setActiveItemKey('alignLeft')}
-                toolbarKey="alignLeft"
-              >
-                <AlignLeft className="w-4 h-4" />
-              </ToolbarButton>
-              <ToolbarButton
-                onClick={() => setTextAlign('center')}
-                isActive={editor.isActive({ textAlign: 'center' })}
-                title="Align center"
-                tabIndex={tabIndexFor('alignCenter')}
-                onFocus={() => setActiveItemKey('alignCenter')}
-                toolbarKey="alignCenter"
-              >
-                <AlignCenter className="w-4 h-4" />
-              </ToolbarButton>
-              <ToolbarButton
-                onClick={() => setTextAlign('right')}
-                isActive={editor.isActive({ textAlign: 'right' })}
-                title="Align right"
-                tabIndex={tabIndexFor('alignRight')}
-                onFocus={() => setActiveItemKey('alignRight')}
-                toolbarKey="alignRight"
-              >
-                <AlignRight className="w-4 h-4" />
-              </ToolbarButton>
-              <ToolbarButton
-                onClick={() => setTextAlign('justify')}
-                isActive={editor.isActive({ textAlign: 'justify' })}
-                title="Justify"
-                tabIndex={tabIndexFor('alignJustify')}
-                onFocus={() => setActiveItemKey('alignJustify')}
-                toolbarKey="alignJustify"
-              >
-                <AlignJustify className="w-4 h-4" />
-              </ToolbarButton>
-
-              <ToolbarDivider />
-            </div>
-
-            {/* Add - dropdown: Article Title, Cover Image URL, Excerpt, Tags */}
-            <DropdownMenu.Root>
-              <DropdownMenu.Trigger asChild>
-                <button
-                  type="button"
-                  onMouseDown={(e) => e.preventDefault()}
-                  data-toolbar-item="true"
-                  data-toolbar-key="add"
-                  tabIndex={tabIndexFor('add')}
-                  className={`p-2 rounded hover:bg-muted text-foreground transition-colors cursor-pointer shrink-0 ${focusRing}`}
-                  title="Add"
-                  aria-label="Add"
-                >
-                  <Plus className="w-4 h-4" />
-                </button>
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content
-                  className="bg-popover text-popover-foreground rounded-lg shadow-lg border border-border py-1 z-50 min-w-[200px]"
-                  sideOffset={4}
-                  align="start"
-                >
-                  <DropdownMenu.Item
-                    onSelect={() => onFocusCoverImage?.()}
-                    className="px-4 py-2.5 text-sm hover:bg-muted cursor-pointer outline-none flex items-center gap-2"
-                  >
-                    <Image className="w-4 h-4 shrink-0" />
-                    Cover Image
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item
-                    onSelect={() => onFocusTitle?.()}
-                    className="px-4 py-2.5 text-sm hover:bg-muted cursor-pointer outline-none flex items-center gap-2"
-                  >
-                    <Type className="w-4 h-4 shrink-0" />
-                    Article Title
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item
-                    onSelect={() => onFocusExcerpt?.()}
-                    className="px-4 py-2.5 text-sm hover:bg-muted cursor-pointer outline-none flex items-center gap-2"
-                  >
-                    <FileText className="w-4 h-4 shrink-0" />
-                    Article Excerpt
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item
-                    onSelect={() => onFocusTags?.()}
-                    className="px-4 py-2.5 text-sm hover:bg-muted cursor-pointer outline-none flex items-center gap-2"
-                  >
-                    <Tag className="w-4 h-4 shrink-0" />
-                    Tags
-                  </DropdownMenu.Item>
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
-            </DropdownMenu.Root>
-
-            {/* Link */}
-            <div ref={linkAnchorRef} className="relative shrink-0">
-              {editor.isActive('link') ? (
-                <ToolbarButton
-                  onClick={removeLink}
-                  isActive
-                  title={`Remove link (${shortcut('K')})`}
-                  tabIndex={tabIndexFor('linkRemove')}
-                  onFocus={() => setActiveItemKey('linkRemove')}
-                  toolbarKey="linkRemove"
-                >
-                  <Link2 className="w-4 h-4" />
-                </ToolbarButton>
-              ) : (
-                <ToolbarButton
-                  onClick={() => setShowLinkInput(!showLinkInput)}
-                  title={`Insert link (${shortcut('K')})`}
-                  tabIndex={tabIndexFor('linkInsert')}
-                  onFocus={() => setActiveItemKey('linkInsert')}
-                  toolbarKey="linkInsert"
-                >
-                  <Link2 className="w-4 h-4" />
-                </ToolbarButton>
-              )}
-            </div>
-
-            {/* More: alignment, image, YouTube on small screens */}
-            <div className="md:hidden shrink-0">
-              <DropdownMenu.Root>
-                <DropdownMenu.Trigger asChild>
-                  <button
-                    type="button"
-                    onMouseDown={(e) => e.preventDefault()}
-                    data-toolbar-item="true"
-                    data-toolbar-key="more"
-                    tabIndex={tabIndexFor('more')}
-                    className={`p-2 rounded hover:bg-muted text-foreground transition-colors cursor-pointer shrink-0 ${focusRing}`}
-                    title="More formatting"
-                    aria-label="More formatting"
-                  >
-                    <MoreHorizontal className="w-4 h-4" />
-                  </button>
-                </DropdownMenu.Trigger>
-                <DropdownMenu.Portal>
-                  <DropdownMenu.Content
-                    className="bg-popover text-popover-foreground rounded-lg shadow-lg border border-border py-1 z-50 min-w-[200px]"
-                    sideOffset={4}
-                    align="start"
-                  >
-                    <DropdownMenu.Label className="px-3 py-1.5 text-xs font-medium text-muted-foreground">
-                      Alignment
-                    </DropdownMenu.Label>
-                    <DropdownMenu.Item
-                      onSelect={() => setTextAlign('left')}
-                      className="px-4 py-2 text-sm hover:bg-muted cursor-pointer outline-none flex items-center gap-2"
-                    >
-                      <AlignLeft className="w-4 h-4 shrink-0" />
-                      Align left
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Item
-                      onSelect={() => setTextAlign('center')}
-                      className="px-4 py-2 text-sm hover:bg-muted cursor-pointer outline-none flex items-center gap-2"
-                    >
-                      <AlignCenter className="w-4 h-4 shrink-0" />
-                      Align center
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Item
-                      onSelect={() => setTextAlign('right')}
-                      className="px-4 py-2 text-sm hover:bg-muted cursor-pointer outline-none flex items-center gap-2"
-                    >
-                      <AlignRight className="w-4 h-4 shrink-0" />
-                      Align right
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Item
-                      onSelect={() => setTextAlign('justify')}
-                      className="px-4 py-2 text-sm hover:bg-muted cursor-pointer outline-none flex items-center gap-2"
-                    >
-                      <AlignJustify className="w-4 h-4 shrink-0" />
-                      Justify
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Separator className="h-px bg-border my-1" />
-                    <DropdownMenu.Item
-                      onSelect={() => setShowImageDialog(true)}
-                      className="px-4 py-2 text-sm hover:bg-muted cursor-pointer outline-none flex items-center gap-2"
-                    >
-                      <Image className="w-4 h-4 shrink-0" />
-                      Insert image
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Item
-                      onSelect={() => setShowYouTubeDialog(true)}
-                      className="px-4 py-2 text-sm hover:bg-muted cursor-pointer outline-none flex items-center gap-2"
-                    >
-                      <Youtube className="w-4 h-4 shrink-0" />
-                      Embed YouTube
-                    </DropdownMenu.Item>
-                  </DropdownMenu.Content>
-                </DropdownMenu.Portal>
-              </DropdownMenu.Root>
-            </div>
-
-            {/* Image */}
-            <ToolbarButton
-              ref={imageDialogTriggerRef}
-              onClick={() => setShowImageDialog(true)}
-              title="Insert image"
-              className="hidden md:inline-flex"
-              tabIndex={tabIndexFor('image')}
-              onFocus={() => setActiveItemKey('image')}
-              toolbarKey="image"
-            >
-              <Image className="w-4 h-4" />
-            </ToolbarButton>
-
-            {/* YouTube embed */}
-            <ToolbarButton
-              ref={youtubeDialogTriggerRef}
-              onClick={() => setShowYouTubeDialog(true)}
-              title="Embed YouTube video"
-              className="hidden md:inline-flex"
-              tabIndex={tabIndexFor('youtube')}
-              onFocus={() => setActiveItemKey('youtube')}
-              toolbarKey="youtube"
-            >
-              <Youtube className="w-4 h-4" />
-            </ToolbarButton>
+        <div className="min-w-0 flex-1 md:overflow-x-auto md:overflow-y-hidden md:overscroll-x-contain md:[scrollbar-width:thin]">
+          <div className="flex min-h-[44px] flex-wrap items-center gap-0.5 md:inline-flex md:flex-nowrap">
+            {formattingControls}
+            {desktopAlignmentControls}
+            {addMenu}
+            {linkControl}
+            {desktopMediaControls}
           </div>
         </div>
 
-        <div className="flex shrink-0 items-center border-l border-border pl-2">
-          <div className="relative">
-            <button
-              type="button"
-              onMouseDown={(e) => e.preventDefault()}
-              data-toolbar-item="true"
-              data-toolbar-key="notes"
-              tabIndex={tabIndexFor('notes')}
-              className={`flex items-center gap-2 pl-3 pr-2 py-2 rounded hover:bg-muted text-sm font-medium ${focusRing} ${showNotes ? 'bg-muted text-primary' : 'text-foreground'}`}
-              title="Notes"
-              onClick={() => setShowNotes(!showNotes)}
-              onFocus={() => setActiveItemKey('notes')}
-            >
-              <FileText className="w-4 h-4" />
-              Notes
-            </button>
-            {showNotes && (
-              <div className="absolute top-full right-0 mt-1 bg-popover border border-border rounded-lg shadow-lg z-50 w-72">
-                <div className="px-3 py-2 border-b border-border">
-                  <p className="text-xs font-medium text-muted-foreground">
-                    Personal Notes
-                  </p>
-                  <p className="mt-1 text-xs text-muted-foreground/80 leading-snug">
-                    Private planning notes for you only. They are saved with
-                    this draft and are not published with your article.
-                  </p>
-                </div>
-                <textarea
-                  value={notes}
-                  onChange={(e) => onNotesChange?.(e.target.value)}
-                  placeholder="Jot down ideas, reminders, or notes..."
-                  className="w-full p-3 text-sm text-foreground bg-popover placeholder:text-muted-foreground resize-none focus:outline-none rounded-b-lg"
-                  rows={6}
-                />
-              </div>
-            )}
-          </div>
+        <div className="flex shrink-0 items-start gap-0 border-l border-border pl-2">
+          <div className="md:hidden">{moreMenu}</div>
+          {notesControl}
         </div>
       </div>
 

--- a/components/editor/EditorToolbar.tsx
+++ b/components/editor/EditorToolbar.tsx
@@ -611,8 +611,8 @@ export function EditorToolbar({
               Personal Notes
             </p>
             <p className="mt-1 text-xs leading-snug text-muted-foreground/80">
-              Private planning notes for you only. They are saved with this draft
-              and are not published with your article.
+              Private planning notes for you only. They are saved with this
+              draft and are not published with your article.
             </p>
           </div>
           <textarea

--- a/components/editor/EditorToolbar.tsx
+++ b/components/editor/EditorToolbar.tsx
@@ -99,6 +99,7 @@ const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
         disabled={disabled}
         title={title}
         aria-label={title}
+        aria-pressed={isActive}
         tabIndex={tabIndex}
         onFocus={onFocus}
         data-toolbar-item="true"

--- a/components/editor/EditorToolbar.tsx
+++ b/components/editor/EditorToolbar.tsx
@@ -46,10 +46,7 @@ import {
 } from '@/components/ui/drawer'
 import { ImageUploadDialog } from './ImageUploadDialog'
 import { YouTubeEmbedDialog } from './YouTubeEmbedDialog'
-import {
-  WRITER_NOTES_HELPER_TEXT,
-  WriterNotesPanel,
-} from './WriterNotesPanel'
+import { WRITER_NOTES_HELPER_TEXT, WriterNotesPanel } from './WriterNotesPanel'
 import {
   getVisibleToolbarKeys,
   resolveActiveToolbarKey,

--- a/components/editor/EditorToolbar.tsx
+++ b/components/editor/EditorToolbar.tsx
@@ -24,13 +24,32 @@ import {
   Youtube,
   MoreHorizontal,
 } from 'lucide-react'
-import { useEffect, useState, useRef, useLayoutEffect, forwardRef } from 'react'
+import {
+  useEffect,
+  useState,
+  useRef,
+  useLayoutEffect,
+  useCallback,
+  forwardRef,
+} from 'react'
 import { createPortal } from 'react-dom'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { cn } from '@/lib/utils'
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer'
 import { ImageUploadDialog } from './ImageUploadDialog'
 import { YouTubeEmbedDialog } from './YouTubeEmbedDialog'
+import {
+  WRITER_NOTES_HELPER_TEXT,
+  WriterNotesPanel,
+} from './WriterNotesPanel'
 import {
   getVisibleToolbarKeys,
   resolveActiveToolbarKey,
@@ -154,6 +173,8 @@ export function EditorToolbar({
   const linkAnchorRef = useRef<HTMLDivElement>(null)
   const imageDialogTriggerRef = useRef<HTMLButtonElement>(null)
   const youtubeDialogTriggerRef = useRef<HTMLButtonElement>(null)
+  const notesTriggerRef = useRef<HTMLButtonElement>(null)
+  const notesTextareaRef = useRef<HTMLTextAreaElement>(null)
   const [linkPopoverPos, setLinkPopoverPos] = useState<{
     top: number
     left: number
@@ -180,6 +201,23 @@ export function EditorToolbar({
       setActiveItemKey(resolveActiveToolbarKey(activeItemKey, keys))
     }
   }, [isMobile, isLinkActive, activeItemKey])
+
+  const handleNotesOpenChange = useCallback((open: boolean) => {
+    setShowNotes(open)
+    if (!open) {
+      requestAnimationFrame(() => {
+        notesTriggerRef.current?.focus()
+      })
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!showNotes || !isMobile) return
+    const frame = requestAnimationFrame(() => {
+      notesTextareaRef.current?.focus()
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [showNotes, isMobile])
 
   useLayoutEffect(() => {
     if (!showLinkInput) {
@@ -588,43 +626,93 @@ export function EditorToolbar({
     </DropdownMenu.Root>
   )
 
-  const notesControl = (
-    <div className="relative">
-      <button
-        type="button"
-        onMouseDown={(e) => e.preventDefault()}
-        data-toolbar-item="true"
-        data-toolbar-key="notes"
-        tabIndex={tabIndexFor('notes')}
-        className={`flex items-center gap-1.5 rounded px-2 py-2 text-sm font-medium hover:bg-muted md:gap-2 md:pl-3 md:pr-2 ${focusRing} ${showNotes ? 'bg-muted text-primary' : 'text-foreground'}`}
-        title="Notes"
-        aria-label="Notes"
-        onClick={() => setShowNotes(!showNotes)}
-        onFocus={() => setActiveItemKey('notes')}
+  const notesTriggerButton = (
+    <button
+      ref={notesTriggerRef}
+      type="button"
+      onMouseDown={(e) => e.preventDefault()}
+      data-toolbar-item="true"
+      data-toolbar-key="notes"
+      tabIndex={tabIndexFor('notes')}
+      className={`flex items-center gap-1.5 rounded px-2 py-2 text-sm font-medium hover:bg-muted md:gap-2 md:pl-3 md:pr-2 ${focusRing} ${showNotes ? 'bg-muted text-primary' : 'text-foreground'}`}
+      title="Notes"
+      aria-label="Notes"
+      aria-expanded={showNotes}
+      onClick={() => {
+        if (isMobile) {
+          setShowNotes(true)
+        } else {
+          setShowNotes((open) => !open)
+        }
+      }}
+      onFocus={() => setActiveItemKey('notes')}
+    >
+      <FileText className="h-4 w-4 shrink-0" />
+      <span className="hidden min-[360px]:inline md:inline">Notes</span>
+    </button>
+  )
+
+  const notesControl = isMobile ? (
+    <Drawer open={showNotes} onOpenChange={handleNotesOpenChange}>
+      {notesTriggerButton}
+      <DrawerContent
+        className="max-h-[min(70dvh,32rem)] gap-0 overflow-y-auto px-0 pb-6"
+        onOpenAutoFocus={(e) => {
+          e.preventDefault()
+          notesTextareaRef.current?.focus()
+        }}
+        onCloseAutoFocus={(e) => {
+          e.preventDefault()
+          notesTriggerRef.current?.focus()
+        }}
       >
-        <FileText className="h-4 w-4 shrink-0" />
-        <span className="hidden min-[360px]:inline md:inline">Notes</span>
-      </button>
-      {showNotes && (
-        <div className="absolute top-full right-0 z-50 mt-1 w-72 max-w-[min(18rem,calc(100vw-2rem))] rounded-lg border border-border bg-popover shadow-lg">
-          <div className="border-b border-border px-3 py-2">
-            <p className="text-xs font-medium text-muted-foreground">
-              Personal Notes
-            </p>
-            <p className="mt-1 text-xs leading-snug text-muted-foreground/80">
-              Private planning notes for you only. They are saved with this
-              draft and are not published with your article.
-            </p>
+        <DrawerHeader className="space-y-0 px-4 pb-2 text-left">
+          <div className="flex items-start justify-between gap-3 pr-8">
+            <div className="min-w-0 space-y-1">
+              <DrawerTitle className="text-base">Personal Notes</DrawerTitle>
+              <DrawerDescription className="text-left text-xs leading-snug">
+                {WRITER_NOTES_HELPER_TEXT}
+              </DrawerDescription>
+            </div>
+            <DrawerClose asChild>
+              <button
+                type="button"
+                className={cn(
+                  'shrink-0 rounded-md px-3 py-1.5 text-sm font-medium text-primary hover:bg-muted',
+                  focusRing
+                )}
+              >
+                Done
+              </button>
+            </DrawerClose>
           </div>
-          <textarea
-            value={notes}
-            onChange={(e) => onNotesChange?.(e.target.value)}
-            placeholder="Jot down ideas, reminders, or notes..."
-            className="w-full resize-none rounded-b-lg bg-popover p-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
-            rows={6}
+        </DrawerHeader>
+        <WriterNotesPanel
+          ref={notesTextareaRef}
+          notes={notes}
+          onNotesChange={onNotesChange}
+          showHeader={false}
+          textareaClassName="min-h-[8rem] rounded-none border-0 bg-background"
+        />
+      </DrawerContent>
+    </Drawer>
+  ) : (
+    <div className="relative">
+      {notesTriggerButton}
+      {showNotes ? (
+        <div
+          className="absolute top-full right-0 z-50 mt-1 w-72 max-w-[min(18rem,calc(100vw-2rem))] overflow-hidden rounded-lg border border-border bg-popover shadow-lg"
+          role="dialog"
+          aria-label="Personal notes"
+        >
+          <WriterNotesPanel
+            ref={notesTextareaRef}
+            notes={notes}
+            onNotesChange={onNotesChange}
+            textareaClassName="rounded-b-lg"
           />
         </div>
-      )}
+      ) : null}
     </div>
   )
 

--- a/components/editor/WriterNotesPanel.tsx
+++ b/components/editor/WriterNotesPanel.tsx
@@ -18,13 +18,7 @@ export const WriterNotesPanel = forwardRef<
   HTMLTextAreaElement,
   WriterNotesPanelProps
 >(function WriterNotesPanel(
-  {
-    notes,
-    onNotesChange,
-    className,
-    textareaClassName,
-    showHeader = true,
-  },
+  { notes, onNotesChange, className, textareaClassName, showHeader = true },
   ref
 ) {
   return (

--- a/components/editor/WriterNotesPanel.tsx
+++ b/components/editor/WriterNotesPanel.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { forwardRef } from 'react'
+import { cn } from '@/lib/utils'
+
+export interface WriterNotesPanelProps {
+  notes: string
+  onNotesChange?: (value: string) => void
+  className?: string
+  textareaClassName?: string
+  showHeader?: boolean
+}
+
+export const WRITER_NOTES_HELPER_TEXT =
+  'Private planning notes for you only. They are saved with this draft and are not published with your article.'
+
+export const WriterNotesPanel = forwardRef<
+  HTMLTextAreaElement,
+  WriterNotesPanelProps
+>(function WriterNotesPanel(
+  {
+    notes,
+    onNotesChange,
+    className,
+    textareaClassName,
+    showHeader = true,
+  },
+  ref
+) {
+  return (
+    <div className={cn(className)}>
+      {showHeader ? (
+        <div className="border-b border-border px-3 py-2">
+          <p className="text-xs font-medium text-muted-foreground">
+            Personal Notes
+          </p>
+          <p className="mt-1 text-xs leading-snug text-muted-foreground/80">
+            {WRITER_NOTES_HELPER_TEXT}
+          </p>
+        </div>
+      ) : null}
+      <textarea
+        ref={ref}
+        value={notes}
+        onChange={(e) => onNotesChange?.(e.target.value)}
+        placeholder="Jot down ideas, reminders, or notes..."
+        aria-label="Personal notes"
+        className={cn(
+          'w-full resize-none bg-popover p-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          textareaClassName
+        )}
+        rows={6}
+      />
+    </div>
+  )
+})

--- a/components/editor/editorToolbarKeys.test.ts
+++ b/components/editor/editorToolbarKeys.test.ts
@@ -19,6 +19,12 @@ describe('getVisibleToolbarKeys', () => {
     expect(keys).not.toContain('youtube')
   })
 
+  it('ends with more then notes on mobile', () => {
+    const keys = getVisibleToolbarKeys(true, false)
+    expect(keys.at(-2)).toBe('more')
+    expect(keys.at(-1)).toBe('notes')
+  })
+
   it('swaps link insert for link remove when a link is active', () => {
     const keys = getVisibleToolbarKeys(false, true)
     expect(keys).toContain('linkRemove')

--- a/components/editor/editorToolbarKeys.ts
+++ b/components/editor/editorToolbarKeys.ts
@@ -1,4 +1,7 @@
-/** Ordered toolbar control keys matching DOM order in EditorToolbar. */
+/**
+ * Ordered toolbar control keys matching DOM order in EditorToolbar.
+ * Mobile: wrap cluster (heading..link), then pinned column (more, notes).
+ */
 export function getVisibleToolbarKeys(
   isMobile: boolean,
   isLinkActive: boolean

--- a/components/highlights/HighlightDetailsPanel.test.tsx
+++ b/components/highlights/HighlightDetailsPanel.test.tsx
@@ -1,9 +1,12 @@
 /** @vitest-environment jsdom */
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockMutation = vi.hoisted(() => vi.fn())
 
 vi.mock('convex/react', () => ({
-  useMutation: () => vi.fn(),
+  useMutation: () => mockMutation,
 }))
 
 vi.mock('@/hooks/convex', () => ({
@@ -47,6 +50,10 @@ const baseHighlight = {
 }
 
 describe('HighlightDetailsPanel', () => {
+  beforeEach(() => {
+    mockMutation.mockReset()
+  })
+
   it('calls onClose when Escape is pressed', () => {
     const onClose = vi.fn()
     render(
@@ -103,5 +110,29 @@ describe('HighlightDetailsPanel', () => {
     expect(
       screen.getByRole('button', { name: 'Close highlight details' })
     ).toBeInTheDocument()
+  })
+
+  it('notifies the parent after a successful highlight delete', async () => {
+    mockMutation.mockResolvedValue(undefined)
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    const onDeleted = vi.fn()
+
+    render(
+      <HighlightDetailsPanel
+        highlight={baseHighlight}
+        position={{ top: 100, left: 200 }}
+        onClose={onClose}
+        onDeleted={onDeleted}
+        currentUserId={baseHighlight.userId}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Delete Highlight' }))
+    await user.click(screen.getByRole('button', { name: 'Delete highlight' }))
+
+    expect(mockMutation).toHaveBeenCalledWith({ id: baseHighlight._id })
+    expect(onDeleted).toHaveBeenCalledWith(baseHighlight._id)
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/components/highlights/HighlightDetailsPanel.tsx
+++ b/components/highlights/HighlightDetailsPanel.tsx
@@ -8,6 +8,16 @@ import type { Id } from '@/types/convex'
 import { motion } from 'motion/react'
 import { FocusScope } from '@radix-ui/react-focus-scope'
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import {
   X,
   Coins,
   User,
@@ -65,6 +75,7 @@ export function HighlightDetailsPanel({
   const [isEditing, setIsEditing] = useState(false)
   const [editedNote, setEditedNote] = useState(highlight.note || '')
   const [isDeleting, setIsDeleting] = useState(false)
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
   const panelRef = useRef<HTMLDivElement>(null)
   const closeButtonRef = useRef<HTMLButtonElement>(null)
   const clampedPosition = useClampedFixedPosition(position, panelRef, {
@@ -74,6 +85,7 @@ export function HighlightDetailsPanel({
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
+      if (deleteConfirmOpen) return
       if (e.key !== 'Escape') return
       e.preventDefault()
       e.stopPropagation()
@@ -81,7 +93,7 @@ export function HighlightDetailsPanel({
     }
     document.addEventListener('keydown', onKeyDown, true)
     return () => document.removeEventListener('keydown', onKeyDown, true)
-  }, [onClose])
+  }, [deleteConfirmOpen, onClose])
 
   // Check if current user owns this highlight
   const isOwner = currentUserId && currentUserId === highlight.userId
@@ -124,14 +136,13 @@ export function HighlightDetailsPanel({
     }
   }
 
-  // Handle delete
-  const handleDelete = async () => {
-    if (!confirm('Are you sure you want to delete this highlight?')) return
-
+  const handleConfirmDelete = async () => {
+    if (isDeleting) return
     setIsDeleting(true)
     try {
       await deleteHighlight({ id: highlight._id })
       toast.success('Highlight deleted')
+      setDeleteConfirmOpen(false)
       onClose()
     } catch (error) {
       console.error('Failed to delete highlight:', error)
@@ -145,6 +156,10 @@ export function HighlightDetailsPanel({
     highlight.text.length > 150
       ? highlight.text.slice(0, 150) + '...'
       : highlight.text
+  const confirmSnippet =
+    highlight.text.trim().length > 90
+      ? `${highlight.text.trim().slice(0, 90)}…`
+      : highlight.text.trim()
 
   return (
     <motion.div
@@ -164,7 +179,7 @@ export function HighlightDetailsPanel({
       tabIndex={-1}
     >
       <FocusScope
-        trapped
+        trapped={!deleteConfirmOpen}
         loop
         onMountAutoFocus={(e) => {
           e.preventDefault()
@@ -332,7 +347,7 @@ export function HighlightDetailsPanel({
                     <span>Edit Note</span>
                   </button>
                   <button
-                    onClick={handleDelete}
+                    onClick={() => setDeleteConfirmOpen(true)}
                     disabled={isDeleting}
                     className={cn(
                       'w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg transition-colors text-sm font-medium',
@@ -401,6 +416,56 @@ export function HighlightDetailsPanel({
           </div>
         )}
       </FocusScope>
+
+      <AlertDialog
+        open={deleteConfirmOpen}
+        onOpenChange={(open) => {
+          if (isDeleting) return
+          setDeleteConfirmOpen(open)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this highlight?</AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-3">
+                <p className="text-sm text-muted-foreground">
+                  This will permanently delete the highlight and its note. This
+                  action cannot be undone.
+                </p>
+                {confirmSnippet.length > 0 ? (
+                  <div className="rounded-md border border-border bg-muted/40 p-3 text-sm text-foreground">
+                    <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                      Highlight
+                    </div>
+                    <p className="mt-1 italic">&ldquo;{confirmSnippet}&rdquo;</p>
+                  </div>
+                ) : null}
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 disabled:cursor-not-allowed"
+              onClick={(e) => {
+                e.preventDefault()
+                void handleConfirmDelete()
+              }}
+            >
+              {isDeleting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Deleting...
+                </>
+              ) : (
+                'Delete highlight'
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </motion.div>
   )
 }

--- a/components/highlights/HighlightDetailsPanel.tsx
+++ b/components/highlights/HighlightDetailsPanel.tsx
@@ -54,6 +54,7 @@ interface HighlightDetailsPanelProps {
   }
   position: { top: number; left: number }
   onClose: () => void
+  onDeleted?: (highlightId: Id<'highlights'>) => void
   currentUserId?: Id<'users'>
   // Article data for tipping
   articleId?: Id<'articles'>
@@ -66,6 +67,7 @@ export function HighlightDetailsPanel({
   highlight,
   position,
   onClose,
+  onDeleted,
   currentUserId,
   articleId,
   articleSlug,
@@ -143,6 +145,7 @@ export function HighlightDetailsPanel({
       await deleteHighlight({ id: highlight._id })
       toast.success('Highlight deleted')
       setDeleteConfirmOpen(false)
+      onDeleted?.(highlight._id)
       onClose()
     } catch (error) {
       console.error('Failed to delete highlight:', error)

--- a/components/highlights/HighlightDetailsPanel.tsx
+++ b/components/highlights/HighlightDetailsPanel.tsx
@@ -438,7 +438,9 @@ export function HighlightDetailsPanel({
                     <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
                       Highlight
                     </div>
-                    <p className="mt-1 italic">&ldquo;{confirmSnippet}&rdquo;</p>
+                    <p className="mt-1 italic">
+                      &ldquo;{confirmSnippet}&rdquo;
+                    </p>
                   </div>
                 ) : null}
               </div>


### PR DESCRIPTION
## Summary

Polishes the write editor toolbar for mobile and desktop: heading/add dropdowns, a pinned **More** menu on small screens, **Personal Notes** in the toolbar (drawer on mobile, popover on desktop), improved keyboard focus and aria labels, and a **destructive confirmation** before deleting highlights.


## Changes

### Mobile toolbar layout
- **Responsive layout**: Primary formatting controls wrap on mobile; alignment, image, and YouTube move into a **More formatting** menu (`md:hidden`).
- **Pinned column**: More + Notes stay visible on the right with a left border so they do not scroll away with the main toolbar.
- **Desktop**: Alignment buttons and image/YouTube remain inline; horizontal scroll on the formatting row when needed.
- **`editorToolbarKeys`**: Centralizes visible control order; mobile ends with `more` then `notes`; desktop uses `image`/`youtube` instead of `more`.

### Toolbar dropdowns
- **Heading dropdown**: Paragraph + H1-H6 via Radix menu; trigger shows current style (label hidden on small screens, icon + chevron remain).
- **Add menu**: Groups insert actions (existing add flow).
- **More menu (mobile)**: Text alignment (left/center/right/justify), insert image, embed YouTube.

### Writer notes in toolbar
- **`WriterNotesPanel`**: Shared textarea + helper copy ("private planning notes... saved with draft, not published").
- **Desktop**: Notes button toggles a popover dialog below the toolbar.
- **Mobile**: Notes opens a bottom **drawer** with title, helper text, **Done** close, and focus returned to the trigger on dismiss.
- Wired through `WriteEditorWorkspace` via existing `writerNotes` / draft save (no new persistence layer).

### Accessibility
- `role="toolbar"` with roving tabindex / arrow-key navigation across visible controls.
- `focus-visible` rings on toolbar and action-bar buttons.
- `aria-label` / `aria-expanded` on Notes, heading trigger, More, undo/redo, and action-bar overflow menu.

### Destructive highlight delete
- **`HighlightDetailsPanel`**: Delete opens an `AlertDialog` with warning copy, a snippet of the highlighted text, and a **destructive** confirm button.
- Prevents accidental deletes; blocks dialog close and Escape-to-close-panel while delete is in progress.
- `FocusScope` trap disabled while confirm dialog is open so focus stays in the modal.
- Follow-up QA fix: after successful delete, the article UI removes the deleted highlight immediately instead of requiring a page refresh.

### Editor action bar
- Matching `focus-visible` styles and `aria-label` on undo/redo and the overflow trigger.

## Files touched (ENG-154 scope)

- `components/editor/EditorToolbar.tsx` (+ `EditorToolbar.test.tsx`)
- `components/editor/WriterNotesPanel.tsx` (new)
- `components/editor/editorToolbarKeys.ts` (+ tests)
- `components/editor/EditorActionBar.tsx`
- `components/highlights/HighlightDetailsPanel.tsx`
- `components/articles/HighlightableArticle.tsx`

## Testing

- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run test:once`
- `bun run build`
- Focused after QA fix: `bunx vitest run components/highlights/HighlightDetailsPanel.test.tsx`
- GitHub checks after updating with `development` and after follow-up commit `31bf062`: Build, Dependency Audit, Lint/Typecheck/Test, Commit subjects, PR title, `Required`, `PR Hygiene Required`, Vercel, and Vercel Preview Comments all passed.
- Manual logged-in preview QA passed for desktop toolbar, mobile toolbar/More menu, Notes desktop popover, Notes mobile bottom drawer, draft delete confirmation, and highlight delete confirmation after the follow-up fix.

## Notes

- Updated this PR branch with latest `development` before merge.
- Local build required the ignored `.env.local` Convex URL in the temporary worktree; the first sandboxed build failed only because Google Fonts network access was blocked, then passed with network access.
- Secret/ignored-file check passed: PR diff contains only component/test files, `.env.local` and the local evidence doc are ignored and not committed, and no secret-like values were found in the PR diff.
- User opened preview `/write` successfully in browser. Console showed Vercel Live feedback iframe CSP noise and Chrome extension runtime messages; these appear unrelated to the Quilltip app.
- Manual preview QA found that highlight delete succeeded and showed a success toast, but the deleted highlight remained visible until refresh. Fixed in commit `31bf062`; the deleted highlight is now removed from the article UI immediately after successful delete.
- After the follow-up fix, logged-in preview QA passed for the ENG-154 editor flows.
