### PR TITLE
feat(dashboard): polish earnings UI with testnet copy, empty states, chart labels, and mobile tip history (ENG-144)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Quilltip is a decentralized publishing platform where writers earn money through
 ### For Readers
 
 - **Interactive Reading** — text highlighting with notes, public/private annotations, color-coded highlights, persistent across sessions
-- **Microtipping** — support authors with $0.01–$100, preset amounts, instant Stellar transactions
+- **Microtipping** — support authors with $0.01–$100, preset amounts, fast Stellar confirmations (testnet practice today)
 - **Content Discovery** — full-text search, tag-based filtering, author collections, trending articles
 
 ### For Collectors

--- a/components/dashboard/EarningsDashboard.tsx
+++ b/components/dashboard/EarningsDashboard.tsx
@@ -16,6 +16,7 @@ import { TipHistory } from '@/components/dashboard/TipHistory'
 import { WithdrawalDialog } from '@/components/dashboard/WithdrawalDialog'
 import { EarningsStats } from '@/components/dashboard/EarningsStats'
 import { EarningsDashboardSkeleton } from '@/components/dashboard/EarningsDashboardSkeleton'
+import { withdrawalFlowNote } from '@/lib/copy/network-status'
 
 export function EarningsDashboard() {
   const [showWithdrawModal, setShowWithdrawModal] = useState(false)
@@ -39,7 +40,7 @@ export function EarningsDashboard() {
         stellarAddress: args.stellarAddress,
       })
       toast.success(
-        `Withdrawal initiated! $${args.amountUsd.toFixed(2)} in testnet XLM will be sent to your Stellar wallet, typically within seconds on testnet.`
+        `Withdrawal requested for $${args.amountUsd.toFixed(2)}. ${withdrawalFlowNote()}`
       )
     } catch (error) {
       console.error('Withdrawal error:', error)

--- a/components/dashboard/EarningsDashboard.tsx
+++ b/components/dashboard/EarningsDashboard.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from 'react'
 import { useMutation } from 'convex/react'
 import { api } from '@/convex/_generated/api'
+import { useRouter } from 'next/navigation'
 import {
   useAuthorEarnings,
   useUserByUsername,
@@ -17,10 +18,13 @@ import { WithdrawalDialog } from '@/components/dashboard/WithdrawalDialog'
 import { EarningsStats } from '@/components/dashboard/EarningsStats'
 import { EarningsDashboardSkeleton } from '@/components/dashboard/EarningsDashboardSkeleton'
 import { withdrawalFlowNote } from '@/lib/copy/network-status'
+import { useProfileTabNavigation } from '@/hooks/useProfileTabNavigation'
 
 export function EarningsDashboard() {
   const [showWithdrawModal, setShowWithdrawModal] = useState(false)
   const withdrawTriggerRef = useRef<HTMLButtonElement>(null)
+  const router = useRouter()
+  const navigateToTab = useProfileTabNavigation()
 
   const { user: currentUser } = useAuth()
 
@@ -56,16 +60,37 @@ export function EarningsDashboard() {
   }
 
   if (!earnings) {
+    const hasWallet = Boolean(userProfile?.stellarAddress)
+    const primaryLabel = hasWallet ? 'Write your first post' : 'Set up wallet'
+    const primaryAction = () => {
+      if (hasWallet) {
+        router.push('/write')
+      } else {
+        navigateToTab('wallet')
+      }
+    }
+
     return (
       <div className="space-y-6">
-        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-12 text-center">
+        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-8 sm:p-12 text-center">
           <Coins className="w-16 h-16 text-muted-foreground mx-auto mb-4" />
           <h3 className="text-lg font-semibold text-foreground mb-2">
             No testnet tips yet
           </h3>
-          <p className="text-muted-foreground">
-            Share great content and receive practice tips on Stellar testnet.
+          <p className="text-muted-foreground mx-auto max-w-md">
+            Publish a post, share it with readers, and you’ll start seeing tips
+            here. Set up a Stellar wallet so you can withdraw your earnings when
+            you’re ready.
           </p>
+          <div className="mt-6 flex justify-center">
+            <button
+              type="button"
+              onClick={primaryAction}
+              className="w-full sm:w-auto px-4 py-2 bg-brand text-brand-foreground rounded-lg hover:bg-brand-hover inline-flex items-center justify-center"
+            >
+              {primaryLabel}
+            </button>
+          </div>
         </div>
       </div>
     )

--- a/components/dashboard/EarningsDashboardSkeleton.tsx
+++ b/components/dashboard/EarningsDashboardSkeleton.tsx
@@ -21,7 +21,7 @@ function MonthlyChartSkeleton() {
   return (
     <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
       <Skeleton className="h-6 w-40 mb-4" />
-      <div className="grid grid-cols-6 gap-2">
+      <div className="grid grid-cols-3 sm:grid-cols-6 gap-2">
         {Array.from({ length: 6 }).map((_, i) => (
           <div key={i} className="text-center">
             <Skeleton className="h-3 w-full mb-1 mx-auto" />

--- a/components/dashboard/EarningsStats.test.tsx
+++ b/components/dashboard/EarningsStats.test.tsx
@@ -54,12 +54,12 @@ describe('EarningsStats', () => {
     expect(screen.getByText('5 testnet tips received')).toBeInTheDocument()
   })
 
-  it('renders monthly chart labels in display order', () => {
+  it('renders monthly chart with readable labels for recent months', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2024, 5, 15))
     const earnings = makeEarnings({
       monthlyEarnings: {
-        '2024-01': 10,
-        '2024-02': 20,
-        '2024-03': 30,
+        '2024-06': 30,
       },
     })
     render(
@@ -71,9 +71,12 @@ describe('EarningsStats', () => {
       />
     )
 
-    expect(screen.getByText('2024-01')).toBeInTheDocument()
-    expect(screen.getByText('2024-02')).toBeInTheDocument()
-    expect(screen.getByText('2024-03')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /monthly earnings/i })
+    ).toBeInTheDocument()
+    expect(screen.getByText('$30')).toBeInTheDocument()
+    expect(screen.queryByText('2024-06')).not.toBeInTheDocument()
+    vi.useRealTimers()
   })
 
   it('shows wallet setup notice when profile has no Stellar address', () => {

--- a/components/dashboard/EarningsStats.tsx
+++ b/components/dashboard/EarningsStats.tsx
@@ -107,9 +107,9 @@ export function EarningsStats({
         </div>
       </div>
 
-      {earnings.monthlyEarnings && (
-        <MonthlyEarningsChart monthlyEarnings={earnings.monthlyEarnings} />
-      )}
+      <MonthlyEarningsChart
+        monthlyEarnings={earnings.monthlyEarnings ?? {}}
+      />
 
       {earnings.topArticles && earnings.topArticles.length > 0 && (
         <TopEarningArticles articles={earnings.topArticles} />

--- a/components/dashboard/EarningsStats.tsx
+++ b/components/dashboard/EarningsStats.tsx
@@ -8,7 +8,10 @@ import { TopEarningArticles } from '@/components/dashboard/top-earning-articles'
 import { WalletSetupNotice } from '@/components/dashboard/wallet-setup-notice'
 import { useProfileTabNavigation } from '@/hooks/useProfileTabNavigation'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { networkLabelLowercase, practiceFundsNote } from '@/lib/copy/network-status'
+import {
+  networkLabelLowercase,
+  practiceFundsNote,
+} from '@/lib/copy/network-status'
 
 export type EarningsStatsProps = {
   earnings: Doc<'authorEarnings'>

--- a/components/dashboard/EarningsStats.tsx
+++ b/components/dashboard/EarningsStats.tsx
@@ -8,7 +8,7 @@ import { TopEarningArticles } from '@/components/dashboard/top-earning-articles'
 import { WalletSetupNotice } from '@/components/dashboard/wallet-setup-notice'
 import { useProfileTabNavigation } from '@/hooks/useProfileTabNavigation'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
+import { networkLabelLowercase, practiceFundsNote } from '@/lib/copy/network-status'
 
 export type EarningsStatsProps = {
   earnings: Doc<'authorEarnings'>
@@ -35,7 +35,7 @@ export function EarningsStats({
     <>
       <Alert className="border-border bg-muted/60">
         <AlertDescription className="text-sm text-muted-foreground">
-          {TESTNET_PRACTICE_NOTE}
+          {practiceFundsNote()}
         </AlertDescription>
       </Alert>
 
@@ -51,7 +51,7 @@ export function EarningsStats({
             ${earnings.totalEarnedUsd.toFixed(2)}
           </p>
           <p className="text-sm text-muted-foreground mt-1">
-            {earnings.tipCount} testnet tips received
+            {earnings.tipCount} {networkLabelLowercase()} tips received
           </p>
         </div>
 
@@ -81,8 +81,8 @@ export function EarningsStats({
           </button>
           {showMinimumWithdrawalHelper && (
             <p className="mt-2 text-sm text-muted-foreground">
-              Testnet withdrawals require a minimum available balance of $
-              {minWithdrawalUsd.toFixed(2)}. Add testnet tips until your balance
+              Withdrawals require a minimum available balance of $
+              {minWithdrawalUsd.toFixed(2)}. Add more tips until your balance
               reaches this amount.
             </p>
           )}

--- a/components/dashboard/EarningsStats.tsx
+++ b/components/dashboard/EarningsStats.tsx
@@ -107,9 +107,7 @@ export function EarningsStats({
         </div>
       </div>
 
-      <MonthlyEarningsChart
-        monthlyEarnings={earnings.monthlyEarnings ?? {}}
-      />
+      <MonthlyEarningsChart monthlyEarnings={earnings.monthlyEarnings ?? {}} />
 
       {earnings.topArticles && earnings.topArticles.length > 0 && (
         <TopEarningArticles articles={earnings.topArticles} />

--- a/components/dashboard/TipHistory.test.tsx
+++ b/components/dashboard/TipHistory.test.tsx
@@ -59,15 +59,68 @@ describe('TipHistory', () => {
     ]
     render(<TipHistory tips={tips} />)
 
-    expect(screen.getByText('bob')).toBeInTheDocument()
-    expect(screen.getByText('My Article')).toBeInTheDocument()
-    expect(screen.getByText('+$12.50')).toBeInTheDocument()
+    expect(screen.getAllByText('bob').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('My Article').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('+$12.50').length).toBeGreaterThan(0)
   })
 
   it('uses Anonymous when no tipper name', () => {
     const tips = [makeTip({ tipper: null })]
     render(<TipHistory tips={tips} />)
-    expect(screen.getByText('Anonymous')).toBeInTheDocument()
+    expect(screen.getAllByText('Anonymous').length).toBeGreaterThan(0)
+  })
+
+  it('renders a mobile card list alongside the desktop table', () => {
+    const tips = [
+      makeTip({
+        _id: 'a1' as Id<'tips'>,
+        articleTitle: 'Mobile Article',
+        amountUsd: 7,
+        tipper: { username: 'carol' },
+      }),
+    ]
+    render(<TipHistory tips={tips} />)
+
+    const mobileList = screen.getByTestId('tip-history-mobile-list')
+    expect(mobileList).toHaveClass('md:hidden')
+    expect(mobileList).toHaveTextContent('Mobile Article')
+    expect(mobileList).toHaveTextContent('carol')
+    expect(mobileList).toHaveTextContent('+$7.00')
+    expect(screen.getByRole('table')).toBeInTheDocument()
+  })
+
+  it('sorts tips via mobile sort controls', () => {
+    const tips = [
+      makeTip({
+        _id: 'a1' as Id<'tips'>,
+        amountUsd: 3,
+        createdAt: new Date('2024-03-01T00:00:00Z').getTime(),
+        tipper: { username: 'bob' },
+      }),
+      makeTip({
+        _id: 'a2' as Id<'tips'>,
+        amountUsd: 10,
+        createdAt: new Date('2024-03-02T00:00:00Z').getTime(),
+        tipper: { username: 'alice' },
+      }),
+    ]
+
+    render(<TipHistory tips={tips} />)
+
+    const sortSelect = screen.getByLabelText('Sort tips by')
+    fireEvent.change(sortSelect, { target: { value: 'amountUsd' } })
+
+    const mobileList = screen.getByTestId('tip-history-mobile-list')
+    expect(mobileList.textContent?.indexOf('+$3.00')).toBeLessThan(
+      mobileList.textContent?.indexOf('+$10.00') ?? -1
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /sort direction: ascending/i })
+    )
+    expect(mobileList.textContent?.indexOf('+$10.00')).toBeLessThan(
+      mobileList.textContent?.indexOf('+$3.00') ?? -1
+    )
   })
 
   it('shows relative time with absolute date on title and aria-label', () => {
@@ -79,7 +132,7 @@ describe('TipHistory', () => {
 
     render(<TipHistory tips={[makeTip({ createdAt })]} />)
 
-    const timeEl = screen.getByText('2 days ago')
+    const timeEl = screen.getAllByText('2 days ago')[0]
     expect(timeEl.tagName).toBe('TIME')
     expect(timeEl).toHaveAttribute('dateTime', tipDate.toISOString())
     expect(timeEl).toHaveAttribute('title', absolute)

--- a/components/dashboard/TipHistory.test.tsx
+++ b/components/dashboard/TipHistory.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   TipHistory,
@@ -132,7 +132,9 @@ describe('TipHistory', () => {
 
     render(<TipHistory tips={[makeTip({ createdAt })]} />)
 
-    const timeEl = screen.getAllByText('2 days ago')[0]
+    const timeEl = within(
+      screen.getByTestId('tip-history-mobile-list')
+    ).getByText('2 days ago')
     expect(timeEl.tagName).toBe('TIME')
     expect(timeEl).toHaveAttribute('dateTime', tipDate.toISOString())
     expect(timeEl).toHaveAttribute('title', absolute)

--- a/components/dashboard/TipHistory.tsx
+++ b/components/dashboard/TipHistory.tsx
@@ -17,6 +17,39 @@ type PageSize = 10 | 25 | 50 | 'all'
 type SortKey = 'tipper' | 'articleTitle' | 'amountUsd' | 'createdAt'
 type SortDir = 'asc' | 'desc'
 
+const SORT_OPTIONS: { value: SortKey; label: string }[] = [
+  { value: 'tipper', label: 'Tipper' },
+  { value: 'articleTitle', label: 'Article' },
+  { value: 'amountUsd', label: 'Amount' },
+  { value: 'createdAt', label: 'Date' },
+]
+
+function getTipperName(tip: ReceivedTipRow) {
+  return tip.tipper?.name || tip.tipper?.username || 'Anonymous'
+}
+
+function formatTipDate(createdAt: number) {
+  const tipDate = new Date(createdAt)
+  const relative = formatDistanceToNow(tipDate, { addSuffix: true })
+  const absolute = tipDate.toLocaleDateString('en-US', { dateStyle: 'long' })
+  const a11yLabel = `${relative}. ${absolute}.`
+  return { tipDate, relative, absolute, a11yLabel }
+}
+
+function TipDateTime({ createdAt }: { createdAt: number }) {
+  const { tipDate, relative, absolute, a11yLabel } = formatTipDate(createdAt)
+  return (
+    <time
+      dateTime={tipDate.toISOString()}
+      title={absolute}
+      aria-label={a11yLabel}
+      className="text-xs text-muted-foreground"
+    >
+      {relative}
+    </time>
+  )
+}
+
 function csvEscape(value: string) {
   const mustQuote = /[",\n\r]/.test(value)
   if (!mustQuote) return value
@@ -43,9 +76,6 @@ export function TipHistory({ tips }: TipHistoryProps) {
 
   const sortedTips = useMemo(() => {
     if (!list) return null
-
-    const getTipperName = (tip: ReceivedTipRow) =>
-      tip.tipper?.name || tip.tipper?.username || 'Anonymous'
 
     const dir = sortDir === 'asc' ? 1 : -1
 
@@ -105,10 +135,9 @@ export function TipHistory({ tips }: TipHistoryProps) {
 
     const header = ['Tipper', 'Article', 'AmountUsd', 'CreatedAt']
     const rows = visibleTips.map((tip) => {
-      const tipperName = tip.tipper?.name || tip.tipper?.username || 'Anonymous'
       const createdAtIso = new Date(tip.createdAt).toISOString()
       return [
-        tipperName,
+        getTipperName(tip),
         tip.articleTitle,
         tip.amountUsd.toFixed(2),
         createdAtIso,
@@ -127,10 +156,35 @@ export function TipHistory({ tips }: TipHistoryProps) {
   return (
     <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border">
       <div className="p-6 border-b border-border">
-        <div className="flex items-center justify-between gap-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <h3 className="text-lg font-semibold">Recent Tips</h3>
           {list ? (
-            <div className="flex items-center gap-3">
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="flex flex-wrap items-center gap-2 md:hidden">
+                <label className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <span>Sort by</span>
+                  <select
+                    className="h-8 rounded-md border border-border bg-background px-2 text-foreground"
+                    value={sortKey}
+                    onChange={(e) => setSort(e.target.value as SortKey)}
+                    aria-label="Sort tips by"
+                  >
+                    {SORT_OPTIONS.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <button
+                  type="button"
+                  onClick={() => setSort(sortKey)}
+                  className="h-8 rounded-md border border-border bg-background px-3 text-sm text-foreground hover:bg-muted"
+                  aria-label={`Sort direction: ${sortDir === 'asc' ? 'ascending' : 'descending'}`}
+                >
+                  {sortDir === 'asc' ? 'Ascending' : 'Descending'}
+                </button>
+              </div>
               <button
                 type="button"
                 onClick={onDownloadCsv}
@@ -162,81 +216,95 @@ export function TipHistory({ tips }: TipHistoryProps) {
         </div>
       </div>
       {visibleTips ? (
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead className="border-b border-border bg-muted/30">
-              <tr>
-                <th
-                  scope="col"
-                  aria-sort={ariaSort('tipper')}
-                  className="px-4 py-3 text-left font-medium text-foreground"
-                >
-                  <button
-                    type="button"
-                    onClick={() => setSort('tipper')}
-                    className="inline-flex items-center hover:underline"
+        <>
+          <div
+            data-testid="tip-history-mobile-list"
+            className="md:hidden divide-y divide-border"
+          >
+            {visibleTips.map((tip) => (
+              <div key={tip._id} className="p-4 hover:bg-muted/40">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <p className="font-medium text-foreground line-clamp-2">
+                      {tip.articleTitle}
+                    </p>
+                    <p className="mt-1 text-sm text-muted-foreground truncate">
+                      {getTipperName(tip)}
+                    </p>
+                  </div>
+                  <p className="shrink-0 font-semibold text-success-foreground">
+                    +${tip.amountUsd.toFixed(2)}
+                  </p>
+                </div>
+                <div className="mt-2">
+                  <TipDateTime createdAt={tip.createdAt} />
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="hidden md:block overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="border-b border-border bg-muted/30">
+                <tr>
+                  <th
+                    scope="col"
+                    aria-sort={ariaSort('tipper')}
+                    className="px-4 py-3 text-left font-medium text-foreground"
                   >
-                    Tipper{sortIndicator('tipper')}
-                  </button>
-                </th>
-                <th
-                  scope="col"
-                  aria-sort={ariaSort('articleTitle')}
-                  className="px-4 py-3 text-left font-medium text-foreground"
-                >
-                  <button
-                    type="button"
-                    onClick={() => setSort('articleTitle')}
-                    className="inline-flex items-center hover:underline"
+                    <button
+                      type="button"
+                      onClick={() => setSort('tipper')}
+                      className="inline-flex items-center hover:underline"
+                    >
+                      Tipper{sortIndicator('tipper')}
+                    </button>
+                  </th>
+                  <th
+                    scope="col"
+                    aria-sort={ariaSort('articleTitle')}
+                    className="px-4 py-3 text-left font-medium text-foreground"
                   >
-                    Article{sortIndicator('articleTitle')}
-                  </button>
-                </th>
-                <th
-                  scope="col"
-                  aria-sort={ariaSort('amountUsd')}
-                  className="px-4 py-3 text-right font-medium text-foreground"
-                >
-                  <button
-                    type="button"
-                    onClick={() => setSort('amountUsd')}
-                    className="inline-flex items-center hover:underline"
+                    <button
+                      type="button"
+                      onClick={() => setSort('articleTitle')}
+                      className="inline-flex items-center hover:underline"
+                    >
+                      Article{sortIndicator('articleTitle')}
+                    </button>
+                  </th>
+                  <th
+                    scope="col"
+                    aria-sort={ariaSort('amountUsd')}
+                    className="px-4 py-3 text-right font-medium text-foreground"
                   >
-                    Amount{sortIndicator('amountUsd')}
-                  </button>
-                </th>
-                <th
-                  scope="col"
-                  aria-sort={ariaSort('createdAt')}
-                  className="px-4 py-3 text-right font-medium text-foreground"
-                >
-                  <button
-                    type="button"
-                    onClick={() => setSort('createdAt')}
-                    className="inline-flex items-center hover:underline"
+                    <button
+                      type="button"
+                      onClick={() => setSort('amountUsd')}
+                      className="inline-flex items-center hover:underline"
+                    >
+                      Amount{sortIndicator('amountUsd')}
+                    </button>
+                  </th>
+                  <th
+                    scope="col"
+                    aria-sort={ariaSort('createdAt')}
+                    className="px-4 py-3 text-right font-medium text-foreground"
                   >
-                    Date{sortIndicator('createdAt')}
-                  </button>
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {visibleTips.map((tip) => {
-                const tipDate = new Date(tip.createdAt)
-                const relative = formatDistanceToNow(tipDate, {
-                  addSuffix: true,
-                })
-                const absolute = tipDate.toLocaleDateString('en-US', {
-                  dateStyle: 'long',
-                })
-                const a11yLabel = `${relative}. ${absolute}.`
-                const tipperName =
-                  tip.tipper?.name || tip.tipper?.username || 'Anonymous'
-
-                return (
+                    <button
+                      type="button"
+                      onClick={() => setSort('createdAt')}
+                      className="inline-flex items-center hover:underline"
+                    >
+                      Date{sortIndicator('createdAt')}
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {visibleTips.map((tip) => (
                   <tr key={tip._id} className="hover:bg-muted/40">
                     <td className="px-4 py-3 font-medium text-foreground">
-                      {tipperName}
+                      {getTipperName(tip)}
                     </td>
                     <td className="px-4 py-3 text-muted-foreground">
                       {tip.articleTitle}
@@ -245,21 +313,14 @@ export function TipHistory({ tips }: TipHistoryProps) {
                       +${tip.amountUsd.toFixed(2)}
                     </td>
                     <td className="px-4 py-3 text-right">
-                      <time
-                        dateTime={tipDate.toISOString()}
-                        title={absolute}
-                        aria-label={a11yLabel}
-                        className="text-xs text-muted-foreground"
-                      >
-                        {relative}
-                      </time>
+                      <TipDateTime createdAt={tip.createdAt} />
                     </td>
                   </tr>
-                )
-              })}
-            </tbody>
-          </table>
-        </div>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
       ) : (
         <div className="flex min-h-[12rem] flex-col items-center justify-center gap-2 px-6 py-10 text-center">
           <p className="font-medium text-foreground">No tips yet</p>

--- a/components/dashboard/WithdrawEarningsDialog.tsx
+++ b/components/dashboard/WithdrawEarningsDialog.tsx
@@ -14,7 +14,11 @@ import {
 } from '@/components/ui/dialog'
 import { api } from '@/convex/_generated/api'
 import { MIN_WITHDRAWAL_USD } from '@/lib/constants'
-import { TESTNET_WITHDRAWAL_NOTE } from '@/lib/copy/network-status'
+import {
+  TESTNET_WITHDRAWAL_NOTE,
+  withdrawalAcknowledgementLabel,
+  withdrawalFlowNote,
+} from '@/lib/copy/network-status'
 
 interface WithdrawEarningsDialogProps {
   open: boolean
@@ -35,6 +39,7 @@ export function WithdrawEarningsDialog({
   const [withdrawAmount, setWithdrawAmount] = useState('')
   const [stellarAddress, setStellarAddress] = useState('')
   const [isWithdrawing, setIsWithdrawing] = useState(false)
+  const [acknowledged, setAcknowledged] = useState(false)
 
   const withdrawEarnings = useMutation(api.tips.withdrawEarnings)
 
@@ -42,6 +47,7 @@ export function WithdrawEarningsDialog({
     if (open) {
       setWithdrawAmount('')
       setStellarAddress(savedStellarAddress ?? '')
+      setAcknowledged(false)
     }
   }, [open, savedStellarAddress])
 
@@ -80,7 +86,7 @@ export function WithdrawEarningsDialog({
       })
 
       toast.success(
-        `Withdrawal initiated! $${amount.toFixed(2)} in testnet XLM will be sent to your Stellar wallet, typically within seconds on testnet.`
+        `Withdrawal requested for $${amount.toFixed(2)}. ${withdrawalFlowNote()}`
       )
       onOpenChange(false)
     } catch (error) {
@@ -178,7 +184,21 @@ export function WithdrawEarningsDialog({
               {TESTNET_WITHDRAWAL_NOTE} Transaction fees are covered by
               Quilltip.
             </p>
+            <p className="mt-2 text-sm text-info-foreground">
+              {withdrawalFlowNote()}
+            </p>
           </div>
+
+          <label className="flex items-start gap-2 rounded-lg border border-border bg-card p-3 text-sm text-foreground">
+            <input
+              type="checkbox"
+              checked={acknowledged}
+              onChange={(e) => setAcknowledged(e.target.checked)}
+              disabled={isWithdrawing}
+              className="mt-0.5 h-4 w-4 accent-foreground"
+            />
+            <span>{withdrawalAcknowledgementLabel()}</span>
+          </label>
         </div>
 
         <DialogFooter className="gap-3 sm:gap-0">
@@ -196,7 +216,8 @@ export function WithdrawEarningsDialog({
             disabled={
               isWithdrawing ||
               !withdrawAmount ||
-              !effectiveAddress.startsWith('G')
+              !effectiveAddress.startsWith('G') ||
+              !acknowledged
             }
             className="flex-1 px-4 py-2 bg-brand text-brand-foreground rounded-lg hover:bg-brand-hover disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 sm:flex-none"
           >

--- a/components/dashboard/WithdrawEarningsDialog.tsx
+++ b/components/dashboard/WithdrawEarningsDialog.tsx
@@ -15,9 +15,11 @@ import {
 import { api } from '@/convex/_generated/api'
 import { MIN_WITHDRAWAL_USD } from '@/lib/constants'
 import {
-  TESTNET_WITHDRAWAL_NOTE,
   withdrawalAcknowledgementLabel,
+  withdrawalDialogDescription,
+  withdrawalDialogTitle,
   withdrawalFlowNote,
+  withdrawalNote,
 } from '@/lib/copy/network-status'
 
 interface WithdrawEarningsDialogProps {
@@ -118,10 +120,8 @@ export function WithdrawEarningsDialog({
         }}
       >
         <DialogHeader>
-          <DialogTitle>Withdraw Testnet Earnings</DialogTitle>
-          <DialogDescription>
-            Send testnet XLM to your Stellar wallet
-          </DialogDescription>
+          <DialogTitle>{withdrawalDialogTitle()}</DialogTitle>
+          <DialogDescription>{withdrawalDialogDescription()}</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
@@ -181,8 +181,7 @@ export function WithdrawEarningsDialog({
 
           <div className="bg-info border border-info/50 rounded-lg p-3">
             <p className="text-sm text-info-foreground">
-              {TESTNET_WITHDRAWAL_NOTE} Transaction fees are covered by
-              Quilltip.
+              {withdrawalNote()} Transaction fees are covered by Quilltip.
             </p>
             <p className="mt-2 text-sm text-info-foreground">
               {withdrawalFlowNote()}

--- a/components/dashboard/WithdrawalDialog.test.tsx
+++ b/components/dashboard/WithdrawalDialog.test.tsx
@@ -41,6 +41,7 @@ describe('WithdrawalDialog', () => {
 
     await user.type(screen.getByLabelText(/Amount \(USD\)/i), '10')
     setStellarAddress(VALID_TEST_PUBLIC_KEY)
+    await user.click(screen.getByRole('checkbox'))
     await user.click(screen.getByRole('button', { name: /Withdraw$/i }))
 
     await waitFor(() => {
@@ -69,6 +70,7 @@ describe('WithdrawalDialog', () => {
     )
 
     await user.type(screen.getByLabelText(/Amount \(USD\)/i), '20')
+    await user.click(screen.getByRole('checkbox'))
     await user.click(screen.getByRole('button', { name: /Withdraw$/i }))
 
     expect(onWithdraw).toHaveBeenCalledWith({

--- a/components/dashboard/WithdrawalDialog.tsx
+++ b/components/dashboard/WithdrawalDialog.tsx
@@ -13,9 +13,11 @@ import {
 } from '@/components/ui/dialog'
 import { isValidStellarAccountId } from '@/lib/stellar/is-valid-stellar-account-id'
 import {
-  TESTNET_WITHDRAWAL_NOTE,
   withdrawalAcknowledgementLabel,
+  withdrawalDialogDescription,
+  withdrawalDialogTitle,
   withdrawalFlowNote,
+  withdrawalNote,
 } from '@/lib/copy/network-status'
 
 export type WithdrawalDialogProps = {
@@ -116,10 +118,8 @@ export function WithdrawalDialog({
         }}
       >
         <DialogHeader>
-          <DialogTitle>Withdraw Testnet Earnings</DialogTitle>
-          <DialogDescription>
-            Send testnet XLM to your Stellar wallet
-          </DialogDescription>
+          <DialogTitle>{withdrawalDialogTitle()}</DialogTitle>
+          <DialogDescription>{withdrawalDialogDescription()}</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
@@ -190,8 +190,7 @@ export function WithdrawalDialog({
 
           <div className="bg-info border border-info/50 rounded-lg p-3">
             <p className="text-sm text-info-foreground">
-              {TESTNET_WITHDRAWAL_NOTE} Transaction fees are covered by
-              Quilltip.
+              {withdrawalNote()} Transaction fees are covered by Quilltip.
             </p>
             <p className="mt-2 text-sm text-info-foreground">
               {withdrawalFlowNote()}

--- a/components/dashboard/WithdrawalDialog.tsx
+++ b/components/dashboard/WithdrawalDialog.tsx
@@ -12,7 +12,11 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { isValidStellarAccountId } from '@/lib/stellar/is-valid-stellar-account-id'
-import { TESTNET_WITHDRAWAL_NOTE } from '@/lib/copy/network-status'
+import {
+  TESTNET_WITHDRAWAL_NOTE,
+  withdrawalAcknowledgementLabel,
+  withdrawalFlowNote,
+} from '@/lib/copy/network-status'
 
 export type WithdrawalDialogProps = {
   open: boolean
@@ -39,11 +43,13 @@ export function WithdrawalDialog({
   const [withdrawAmount, setWithdrawAmount] = useState('')
   const [stellarAddress, setStellarAddress] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [acknowledged, setAcknowledged] = useState(false)
 
   useEffect(() => {
     if (open) {
       setWithdrawAmount('')
       setStellarAddress(savedStellarAddress ?? '')
+      setAcknowledged(false)
     }
   }, [open, savedStellarAddress])
 
@@ -187,7 +193,21 @@ export function WithdrawalDialog({
               {TESTNET_WITHDRAWAL_NOTE} Transaction fees are covered by
               Quilltip.
             </p>
+            <p className="mt-2 text-sm text-info-foreground">
+              {withdrawalFlowNote()}
+            </p>
           </div>
+
+          <label className="flex items-start gap-2 rounded-lg border border-border bg-card p-3 text-sm text-foreground">
+            <input
+              type="checkbox"
+              checked={acknowledged}
+              onChange={(e) => setAcknowledged(e.target.checked)}
+              disabled={isSubmitting}
+              className="mt-0.5 h-4 w-4 accent-foreground"
+            />
+            <span>{withdrawalAcknowledgementLabel()}</span>
+          </label>
         </div>
 
         <DialogFooter className="gap-3 sm:gap-0">
@@ -206,7 +226,8 @@ export function WithdrawalDialog({
               isSubmitting ||
               !withdrawAmount ||
               !trimmedAddress ||
-              !isValidStellarAccountId(trimmedAddress)
+              !isValidStellarAccountId(trimmedAddress) ||
+              !acknowledged
             }
             className="flex-1 px-4 py-2 bg-brand text-brand-foreground rounded-lg hover:bg-brand-hover disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 sm:flex-none"
           >

--- a/components/dashboard/monthly-earnings-chart.test.tsx
+++ b/components/dashboard/monthly-earnings-chart.test.tsx
@@ -1,0 +1,69 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MonthlyEarningsChart } from '@/components/dashboard/monthly-earnings-chart'
+
+describe('MonthlyEarningsChart', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2024, 5, 15))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders readable month labels instead of raw keys', () => {
+    render(
+      <MonthlyEarningsChart
+        monthlyEarnings={{
+          '2024-01': 10,
+          '2024-02': 20,
+          '2024-03': 30,
+        }}
+      />
+    )
+
+    expect(screen.getByText('Jan')).toBeInTheDocument()
+    expect(screen.getByText('Feb')).toBeInTheDocument()
+    expect(screen.getByText('Mar')).toBeInTheDocument()
+    expect(screen.queryByText('2024-01')).not.toBeInTheDocument()
+    expect(screen.queryByText('2024-02')).not.toBeInTheDocument()
+    expect(screen.queryByText('2024-03')).not.toBeInTheDocument()
+  })
+
+  it('renders six month slots for sparse data', () => {
+    const { container } = render(
+      <MonthlyEarningsChart monthlyEarnings={{ '2024-06': 30 }} />
+    )
+
+    expect(container.querySelectorAll('.grid > div')).toHaveLength(6)
+    expect(screen.getByText('$30')).toBeInTheDocument()
+    expect(screen.getAllByText('$0')).toHaveLength(5)
+  })
+
+  it('shows helper text when all amounts are zero', () => {
+    render(<MonthlyEarningsChart monthlyEarnings={{}} />)
+
+    expect(
+      screen.getByText(/no earnings in the last 6 months/i)
+    ).toBeInTheDocument()
+    expect(screen.getAllByText('$0')).toHaveLength(6)
+  })
+
+  it('includes year on labels when the window spans two years', () => {
+    vi.setSystemTime(new Date(2025, 0, 15))
+
+    render(
+      <MonthlyEarningsChart
+        monthlyEarnings={{
+          '2024-12': 5,
+          '2025-01': 10,
+        }}
+      />
+    )
+
+    expect(screen.getByText('Dec 2024')).toBeInTheDocument()
+    expect(screen.getByText('Jan 2025')).toBeInTheDocument()
+  })
+})

--- a/components/dashboard/monthly-earnings-chart.tsx
+++ b/components/dashboard/monthly-earnings-chart.tsx
@@ -1,5 +1,11 @@
 'use client'
 
+import {
+  buildLastSixMonthSlots,
+  formatMonthLabel,
+  monthWindowSpansTwoYears,
+} from '@/lib/earnings/monthly-earnings'
+
 type MonthlyEarningsChartProps = {
   monthlyEarnings: Record<string, number>
 }
@@ -7,26 +13,42 @@ type MonthlyEarningsChartProps = {
 export function MonthlyEarningsChart({
   monthlyEarnings,
 }: MonthlyEarningsChartProps) {
-  if (Object.keys(monthlyEarnings).length === 0) {
-    return null
-  }
+  const slots = buildLastSixMonthSlots(monthlyEarnings)
+  const showYear = monthWindowSpansTwoYears(slots.map((slot) => slot.monthKey))
+  const allZero = slots.every((slot) => slot.amountUsd === 0)
 
   return (
     <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
-      <h3 className="text-lg font-semibold mb-4">Monthly Earnings</h3>
-      <div className="grid grid-cols-6 gap-2">
-        {Object.entries(monthlyEarnings)
-          .sort(([a], [b]) => b.localeCompare(a))
-          .slice(0, 6)
-          .reverse()
-          .map(([month, amount]) => (
-            <div key={month} className="text-center">
-              <div className="text-xs text-muted-foreground mb-1">{month}</div>
-              <div className="bg-success text-success-foreground rounded-lg p-2">
-                <p className="text-sm font-semibold">${amount.toFixed(0)}</p>
+      <div className="mb-4">
+        <h3 className="text-lg font-semibold">Monthly Earnings</h3>
+        {allZero && (
+          <p className="text-sm text-muted-foreground mt-1">
+            No earnings in the last 6 months
+          </p>
+        )}
+      </div>
+      <div className="grid grid-cols-3 sm:grid-cols-6 gap-2">
+        {slots.map((slot) => {
+          const hasEarnings = slot.amountUsd > 0
+          return (
+            <div key={slot.monthKey} className="min-w-0 text-center">
+              <div className="text-xs text-muted-foreground mb-1 whitespace-nowrap">
+                {formatMonthLabel(slot.monthKey, { showYear })}
+              </div>
+              <div
+                className={
+                  hasEarnings
+                    ? 'bg-success text-success-foreground rounded-lg p-2'
+                    : 'bg-muted text-muted-foreground rounded-lg border border-border p-2'
+                }
+              >
+                <p className="text-sm font-semibold">
+                  ${slot.amountUsd.toFixed(0)}
+                </p>
               </div>
             </div>
-          ))}
+          )
+        })}
       </div>
     </div>
   )

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -40,6 +40,10 @@ import {
 import { InstallWalletDialog } from '@/components/stellar/InstallWalletDialog'
 import { WalletTooltip } from '@/components/guide/WalletTooltip'
 import {
+  networkLabelLowercase,
+  tipFlowShortNote,
+} from '@/lib/copy/network-status'
+import {
   NO_WALLET_AVAILABLE_ERROR_CODE,
   ALBEDO_INSECURE_LOCALHOST_ERROR_CODE,
 } from '@/lib/stellar/wallet-adapter'
@@ -601,8 +605,11 @@ export function HighlightTipButton({
           )}
 
           <p className="text-xs text-muted-foreground text-center mt-2 flex items-center justify-center gap-1 flex-wrap">
-            Powered by Stellar testnet <WalletTooltip concept="testnet" /> •
-            Fast testnet settlement • Low fees
+            Powered by Stellar {networkLabelLowercase()}{' '}
+            {networkLabelLowercase() === 'testnet' ? (
+              <WalletTooltip concept="testnet" />
+            ) : null}{' '}
+            • {tipFlowShortNote()}
           </p>
         </DialogContent>
       </Dialog>

--- a/components/stellar/WalletSettings.test.tsx
+++ b/components/stellar/WalletSettings.test.tsx
@@ -85,7 +85,7 @@ describe('WalletSettings', () => {
     ).toBeInTheDocument()
     expect(
       screen.getByText(
-        /Connect your Stellar testnet wallet to send and receive practice tips/i
+        /Connect your Stellar testnet wallet to send and receive tips/i
       )
     ).toBeInTheDocument()
     expect(screen.queryByText(/undefined/i)).not.toBeInTheDocument()

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -35,6 +35,7 @@ import {
   NO_WALLET_AVAILABLE_ERROR_CODE,
   ALBEDO_INSECURE_LOCALHOST_ERROR_CODE,
 } from '@/lib/stellar/wallet-adapter'
+import { networkLabelLowercase, practiceFundsNote } from '@/lib/copy/network-status'
 
 interface WalletSettingsProps {
   walletAddress?: string | null
@@ -209,11 +210,13 @@ export function WalletSettings({
             <Wallet className="h-5 w-5" />
             Stellar Wallet
             <WalletTooltip concept="stellar" />
-            <WalletTooltip concept="testnet" />
+            {networkLabelLowercase() === 'testnet' ? (
+              <WalletTooltip concept="testnet" />
+            ) : null}
           </CardTitle>
           <CardDescription>
             {isOwnProfile
-              ? 'Manage your Stellar testnet wallet for sending and receiving practice tips'
+              ? `Manage your Stellar ${networkLabelLowercase()} wallet for sending and receiving tips`
               : 'Copy the wallet address, or tip this author from their articles.'}
           </CardDescription>
         </CardHeader>
@@ -231,14 +234,21 @@ export function WalletSettings({
           )}
 
           {isOwnProfile ? (
+            <Alert>
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{practiceFundsNote()}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          {isOwnProfile ? (
             <>
               {!walletAddress ? (
                 <div className="space-y-4">
                   <Alert>
                     <AlertCircle className="h-4 w-4" />
                     <AlertDescription>
-                      Connect your Stellar testnet wallet to send and receive
-                      practice tips
+                      Connect your Stellar {networkLabelLowercase()} wallet to
+                      send and receive tips
                     </AlertDescription>
                   </Alert>
 
@@ -325,7 +335,11 @@ export function WalletSettings({
                       onClick={() =>
                         walletAddress &&
                         window.open(
-                          `https://stellar.expert/explorer/testnet/account/${walletAddress}`,
+                          `https://stellar.expert/explorer/${
+                            networkLabelLowercase() === 'testnet'
+                              ? 'testnet'
+                              : 'public'
+                          }/account/${walletAddress}`,
                           '_blank'
                         )
                       }
@@ -382,7 +396,9 @@ export function WalletSettings({
                 onClick={() =>
                   walletAddress &&
                   window.open(
-                    `https://stellar.expert/explorer/testnet/account/${walletAddress}`,
+                    `https://stellar.expert/explorer/${
+                      networkLabelLowercase() === 'testnet' ? 'testnet' : 'public'
+                    }/account/${walletAddress}`,
                     '_blank'
                   )
                 }

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -35,7 +35,10 @@ import {
   NO_WALLET_AVAILABLE_ERROR_CODE,
   ALBEDO_INSECURE_LOCALHOST_ERROR_CODE,
 } from '@/lib/stellar/wallet-adapter'
-import { networkLabelLowercase, practiceFundsNote } from '@/lib/copy/network-status'
+import {
+  networkLabelLowercase,
+  practiceFundsNote,
+} from '@/lib/copy/network-status'
 
 interface WalletSettingsProps {
   walletAddress?: string | null
@@ -397,7 +400,9 @@ export function WalletSettings({
                   walletAddress &&
                   window.open(
                     `https://stellar.expert/explorer/${
-                      networkLabelLowercase() === 'testnet' ? 'testnet' : 'public'
+                      networkLabelLowercase() === 'testnet'
+                        ? 'testnet'
+                        : 'public'
                     }/account/${walletAddress}`,
                     '_blank'
                   )

--- a/components/stellar/WalletStatus.tsx
+++ b/components/stellar/WalletStatus.tsx
@@ -19,6 +19,7 @@ import {
   NO_WALLET_AVAILABLE_ERROR_CODE,
   ALBEDO_INSECURE_LOCALHOST_ERROR_CODE,
 } from '@/lib/stellar/wallet-adapter'
+import { networkLabelLowercase } from '@/lib/copy/network-status'
 
 interface WalletStatusProps {
   className?: string
@@ -122,8 +123,8 @@ export function WalletStatus({ className }: WalletStatusProps) {
               <div>
                 <h3 className="font-semibold">Wallet Not Connected</h3>
                 <p className="text-sm text-muted-foreground">
-                  Connect your Stellar testnet wallet to start practice tipping
-                  authors
+                  Connect your Stellar {networkLabelLowercase()} wallet to start
+                  tipping authors
                 </p>
                 <p className="text-xs text-muted-foreground mt-2">
                   Supports Freighter, xBull, Albedo, Rabet, and more

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -49,6 +49,10 @@ import { applyPendingAmountFields } from '@/lib/tip/applyPendingTipFormState'
 import { clearPendingTipIntent } from '@/lib/tip/pendingTipIntent'
 import type { ArticlePendingTipIntent } from '@/lib/tip/pendingTipIntent'
 import { useArticleTipResume } from '@/hooks/useArticleTipResume'
+import {
+  networkLabelLowercase,
+  tipFlowShortNote,
+} from '@/lib/copy/network-status'
 
 interface TipButtonProps {
   articleId: Id<'articles'>
@@ -506,9 +510,12 @@ export function TipButton({
           )}
 
           <p className="text-xs text-muted-foreground text-center flex items-center justify-center gap-1 flex-wrap">
-            Powered by Stellar testnet <WalletTooltip concept="stellar" />{' '}
-            <WalletTooltip concept="testnet" /> • Fast testnet settlement • Low
-            fees
+            Powered by Stellar {networkLabelLowercase()}{' '}
+            <WalletTooltip concept="stellar" />{' '}
+            {networkLabelLowercase() === 'testnet' ? (
+              <WalletTooltip concept="testnet" />
+            ) : null}{' '}
+            • {tipFlowShortNote()}
           </p>
         </DialogContent>
       </Dialog>

--- a/lib/copy/network-status.ts
+++ b/lib/copy/network-status.ts
@@ -1,12 +1,65 @@
 import { MIN_WITHDRAWAL_USD } from '@/lib/constants'
+import { STELLAR_CONFIG } from '@/lib/stellar/config'
 
-export const TESTNET_PRACTICE_NOTE =
-  'Quilltip runs on Stellar testnet. Tips use free test XLM for practice—not real money.'
+type SupportedNetwork = 'TESTNET' | 'MAINNET'
 
-export const TESTNET_TIP_SPEED_NOTE =
-  'Tips settle in about 3 seconds on Stellar testnet with near-zero fees.'
+function getNetwork(): SupportedNetwork {
+  return STELLAR_CONFIG.NETWORK === 'MAINNET' ? 'MAINNET' : 'TESTNET'
+}
 
-export const TESTNET_WITHDRAWAL_NOTE = `Move testnet earnings to your Stellar wallet once your available balance reaches $${MIN_WITHDRAWAL_USD.toFixed(0)}. Test funds only—not withdrawable as real money.`
+export function networkLabelLowercase(): 'testnet' | 'mainnet' {
+  return getNetwork() === 'MAINNET' ? 'mainnet' : 'testnet'
+}
+
+export function practiceFundsNote(): string {
+  if (getNetwork() === 'MAINNET') {
+    return 'Quilltip runs on Stellar mainnet. Tips use real funds.'
+  }
+  return 'Quilltip runs on Stellar testnet. Tips use free test XLM for practice—not real money.'
+}
+
+export function tipSpeedNote(): string {
+  const network = networkLabelLowercase()
+  return `Tips typically confirm in a few seconds on Stellar ${network} with near-zero fees.`
+}
+
+/**
+ * Explains what "withdraw" actually does today vs future mainnet behavior.
+ * Keep this aligned with `convex/tips.ts` withdrawEarnings.
+ */
+export function withdrawalFlowNote(): string {
+  if (getNetwork() === 'MAINNET') {
+    return 'Withdrawals submit an on-chain transfer to your Stellar wallet. Confirmation time depends on the network.'
+  }
+  return 'Withdrawals are testnet-only today and are simulated off-chain. Your dashboard marks them complete after a short delay.'
+}
+
+export function withdrawalNote(): string {
+  if (getNetwork() === 'MAINNET') {
+    return `Move earnings to your Stellar wallet once your available balance reaches $${MIN_WITHDRAWAL_USD.toFixed(0)}.`
+  }
+  return `Move testnet earnings to your Stellar wallet once your available balance reaches $${MIN_WITHDRAWAL_USD.toFixed(0)}. Test funds only—not withdrawable as real money.`
+}
+
+export function tipFlowShortNote(): string {
+  const network = networkLabelLowercase()
+  if (getNetwork() === 'MAINNET') {
+    return `Fast confirmation on Stellar ${network}. You sign in your wallet → the network confirms → your dashboard updates.`
+  }
+  return `Fast testnet confirmation. You sign in your wallet → the network confirms → your dashboard updates.`
+}
+
+export function withdrawalAcknowledgementLabel(): string {
+  if (getNetwork() === 'MAINNET') {
+    return 'I understand this will submit an on-chain transfer and may take time to confirm.'
+  }
+  return 'I understand these are testnet practice funds and withdrawals are simulated off-chain.'
+}
+
+// Backwards-compatible exports (existing imports across the app).
+export const TESTNET_PRACTICE_NOTE = practiceFundsNote()
+export const TESTNET_TIP_SPEED_NOTE = tipSpeedNote()
+export const TESTNET_WITHDRAWAL_NOTE = withdrawalNote()
 
 export const MAINNET_COMING_NOTE =
   'We are working toward a mainnet launch where tips will use real funds. Until then, everything on Quilltip is testnet practice.'

--- a/lib/copy/network-status.ts
+++ b/lib/copy/network-status.ts
@@ -41,6 +41,18 @@ export function withdrawalNote(): string {
   return `Move testnet earnings to your Stellar wallet once your available balance reaches $${MIN_WITHDRAWAL_USD.toFixed(0)}. Test funds only—not withdrawable as real money.`
 }
 
+export function withdrawalDialogTitle(): string {
+  return getNetwork() === 'MAINNET'
+    ? 'Withdraw Earnings'
+    : 'Withdraw Testnet Earnings'
+}
+
+export function withdrawalDialogDescription(): string {
+  return getNetwork() === 'MAINNET'
+    ? 'Send earnings to your Stellar wallet'
+    : 'Send testnet XLM to your Stellar wallet'
+}
+
 export function tipFlowShortNote(): string {
   const network = networkLabelLowercase()
   if (getNetwork() === 'MAINNET') {

--- a/lib/earnings/monthly-earnings.test.ts
+++ b/lib/earnings/monthly-earnings.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildLastSixMonthSlots,
+  formatMonthLabel,
+  monthWindowSpansTwoYears,
+  parseMonthKey,
+} from '@/lib/earnings/monthly-earnings'
+
+describe('parseMonthKey', () => {
+  it('parses a valid YYYY-MM key', () => {
+    const date = parseMonthKey('2024-01')
+    expect(date).not.toBeNull()
+    expect(date?.getFullYear()).toBe(2024)
+    expect(date?.getMonth()).toBe(0)
+  })
+
+  it('returns null for invalid keys', () => {
+    expect(parseMonthKey('2024-13')).toBeNull()
+    expect(parseMonthKey('invalid')).toBeNull()
+  })
+})
+
+describe('formatMonthLabel', () => {
+  it('formats as short month without year by default', () => {
+    expect(formatMonthLabel('2024-01', { showYear: false })).toBe('Jan')
+    expect(formatMonthLabel('2024-03', { showYear: false })).toBe('Mar')
+  })
+
+  it('includes year when showYear is true', () => {
+    expect(formatMonthLabel('2024-01', { showYear: true })).toBe('Jan 2024')
+  })
+
+  it('falls back to the raw key for invalid input', () => {
+    expect(formatMonthLabel('not-a-month', { showYear: false })).toBe(
+      'not-a-month'
+    )
+  })
+})
+
+describe('monthWindowSpansTwoYears', () => {
+  it('returns false when all months are in the same year', () => {
+    expect(
+      monthWindowSpansTwoYears([
+        '2024-01',
+        '2024-02',
+        '2024-03',
+        '2024-04',
+        '2024-05',
+        '2024-06',
+      ])
+    ).toBe(false)
+  })
+
+  it('returns true when the window crosses a year boundary', () => {
+    expect(
+      monthWindowSpansTwoYears([
+        '2024-08',
+        '2024-09',
+        '2024-10',
+        '2024-11',
+        '2024-12',
+        '2025-01',
+      ])
+    ).toBe(true)
+  })
+})
+
+describe('buildLastSixMonthSlots', () => {
+  it('returns six chronological slots ending at the current month', () => {
+    const now = new Date(2024, 5, 15)
+    const slots = buildLastSixMonthSlots({ '2024-06': 30 }, now)
+
+    expect(slots).toHaveLength(6)
+    expect(slots.map((slot) => slot.monthKey)).toEqual([
+      '2024-01',
+      '2024-02',
+      '2024-03',
+      '2024-04',
+      '2024-05',
+      '2024-06',
+    ])
+    expect(slots.find((slot) => slot.monthKey === '2024-06')?.amountUsd).toBe(
+      30
+    )
+    expect(slots.filter((slot) => slot.amountUsd > 0)).toHaveLength(1)
+  })
+})

--- a/lib/earnings/monthly-earnings.ts
+++ b/lib/earnings/monthly-earnings.ts
@@ -1,0 +1,87 @@
+const MONTH_KEY_RE = /^(\d{4})-(\d{2})$/
+
+export type MonthlyEarningsSlot = {
+  monthKey: string
+  amountUsd: number
+}
+
+export function parseMonthKey(monthKey: string): Date | null {
+  const match = MONTH_KEY_RE.exec(monthKey)
+  if (!match) {
+    return null
+  }
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  if (month < 1 || month > 12) {
+    return null
+  }
+
+  return new Date(year, month - 1, 1)
+}
+
+export function formatMonthKey(monthKey: string): string {
+  const date = parseMonthKey(monthKey)
+  if (!date) {
+    return monthKey
+  }
+
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`
+}
+
+export function formatMonthLabel(
+  monthKey: string,
+  options: { showYear: boolean }
+): string {
+  const date = parseMonthKey(monthKey)
+  if (!date) {
+    return monthKey
+  }
+
+  if (options.showYear) {
+    return date.toLocaleString(undefined, {
+      month: 'short',
+      year: 'numeric',
+    })
+  }
+
+  return date.toLocaleString(undefined, { month: 'short' })
+}
+
+export function monthWindowSpansTwoYears(monthKeys: string[]): boolean {
+  if (monthKeys.length === 0) {
+    return false
+  }
+
+  const firstKey = monthKeys[0]
+  const lastKey = monthKeys[monthKeys.length - 1]
+  if (!firstKey || !lastKey) {
+    return false
+  }
+
+  const first = parseMonthKey(firstKey)
+  const last = parseMonthKey(lastKey)
+  if (!first || !last) {
+    return false
+  }
+
+  return first.getFullYear() !== last.getFullYear()
+}
+
+export function buildLastSixMonthSlots(
+  monthlyEarnings: Record<string, number>,
+  now: Date = new Date()
+): MonthlyEarningsSlot[] {
+  const slots: MonthlyEarningsSlot[] = []
+
+  for (let offset = 5; offset >= 0; offset -= 1) {
+    const date = new Date(now.getFullYear(), now.getMonth() - offset, 1)
+    const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`
+    slots.push({
+      monthKey,
+      amountUsd: monthlyEarnings[monthKey] ?? 0,
+    })
+  }
+
+  return slots
+}


### PR DESCRIPTION
## Summary

Polishes the writer earnings dashboard so testnet vs mainnet behavior is clear, empty states guide next steps, the monthly earnings chart is easier to read on small screens, and tip history works well on mobile.

## Changes

### Testnet / network copy (`lib/copy/network-status.ts`)
- Centralizes network-aware messaging (practice funds, tip speed, withdrawal notes, acknowledgement text, withdrawal flow) based on `STELLAR_CONFIG.NETWORK`.
- Keeps backwards-compatible exports (`TESTNET_PRACTICE_NOTE`, etc.) for existing imports.
- Wires updated copy into earnings stats, withdrawal dialogs, wallet settings, and tip flows (`TipButton`, `HighlightTipButton`, `WalletStatus`).

### Earnings empty state (`EarningsDashboard`)
- Replaces a static “no tips” message with actionable guidance.
- Primary CTA: **Set up wallet** (profile wallet tab) when no Stellar address is saved, or **Write your first post** when a wallet exists.
- Responsive padding and copy that explains publishing + wallet setup.

### Monthly earnings chart (`monthly-earnings-chart`, `lib/earnings/monthly-earnings`)
- Extracts last-6-month slot building and month label formatting into tested utilities.
- Shows short month labels; includes year when the 6-month window crosses a calendar year.
- Adds “No earnings in the last 6 months” when all months are zero.
- Uses a 3-column grid on mobile and 6 columns on larger breakpoints for readable labels.

### Tip history — mobile + sorting (`TipHistory`)
- Adds a card-style mobile list (`md:hidden`) alongside the existing sortable desktop table.
- Mobile: sort-by dropdown, ascending/descending toggle, row count selector, CSV export.
- Desktop: column header sorting with `aria-sort` indicators.
- Empty state: “No tips yet” with helper text when the list is empty.
- Improved date display (`<time>` with relative + absolute labels for accessibility).

### Withdrawals (`WithdrawalDialog`, `WithdrawEarningsDialog`, `EarningsStats`)
- Requires acknowledgement checkbox before withdraw (testnet: simulated off-chain; mainnet-ready copy for future).
- Success toasts use `withdrawalFlowNote()` so users know what “withdraw” means on the current network.
- Earnings stats banner uses `practiceFundsNote()`; tip count label uses `networkLabelLowercase()`.
- Minimum-balance helper when wallet is set up but balance is below threshold.

### Tests
- `monthly-earnings-chart.test.tsx`, `lib/earnings/monthly-earnings.test.ts`
- Updated `TipHistory.test.tsx` (mobile list), `EarningsStats.test.tsx`, `WithdrawalDialog.test.tsx`, `WalletSettings.test.tsx`

## Testing

- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run test:once components/dashboard/WithdrawalDialog.test.tsx components/dashboard/EarningsStats.test.tsx components/dashboard/TipHistory.test.tsx components/dashboard/monthly-earnings-chart.test.tsx lib/earnings/monthly-earnings.test.ts components/stellar/WalletSettings.test.tsx`
- `bun run test:once`
- `bun run build`
- Manual preview QA for ENG-144 earnings/dashboard flows passed.

## Notes

- Branch was updated with latest `origin/development`; the merge conflict in `components/stellar/WalletSettings.tsx` was resolved by keeping ENG-144 network-aware owner wallet copy and ENG-143 non-owner profile wording.
- Added a small follow-up fix so withdrawal dialog title, description, and note use the centralized network copy helpers instead of hardcoded testnet text.
- Preview QA passed for the ENG-144 earnings/dashboard surfaces; local evidence notes were recorded separately and remain gitignored.
