### PR TITLE
feat(nft): ownership readiness, two-step transfer confirmation, and profile NFT cards (ENG-155)

### DIFF
--- a/app/[username]/[slug]/page.tsx
+++ b/app/[username]/[slug]/page.tsx
@@ -177,7 +177,6 @@ export default function ArticlePage({ params }: ArticlePageProps) {
                       articleSlug={article.slug}
                       authorId={article.author.id}
                       currentUserId={user?._id as Id<'users'> | undefined}
-                      currentUserAddress={user?.stellarAddress}
                     />
                   </div>
 

--- a/components/nft/NFTIntegration.test.tsx
+++ b/components/nft/NFTIntegration.test.tsx
@@ -74,7 +74,6 @@ describe('NFTIntegration transfer actions', () => {
         articleSlug="test-article"
         authorId={authorId}
         currentUserId={newOwnerId}
-        currentUserAddress={sharedStellarAddress}
       />
     )
 
@@ -96,7 +95,6 @@ describe('NFTIntegration transfer actions', () => {
         articleSlug="test-article"
         authorId={authorId}
         currentUserId={oldOwnerId}
-        currentUserAddress={sharedStellarAddress}
       />
     )
 

--- a/components/nft/NFTIntegration.test.tsx
+++ b/components/nft/NFTIntegration.test.tsx
@@ -103,8 +103,6 @@ describe('NFTIntegration transfer actions', () => {
     expect(
       screen.queryByRole('button', { name: /Transfer NFT/i })
     ).not.toBeInTheDocument()
-    expect(
-      screen.getByText(/don.t own this NFT/i)
-    ).toBeInTheDocument()
+    expect(screen.getByText(/don.t own this NFT/i)).toBeInTheDocument()
   })
 })

--- a/components/nft/NFTIntegration.test.tsx
+++ b/components/nft/NFTIntegration.test.tsx
@@ -1,0 +1,112 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NFTIntegration } from '@/components/nft/NFTIntegration'
+import type { Id } from '@/types/convex'
+
+const mockUseNFTByArticle = vi.hoisted(() => vi.fn())
+
+vi.mock('@/hooks/convex', () => ({
+  useNFTByArticle: (articleId: Id<'articles'> | undefined) =>
+    mockUseNFTByArticle(articleId),
+}))
+
+vi.mock('./MintButton', () => ({
+  MintButton: () => <div data-testid="mint-button" />,
+}))
+
+vi.mock('./TransferModal', () => ({
+  TransferModal: () => <div data-testid="transfer-modal" />,
+}))
+
+const articleId = 'jd7aaaaaaaaaaaaaaaa' as Id<'articles'>
+const authorId = 'jd7bbbbbbbbbbbbbbbb' as Id<'users'>
+const oldOwnerId = 'jd7cccccccccccccccc' as Id<'users'>
+const newOwnerId = 'jd7dddddddddddddddd' as Id<'users'>
+const sharedStellarAddress =
+  'GAEV4UC0WEUWGLAQW7NYYPULUA65XMVYYA670GTHL0M705E2ZINYFXPM'
+
+function mintedNftStatus(ownerUserId: Id<'users'>) {
+  return {
+    _id: 'jd7eeeeeeeeeeeeeeee' as Id<'articleNFTs'>,
+    isMinted: true as const,
+    isEligible: true,
+    totalTips: 5000,
+    tipThreshold: 1000,
+    owner: sharedStellarAddress,
+    mintedAt: new Date().toISOString(),
+    transferCount: 1,
+    rarity: 'epic' as const,
+    ownerInfo: {
+      id: ownerUserId,
+      name: 'Owner',
+      username: ownerUserId === newOwnerId ? 'suraj' : 'yash0057',
+      avatar: null,
+      stellarAddress: sharedStellarAddress,
+    },
+    minterInfo: {
+      id: authorId,
+      name: 'Author',
+      username: 'yash0057',
+      avatar: null,
+    },
+  }
+}
+
+async function openActionsTab(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('tab', { name: /^Actions$/i }))
+}
+
+describe('NFTIntegration transfer actions', () => {
+  beforeEach(() => {
+    mockUseNFTByArticle.mockReset()
+  })
+
+  it('shows Transfer NFT when the signed-in user owns the NFT by user id', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockUseNFTByArticle.mockReturnValue(mintedNftStatus(newOwnerId))
+
+    render(
+      <NFTIntegration
+        articleId={articleId}
+        articleTitle="Test Article"
+        articleSlug="test-article"
+        authorId={authorId}
+        currentUserId={newOwnerId}
+        currentUserAddress={sharedStellarAddress}
+      />
+    )
+
+    await openActionsTab(user)
+
+    expect(
+      screen.getByRole('button', { name: /Transfer NFT/i })
+    ).toBeInTheDocument()
+  })
+
+  it('hides Transfer NFT for a former owner who shares the same stellar address', async () => {
+    const user = userEvent.setup({ delay: null })
+    mockUseNFTByArticle.mockReturnValue(mintedNftStatus(newOwnerId))
+
+    render(
+      <NFTIntegration
+        articleId={articleId}
+        articleTitle="Test Article"
+        articleSlug="test-article"
+        authorId={authorId}
+        currentUserId={oldOwnerId}
+        currentUserAddress={sharedStellarAddress}
+      />
+    )
+
+    await openActionsTab(user)
+
+    expect(
+      screen.queryByRole('button', { name: /Transfer NFT/i })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByText(/don.t own this NFT/i)
+    ).toBeInTheDocument()
+  })
+})

--- a/components/nft/NFTIntegration.tsx
+++ b/components/nft/NFTIntegration.tsx
@@ -55,9 +55,10 @@ export function NFTIntegration({
   const isOwner =
     nftStatus != null &&
     nftStatus.isMinted === true &&
-    currentUserAddress === nftStatus.owner
+    currentUserId != null &&
+    nftStatus.ownerInfo?.id === currentUserId
   const canMint = isAuthor && !nftStatus?.isMinted && nftStatus?.isEligible
-  const canTransfer = isOwner && nftStatus?.isMinted === true
+  const canTransfer = isOwner
 
   const progressPercentage = nftStatus
     ? (nftStatus.totalTips / nftStatus.tipThreshold) * 100
@@ -277,6 +278,7 @@ export function NFTIntegration({
           articleId={articleId}
           articleTitle={articleTitle}
           currentOwner={nftStatus.owner}
+          currentOwnerUsername={nftStatus.ownerInfo?.username}
           nftId={nftStatus._id}
           onTransferComplete={handleTransferComplete}
           triggerRef={transferTriggerRef}

--- a/components/nft/NFTIntegration.tsx
+++ b/components/nft/NFTIntegration.tsx
@@ -25,7 +25,6 @@ interface NFTIntegrationProps {
   articleSlug: string
   authorId: Id<'users'>
   currentUserId?: Id<'users'>
-  currentUserAddress?: string | null
 }
 
 export function NFTIntegration({
@@ -34,7 +33,6 @@ export function NFTIntegration({
   articleSlug,
   authorId,
   currentUserId,
-  currentUserAddress,
 }: NFTIntegrationProps) {
   const [showTransferModal, setShowTransferModal] = useState(false)
   const transferTriggerRef = useRef<HTMLButtonElement>(null)

--- a/components/nft/NftCard.test.tsx
+++ b/components/nft/NftCard.test.tsx
@@ -10,7 +10,7 @@ vi.mock('next/image', () => ({
   }: {
     src: string
     alt: string
-  // eslint-disable-next-line @next/next/no-img-element -- mock for next/image
+    // eslint-disable-next-line @next/next/no-img-element -- mock for next/image
   }) => <img src={src} alt={alt} />,
 }))
 
@@ -36,10 +36,7 @@ const baseProps = {
 describe('NftCard', () => {
   it('renders cover image when coverImage is set', () => {
     render(
-      <NftCard
-        {...baseProps}
-        coverImage="https://example.com/cover.jpg"
-      />
+      <NftCard {...baseProps} coverImage="https://example.com/cover.jpg" />
     )
 
     const img = screen.getByRole('img', { name: 'Test Article' })
@@ -62,12 +59,7 @@ describe('NftCard', () => {
   })
 
   it('shows excerpt and footer when provided', () => {
-    render(
-      <NftCard
-        {...baseProps}
-        excerpt="A short summary of the article."
-      />
-    )
+    render(<NftCard {...baseProps} excerpt="A short summary of the article." />)
 
     expect(
       screen.getByText('A short summary of the article.')

--- a/components/nft/NftCard.test.tsx
+++ b/components/nft/NftCard.test.tsx
@@ -1,0 +1,78 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { NftCard } from '@/components/nft/NftCard'
+
+vi.mock('next/image', () => ({
+  default: ({
+    src,
+    alt,
+  }: {
+    src: string
+    alt: string
+  // eslint-disable-next-line @next/next/no-img-element -- mock for next/image
+  }) => <img src={src} alt={alt} />,
+}))
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+  }: {
+    href: string
+    children: React.ReactNode
+  }) => <a href={href}>{children}</a>,
+}))
+
+const baseProps = {
+  title: 'Test Article',
+  slug: 'test-article',
+  authorUsername: 'writer',
+  tokenId: 'abc123def456',
+  footerLabel: 'Minted by',
+  footerUsername: 'minter',
+}
+
+describe('NftCard', () => {
+  it('renders cover image when coverImage is set', () => {
+    render(
+      <NftCard
+        {...baseProps}
+        coverImage="https://example.com/cover.jpg"
+      />
+    )
+
+    const img = screen.getByRole('img', { name: 'Test Article' })
+    expect(img).toHaveAttribute('src', 'https://example.com/cover.jpg')
+  })
+
+  it('renders fallback without img when coverImage is missing', () => {
+    render(<NftCard {...baseProps} />)
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(screen.getByText('No cover image')).toBeInTheDocument()
+  })
+
+  it('links to the article page', () => {
+    render(<NftCard {...baseProps} />)
+
+    const links = screen.getAllByRole('link', { name: /Test Article/i })
+    expect(links.length).toBeGreaterThan(0)
+    expect(links[0]).toHaveAttribute('href', '/writer/test-article')
+  })
+
+  it('shows excerpt and footer when provided', () => {
+    render(
+      <NftCard
+        {...baseProps}
+        excerpt="A short summary of the article."
+      />
+    )
+
+    expect(
+      screen.getByText('A short summary of the article.')
+    ).toBeInTheDocument()
+    expect(screen.getByText(/Minted by @minter/)).toBeInTheDocument()
+    expect(screen.getByText(/Token ID: abc123de/)).toBeInTheDocument()
+  })
+})

--- a/components/nft/NftCard.tsx
+++ b/components/nft/NftCard.tsx
@@ -96,7 +96,9 @@ export function NftCard({
         )}
 
         {excerpt && (
-          <p className="text-sm text-muted-foreground line-clamp-2">{excerpt}</p>
+          <p className="text-sm text-muted-foreground line-clamp-2">
+            {excerpt}
+          </p>
         )}
 
         <p className="text-sm text-muted-foreground pt-1">

--- a/components/nft/NftCard.tsx
+++ b/components/nft/NftCard.tsx
@@ -1,0 +1,118 @@
+import Link from 'next/link'
+import Image from 'next/image'
+import { FileText } from 'lucide-react'
+
+export interface NftCardProps {
+  title: string
+  slug?: string
+  authorUsername?: string
+  coverImage?: string
+  excerpt?: string
+  tokenId: string
+  footerLabel: string
+  footerUsername?: string
+  href?: string
+}
+
+function buildArticleHref(
+  authorUsername: string | undefined,
+  slug: string | undefined
+): string | undefined {
+  if (!authorUsername || !slug) return undefined
+  return `/${authorUsername}/${slug}`
+}
+
+export function NftCard({
+  title,
+  slug,
+  authorUsername,
+  coverImage,
+  excerpt,
+  tokenId,
+  footerLabel,
+  footerUsername,
+  href,
+}: NftCardProps) {
+  const articleHref = href ?? buildArticleHref(authorUsername, slug)
+  const displayTitle = title || 'Untitled'
+  const truncatedTokenId =
+    tokenId.length > 8 ? `${tokenId.slice(0, 8)}...` : tokenId
+
+  const media = coverImage ? (
+    <div className="relative aspect-video w-full overflow-hidden rounded-lg">
+      <Image
+        src={coverImage}
+        alt={displayTitle}
+        fill
+        sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+        className="object-cover"
+      />
+    </div>
+  ) : (
+    <div
+      className="aspect-video w-full rounded-lg border border-border bg-muted flex flex-col items-center justify-center gap-2 px-4"
+      aria-hidden
+    >
+      <FileText className="h-10 w-10 text-muted-foreground/60" />
+      <span className="sr-only">No cover image</span>
+    </div>
+  )
+
+  const cardBody = (
+    <>
+      {articleHref ? (
+        <Link
+          href={articleHref}
+          className="focus-ring block rounded-lg"
+          scroll={false}
+        >
+          {media}
+        </Link>
+      ) : (
+        media
+      )}
+
+      <div className="mt-4 min-w-0 space-y-1">
+        {articleHref ? (
+          <Link
+            href={articleHref}
+            className="focus-ring block rounded-md"
+            scroll={false}
+          >
+            <h4 className="font-semibold text-foreground truncate hover:text-brand-blue transition-colors">
+              {displayTitle}
+            </h4>
+          </Link>
+        ) : (
+          <h4 className="font-semibold text-foreground truncate">
+            {displayTitle}
+          </h4>
+        )}
+
+        {authorUsername && (
+          <p className="text-sm text-muted-foreground truncate">
+            @{authorUsername}
+          </p>
+        )}
+
+        {excerpt && (
+          <p className="text-sm text-muted-foreground line-clamp-2">{excerpt}</p>
+        )}
+
+        <p className="text-sm text-muted-foreground pt-1">
+          Token ID: {truncatedTokenId}
+        </p>
+
+        <p className="text-xs text-muted-foreground/80">
+          {footerLabel} @{footerUsername || 'unknown'}
+        </p>
+      </div>
+    </>
+  )
+
+  return (
+    <article className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-3 sm:p-4 min-w-0">
+      {cardBody}
+    </article>
+  )
+}

--- a/components/nft/TransferModal.test.tsx
+++ b/components/nft/TransferModal.test.tsx
@@ -37,6 +37,7 @@ function ControlledTransferModal() {
         articleId={articleId}
         articleTitle="Test Article"
         currentOwner="seller"
+        currentOwnerUsername="seller"
         nftId={nftId}
       />
       <button type="button" onClick={() => setOpen(true)}>
@@ -46,10 +47,176 @@ function ControlledTransferModal() {
   )
 }
 
+async function reviewAndConfirmTransfer(
+  user: ReturnType<typeof userEvent.setup>
+) {
+  await user.type(
+    screen.getByLabelText(/Transfer To \(Username\)/i),
+    'buyername'
+  )
+  await user.click(screen.getByRole('button', { name: /^Review transfer$/i }))
+  await screen.findByTestId('transfer-confirm-recipient')
+  await user.click(screen.getByRole('button', { name: /^Confirm transfer$/i }))
+}
+
 describe('TransferModal', () => {
   beforeEach(() => {
     mockTransfer.mockReset()
     vi.mocked(toast.error).mockClear()
+  })
+
+  it('blocks transfer to the current owner on review', async () => {
+    const user = userEvent.setup({ delay: null })
+
+    render(
+      <TransferModal
+        isOpen
+        onClose={() => {}}
+        articleId={articleId}
+        articleTitle="Test Article"
+        currentOwner="GAEV4UC0WEUWGLAQW7NYYPULUA65XMVYYA670GTHL0M705E2ZINYFXPM"
+        currentOwnerUsername="seller"
+        nftId={nftId}
+      />
+    )
+
+    await user.type(
+      screen.getByLabelText(/Transfer To \(Username\)/i),
+      'seller'
+    )
+    await user.click(screen.getByRole('button', { name: /^Review transfer$/i }))
+
+    expect(screen.getByTestId('transfer-modal-message')).toHaveTextContent(
+      'Cannot transfer to the current owner'
+    )
+    expect(
+      screen.queryByRole('button', { name: /^Confirm transfer$/i })
+    ).not.toBeInTheDocument()
+    expect(mockTransfer).not.toHaveBeenCalled()
+  })
+
+  it('does not call transferNFT when only reviewing', async () => {
+    const user = userEvent.setup({ delay: null })
+
+    render(
+      <TransferModal
+        isOpen
+        onClose={() => {}}
+        articleId={articleId}
+        articleTitle="Test Article"
+        currentOwner="seller"
+        currentOwnerUsername="seller"
+        nftId={nftId}
+      />
+    )
+
+    await user.type(
+      screen.getByLabelText(/Transfer To \(Username\)/i),
+      'buyername'
+    )
+    await user.click(screen.getByRole('button', { name: /^Review transfer$/i }))
+
+    expect(screen.getByTestId('transfer-confirm-recipient')).toHaveTextContent(
+      '@buyername'
+    )
+    expect(mockTransfer).not.toHaveBeenCalled()
+  })
+
+  it('shows recipient and asset details on the confirmation step', async () => {
+    const user = userEvent.setup({ delay: null })
+
+    render(
+      <TransferModal
+        isOpen
+        onClose={() => {}}
+        articleId={articleId}
+        articleTitle="Test Article"
+        currentOwner="seller"
+        currentOwnerUsername="seller"
+        nftId={nftId}
+      />
+    )
+
+    await user.type(
+      screen.getByLabelText(/Transfer To \(Username\)/i),
+      'buyername'
+    )
+    await user.click(screen.getByRole('button', { name: /^Review transfer$/i }))
+
+    expect(screen.getByTestId('transfer-confirm-recipient')).toHaveTextContent(
+      '@buyername'
+    )
+    expect(screen.getByTestId('transfer-confirm-asset')).toHaveTextContent(
+      'Test Article'
+    )
+    expect(
+      screen.getByTestId('transfer-confirm-current-owner')
+    ).toHaveTextContent('@seller')
+    expect(screen.getByTestId('transfer-confirm-nft-id')).toHaveTextContent(
+      nftId
+    )
+    expect(screen.getByTestId('transfer-confirm-warning')).toHaveTextContent(
+      'Test Article'
+    )
+    expect(screen.getByTestId('transfer-confirm-warning')).toHaveTextContent(
+      '@buyername'
+    )
+    expect(screen.getByTestId('transfer-confirm-warning')).toHaveTextContent(
+      'cannot be undone'
+    )
+  })
+
+  it('does not transfer when cancel is clicked on the confirmation step', async () => {
+    const user = userEvent.setup({ delay: null })
+
+    render(
+      <TransferModal
+        isOpen
+        onClose={() => {}}
+        articleId={articleId}
+        articleTitle="Test Article"
+        currentOwner="seller"
+        currentOwnerUsername="seller"
+        nftId={nftId}
+      />
+    )
+
+    await user.type(
+      screen.getByLabelText(/Transfer To \(Username\)/i),
+      'buyername'
+    )
+    await user.click(screen.getByRole('button', { name: /^Review transfer$/i }))
+    await user.click(screen.getByRole('button', { name: /^Cancel$/i }))
+
+    expect(mockTransfer).not.toHaveBeenCalled()
+  })
+
+  it('does not transfer when back is clicked on the confirmation step', async () => {
+    const user = userEvent.setup({ delay: null })
+
+    render(
+      <TransferModal
+        isOpen
+        onClose={() => {}}
+        articleId={articleId}
+        articleTitle="Test Article"
+        currentOwner="seller"
+        currentOwnerUsername="seller"
+        nftId={nftId}
+      />
+    )
+
+    await user.type(
+      screen.getByLabelText(/Transfer To \(Username\)/i),
+      'buyername'
+    )
+    await user.click(screen.getByRole('button', { name: /^Review transfer$/i }))
+    await user.click(screen.getByRole('button', { name: /^Back$/i }))
+
+    expect(mockTransfer).not.toHaveBeenCalled()
+    expect(
+      screen.getByLabelText(/Transfer To \(Username\)/i)
+    ).toBeInTheDocument()
   })
 
   it('shows a single success message in the message slot after transfer', async () => {
@@ -63,15 +230,12 @@ describe('TransferModal', () => {
         articleId={articleId}
         articleTitle="Test Article"
         currentOwner="seller"
+        currentOwnerUsername="seller"
         nftId={nftId}
       />
     )
 
-    await user.type(
-      screen.getByLabelText(/Transfer To \(Username\)/i),
-      'buyername'
-    )
-    await user.click(screen.getByRole('button', { name: /^Transfer NFT$/i }))
+    await reviewAndConfirmTransfer(user)
 
     await waitFor(() => {
       expect(screen.getByTestId('transfer-modal-message')).toHaveTextContent(
@@ -97,15 +261,12 @@ describe('TransferModal', () => {
         articleId={articleId}
         articleTitle="Test Article"
         currentOwner="seller"
+        currentOwnerUsername="seller"
         nftId={nftId}
       />
     )
 
-    await user.type(
-      screen.getByLabelText(/Transfer To \(Username\)/i),
-      'buyername'
-    )
-    await user.click(screen.getByRole('button', { name: /^Transfer NFT$/i }))
+    await reviewAndConfirmTransfer(user)
 
     await waitFor(() => {
       expect(screen.getByTestId('transfer-modal-message')).toHaveTextContent(
@@ -125,7 +286,7 @@ describe('TransferModal', () => {
     )
   })
 
-  it('shows progress only in the message slot while the button stays Transfer NFT', async () => {
+  it('shows progress only in the message slot while the button stays Confirm transfer', async () => {
     const user = userEvent.setup({ delay: null })
     let resolveTransfer!: (value: string) => void
     const transferPromise = new Promise<string>((resolve) => {
@@ -140,22 +301,19 @@ describe('TransferModal', () => {
         articleId={articleId}
         articleTitle="Test Article"
         currentOwner="seller"
+        currentOwnerUsername="seller"
         nftId={nftId}
       />
     )
 
-    await user.type(
-      screen.getByLabelText(/Transfer To \(Username\)/i),
-      'buyername'
-    )
-    await user.click(screen.getByRole('button', { name: /^Transfer NFT$/i }))
+    await reviewAndConfirmTransfer(user)
 
     const slot = screen.getByTestId('transfer-modal-message')
     await waitFor(() => {
       expect(slot).toHaveTextContent('Processing transfer...')
     })
 
-    const submit = screen.getByRole('button', { name: /^Transfer NFT$/i })
+    const submit = screen.getByRole('button', { name: /^Confirm transfer$/i })
     expect(submit.textContent).not.toMatch(/Processing transfer/i)
 
     resolveTransfer!('transfer_id')
@@ -170,7 +328,7 @@ describe('TransferModal', () => {
     render(<ControlledTransferModal />)
 
     await user.type(screen.getByLabelText(/Transfer To \(Username\)/i), 'ab')
-    await user.click(screen.getByRole('button', { name: /^Transfer NFT$/i }))
+    await user.click(screen.getByRole('button', { name: /^Review transfer$/i }))
     await waitFor(() => {
       expect(screen.getByTestId('transfer-modal-message')).toHaveTextContent(
         'Invalid username format'

--- a/components/nft/TransferModal.tsx
+++ b/components/nft/TransferModal.tsx
@@ -76,9 +76,7 @@ export function TransferModal({
     nftId || (nftData && nftData.isMinted ? nftData._id : null)
 
   const nftTokenId =
-    nftData && nftData.isMinted && 'tokenId' in nftData
-      ? nftData.tokenId
-      : null
+    nftData && nftData.isMinted && 'tokenId' in nftData ? nftData.tokenId : null
 
   const nftIdentifier = nftTokenId ?? actualNftId ?? 'Unknown'
 
@@ -240,9 +238,7 @@ export function TransferModal({
       >
         <DialogHeader>
           <DialogTitle>
-            {step === 'details'
-              ? 'Transfer NFT Ownership'
-              : 'Confirm transfer'}
+            {step === 'details' ? 'Transfer NFT Ownership' : 'Confirm transfer'}
           </DialogTitle>
           <DialogDescription>
             {step === 'details'
@@ -356,7 +352,11 @@ export function TransferModal({
           </div>
         </div>
 
-        <DialogFooter className={step === 'confirm' ? 'sm:flex-row sm:justify-between' : undefined}>
+        <DialogFooter
+          className={
+            step === 'confirm' ? 'sm:flex-row sm:justify-between' : undefined
+          }
+        >
           {step === 'confirm' ? (
             <Button
               type="button"
@@ -396,7 +396,10 @@ export function TransferModal({
               >
                 {isBusy ? (
                   <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+                    <Loader2
+                      className="mr-2 h-4 w-4 animate-spin"
+                      aria-hidden
+                    />
                     Confirm transfer
                   </>
                 ) : (

--- a/components/nft/TransferModal.tsx
+++ b/components/nft/TransferModal.tsx
@@ -20,6 +20,8 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { userFacingTransferNftError } from '@/lib/convex/userFacingTransferNftError'
 
+type TransferStep = 'details' | 'confirm'
+
 type TransferMessage =
   | { kind: 'none' }
   | { kind: 'progress'; text: string }
@@ -34,10 +36,17 @@ interface TransferModalProps {
   onClose: () => void
   articleId: string
   articleTitle: string
+  /** Stellar address (or fallback label) shown in the UI */
   currentOwner: string
+  /** Username of the current owner; used to block self-transfer on review */
+  currentOwnerUsername?: string
   nftId?: Id<'articleNFTs'>
   onTransferComplete?: (newOwner: string) => void
   triggerRef?: RefObject<HTMLElement | null>
+}
+
+function validateRecipientUsername(username: string): boolean {
+  return /^[a-zA-Z0-9_-]{3,30}$/.test(username)
 }
 
 export function TransferModal({
@@ -46,11 +55,13 @@ export function TransferModal({
   articleId,
   articleTitle,
   currentOwner,
+  currentOwnerUsername,
   nftId,
   onTransferComplete,
   triggerRef,
 }: TransferModalProps) {
   const [recipientUsername, setRecipientUsername] = useState('')
+  const [step, setStep] = useState<TransferStep>('details')
   const [transferMessage, setTransferMessage] = useState<TransferMessage>({
     kind: 'none',
   })
@@ -64,11 +75,19 @@ export function TransferModal({
   const actualNftId =
     nftId || (nftData && nftData.isMinted ? nftData._id : null)
 
+  const nftTokenId =
+    nftData && nftData.isMinted && 'tokenId' in nftData
+      ? nftData.tokenId
+      : null
+
+  const nftIdentifier = nftTokenId ?? actualNftId ?? 'Unknown'
+
   const prevOpenRef = useRef(false)
 
   useEffect(() => {
     if (isOpen && !prevOpenRef.current) {
       setRecipientUsername('')
+      setStep('details')
       setTransferMessage({ kind: 'none' })
     }
     prevOpenRef.current = isOpen
@@ -76,42 +95,64 @@ export function TransferModal({
 
   const isBusy = transferMessage.kind === 'progress'
 
-  const validateUsername = (username: string): boolean => {
-    return /^[a-zA-Z0-9_-]{3,30}$/.test(username)
+  const validateTransferInput = (): string | null => {
+    if (!recipientUsername.trim()) {
+      return 'Please enter a recipient username'
+    }
+
+    if (!validateRecipientUsername(recipientUsername)) {
+      return 'Invalid username format. Use only letters, numbers, underscores, and hyphens (3-30 characters).'
+    }
+
+    const ownerUsername =
+      currentOwnerUsername ??
+      (nftData && nftData.isMinted ? nftData.ownerInfo?.username : undefined)
+
+    if (
+      ownerUsername &&
+      recipientUsername.toLowerCase() === ownerUsername.toLowerCase()
+    ) {
+      return 'Cannot transfer to the current owner'
+    }
+
+    if (!actualNftId) {
+      return 'NFT not found for this article'
+    }
+
+    return null
+  }
+
+  const handleReview = () => {
+    setTransferMessage({ kind: 'none' })
+
+    const validationError = validateTransferInput()
+    if (validationError) {
+      setTransferMessage({ kind: 'error', text: validationError })
+      return
+    }
+
+    setStep('confirm')
+  }
+
+  const handleBack = () => {
+    if (isBusy) return
+    setTransferMessage({ kind: 'none' })
+    setStep('details')
   }
 
   const handleTransfer = async () => {
     setTransferMessage({ kind: 'none' })
 
-    if (!recipientUsername.trim()) {
-      setTransferMessage({
-        kind: 'error',
-        text: 'Please enter a recipient username',
-      })
-      return
-    }
-
-    if (!validateUsername(recipientUsername)) {
-      setTransferMessage({
-        kind: 'error',
-        text: 'Invalid username format. Use only letters, numbers, underscores, and hyphens (3-30 characters).',
-      })
-      return
-    }
-
-    if (recipientUsername.toLowerCase() === currentOwner.toLowerCase()) {
-      setTransferMessage({
-        kind: 'error',
-        text: 'Cannot transfer to the current owner',
-      })
+    const validationError = validateTransferInput()
+    if (validationError) {
+      setTransferMessage({ kind: 'error', text: validationError })
+      if (step === 'confirm') {
+        setStep('details')
+      }
       return
     }
 
     if (!actualNftId) {
-      setTransferMessage({
-        kind: 'error',
-        text: 'NFT not found for this article',
-      })
       return
     }
 
@@ -150,6 +191,7 @@ export function TransferModal({
   const handleClose = () => {
     if (isBusy) return
     setRecipientUsername('')
+    setStep('details')
     setTransferMessage({ kind: 'none' })
     onClose()
   }
@@ -172,6 +214,8 @@ export function TransferModal({
       <AlertCircle className="h-4 w-4 shrink-0 text-red-500" />
     ) : null
 
+  const irreversibleWarning = `You are transferring ownership of the NFT for "${articleTitle}" to @${recipientUsername}. This cannot be undone.`
+
   return (
     <Dialog
       open={isOpen}
@@ -180,7 +224,7 @@ export function TransferModal({
       }}
     >
       <DialogContent
-        className="w-[calc(100vw-2rem)] sm:max-w-md"
+        className="w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] overflow-x-hidden sm:max-w-md"
         onCloseAutoFocus={(e) => {
           if (triggerRef?.current) {
             e.preventDefault()
@@ -195,37 +239,102 @@ export function TransferModal({
         }}
       >
         <DialogHeader>
-          <DialogTitle>Transfer NFT Ownership</DialogTitle>
+          <DialogTitle>
+            {step === 'details'
+              ? 'Transfer NFT Ownership'
+              : 'Confirm transfer'}
+          </DialogTitle>
           <DialogDescription>
-            Transfer ownership of &quot;{articleTitle}&quot; to another user.
-            This action cannot be undone.
+            {step === 'details'
+              ? `Transfer ownership of "${articleTitle}" to another user.`
+              : 'Review the details below before completing this transfer.'}
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Label className="text-sm text-muted-foreground">
-              Current Owner
-            </Label>
-            <div className="max-w-full overflow-hidden px-3 py-2 bg-muted rounded-lg text-sm font-mono break-all">
-              @{currentOwner}
-            </div>
-          </div>
+        <div className="min-w-0 space-y-4">
+          {step === 'details' ? (
+            <>
+              <div className="space-y-2">
+                <Label className="text-sm text-muted-foreground">
+                  Current Owner
+                </Label>
+                <div className="max-w-full overflow-hidden rounded-lg bg-muted px-3 py-2 font-mono text-sm break-all">
+                  @{currentOwner}
+                </div>
+              </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="recipient">Transfer To (Username)</Label>
-            <Input
-              id="recipient"
-              placeholder="Enter recipient username"
-              value={recipientUsername}
-              onChange={(e) => setRecipientUsername(e.target.value)}
-              disabled={isBusy || transferMessage.kind === 'success'}
-              className="font-mono"
-            />
-            <p className="text-xs text-muted-foreground">
-              Enter the username of the recipient (e.g., johndoe)
-            </p>
-          </div>
+              <div className="space-y-2">
+                <Label htmlFor="recipient">Transfer To (Username)</Label>
+                <Input
+                  id="recipient"
+                  placeholder="Enter recipient username"
+                  value={recipientUsername}
+                  onChange={(e) => setRecipientUsername(e.target.value)}
+                  disabled={isBusy || transferMessage.kind === 'success'}
+                  className="font-mono"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Enter the username of the recipient (e.g., johndoe)
+                </p>
+              </div>
+            </>
+          ) : (
+            <>
+              <p
+                className="min-w-0 break-words rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+                data-testid="transfer-confirm-warning"
+              >
+                {irreversibleWarning}
+              </p>
+
+              <div className="min-w-0 space-y-2 overflow-hidden rounded-md border border-border bg-muted/40 p-3 text-sm">
+                <div className="min-w-0">
+                  <div className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                    Recipient
+                  </div>
+                  <p
+                    className="mt-0.5 font-mono font-medium break-all"
+                    data-testid="transfer-confirm-recipient"
+                  >
+                    @{recipientUsername}
+                  </p>
+                </div>
+                <div className="min-w-0">
+                  <div className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                    Asset
+                  </div>
+                  <p
+                    className="mt-0.5 break-words font-medium"
+                    data-testid="transfer-confirm-asset"
+                  >
+                    {articleTitle}
+                  </p>
+                </div>
+                <div className="min-w-0">
+                  <div className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                    NFT identifier
+                  </div>
+                  <p
+                    className="mt-0.5 font-mono text-xs break-all"
+                    data-testid="transfer-confirm-nft-id"
+                  >
+                    {nftIdentifier}
+                  </p>
+                </div>
+                <div className="min-w-0">
+                  <div className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                    Current owner
+                  </div>
+                  <p
+                    className="mt-0.5 font-mono text-xs break-all"
+                    data-testid="transfer-confirm-current-owner"
+                  >
+                    @{currentOwner}
+                  </p>
+                </div>
+              </div>
+            </>
+          )}
 
           <div
             className="flex min-h-[3.75rem] items-center rounded-lg"
@@ -247,32 +356,58 @@ export function TransferModal({
           </div>
         </div>
 
-        <DialogFooter>
-          <Button variant="outline" onClick={handleClose} disabled={isBusy}>
-            Cancel
-          </Button>
-          <Button
-            onClick={handleTransfer}
-            disabled={
-              isBusy ||
-              transferMessage.kind === 'success' ||
-              !recipientUsername.trim()
-            }
-            aria-busy={isBusy}
-            className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600"
-          >
-            {isBusy ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
-                Transfer NFT
-              </>
-            ) : (
-              <>
+        <DialogFooter className={step === 'confirm' ? 'sm:flex-row sm:justify-between' : undefined}>
+          {step === 'confirm' ? (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={handleBack}
+              disabled={isBusy || transferMessage.kind === 'success'}
+              className="sm:mr-auto"
+            >
+              Back
+            </Button>
+          ) : null}
+          <div className="flex w-full flex-col-reverse gap-2 sm:w-auto sm:flex-row sm:justify-end">
+            <Button variant="outline" onClick={handleClose} disabled={isBusy}>
+              Cancel
+            </Button>
+            {step === 'details' ? (
+              <Button
+                type="button"
+                onClick={handleReview}
+                disabled={
+                  isBusy ||
+                  transferMessage.kind === 'success' ||
+                  !recipientUsername.trim()
+                }
+                className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600"
+              >
                 <Send className="mr-2 h-4 w-4" aria-hidden />
-                Transfer NFT
-              </>
+                Review transfer
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                onClick={() => void handleTransfer()}
+                disabled={isBusy || transferMessage.kind === 'success'}
+                aria-busy={isBusy}
+                className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600"
+              >
+                {isBusy ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+                    Confirm transfer
+                  </>
+                ) : (
+                  <>
+                    <Send className="mr-2 h-4 w-4" aria-hidden />
+                    Confirm transfer
+                  </>
+                )}
+              </Button>
             )}
-          </Button>
+          </div>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/components/nft/index.ts
+++ b/components/nft/index.ts
@@ -1,5 +1,7 @@
 // NFT Component Exports
 export { MintButton } from './MintButton'
+export { NftCard } from './NftCard'
+export type { NftCardProps } from './NftCard'
 export { NFTBadge } from './NFTBadge'
 export { TransferModal } from './TransferModal'
 export { NFTIntegration } from './NFTIntegration'

--- a/components/profile/ProfileNftsTabContent.tsx
+++ b/components/profile/ProfileNftsTabContent.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import Link from 'next/link'
 import { usePathname, useSearchParams } from 'next/navigation'
 import {
   useNFTsByOwnerPaginated,
@@ -12,7 +13,8 @@ import { ProfileNftsTabSkeleton } from '@/components/profile/ProfileNftsTabSkele
 import { PaginationTransition } from '@/components/profile/PaginationTransition'
 import Pagination from '@/components/articles/Pagination'
 import { buildProfileNftPaginationHref } from '@/lib/profile/buildProfileNftPaginationHref'
-import { Image, Trophy } from 'lucide-react'
+import { NftCard } from '@/components/nft/NftCard'
+import { ImageIcon, Trophy } from 'lucide-react'
 
 const NFT_PAGE_LIMIT = 9
 
@@ -102,23 +104,17 @@ export function ProfileNftsTabContent({
           <PaginationTransition isPaginating={owned.isPaginating}>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {ownedNfts.map((nft) => (
-                <div
+                <NftCard
                   key={nft._id}
-                  className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-4"
-                >
-                  <div className="aspect-video bg-gradient-to-br from-purple-400 to-pink-400 rounded-lg mb-4 flex items-center justify-center">
-                    <Image className="w-12 h-12 text-white" aria-label="NFT" />
-                  </div>
-                  <h4 className="font-semibold text-foreground truncate">
-                    {nft.article?.title || 'Untitled'}
-                  </h4>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Token ID: {nft.tokenId.slice(0, 8)}...
-                  </p>
-                  <p className="text-xs text-muted-foreground/80 mt-2">
-                    Minted by @{nft.minter?.username || 'unknown'}
-                  </p>
-                </div>
+                  title={nft.article?.title || 'Untitled'}
+                  slug={nft.article?.slug}
+                  authorUsername={nft.article?.authorUsername}
+                  coverImage={nft.article?.coverImage}
+                  excerpt={nft.article?.excerpt}
+                  tokenId={nft.tokenId}
+                  footerLabel="Minted by"
+                  footerUsername={nft.minter?.username}
+                />
               ))}
             </div>
           </PaginationTransition>
@@ -149,23 +145,17 @@ export function ProfileNftsTabContent({
           <PaginationTransition isPaginating={minted.isPaginating}>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {mintedNfts.map((nft) => (
-                <div
+                <NftCard
                   key={nft._id}
-                  className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-4"
-                >
-                  <div className="aspect-video bg-gradient-to-br from-blue-400 to-green-400 rounded-lg mb-4 flex items-center justify-center">
-                    <Image className="w-12 h-12 text-white" aria-label="NFT" />
-                  </div>
-                  <h4 className="font-semibold text-foreground truncate">
-                    {nft.article?.title || 'Untitled'}
-                  </h4>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Token ID: {nft.tokenId.slice(0, 8)}...
-                  </p>
-                  <p className="text-xs text-muted-foreground/80 mt-2">
-                    Owner: @{nft.currentOwnerInfo?.username || 'unknown'}
-                  </p>
-                </div>
+                  title={nft.article?.title || 'Untitled'}
+                  slug={nft.article?.slug}
+                  authorUsername={nft.article?.authorUsername}
+                  coverImage={nft.article?.coverImage}
+                  excerpt={nft.article?.excerpt}
+                  tokenId={nft.tokenId}
+                  footerLabel="Owner"
+                  footerUsername={nft.currentOwnerInfo?.username}
+                />
               ))}
             </div>
           </PaginationTransition>
@@ -191,15 +181,27 @@ export function ProfileNftsTabContent({
       )}
 
       {bothEmpty && (
-        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-12 text-center">
-          <Image
+        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-8 sm:p-12 text-center">
+          <ImageIcon
             className="w-12 h-12 text-muted-foreground/50 mx-auto mb-4"
-            aria-label="No NFTs"
+            aria-hidden
           />
-          <p className="text-muted-foreground text-lg">
-            {isOwnProfile ? "You don't" : `${displayName} doesn't`} have any
-            NFTs yet.
+          <h3 className="text-lg font-semibold text-foreground mb-2">
+            No NFTs yet
+          </h3>
+          <p className="text-muted-foreground max-w-md mx-auto">
+            {isOwnProfile
+              ? 'Articles earn NFTs when they reach the tip threshold. Mint or collect one to see it here.'
+              : `${displayName} doesn't have any NFTs yet.`}
           </p>
+          {isOwnProfile && (
+            <Link
+              href="/articles"
+              className="focus-ring inline-block mt-6 text-sm font-medium text-brand-blue hover:underline"
+            >
+              Browse articles
+            </Link>
+          )}
         </div>
       )}
     </div>

--- a/components/profile/ProfileNftsTabSkeleton.tsx
+++ b/components/profile/ProfileNftsTabSkeleton.tsx
@@ -1,19 +1,28 @@
 import { Skeleton } from '@/components/ui/skeleton'
 
+function NftCardSkeleton() {
+  return (
+    <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-3 sm:p-4 min-w-0">
+      <Skeleton className="aspect-video w-full rounded-lg" />
+      <Skeleton className="h-5 w-3/4 mt-4" />
+      <Skeleton className="h-4 w-1/3 mt-2" />
+      <Skeleton className="h-4 w-full mt-2" />
+      <Skeleton className="h-4 w-1/2 mt-3" />
+      <Skeleton className="h-3 w-2/5 mt-2" />
+    </div>
+  )
+}
+
 export function ProfileNftsTabSkeleton() {
   return (
     <div className="space-y-8">
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <div
-            key={i}
-            className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-4"
-          >
-            <Skeleton className="aspect-video w-full rounded-lg mb-4" />
-            <Skeleton className="h-5 w-3/4 mb-2" />
-            <Skeleton className="h-4 w-1/2" />
-          </div>
-        ))}
+      <div>
+        <Skeleton className="h-7 w-40 mb-4" />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <NftCardSkeleton key={i} />
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/convex/nfts.ts
+++ b/convex/nfts.ts
@@ -501,6 +501,8 @@ export const getUserMintedNFTsPaginated = query({
                 id: article._id,
                 title: article.title,
                 slug: article.slug,
+                excerpt: article.excerpt,
+                coverImage: article.coverImage,
                 authorUsername: article.authorUsername,
               }
             : null,


### PR DESCRIPTION
## Summary

Prepares NFT ownership and transfer UX for production use: ownership is enforced by Convex user id (not Stellar address), transfers require an explicit review-and-confirm step with irreversibility messaging, and profile NFT tabs use a shared card component with richer article metadata.

## Changes

### Ownership readiness (`NFTIntegration`, article page)
- Determines transfer eligibility with `ownerInfo.id === currentUserId` instead of comparing Stellar addresses.
- Removes the `currentUserAddress` prop from `NFTIntegration` and the article page.
- Regression test: a former owner who still shares the same Stellar address as the current owner does **not** see **Transfer NFT** and sees the non-owner message instead.

### Two-step transfer with irreversible confirmation (`TransferModal`)
- Adds a **details** → **confirm** flow: enter recipient username → **Review transfer** → review summary → **Confirm transfer**.
- Confirmation step shows a destructive warning (“cannot be undone”), recipient, article title, NFT identifier, and current owner.
- Blocks self-transfer to the current owner on review (before any mutation).
- **Back** and **Cancel** on the confirm step do not call `transferNFT`.
- Uses `userFacingTransferNftError` for mutation errors; single `aria-live` message slot for progress, success, and error (no duplicate banners).
- Disables close/escape/outside-click while transfer is in progress; returns focus to the trigger button on close.

### Profile NFT presentation (`NftCard`, `ProfileNftsTabContent`)
- Introduces reusable `NftCard` (cover image or fallback, title link, author, excerpt, truncated token id, minted-by / owner footer).
- Replaces inline profile tab markup with `NftCard` for owned and minted grids.
- Improves empty state copy and adds **Browse articles** for own profile.
- Aligns `ProfileNftsTabSkeleton` with the new card layout.

### Backend (`convex/nfts.ts`)
- `getUserMintedNFTsPaginated` now returns `excerpt` and `coverImage` on article payloads so minted NFT cards can render consistently with owned NFTs.

### Tests
- `NFTIntegration.test.tsx` — transfer button visibility by user id vs shared address
- `TransferModal.test.tsx` — review/confirm flow, irreversible warning copy, cancel/back, self-transfer block, success/error/progress messaging, modal reset on reopen
- `NftCard.test.tsx` — cover image, fallback, links



## Testing

- `bun run test:once components/nft/NFTIntegration.test.tsx components/nft/TransferModal.test.tsx components/nft/NftCard.test.tsx`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run test:once`
- `bun run build` (temp worktree needed local `NEXT_PUBLIC_` env values; sandboxed run also needed Google Fonts network access)
- GitHub checks: `Required`, `PR Hygiene Required`, `Build`, `Lint, Typecheck & Test`, `Dependency Audit`, and Vercel passed

## Notes

- Manual preview QA passed on preview for the NFT transfer confirmation flow and profile NFT card rendering per Pragya on 2026-06-03. Preview: https://quilltip-git-eng-155-nf-884fff-pragya-sharmas-projects-a6320130.vercel.app
- No contract files, env files, screenshots, private evidence, or local QA artifacts are included in this PR.