### PR TITLE
fix: support batch tip verification

### DIFF
--- a/convex/highlightTips.test.ts
+++ b/convex/highlightTips.test.ts
@@ -68,6 +68,55 @@ function buildHighlightTipEnvelope(opts: {
   return tx.toEnvelope().toXDR('base64')
 }
 
+function buildHighlightBatchTipEnvelope(opts: {
+  tipper: string
+  author: string
+  contractId: string
+  amountStroops: bigint
+  highlightId?: string
+  articleId?: string
+}): string {
+  const account = new Account(opts.tipper, '1')
+  const contract = new Contract(opts.contractId)
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      contract.call(
+        'batch_tip_highlights',
+        nativeToScVal(opts.tipper, { type: 'address' }),
+        nativeToScVal(
+          [
+            {
+              highlight_id: opts.highlightId ?? 'hash-abc',
+              article_id: opts.articleId ?? 'article1',
+              author: opts.author,
+              amount: opts.amountStroops,
+            },
+            {
+              highlight_id: 'hash-def',
+              article_id: opts.articleId ?? 'article1',
+              author: opts.author,
+              amount: opts.amountStroops,
+            },
+          ],
+          {
+            type: {
+              highlight_id: ['symbol', 'string'],
+              article_id: ['symbol', 'symbol'],
+              author: ['symbol', 'address'],
+              amount: ['symbol', 'i128'],
+            },
+          }
+        )
+      )
+    )
+    .setTimeout(30)
+    .build()
+  return tx.toEnvelope().toXDR('base64')
+}
+
 async function seed(t: ReturnType<typeof convexTest>) {
   return await t.run(async (ctx) => {
     const now = Date.now()
@@ -609,6 +658,40 @@ describe('verifyHighlightTip action', () => {
 
       const article = await ctx.db.get(articleId)
       expect(article?.tipCount).toBe(1)
+    })
+  })
+
+  it('flips to CONFIRMED when Horizon returns a matching batch_tip_highlights', async () => {
+    const t = convexTest(schema, modules)
+    const { tipperId, articleId } = await seed(t)
+
+    const asTipper = t.withIdentity({ subject: tipperId })
+    const tipId = await asTipper.mutation(
+      api.highlightTips.create,
+      tipArgs(articleId, 'stellar-batch-tx-1')
+    )
+
+    stubHorizonResponse({
+      successful: true,
+      source_account: TIPPER_STELLAR,
+      ledger: 999,
+      envelope_xdr: buildHighlightBatchTipEnvelope({
+        tipper: TIPPER_STELLAR,
+        author: AUTHOR_STELLAR,
+        contractId: TIPPING_CONTRACT_ID,
+        amountStroops: TIP_STROOPS,
+      }),
+    })
+
+    await t.action(internal.stellarVerify.verifyHighlightTip, {
+      highlightTipId: tipId,
+      attempt: 1,
+    })
+
+    await t.run(async (ctx) => {
+      const tip = await ctx.db.get(tipId)
+      expect(tip?.status).toBe('CONFIRMED')
+      expect(tip?.stellarLedger).toBe(999)
     })
   })
 

--- a/convex/lib/constants.ts
+++ b/convex/lib/constants.ts
@@ -43,15 +43,21 @@ export function verifyDelayMs(attempt: number): number {
 // by the verifier are fixed for these names:
 //   tip_article / tip_article_with_arweave:
 //     [tipper, article_id, author, amount, (arweave_tx_id)]
+//   batch_tip:
+//     [tipper, [{ article_id, author, amount }]]
 //   tip_highlight_direct / tip_highlight_with_arweave:
 //     [tipper, highlight_id, article_id, author, amount, (arweave_tx_id)]
+//   batch_tip_highlights:
+//     [tipper, [{ highlight_id, article_id, author, amount }]]
 export const TIP_ARTICLE_FUNCTIONS = [
   'tip_article',
   'tip_article_with_arweave',
+  'batch_tip',
 ] as const
 export const TIP_HIGHLIGHT_FUNCTIONS = [
   'tip_highlight_direct',
   'tip_highlight_with_arweave',
+  'batch_tip_highlights',
 ] as const
 
 // Tipping contract ID is deployment-specific, so it is read from env at

--- a/convex/lib/horizon.test.ts
+++ b/convex/lib/horizon.test.ts
@@ -1,10 +1,29 @@
 /// <reference types="vite/client" />
 import { describe, expect, it } from 'vitest'
 import { verifyTipTransaction } from './horizon'
+import {
+  Account,
+  BASE_FEE,
+  Contract,
+  Keypair,
+  Networks,
+  TransactionBuilder,
+  nativeToScVal,
+} from '@stellar/stellar-sdk'
 
 const HORIZON = 'https://horizon-testnet.stellar.org'
 const TX = 'abc123'
-const SOURCE = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV'
+const SOURCE_KEYPAIR = Keypair.random()
+const AUTHOR_ONE_KEYPAIR = Keypair.random()
+const AUTHOR_TWO_KEYPAIR = Keypair.random()
+const ATTACKER_KEYPAIR = Keypair.random()
+const SOURCE = SOURCE_KEYPAIR.publicKey()
+const AUTHOR_ONE = AUTHOR_ONE_KEYPAIR.publicKey()
+const AUTHOR_TWO = AUTHOR_TWO_KEYPAIR.publicKey()
+const ATTACKER = ATTACKER_KEYPAIR.publicKey()
+const CONTRACT_ID = 'CC7Q3HDXQHMSI2WUE6C2KC35TRLPL22T3WEGZ67AB7KK5PDDJHQPZMZY'
+const WRONG_CONTRACT_ID =
+  'CAS44OQK7A6W5FDRAH3K3ZN7TTQTJ5ESRVG6MB2HBVFWZ5TVH26UUB4S'
 
 function makeFetch(
   response:
@@ -26,6 +45,91 @@ function makeFetch(
       },
     }
   }
+}
+
+function horizonBody(envelopeXdr: string) {
+  return {
+    successful: true,
+    source_account: SOURCE,
+    ledger: 12345,
+    envelope_xdr: envelopeXdr,
+  }
+}
+
+function buildArticleBatchEnvelope(opts: {
+  contractId?: string
+  tips: Array<{ articleId: string; author: string; amount: bigint }>
+}) {
+  const account = new Account(SOURCE, '1')
+  const contract = new Contract(opts.contractId ?? CONTRACT_ID)
+  const tips = opts.tips.map((tip) => ({
+    article_id: tip.articleId,
+    author: tip.author,
+    amount: tip.amount,
+  }))
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      contract.call(
+        'batch_tip',
+        nativeToScVal(SOURCE, { type: 'address' }),
+        nativeToScVal(tips, {
+          type: {
+            article_id: ['symbol', 'symbol'],
+            author: ['symbol', 'address'],
+            amount: ['symbol', 'i128'],
+          },
+        })
+      )
+    )
+    .setTimeout(30)
+    .build()
+
+  return tx.toEnvelope().toXDR('base64')
+}
+
+function buildHighlightBatchEnvelope(opts: {
+  tips: Array<{
+    highlightId: string
+    articleId: string
+    author: string
+    amount: bigint
+  }>
+}) {
+  const account = new Account(SOURCE, '1')
+  const contract = new Contract(CONTRACT_ID)
+  const tips = opts.tips.map((tip) => ({
+    highlight_id: tip.highlightId,
+    article_id: tip.articleId,
+    author: tip.author,
+    amount: tip.amount,
+  }))
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      contract.call(
+        'batch_tip_highlights',
+        nativeToScVal(SOURCE, { type: 'address' }),
+        nativeToScVal(tips, {
+          type: {
+            highlight_id: ['symbol', 'string'],
+            article_id: ['symbol', 'symbol'],
+            author: ['symbol', 'address'],
+            amount: ['symbol', 'i128'],
+          },
+        })
+      )
+    )
+    .setTimeout(30)
+    .build()
+
+  return tx.toEnvelope().toXDR('base64')
 }
 
 describe('verifyTipTransaction', () => {
@@ -82,6 +186,29 @@ describe('verifyTipTransaction', () => {
       ok: false,
       kind: 'transient',
       reason: 'network_error',
+    })
+  })
+
+  it('returns transient server_error before parsing an expected batch invocation', async () => {
+    const fetchImpl = makeFetch({ status: 503 })
+    const result = await verifyTipTransaction(fetchImpl, {
+      txId: TX,
+      expectedSource: SOURCE,
+      horizonUrl: HORIZON,
+      invocation: {
+        contractId: CONTRACT_ID,
+        allowedFunctions: ['batch_tip'],
+        authorAddress: AUTHOR_ONE,
+        minStroops: BigInt(100_000_000),
+        batchTips: [
+          { authorAddress: AUTHOR_ONE, minStroops: BigInt(100_000_000) },
+        ],
+      },
+    })
+    expect(result).toEqual({
+      ok: false,
+      kind: 'transient',
+      reason: 'server_error',
     })
   })
 
@@ -191,5 +318,244 @@ describe('verifyTipTransaction', () => {
       horizonUrl: `${HORIZON}/`,
     })
     expect(capturedUrl).toBe(`${HORIZON}/transactions/${TX}`)
+  })
+
+  it('accepts batch_tip when every article tip matches expected batch items', async () => {
+    const envelopeXdr = buildArticleBatchEnvelope({
+      tips: [
+        {
+          articleId: 'article-one',
+          author: AUTHOR_ONE,
+          amount: BigInt(100_000_000),
+        },
+        {
+          articleId: 'article-two',
+          author: AUTHOR_TWO,
+          amount: BigInt(250_000_000),
+        },
+      ],
+    })
+    const fetchImpl = makeFetch({ status: 200, body: horizonBody(envelopeXdr) })
+
+    const result = await verifyTipTransaction(fetchImpl, {
+      txId: TX,
+      expectedSource: SOURCE,
+      horizonUrl: HORIZON,
+      invocation: {
+        contractId: CONTRACT_ID,
+        allowedFunctions: ['batch_tip'],
+        authorAddress: AUTHOR_ONE,
+        minStroops: BigInt(100_000_000),
+        batchTips: [
+          { authorAddress: AUTHOR_ONE, minStroops: BigInt(100_000_000) },
+          { authorAddress: AUTHOR_TWO, minStroops: BigInt(200_000_000) },
+        ],
+      },
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      ledger: 12345,
+      onChainStroops: BigInt(350_000_000),
+    })
+  })
+
+  it('accepts batch_tip_highlights when every highlight tip matches expected batch items', async () => {
+    const envelopeXdr = buildHighlightBatchEnvelope({
+      tips: [
+        {
+          highlightId: 'highlight-1',
+          articleId: 'article-one',
+          author: AUTHOR_ONE,
+          amount: BigInt(125_000_000),
+        },
+        {
+          highlightId: 'highlight-2',
+          articleId: 'article-two',
+          author: AUTHOR_TWO,
+          amount: BigInt(175_000_000),
+        },
+      ],
+    })
+    const fetchImpl = makeFetch({ status: 200, body: horizonBody(envelopeXdr) })
+
+    const result = await verifyTipTransaction(fetchImpl, {
+      txId: TX,
+      expectedSource: SOURCE,
+      horizonUrl: HORIZON,
+      invocation: {
+        contractId: CONTRACT_ID,
+        allowedFunctions: ['batch_tip_highlights'],
+        authorAddress: AUTHOR_ONE,
+        minStroops: BigInt(100_000_000),
+        batchTips: [
+          { authorAddress: AUTHOR_ONE, minStroops: BigInt(100_000_000) },
+          { authorAddress: AUTHOR_TWO, minStroops: BigInt(150_000_000) },
+        ],
+      },
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      ledger: 12345,
+      onChainStroops: BigInt(300_000_000),
+    })
+  })
+
+  it('rejects batch_tip when the contract is wrong', async () => {
+    const envelopeXdr = buildArticleBatchEnvelope({
+      contractId: WRONG_CONTRACT_ID,
+      tips: [
+        {
+          articleId: 'article-one',
+          author: AUTHOR_ONE,
+          amount: BigInt(100_000_000),
+        },
+      ],
+    })
+    const fetchImpl = makeFetch({ status: 200, body: horizonBody(envelopeXdr) })
+
+    const result = await verifyTipTransaction(fetchImpl, {
+      txId: TX,
+      expectedSource: SOURCE,
+      horizonUrl: HORIZON,
+      invocation: {
+        contractId: CONTRACT_ID,
+        allowedFunctions: ['batch_tip'],
+        authorAddress: AUTHOR_ONE,
+        minStroops: BigInt(100_000_000),
+        batchTips: [
+          { authorAddress: AUTHOR_ONE, minStroops: BigInt(100_000_000) },
+        ],
+      },
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      kind: 'permanent',
+      reason: 'contract_mismatch',
+    })
+  })
+
+  it('rejects batch_tip when any article tip author is wrong', async () => {
+    const envelopeXdr = buildArticleBatchEnvelope({
+      tips: [
+        {
+          articleId: 'article-one',
+          author: AUTHOR_ONE,
+          amount: BigInt(100_000_000),
+        },
+        {
+          articleId: 'article-two',
+          author: ATTACKER,
+          amount: BigInt(250_000_000),
+        },
+      ],
+    })
+    const fetchImpl = makeFetch({ status: 200, body: horizonBody(envelopeXdr) })
+
+    const result = await verifyTipTransaction(fetchImpl, {
+      txId: TX,
+      expectedSource: SOURCE,
+      horizonUrl: HORIZON,
+      invocation: {
+        contractId: CONTRACT_ID,
+        allowedFunctions: ['batch_tip'],
+        authorAddress: AUTHOR_ONE,
+        minStroops: BigInt(100_000_000),
+        batchTips: [
+          { authorAddress: AUTHOR_ONE, minStroops: BigInt(100_000_000) },
+          { authorAddress: AUTHOR_TWO, minStroops: BigInt(200_000_000) },
+        ],
+      },
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      kind: 'permanent',
+      reason: 'author_mismatch',
+    })
+  })
+
+  it('rejects batch_tip when any article tip amount is too small', async () => {
+    const envelopeXdr = buildArticleBatchEnvelope({
+      tips: [
+        {
+          articleId: 'article-one',
+          author: AUTHOR_ONE,
+          amount: BigInt(100_000_000),
+        },
+        {
+          articleId: 'article-two',
+          author: AUTHOR_TWO,
+          amount: BigInt(50_000_000),
+        },
+      ],
+    })
+    const fetchImpl = makeFetch({ status: 200, body: horizonBody(envelopeXdr) })
+
+    const result = await verifyTipTransaction(fetchImpl, {
+      txId: TX,
+      expectedSource: SOURCE,
+      horizonUrl: HORIZON,
+      invocation: {
+        contractId: CONTRACT_ID,
+        allowedFunctions: ['batch_tip'],
+        authorAddress: AUTHOR_ONE,
+        minStroops: BigInt(100_000_000),
+        batchTips: [
+          { authorAddress: AUTHOR_ONE, minStroops: BigInt(100_000_000) },
+          { authorAddress: AUTHOR_TWO, minStroops: BigInt(200_000_000) },
+        ],
+      },
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      kind: 'permanent',
+      reason: 'amount_mismatch',
+    })
+  })
+
+  it('rejects batch_tip_highlights when any highlight tip amount is too small', async () => {
+    const envelopeXdr = buildHighlightBatchEnvelope({
+      tips: [
+        {
+          highlightId: 'highlight-1',
+          articleId: 'article-one',
+          author: AUTHOR_ONE,
+          amount: BigInt(125_000_000),
+        },
+        {
+          highlightId: 'highlight-2',
+          articleId: 'article-two',
+          author: AUTHOR_TWO,
+          amount: BigInt(50_000_000),
+        },
+      ],
+    })
+    const fetchImpl = makeFetch({ status: 200, body: horizonBody(envelopeXdr) })
+
+    const result = await verifyTipTransaction(fetchImpl, {
+      txId: TX,
+      expectedSource: SOURCE,
+      horizonUrl: HORIZON,
+      invocation: {
+        contractId: CONTRACT_ID,
+        allowedFunctions: ['batch_tip_highlights'],
+        authorAddress: AUTHOR_ONE,
+        minStroops: BigInt(100_000_000),
+        batchTips: [
+          { authorAddress: AUTHOR_ONE, minStroops: BigInt(100_000_000) },
+          { authorAddress: AUTHOR_TWO, minStroops: BigInt(150_000_000) },
+        ],
+      },
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      kind: 'permanent',
+      reason: 'amount_mismatch',
+    })
   })
 })

--- a/convex/lib/horizon.ts
+++ b/convex/lib/horizon.ts
@@ -44,6 +44,12 @@ export type TipInvocationExpectations = {
   allowedFunctions: readonly string[]
   authorAddress: string
   minStroops: bigint
+  batchTips?: readonly TipInvocationTipExpectation[]
+}
+
+export type TipInvocationTipExpectation = {
+  authorAddress: string
+  minStroops: bigint
 }
 
 type MinimalFetch = (
@@ -188,6 +194,13 @@ function verifyInvocation(
   }
 
   const fnArgs = ic.args()
+  if (fnName === 'batch_tip' || fnName === 'batch_tip_highlights') {
+    return verifyBatchInvocation(fnName, fnArgs, {
+      expectedSource: args.expectedSource,
+      invocation: args.invocation,
+    })
+  }
+
   const isHighlightFn =
     fnName === 'tip_highlight_direct' || fnName === 'tip_highlight_with_arweave'
   const tipperIdx = 0
@@ -234,6 +247,101 @@ function verifyInvocation(
   }
 
   return { kind: 'ok', onChainStroops: nativeAmount }
+}
+
+function verifyBatchInvocation(
+  fnName: string,
+  fnArgs: xdr.ScVal[],
+  args: {
+    expectedSource: string
+    invocation: TipInvocationExpectations
+  }
+): InvocationOk | InvocationFail {
+  if (fnArgs.length !== 2) {
+    return { kind: 'fail', reason: 'malformed_response' }
+  }
+
+  const tipperArg = fnArgs[0]
+  const tipsArg = fnArgs[1]
+  if (!tipperArg || !tipsArg) {
+    return { kind: 'fail', reason: 'malformed_response' }
+  }
+
+  let nativeTipper: unknown
+  let nativeTips: unknown
+  try {
+    nativeTipper = scValToNative(tipperArg)
+    nativeTips = scValToNative(tipsArg)
+  } catch {
+    return { kind: 'fail', reason: 'malformed_response' }
+  }
+
+  if (typeof nativeTipper !== 'string') {
+    return { kind: 'fail', reason: 'malformed_response' }
+  }
+  if (nativeTipper !== args.expectedSource) {
+    return { kind: 'fail', reason: 'tipper_mismatch' }
+  }
+  if (!Array.isArray(nativeTips) || nativeTips.length === 0) {
+    return { kind: 'fail', reason: 'malformed_response' }
+  }
+
+  const expectations = args.invocation.batchTips
+  if (expectations && expectations.length !== nativeTips.length) {
+    return { kind: 'fail', reason: 'malformed_response' }
+  }
+
+  let totalStroops = BigInt(0)
+  for (let index = 0; index < nativeTips.length; index++) {
+    const tip = nativeTips[index]
+    if (!isNativeBatchTip(tip, fnName)) {
+      return { kind: 'fail', reason: 'malformed_response' }
+    }
+
+    const expected = expectations?.[index] ?? {
+      authorAddress: args.invocation.authorAddress,
+      minStroops: args.invocation.minStroops,
+    }
+
+    if (tip.author !== expected.authorAddress) {
+      return { kind: 'fail', reason: 'author_mismatch' }
+    }
+    if (tip.amount < expected.minStroops) {
+      return { kind: 'fail', reason: 'amount_mismatch' }
+    }
+
+    totalStroops += tip.amount
+  }
+
+  return { kind: 'ok', onChainStroops: totalStroops }
+}
+
+type NativeBatchTip = {
+  article_id: string
+  author: string
+  amount: bigint
+  highlight_id?: string
+}
+
+function isNativeBatchTip(
+  value: unknown,
+  fnName: string
+): value is NativeBatchTip {
+  if (typeof value !== 'object' || value === null) return false
+  const tip = value as Record<string, unknown>
+  if (
+    typeof tip.article_id !== 'string' ||
+    typeof tip.author !== 'string' ||
+    typeof tip.amount !== 'bigint'
+  ) {
+    return false
+  }
+
+  if (fnName === 'batch_tip_highlights') {
+    return typeof tip.highlight_id === 'string'
+  }
+
+  return tip.highlight_id === undefined
 }
 
 function extractInnerTransaction(

--- a/convex/reconcileTips.test.ts
+++ b/convex/reconcileTips.test.ts
@@ -72,6 +72,50 @@ function buildArticleTipEnvelope(opts: {
   return tx.toEnvelope().toXDR('base64')
 }
 
+function buildArticleBatchTipEnvelope(opts: {
+  tipper: string
+  author: string
+  contractId: string
+  amountStroops: bigint
+}): string {
+  const account = new Account(opts.tipper, '1')
+  const contract = new Contract(opts.contractId)
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      contract.call(
+        'batch_tip',
+        nativeToScVal(opts.tipper, { type: 'address' }),
+        nativeToScVal(
+          [
+            {
+              article_id: 'article1',
+              author: opts.author,
+              amount: opts.amountStroops,
+            },
+            {
+              article_id: 'article2',
+              author: opts.author,
+              amount: opts.amountStroops,
+            },
+          ],
+          {
+            type: {
+              article_id: ['symbol', 'symbol'],
+              author: ['symbol', 'address'],
+              amount: ['symbol', 'i128'],
+            },
+          }
+        )
+      )
+    )
+    .setTimeout(30)
+    .build()
+  return tx.toEnvelope().toXDR('base64')
+}
+
 // Horizon success response shape — must include `source_account` (outer tx
 // source, checked before invocation parsing) alongside the envelope XDR.
 function horizonSuccessBody(envelopeXdr: string, sourceAccount: string) {
@@ -220,6 +264,31 @@ describe('reconcileArticleTips', () => {
     expect(article?.tipCount).toBe(1)
     expect(tipper?.tipsSentCount).toBe(1)
     expect(author?.tipsReceivedCount).toBe(1)
+  })
+
+  it('leaves a CONFIRMED tip untouched when Horizon returns a matching batch_tip', async () => {
+    const t = convexTest(schema, modules)
+    const { tipId } = await seedConfirmedTip(t)
+
+    const envelope = buildArticleBatchTipEnvelope({
+      tipper: TIPPER_STELLAR,
+      author: AUTHOR_STELLAR,
+      contractId: TIPPING_CONTRACT_ID,
+      amountStroops: BigInt(10_000_000),
+    })
+    stubHorizonJson(horizonSuccessBody(envelope, TIPPER_STELLAR))
+
+    const summary = await t.action(
+      internal.reconcileTips.reconcileArticleTips,
+      {}
+    )
+
+    expect(summary.ok).toBe(1)
+    expect(summary.flagged).toBe(0)
+    expect(summary.unreachable).toBe(0)
+
+    const tip = await t.run(async (ctx) => await ctx.db.get(tipId))
+    expect(tip?.status).toBe('CONFIRMED')
   })
 
   it('marks FRAUDULENT and reverses counters on contract_mismatch when flag is on', async () => {


### PR DESCRIPTION
## Summary

Implements ENG-234 batch transaction verification for the Stellar tipping contract verifier.

## Changes

- Add `batch_tip` and `batch_tip_highlights` to the allowed verification function lists.
- Parse batch article and highlight tip argument vectors from Soroban transaction XDR.
- Verify the batch tipper, contract ID, author, and minimum stroops for each batch item.
- Add focused coverage for matching batches, wrong contract, wrong author, wrong amount, and transient Horizon errors.

## Testing

- `bun run test:once convex/lib/horizon.test.ts convex/reconcileTips.test.ts convex/highlightTips.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run test:once`
- `bun run build` (sandboxed run failed on Google Font fetches; approved network rerun passed)

## Notes

- Contract files were not touched.
- Branch was refreshed with latest `development` after PR #194 merged.
- Manual wallet-backed batch QA is not applicable to this verifier-only PR. Batch wallet/Convex evidence remains for ENG-235 / the later local evidence runner task.
