### PR TITLE
feat(articles): reading polish with loading status, share fallbacks, and active TOC (ENG-149)

### DIFF
--- a/app/[username]/[slug]/page.tsx
+++ b/app/[username]/[slug]/page.tsx
@@ -46,6 +46,9 @@ import {
 import { ReadingProgressBar } from '@/components/articles/ReadingProgressBar'
 import { extractH2HeadingsFromTiptapJson } from '@/lib/tiptap/headings'
 import { ArticleTableOfContents } from '@/components/articles/ArticleTableOfContents'
+import { LoadingRegion } from '@/components/a11y/LoadingRegion'
+import { useStaleLoading } from '@/hooks/useStaleLoading'
+import { useRouter } from 'next/navigation'
 
 interface ArticlePageProps {
   params: Promise<{
@@ -58,8 +61,10 @@ export default function ArticlePage({ params }: ArticlePageProps) {
   const { username, slug } = use(params)
   const [showHighlightsPanel, setShowHighlightsPanel] = useState(false)
   const { user } = useAuth()
+  const router = useRouter()
 
   const article = useArticleBySlug(username, slug)
+  const { isStale, reset: resetStale } = useStaleLoading(article === undefined)
 
   const highlights = useArticleHighlightsQuery(article?._id)
 
@@ -87,11 +92,22 @@ export default function ArticlePage({ params }: ArticlePageProps) {
   }
 
   // Show loading while article is being fetched
-  if (!article) {
+  if (article === undefined) {
     return (
       <div className="min-h-screen bg-background">
         <AppNavigation />
-        <ArticlePageLoadingSkeleton />
+        <LoadingRegion
+          label="article"
+          isLoading
+          isStale={isStale}
+          onRetry={() => {
+            resetStale()
+            router.refresh()
+          }}
+          fallback={<ArticlePageLoadingSkeleton />}
+        >
+          <div />
+        </LoadingRegion>
       </div>
     )
   }

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -3,6 +3,8 @@
 import { useUserByUsername, useUserStats } from '@/hooks/convex'
 import { use, useState, useEffect } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { LoadingRegion } from '@/components/a11y/LoadingRegion'
+import { useStaleLoading } from '@/hooks/useStaleLoading'
 import {
   buildProfileTabHref,
   parseProfileTab,
@@ -51,6 +53,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
 
   // Fetch user profile
   const user = useUserByUsername(username)
+  const { isStale, reset: resetStale } = useStaleLoading(user === undefined)
 
   // Sync local wallet address with user data
   useEffect(() => {
@@ -84,11 +87,22 @@ export default function ProfilePage({ params }: ProfilePageProps) {
   }
 
   // Show loading while data is being fetched
-  if (!user) {
+  if (user === undefined) {
     return (
       <div className="min-h-screen bg-background">
         <AppNavigation />
-        <ProfilePageLoadingSkeleton />
+        <LoadingRegion
+          label="profile"
+          isLoading
+          isStale={isStale}
+          onRetry={() => {
+            resetStale()
+            router.refresh()
+          }}
+          fallback={<ProfilePageLoadingSkeleton />}
+        >
+          <div />
+        </LoadingRegion>
       </div>
     )
   }

--- a/app/write/page.tsx
+++ b/app/write/page.tsx
@@ -7,9 +7,14 @@ import { EditorChromeSkeleton } from '@/components/editor/EditorChromeSkeleton'
 import { ErrorBoundary } from '@/components/error/ErrorBoundary'
 import { EditorWorkspaceErrorFallback } from '@/components/error/SectionErrorFallback'
 import { WriteEditorWorkspace } from '@/components/editor/WriteEditorWorkspace'
+import { LoadingRegion } from '@/components/a11y/LoadingRegion'
+import { useStaleLoading } from '@/hooks/useStaleLoading'
+import { useRouter } from 'next/navigation'
 
 export default function WritePage() {
   const { isAuthenticated, isLoading } = useAuth()
+  const router = useRouter()
+  const { isStale, reset: resetStale } = useStaleLoading(isLoading)
 
   useRedirectWhenUnauthenticated(isLoading, isAuthenticated)
 
@@ -17,7 +22,18 @@ export default function WritePage() {
     return (
       <div className="min-h-screen bg-background">
         <AppNavigation />
-        <EditorChromeSkeleton />
+        <LoadingRegion
+          label="editor"
+          isLoading
+          isStale={isStale}
+          onRetry={() => {
+            resetStale()
+            router.refresh()
+          }}
+          fallback={<EditorChromeSkeleton />}
+        >
+          <div />
+        </LoadingRegion>
       </div>
     )
   }

--- a/components/a11y/LoadingRegion.tsx
+++ b/components/a11y/LoadingRegion.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+type LoadingRegionProps = {
+  label: string
+  isLoading: boolean
+  isStale: boolean
+  onRetry: () => void
+  fallback: ReactNode
+  children: ReactNode
+  className?: string
+}
+
+export function LoadingRegion({
+  label,
+  isLoading,
+  isStale,
+  onRetry,
+  fallback,
+  children,
+  className,
+}: LoadingRegionProps) {
+  const prevIsLoadingRef = useRef<boolean>(false)
+  const [announcement, setAnnouncement] = useState<string>('')
+
+  const liveText = useMemo(() => {
+    if (!announcement) return ''
+    return announcement
+  }, [announcement])
+
+  useEffect(() => {
+    const prevIsLoading = prevIsLoadingRef.current
+    prevIsLoadingRef.current = isLoading
+
+    if (isLoading && !prevIsLoading) {
+      setAnnouncement(`Loading ${label}.`)
+      return
+    }
+
+    if (!isLoading && prevIsLoading) {
+      setAnnouncement(`${label} loaded.`)
+    }
+  }, [isLoading, label])
+
+  return (
+    <div
+      className={className}
+      aria-busy={isLoading && !isStale ? true : undefined}
+    >
+      <p className="sr-only" role="status" aria-live="polite">
+        {liveText}
+      </p>
+
+      {isLoading ? (
+        isStale ? (
+          <div
+            role="alert"
+            className={cn(
+              'mx-auto max-w-2xl rounded-lg border border-border bg-muted p-6 text-center',
+              className
+            )}
+          >
+            <p className="font-medium text-foreground">
+              Still loading {label}.
+            </p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              This is taking longer than expected. Try again, or reload the
+              page.
+            </p>
+            <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+              <Button
+                type="button"
+                onClick={onRetry}
+                className="min-w-[9.5rem]"
+              >
+                Try again
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => window.location.reload()}
+              >
+                Reload page
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div aria-hidden>{fallback}</div>
+        )
+      ) : (
+        children
+      )}
+    </div>
+  )
+}
+

--- a/components/a11y/LoadingRegion.tsx
+++ b/components/a11y/LoadingRegion.tsx
@@ -96,4 +96,3 @@ export function LoadingRegion({
     </div>
   )
 }
-

--- a/components/articles/ArticleCardSkeleton.tsx
+++ b/components/articles/ArticleCardSkeleton.tsx
@@ -2,7 +2,10 @@ import { Skeleton } from '@/components/ui/skeleton'
 
 export function ArticleCardSkeleton() {
   return (
-    <div className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border overflow-hidden">
+    <div
+      className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border overflow-hidden"
+      aria-hidden
+    >
       {/* Cover image placeholder */}
       <Skeleton className="h-48 w-full rounded-none" />
 

--- a/components/articles/ArticleEngagementSkeleton.tsx
+++ b/components/articles/ArticleEngagementSkeleton.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 
 export function TipButtonSkeleton() {
   return (
-    <div className="space-y-3">
+    <div className="space-y-3" aria-hidden>
       <Skeleton className="h-10 w-full" />
       <Skeleton className="h-4 w-3/4" />
     </div>
@@ -11,7 +11,7 @@ export function TipButtonSkeleton() {
 
 export function NftSidebarSkeleton() {
   return (
-    <div className="space-y-3">
+    <div className="space-y-3" aria-hidden>
       <Skeleton className="h-4 w-full" />
       <Skeleton className="h-4 w-5/6" />
       <Skeleton className="h-10 w-full" />

--- a/components/articles/ArticlePageLoadingSkeleton.tsx
+++ b/components/articles/ArticlePageLoadingSkeleton.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 
 export function ArticlePageLoadingSkeleton() {
   return (
-    <main className="pt-20">
+    <main className="pt-20" aria-hidden>
       <div className="max-w-4xl mx-auto px-4 py-8">
         <Skeleton className="h-96 w-full rounded-lg mb-8" />
         <Skeleton className="h-8 w-3/4 mb-4" />

--- a/components/articles/ArticleTableOfContents.tsx
+++ b/components/articles/ArticleTableOfContents.tsx
@@ -1,11 +1,14 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { pickActiveId } from '@/lib/articles/tocActiveSection'
 import type { TocHeading } from '@/lib/tiptap/headings'
 
 const ARTICLE_ROOT_SELECTOR = '.article-content'
-/** Below fixed nav (h-16) + thin progress strip; aligns with prose scroll-margin. */
-const ACTIVE_HEADING_TOP_OFFSET_PX = 96
+const TOC_HEADING_ID = 'article-toc-heading'
+
+const TOC_LINK_CLASS =
+  'block w-full text-left text-sm rounded px-2 py-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
 
 interface ArticleTableOfContentsProps {
   headings: TocHeading[]
@@ -17,22 +20,6 @@ function getHeadingElements(ids: string[]): HTMLElement[] {
     .filter((el): el is HTMLElement => el instanceof HTMLElement)
 }
 
-function pickActiveId(ids: string[]): string | null {
-  let active: string | null = null
-  let firstFound: string | null = null
-
-  for (const id of ids) {
-    const el = document.getElementById(id)
-    if (!el) continue
-    if (firstFound == null) firstFound = id
-    if (el.getBoundingClientRect().top <= ACTIVE_HEADING_TOP_OFFSET_PX) {
-      active = id
-    }
-  }
-
-  return active ?? firstFound
-}
-
 export function ArticleTableOfContents({
   headings,
 }: ArticleTableOfContentsProps) {
@@ -41,6 +28,13 @@ export function ArticleTableOfContents({
 
   const ids = useMemo(() => headings.map((h) => h.id), [headings])
 
+  const syncActiveFromScroll = useCallback(() => {
+    setActiveId((prev) => {
+      const next = pickActiveId(ids)
+      return prev === next ? prev : next
+    })
+  }, [ids])
+
   useEffect(() => {
     if (!enabled) return
 
@@ -48,18 +42,27 @@ export function ArticleTableOfContents({
 
     let scrollCleanup: (() => void) | null = null
     let mo: MutationObserver | null = null
+    let raf: number | null = null
 
-    const updateActive = () => {
-      setActiveId(pickActiveId(ids))
+    const scheduleSyncActive = () => {
+      if (raf != null) return
+      raf = requestAnimationFrame(() => {
+        raf = null
+        syncActiveFromScroll()
+      })
     }
 
     const attachScrollListeners = () => {
-      updateActive()
-      window.addEventListener('scroll', updateActive, { passive: true })
-      window.addEventListener('resize', updateActive)
+      syncActiveFromScroll()
+      window.addEventListener('scroll', scheduleSyncActive, { passive: true })
+      window.addEventListener('resize', scheduleSyncActive)
       return () => {
-        window.removeEventListener('scroll', updateActive)
-        window.removeEventListener('resize', updateActive)
+        window.removeEventListener('scroll', scheduleSyncActive)
+        window.removeEventListener('resize', scheduleSyncActive)
+        if (raf != null) {
+          cancelAnimationFrame(raf)
+          raf = null
+        }
       }
     }
 
@@ -83,37 +86,47 @@ export function ArticleTableOfContents({
     return () => {
       mo?.disconnect()
       scrollCleanup?.()
+      if (raf != null) cancelAnimationFrame(raf)
     }
-  }, [enabled, ids])
+  }, [enabled, ids, syncActiveFromScroll])
+
+  const scrollToHeading = useCallback((id: string) => {
+    setActiveId(id)
+    document.getElementById(id)?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'start',
+    })
+  }, [])
 
   if (!enabled) return null
 
   return (
     <div className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-[var(--card-padding)]">
-      <h3 className="text-lg font-semibold mb-3">On this page</h3>
-      <nav aria-label="Table of contents">
+      <h3 id={TOC_HEADING_ID} className="text-lg font-semibold mb-3">
+        On this page
+      </h3>
+      <nav aria-labelledby={TOC_HEADING_ID}>
         <ul className="space-y-1">
           {headings.map((h) => {
             const isActive = activeId === h.id
             return (
               <li key={h.id}>
-                <button
-                  type="button"
-                  onClick={() => {
-                    document.getElementById(h.id)?.scrollIntoView({
-                      behavior: 'smooth',
-                      block: 'start',
-                    })
+                <a
+                  href={`#${h.id}`}
+                  aria-current={isActive ? 'location' : undefined}
+                  onClick={(e) => {
+                    e.preventDefault()
+                    scrollToHeading(h.id)
                   }}
                   className={[
-                    'w-full text-left text-sm rounded px-2 py-1.5 transition-colors',
+                    TOC_LINK_CLASS,
                     isActive
                       ? 'bg-primary/10 text-foreground'
                       : 'text-muted-foreground hover:bg-muted hover:text-foreground',
                   ].join(' ')}
                 >
                   {h.text}
-                </button>
+                </a>
               </li>
             )
           })}

--- a/components/articles/ReadingProgressBar.tsx
+++ b/components/articles/ReadingProgressBar.tsx
@@ -91,45 +91,79 @@ function getScrollProgress(nested: HTMLElement | null): number {
 export function ReadingProgressBar() {
   const [progress, setProgress] = useState(0)
   const nestedRef = useRef<HTMLElement | null>(null)
-  const frameRef = useRef(0)
+  const nestedScrollCleanupRef = useRef<(() => void) | null>(null)
+  const rafPendingRef = useRef(false)
+  const frameRef = useRef<number | null>(null)
 
   useEffect(() => {
+    const updateProgressNow = () => {
+      const next = getScrollProgress(nestedRef.current)
+      setProgress((prev) => (Object.is(prev, next) ? prev : next))
+    }
+
+    const scheduleUpdate = () => {
+      if (rafPendingRef.current) return
+      rafPendingRef.current = true
+      frameRef.current = window.requestAnimationFrame(() => {
+        rafPendingRef.current = false
+        updateProgressNow()
+      })
+    }
+
     const refreshNested = () => {
-      nestedRef.current = findLikelyNestedScrollRoot()
+      const nextNested = findLikelyNestedScrollRoot()
+      if (nestedRef.current === nextNested) return
+
+      nestedScrollCleanupRef.current?.()
+      nestedScrollCleanupRef.current = null
+      nestedRef.current = nextNested
+
+      if (nextNested) {
+        const onNestedScroll = () => scheduleUpdate()
+        nextNested.addEventListener('scroll', onNestedScroll, { passive: true })
+        nestedScrollCleanupRef.current = () => {
+          nextNested.removeEventListener('scroll', onNestedScroll)
+        }
+      }
+
+      scheduleUpdate()
     }
 
     refreshNested()
+    scheduleUpdate()
 
     const ro =
       typeof ResizeObserver !== 'undefined'
         ? new ResizeObserver(() => {
             refreshNested()
+            scheduleUpdate()
           })
         : null
     ro?.observe(document.documentElement)
     if (document.body) ro?.observe(document.body)
 
-    const onLayout = () => refreshNested()
+    const onLayout = () => {
+      refreshNested()
+      scheduleUpdate()
+    }
+    const onScroll = () => scheduleUpdate()
+
     window.addEventListener('load', onLayout)
     window.addEventListener('resize', onLayout)
+    window.addEventListener('scroll', onScroll, { passive: true })
     visualViewport?.addEventListener('resize', onLayout)
 
-    let frameCount = 0
-    const tick = () => {
-      frameCount += 1
-      if (frameCount % 45 === 0) refreshNested()
-
-      const next = getScrollProgress(nestedRef.current)
-      setProgress((prev) => (Object.is(prev, next) ? prev : next))
-
-      frameRef.current = requestAnimationFrame(tick)
-    }
-    frameRef.current = requestAnimationFrame(tick)
-
     return () => {
-      cancelAnimationFrame(frameRef.current)
+      nestedScrollCleanupRef.current?.()
+      nestedScrollCleanupRef.current = null
+
+      if (frameRef.current != null) cancelAnimationFrame(frameRef.current)
+      frameRef.current = null
+      rafPendingRef.current = false
+
       window.removeEventListener('load', onLayout)
       window.removeEventListener('resize', onLayout)
+      window.removeEventListener('scroll', onScroll)
       visualViewport?.removeEventListener('resize', onLayout)
       ro?.disconnect()
     }

--- a/components/articles/ShareButtons.test.tsx
+++ b/components/articles/ShareButtons.test.tsx
@@ -1,0 +1,40 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ShareButtons from '@/components/articles/ShareButtons'
+
+describe('ShareButtons', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    })
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    })
+    vi.spyOn(window, 'open').mockReturnValue(null)
+  })
+
+  it('clears copied feedback when a share popup is blocked', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(
+      <ShareButtons
+        title="Readable article"
+        url="https://example.com/article"
+        excerpt="A readable article"
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /copy link/i }))
+    expect(screen.getByText('Copied!')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /share on twitter/i }))
+
+    expect(
+      screen.getByText('Popup blocked. Share using these links instead.')
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Copied!')).not.toBeInTheDocument()
+  })
+})

--- a/components/articles/ShareButtons.tsx
+++ b/components/articles/ShareButtons.tsx
@@ -19,7 +19,26 @@ export default function ShareButtons({
   const [copied, setCopied] = useState(false)
   const [hasNativeShare, setHasNativeShare] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [showPopupBlockedFallback, setShowPopupBlockedFallback] =
+    useState(false)
   const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined)
+
+  const clearExistingTimeout = () => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    timeoutRef.current = undefined
+  }
+
+  const showTransientError = (message: string, ms = 3000) => {
+    clearExistingTimeout()
+    setError(message)
+    timeoutRef.current = setTimeout(() => setError(null), ms)
+  }
+
+  const showTransientCopied = () => {
+    clearExistingTimeout()
+    setCopied(true)
+    timeoutRef.current = setTimeout(() => setCopied(false), 2000)
+  }
 
   // Clean and encode sharing text
   const shareText = excerpt || title
@@ -45,9 +64,7 @@ export default function ShareButtons({
   // Cleanup timeouts on unmount
   useEffect(() => {
     return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current)
-      }
+      clearExistingTimeout()
     }
   }, [])
 
@@ -59,8 +76,7 @@ export default function ShareButtons({
       // Modern Clipboard API (requires HTTPS)
       if (navigator.clipboard && window.isSecureContext) {
         await navigator.clipboard.writeText(url)
-        setCopied(true)
-        timeoutRef.current = setTimeout(() => setCopied(false), 2000)
+        showTransientCopied()
         return
       }
 
@@ -75,8 +91,7 @@ export default function ShareButtons({
       try {
         const success = document.execCommand('copy')
         if (success) {
-          setCopied(true)
-          timeoutRef.current = setTimeout(() => setCopied(false), 2000)
+          showTransientCopied()
         } else {
           throw new Error('Copy command failed')
         }
@@ -84,8 +99,7 @@ export default function ShareButtons({
         document.body.removeChild(textArea)
       }
     } catch {
-      setError('Failed to copy link. Please manually copy the URL.')
-      timeoutRef.current = setTimeout(() => setError(null), 3000)
+      showTransientError('Failed to copy link. Please manually copy the URL.')
     }
   }
 
@@ -103,14 +117,14 @@ export default function ShareButtons({
     } catch (err: unknown) {
       // User cancelled (AbortError) - don't show error
       if (err instanceof Error && err.name !== 'AbortError') {
-        setError('Sharing failed. Please try another method.')
-        timeoutRef.current = setTimeout(() => setError(null), 3000)
+        showTransientError('Sharing failed. Please try another method.')
       }
     }
   }
 
   // Open share URL in new window
   const openShareWindow = (shareUrl: string) => {
+    setError(null)
     const popup = window.open(
       shareUrl,
       'share-dialog',
@@ -119,8 +133,8 @@ export default function ShareButtons({
 
     // Check if popup was blocked
     if (!popup || popup.closed || typeof popup.closed === 'undefined') {
-      // Fallback: open in same tab
-      window.location.href = shareUrl
+      setShowPopupBlockedFallback(true)
+      showTransientError('Popup was blocked. Use the share options below.')
     }
   }
 
@@ -201,6 +215,78 @@ export default function ShareButtons({
           )}
         </button>
       </div>
+
+      {showPopupBlockedFallback && (
+        <div className="mt-3 rounded-lg border border-border bg-muted/40 p-3">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-foreground">
+              Popup blocked. Share using these links instead.
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                setShowPopupBlockedFallback(false)
+              }}
+              className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4 self-start sm:self-auto"
+            >
+              Dismiss
+            </button>
+          </div>
+
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <a
+              href={shareUrls.twitter}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:text-blue-500 hover:bg-muted transition-colors"
+              aria-label="Open Twitter share in new tab"
+            >
+              <Twitter className="h-4 w-4" />
+              <span>Twitter</span>
+            </a>
+            <a
+              href={shareUrls.linkedin}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:text-blue-600 hover:bg-muted transition-colors"
+              aria-label="Open LinkedIn share in new tab"
+            >
+              <Linkedin className="h-4 w-4" />
+              <span>LinkedIn</span>
+            </a>
+            <a
+              href={shareUrls.facebook}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:text-blue-700 hover:bg-muted transition-colors"
+              aria-label="Open Facebook share in new tab"
+            >
+              <Facebook className="h-4 w-4" />
+              <span>Facebook</span>
+            </a>
+            <button
+              type="button"
+              onClick={handleCopyLink}
+              className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:text-brand-blue hover:bg-muted transition-colors"
+              aria-label="Copy link (fallback panel)"
+            >
+              {copied ? (
+                <>
+                  <Check className="h-4 w-4 text-green-800 dark:text-green-300" />
+                  <span className="text-green-800 dark:text-green-300">
+                    Copied!
+                  </span>
+                </>
+              ) : (
+                <>
+                  <Link className="h-4 w-4" />
+                  <span>Copy Link</span>
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/components/articles/ShareButtons.tsx
+++ b/components/articles/ShareButtons.tsx
@@ -30,6 +30,7 @@ export default function ShareButtons({
 
   const showTransientError = (message: string, ms = 3000) => {
     clearExistingTimeout()
+    setCopied(false)
     setError(message)
     timeoutRef.current = setTimeout(() => setError(null), ms)
   }

--- a/components/dashboard/EarningsDashboard.tsx
+++ b/components/dashboard/EarningsDashboard.tsx
@@ -9,8 +9,9 @@ import {
   useUserByUsername,
   useUserReceivedTips,
 } from '@/hooks/convex'
-import { Coins } from 'lucide-react'
+import { AlertCircle, CheckCircle2, Coins, X } from 'lucide-react'
 import { toast } from 'sonner'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { useAuth } from '@/components/providers/AuthContext'
 import { MIN_WITHDRAWAL_USD } from '@/lib/constants'
 import { TipHistory } from '@/components/dashboard/TipHistory'
@@ -20,8 +21,17 @@ import { EarningsDashboardSkeleton } from '@/components/dashboard/EarningsDashbo
 import { withdrawalFlowNote } from '@/lib/copy/network-status'
 import { useProfileTabNavigation } from '@/hooks/useProfileTabNavigation'
 
+type WithdrawalOutcome =
+  | { kind: 'success'; message: string }
+  | { kind: 'error'; message: string }
+
 export function EarningsDashboard() {
   const [showWithdrawModal, setShowWithdrawModal] = useState(false)
+  const [withdrawalOutcome, setWithdrawalOutcome] =
+    useState<WithdrawalOutcome | null>(null)
+  const [withdrawalDialogError, setWithdrawalDialogError] = useState<
+    string | null
+  >(null)
   const withdrawTriggerRef = useRef<HTMLButtonElement>(null)
   const router = useRouter()
   const navigateToTab = useProfileTabNavigation()
@@ -43,14 +53,17 @@ export function EarningsDashboard() {
         amountUsd: args.amountUsd,
         stellarAddress: args.stellarAddress,
       })
-      toast.success(
-        `Withdrawal requested for $${args.amountUsd.toFixed(2)}. ${withdrawalFlowNote()}`
-      )
+      const successMessage = `Withdrawal requested for $${args.amountUsd.toFixed(2)}. ${withdrawalFlowNote()}`
+      setWithdrawalDialogError(null)
+      setWithdrawalOutcome({ kind: 'success', message: successMessage })
+      toast.success(successMessage)
     } catch (error) {
       console.error('Withdrawal error:', error)
-      toast.error(
+      const message =
         error instanceof Error ? error.message : 'Failed to process withdrawal'
-      )
+      setWithdrawalOutcome({ kind: 'error', message })
+      setWithdrawalDialogError(message)
+      toast.error(message)
       throw error
     }
   }
@@ -98,11 +111,48 @@ export function EarningsDashboard() {
 
   return (
     <div className="space-y-6">
+      {withdrawalOutcome && (
+        <div className="flex items-start gap-2">
+          <Alert
+            variant={
+              withdrawalOutcome.kind === 'error' ? 'destructive' : 'default'
+            }
+            className={
+              withdrawalOutcome.kind === 'success'
+                ? 'flex-1 border-success/50 bg-success/10'
+                : 'flex-1'
+            }
+          >
+            {withdrawalOutcome.kind === 'success' ? (
+              <CheckCircle2 className="h-4 w-4 text-success-foreground" />
+            ) : (
+              <AlertCircle className="h-4 w-4" />
+            )}
+            <AlertTitle>
+              {withdrawalOutcome.kind === 'success'
+                ? 'Withdrawal initiated'
+                : 'Withdrawal failed'}
+            </AlertTitle>
+            <AlertDescription>{withdrawalOutcome.message}</AlertDescription>
+          </Alert>
+          <button
+            type="button"
+            onClick={() => setWithdrawalOutcome(null)}
+            className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Dismiss withdrawal message"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      )}
       <EarningsStats
         earnings={earnings}
         userProfile={userProfile}
         minWithdrawalUsd={MIN_WITHDRAWAL_USD}
-        onOpenWithdrawModal={() => setShowWithdrawModal(true)}
+        onOpenWithdrawModal={() => {
+          setWithdrawalDialogError(null)
+          setShowWithdrawModal(true)
+        }}
         withdrawTriggerRef={withdrawTriggerRef}
       />
 
@@ -116,6 +166,7 @@ export function EarningsDashboard() {
         savedStellarAddress={userProfile?.stellarAddress}
         onWithdraw={handleWithdrawFromDialog}
         triggerRef={withdrawTriggerRef}
+        externalError={withdrawalDialogError}
       />
     </div>
   )

--- a/components/dashboard/WithdrawalDialog.test.tsx
+++ b/components/dashboard/WithdrawalDialog.test.tsx
@@ -126,6 +126,7 @@ describe('WithdrawalDialog', () => {
     )
 
     await user.type(screen.getByLabelText(/Amount \(USD\)/i), '2')
+    await user.click(screen.getByRole('checkbox'))
     await user.click(screen.getByRole('button', { name: /Withdraw$/i }))
 
     expect(onWithdraw).not.toHaveBeenCalled()

--- a/components/dashboard/WithdrawalDialog.test.tsx
+++ b/components/dashboard/WithdrawalDialog.test.tsx
@@ -129,6 +129,9 @@ describe('WithdrawalDialog', () => {
     await user.click(screen.getByRole('button', { name: /Withdraw$/i }))
 
     expect(onWithdraw).not.toHaveBeenCalled()
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Minimum withdrawal amount is $5.00'
+    )
   })
 
   it('renders nothing when closed', () => {

--- a/components/dashboard/WithdrawalDialog.tsx
+++ b/components/dashboard/WithdrawalDialog.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useEffect, useState, type RefObject } from 'react'
-import { Loader2, Wallet } from 'lucide-react'
-import { toast } from 'sonner'
+import { AlertCircle, Loader2, Wallet } from 'lucide-react'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import {
   Dialog,
   DialogContent,
@@ -31,6 +31,7 @@ export type WithdrawalDialogProps = {
     stellarAddress: string
   }) => Promise<void>
   triggerRef: RefObject<HTMLButtonElement | null>
+  externalError?: string | null
 }
 
 export function WithdrawalDialog({
@@ -41,17 +42,20 @@ export function WithdrawalDialog({
   savedStellarAddress,
   onWithdraw,
   triggerRef,
+  externalError = null,
 }: WithdrawalDialogProps) {
   const [withdrawAmount, setWithdrawAmount] = useState('')
   const [stellarAddress, setStellarAddress] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [acknowledged, setAcknowledged] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
 
   useEffect(() => {
     if (open) {
       setWithdrawAmount('')
       setStellarAddress(savedStellarAddress ?? '')
       setAcknowledged(false)
+      setSubmitError(null)
     }
   }, [open, savedStellarAddress])
 
@@ -68,22 +72,23 @@ export function WithdrawalDialog({
     const amount = parseFloat(withdrawAmount)
 
     if (!amount || amount < minWithdrawalUsd) {
-      toast.error(
+      setSubmitError(
         `Minimum withdrawal amount is $${minWithdrawalUsd.toFixed(2)}`
       )
       return
     }
 
     if (!isValidStellarAccountId(trimmedAddress)) {
-      toast.error('Please enter a valid Stellar address')
+      setSubmitError('Please enter a valid Stellar address')
       return
     }
 
     if (amount > availableBalanceUsd) {
-      toast.error('Insufficient balance')
+      setSubmitError('Insufficient balance')
       return
     }
 
+    setSubmitError(null)
     setIsSubmitting(true)
     try {
       await onWithdraw({
@@ -91,12 +96,16 @@ export function WithdrawalDialog({
         stellarAddress: trimmedAddress,
       })
       onOpenChange(false)
-    } catch {
-      // Parent shows toast for mutation errors
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to process withdrawal'
+      setSubmitError(message)
     } finally {
       setIsSubmitting(false)
     }
   }
+
+  const displayError = submitError ?? externalError
 
   if (!open) {
     return null
@@ -141,7 +150,10 @@ export function WithdrawalDialog({
                 max={availableBalanceUsd}
                 step="0.01"
                 value={withdrawAmount}
-                onChange={(e) => setWithdrawAmount(e.target.value)}
+                onChange={(e) => {
+                  setWithdrawAmount(e.target.value)
+                  setSubmitError(null)
+                }}
                 disabled={isSubmitting}
                 className="w-full pl-8 pr-3 py-2 border border-input bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-ring"
                 placeholder={`${minWithdrawalUsd.toFixed(2)}`}
@@ -164,7 +176,10 @@ export function WithdrawalDialog({
               id="stellar-address"
               type="text"
               value={stellarAddress || savedStellarAddress || ''}
-              onChange={(e) => setStellarAddress(e.target.value)}
+              onChange={(e) => {
+                setStellarAddress(e.target.value)
+                setSubmitError(null)
+              }}
               aria-invalid={showAddressError}
               className={`w-full px-3 py-2 border bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-ring read-only:bg-muted/50 ${
                 showAddressError
@@ -208,6 +223,14 @@ export function WithdrawalDialog({
             <span>{withdrawalAcknowledgementLabel()}</span>
           </label>
         </div>
+
+        {displayError && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Withdrawal failed</AlertTitle>
+            <AlertDescription>{displayError}</AlertDescription>
+          </Alert>
+        )}
 
         <DialogFooter className="gap-3 sm:gap-0">
           <button

--- a/components/editor/EditorActionBar.test.tsx
+++ b/components/editor/EditorActionBar.test.tsx
@@ -67,10 +67,10 @@ describe('EditorActionBar autosave status', () => {
     )
     const statuses = screen.getAllByRole('status')
     for (const status of statuses) {
-      expect(status).toHaveTextContent("Couldn't save")
+      expect(status).toHaveTextContent(/Couldn't save:?\s*Network error/)
     }
     expect(container.querySelector('.bg-destructive\\/15')).not.toBeNull()
-    expect(screen.getByText('Save failed')).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent('Network error')
   })
 
   it('shows relative saved label when lastSavedAt is set and not dirty', () => {
@@ -117,7 +117,7 @@ describe('EditorActionBar autosave status', () => {
     )
     const statuses = screen.getAllByRole('status')
     for (const status of statuses) {
-      expect(status).toHaveTextContent("Couldn't save")
+      expect(status).toHaveTextContent(/Couldn't save:?\s*Network error/)
       expect(status).toHaveAttribute(
         'title',
         `Network error · ${AUTO_SAVE_GUIDANCE}`

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { AUTO_SAVE_GUIDANCE } from '@/lib/autosave'
+import { truncateFeedbackMessage } from '@/lib/feedback/flow-feedback'
 import { estimateReadingMinutes } from '@/lib/reading-time'
 
 function draftStatusTitle(
@@ -200,7 +201,12 @@ export function EditorActionBar({
       </>
     )
   } else if (error) {
-    statusText = "Couldn't save"
+    statusText = (
+      <>
+        <span className="shrink-0">Couldn&apos;t save:</span>
+        <span className="truncate">{truncateFeedbackMessage(error, 80)}</span>
+      </>
+    )
     statusClassName = 'text-destructive'
   } else if (hasUnsavedChanges) {
     statusText = 'Unsaved changes'
@@ -397,12 +403,12 @@ export function EditorActionBar({
       </div>
 
       {error && (
-        <div
-          className="border-t border-border bg-destructive/10 px-4 py-2 text-xs text-destructive"
-          title={error}
+        <p
+          role="alert"
+          className="border-t border-border bg-destructive/10 px-4 py-2 text-xs text-destructive break-words"
         >
-          Save failed
-        </div>
+          {error}
+        </p>
       )}
 
       {publishBlockReason && !isPublished && (

--- a/components/editor/EditorChromeSkeleton.tsx
+++ b/components/editor/EditorChromeSkeleton.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 
 export function EditorChromeSkeleton() {
   return (
-    <div className="flex flex-col pt-16">
+    <div className="flex flex-col pt-16" aria-hidden>
       <div className="sticky top-16 z-40 bg-background border-b border-border w-full mb-6 px-4 py-3">
         <div className="max-w-5xl mx-auto flex gap-2">
           <Skeleton className="h-9 w-20" />

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -33,7 +33,8 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
 import { Textarea } from '@/components/ui/textarea'
-import { ChevronDown, Loader2 } from 'lucide-react'
+import { AlertCircle, ChevronDown, Loader2, X } from 'lucide-react'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -45,6 +46,11 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { cn } from '@/lib/utils'
+import type { FlowFeedback } from '@/lib/feedback/flow-feedback'
+import {
+  PUBLISH_EMPTY_CONTENT_FEEDBACK,
+  publishErrorFeedback,
+} from '@/lib/editor/publish-feedback'
 import {
   compressImage,
   uploadFile,
@@ -167,6 +173,13 @@ export function WriteEditorWorkspace() {
   const [backupRecoveryStatus, setBackupRecoveryStatus] = useState<
     'pending' | 'resolved'
   >('pending')
+  const [saveErrorDismissed, setSaveErrorDismissed] = useState(false)
+  const [publishFeedback, setPublishFeedback] = useState<FlowFeedback | null>(
+    null
+  )
+  const [deleteFeedback, setDeleteFeedback] = useState<FlowFeedback | null>(
+    null
+  )
 
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -269,6 +282,7 @@ export function WriteEditorWorkspace() {
       const json = editor.getJSON()
       setEditorContent(json)
       setHasUnsavedChanges(true)
+      setPublishFeedback(null)
     },
   })
 
@@ -289,6 +303,7 @@ export function WriteEditorWorkspace() {
       setArticleId(response.id)
       syncDraftIdInUrl(response.id)
       setHasUnsavedChanges(false)
+      setSaveErrorDismissed(false)
       if (!recoveryDeferredRef.current) {
         clearDraftBackup()
       }
@@ -296,6 +311,7 @@ export function WriteEditorWorkspace() {
     onSaveError: (error) => {
       console.error('Auto-save error:', error)
       setHasUnsavedChanges(true)
+      setSaveErrorDismissed(false)
     },
   })
 
@@ -564,6 +580,7 @@ export function WriteEditorWorkspace() {
 
   const requestPublish = useCallback(() => {
     if (!editor || editor.isEmpty) {
+      setPublishFeedback(PUBLISH_EMPTY_CONTENT_FEEDBACK)
       toast.warning('Please add content before publishing')
       return
     }
@@ -573,17 +590,20 @@ export function WriteEditorWorkspace() {
       toast.warning(listingError)
       return
     }
+    setPublishFeedback(null)
     setPublishConfirmOpen(true)
   }, [editor, title, excerpt, blockPublishForPlaceholderTitle])
 
   const handlePublish = useCallback(async () => {
     if (!editor || editor.isEmpty) {
       setPublishConfirmOpen(false)
+      setPublishFeedback(PUBLISH_EMPTY_CONTENT_FEEDBACK)
       toast.warning('Please add content before publishing')
       return
     }
     if (!editorContent) {
       setPublishConfirmOpen(false)
+      setPublishFeedback(PUBLISH_EMPTY_CONTENT_FEEDBACK)
       toast.warning('Please add content before publishing')
       return
     }
@@ -598,6 +618,7 @@ export function WriteEditorWorkspace() {
       return
     }
 
+    setPublishFeedback(null)
     setIsPublishing(true)
     try {
       await saveNow()
@@ -634,6 +655,7 @@ export function WriteEditorWorkspace() {
         published: true,
         publishedAt: new Date(),
       })
+      setPublishFeedback(null)
 
       if (publishedSlug) setPublishedSlugOverride(publishedSlug)
       setPublishSuccessVisible(true)
@@ -644,7 +666,13 @@ export function WriteEditorWorkspace() {
         setTitleError(TITLE_PUBLISH_ERROR)
         focusTitleField()
       } else {
-        toast.error(`Failed to publish: ${message}`)
+        const feedback = publishErrorFeedback(error)
+        setPublishFeedback(feedback)
+        toast.error(
+          feedback.detail
+            ? `${feedback.title}: ${feedback.detail}`
+            : feedback.title
+        )
       }
     } finally {
       setIsPublishing(false)
@@ -667,6 +695,7 @@ export function WriteEditorWorkspace() {
 
   const handleRequestDelete = useCallback(() => {
     if (!articleId || isDeleting) return
+    setDeleteFeedback(null)
     setDeleteDialogOpen(true)
   }, [articleId, isDeleting])
 
@@ -682,6 +711,13 @@ export function WriteEditorWorkspace() {
       router.push('/')
     } catch (error) {
       console.error('Delete error:', error)
+      const message =
+        error instanceof Error ? error.message : 'Please try again.'
+      setDeleteFeedback({
+        variant: 'destructive',
+        title: 'Failed to delete draft',
+        detail: message,
+      })
       toast.error('Failed to delete draft. Please try again.')
       setIsDeleting(false)
     }
@@ -1024,6 +1060,63 @@ export function WriteEditorWorkspace() {
           />
         </div>
       ) : null}
+      {publishFeedback && (
+        <div className="border-b border-border bg-background">
+          <div className="mx-auto flex max-w-4xl items-start gap-2 px-4 py-3 sm:px-6">
+            <Alert
+              variant={
+                publishFeedback.variant === 'destructive'
+                  ? 'destructive'
+                  : 'default'
+              }
+              className="flex-1"
+            >
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>{publishFeedback.title}</AlertTitle>
+              {publishFeedback.detail ? (
+                <AlertDescription>{publishFeedback.detail}</AlertDescription>
+              ) : null}
+            </Alert>
+            <button
+              type="button"
+              onClick={() => setPublishFeedback(null)}
+              className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+              aria-label="Dismiss publish message"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      )}
+      {error && !saveErrorDismissed && (
+        <div className="border-b border-border bg-background">
+          <div className="mx-auto flex max-w-4xl items-start gap-2 px-4 py-3 sm:px-6">
+            <Alert variant="destructive" className="flex-1">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>Couldn&apos;t save draft</AlertTitle>
+              <AlertDescription className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <span>{error.message}</span>
+                <button
+                  type="button"
+                  onClick={() => void saveNow()}
+                  disabled={isSaving}
+                  className="shrink-0 rounded-md border border-destructive/50 px-3 py-1.5 text-sm font-medium hover:bg-destructive/10 disabled:opacity-50"
+                >
+                  {isSaving ? 'Saving...' : 'Retry save'}
+                </button>
+              </AlertDescription>
+            </Alert>
+            <button
+              type="button"
+              onClick={() => setSaveErrorDismissed(true)}
+              className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+              aria-label="Dismiss save error"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      )}
       <div className="flex min-w-0 flex-1 flex-col pb-8">
         <div className="sticky top-16 z-40 mb-6 w-full bg-background">
           <div className="mx-auto w-full max-w-4xl px-4 sm:px-6">
@@ -1624,6 +1717,15 @@ export function WriteEditorWorkspace() {
               deleted.
             </AlertDialogDescription>
           </AlertDialogHeader>
+          {deleteFeedback && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>{deleteFeedback.title}</AlertTitle>
+              {deleteFeedback.detail ? (
+                <AlertDescription>{deleteFeedback.detail}</AlertDescription>
+              ) : null}
+            </Alert>
+          )}
           <AlertDialogFooter>
             <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
             <AlertDialogAction

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -118,6 +118,10 @@ export function HighlightTipButton({
   const [isLoading, setIsLoading] = useState(false)
   const [tipFlowStep, setTipFlowStep] = useState<TipFlowStep | null>(null)
   const [tipFailure, setTipFailure] = useState<TipFailureMessage | null>(null)
+  const [tipFormError, setTipFormError] = useState<TipFailureMessage | null>(
+    null
+  )
+  const [tipSuccess, setTipSuccess] = useState<string | null>(null)
 
   const convex = useConvex()
   const createHighlightTip = useMutation(api.highlightTips.create)
@@ -209,7 +213,9 @@ export function HighlightTipButton({
     setIsOpen(open)
     onResumeOpenChange?.(open)
     setTipFailure(null)
+    setTipFormError(null)
     if (!open) {
+      setTipSuccess(null)
       setSelectedAmount(null)
       setCustomAmount('')
     }
@@ -246,16 +252,24 @@ export function HighlightTipButton({
       selectedAmount,
       customAmount,
     })
-    if (!validation.ok) return
+    if (!validation.ok) {
+      setTipFormError({ title: validation.message })
+      toast.error(validation.message)
+      return
+    }
     const amountCents = validation.amountCents
 
     if (!isConnected || !publicKey) {
-      toast.error('Please connect your Stellar wallet to send tips')
+      const message = 'Please connect your Stellar wallet to send tips'
+      setTipFormError({ title: message })
+      toast.error(message)
       return
     }
 
     if (!authorStellarAddress) {
-      toast.error('Author has not set up their Stellar wallet yet')
+      const message = 'Author has not set up their Stellar wallet yet'
+      setTipFormError({ title: message })
+      toast.error(message)
       return
     }
 
@@ -267,9 +281,9 @@ export function HighlightTipButton({
     try {
       const cooldown = await convex.query(api.tips.canTip, {})
       if (!cooldown.allowed) {
-        toast.error('Slow down', {
-          description: `Please wait ${cooldown.waitSec}s before tipping again.`,
-        })
+        const detail = `Please wait ${cooldown.waitSec}s before tipping again.`
+        setTipFormError({ title: 'Slow down', detail })
+        toast.error('Slow down', { description: detail })
         return
       }
     } catch (err) {
@@ -280,6 +294,8 @@ export function HighlightTipButton({
     }
 
     setTipFailure(null)
+    setTipFormError(null)
+    setTipSuccess(null)
     setIsLoading(true)
 
     try {
@@ -329,32 +345,35 @@ export function HighlightTipButton({
 
       clearPendingTipIntent()
       setTipFailure(null)
-      setIsOpen(false)
-      setSelectedAmount(null)
-      setCustomAmount('')
+      setTipFormError(null)
+      const successMessage = `Successfully tipped ${authorName} ${formatTipAmount(amountCents)} for this highlight!`
+      setTipSuccess(successMessage)
 
-      toast.success(
-        `Successfully tipped ${authorName} ${formatTipAmount(amountCents)} for this highlight!`,
-        {
-          description: receipt.transactionHash
-            ? `Transaction: ${receipt.transactionHash.slice(0, 8)}...`
-            : undefined,
-          action: receipt.transactionHash
-            ? {
-                label: 'View',
-                onClick: () =>
-                  window.open(
-                    `https://stellar.expert/explorer/testnet/tx/${receipt.transactionHash}`,
-                    '_blank'
-                  ),
-              }
-            : undefined,
+      toast.success(successMessage, {
+        description: receipt.transactionHash
+          ? `Transaction: ${receipt.transactionHash.slice(0, 8)}...`
+          : undefined,
+        action: receipt.transactionHash
+          ? {
+              label: 'View',
+              onClick: () =>
+                window.open(
+                  `https://stellar.expert/explorer/testnet/tx/${receipt.transactionHash}`,
+                  '_blank'
+                ),
+            }
+          : undefined,
+      })
+
+      window.setTimeout(() => {
+        setIsOpen(false)
+        setTipSuccess(null)
+        setSelectedAmount(null)
+        setCustomAmount('')
+        if (onSuccess) {
+          onSuccess()
         }
-      )
-
-      if (onSuccess) {
-        onSuccess()
-      }
+      }, 3000)
     } catch (error) {
       console.error('Highlight tip error:', error)
       setTipFailure(formatTipFailureMessage(error))
@@ -368,6 +387,7 @@ export function HighlightTipButton({
     try {
       const connected = await connect()
       if (connected) {
+        setTipFormError(null)
         toast.success('Wallet connected successfully!')
       }
     } catch (error) {
@@ -383,9 +403,33 @@ export function HighlightTipButton({
         return
       }
 
+      setTipFormError({ title: message })
       toast.error(message)
     }
   }
+
+  const inlineTipAlert = tipSuccess ? (
+    <Alert className="border-success/50 bg-success/10 text-success-foreground">
+      <AlertTitle>Tip sent</AlertTitle>
+      <AlertDescription>{tipSuccess}</AlertDescription>
+    </Alert>
+  ) : tipFailure ? (
+    <Alert variant="destructive">
+      <AlertCircle className="h-4 w-4" />
+      <AlertTitle>{tipFailure.title}</AlertTitle>
+      {tipFailure.detail ? (
+        <AlertDescription>{tipFailure.detail}</AlertDescription>
+      ) : null}
+    </Alert>
+  ) : tipFormError ? (
+    <Alert variant="destructive">
+      <AlertCircle className="h-4 w-4" />
+      <AlertTitle>{tipFormError.title}</AlertTitle>
+      {tipFormError.detail ? (
+        <AlertDescription>{tipFormError.detail}</AlertDescription>
+      ) : null}
+    </Alert>
+  ) : null
 
   const displayText =
     highlightText.length > 60
@@ -428,15 +472,7 @@ export function HighlightTipButton({
             </DialogDescription>
           </DialogHeader>
 
-          {tipFailure && (
-            <Alert variant="destructive">
-              <AlertCircle className="h-4 w-4" />
-              <AlertTitle>{tipFailure.title}</AlertTitle>
-              {tipFailure.detail ? (
-                <AlertDescription>{tipFailure.detail}</AlertDescription>
-              ) : null}
-            </Alert>
-          )}
+          {inlineTipAlert}
 
           <div className="mb-4 p-3 bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800 rounded-lg">
             <p className="text-sm text-foreground italic">
@@ -573,7 +609,11 @@ export function HighlightTipButton({
               <button
                 type="button"
                 onClick={() => void handleTip()}
-                disabled={isLoading || (!selectedAmount && !customAmount)}
+                disabled={
+                  isLoading ||
+                  !!tipSuccess ||
+                  (!selectedAmount && !customAmount)
+                }
                 className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
               >
                 {isLoading ? (

--- a/components/profile/ProfilePageLoadingSkeleton.tsx
+++ b/components/profile/ProfilePageLoadingSkeleton.tsx
@@ -3,7 +3,10 @@ import { ArticleGridSkeleton } from '@/components/articles/ArticleCardSkeleton'
 
 export function ProfilePageLoadingSkeleton() {
   return (
-    <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12">
+    <main
+      className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12"
+      aria-hidden
+    >
       <div className="mb-8">
         <div className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-8">
           <div className="flex flex-col sm:flex-row gap-6">

--- a/components/stellar/WalletSettings.test.tsx
+++ b/components/stellar/WalletSettings.test.tsx
@@ -1,7 +1,11 @@
 /** @vitest-environment jsdom */
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { WalletSettings } from '@/components/stellar/WalletSettings'
+
+const mockConnect = vi.fn()
+const mockDisconnect = vi.fn()
 
 vi.mock('convex/react', () => ({
   useMutation: () => vi.fn(),
@@ -10,8 +14,8 @@ vi.mock('convex/react', () => ({
 vi.mock('@/components/providers/WalletProvider', () => ({
   useWallet: () => ({
     isLoading: false,
-    connect: vi.fn(),
-    disconnect: vi.fn(),
+    connect: mockConnect,
+    disconnect: mockDisconnect,
   }),
 }))
 
@@ -35,6 +39,11 @@ vi.mock('@/components/legal/LegalLinks', () => ({
 }))
 
 describe('WalletSettings', () => {
+  beforeEach(() => {
+    mockConnect.mockReset()
+    mockDisconnect.mockReset()
+  })
+
   it('shows visitor empty alert with profile display name', () => {
     render(
       <WalletSettings
@@ -89,5 +98,20 @@ describe('WalletSettings', () => {
       )
     ).toBeInTheDocument()
     expect(screen.queryByText(/undefined/i)).not.toBeInTheDocument()
+  })
+
+  it('shows persistent alert when connect fails', async () => {
+    mockConnect.mockRejectedValue(new Error('User rejected'))
+    const user = userEvent.setup({ delay: null })
+
+    render(<WalletSettings isOwnProfile walletAddress={null} />)
+
+    await user.click(
+      screen.getByRole('button', { name: /Connect Stellar Wallet/i })
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('User rejected')).toBeInTheDocument()
+    })
   })
 })

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -14,7 +14,8 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import type { FlowFeedback } from '@/lib/feedback/flow-feedback'
 import {
   Wallet,
   Copy,
@@ -64,6 +65,9 @@ export function WalletSettings({
   const [isCopied, setIsCopied] = useState(false)
   const [isConnecting, setIsConnecting] = useState(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
+  const [walletFeedback, setWalletFeedback] = useState<FlowFeedback | null>(
+    null
+  )
 
   const handleCopy = async () => {
     if (!walletAddress) return
@@ -71,15 +75,22 @@ export function WalletSettings({
     try {
       await navigator.clipboard.writeText(walletAddress)
       setIsCopied(true)
+      setWalletFeedback(null)
       toast.success('Wallet address copied to clipboard')
       setTimeout(() => setIsCopied(false), 2000)
     } catch {
+      setWalletFeedback({
+        variant: 'destructive',
+        title: 'Failed to copy address',
+        detail: 'Copy the address manually or try again.',
+      })
       toast.error('Failed to copy address')
     }
   }
 
   const handleConnectWallet = async () => {
     setIsConnecting(true)
+    setWalletFeedback(null)
     try {
       const success = await connect()
       if (success) {
@@ -92,9 +103,15 @@ export function WalletSettings({
             stellarAddress: connectedKey,
           })
           onAddressChange?.(connectedKey)
+          setWalletFeedback(null)
           toast.success('Wallet connected and saved successfully!')
         }
       } else {
+        setWalletFeedback({
+          variant: 'destructive',
+          title: 'Failed to connect wallet',
+          detail: 'Try again or choose a different wallet extension.',
+        })
         toast.error('Failed to connect wallet')
       }
     } catch (error) {
@@ -112,6 +129,11 @@ export function WalletSettings({
         return
       }
 
+      setWalletFeedback({
+        variant: 'destructive',
+        title: 'Failed to connect wallet',
+        detail: message,
+      })
       toast.error(message)
     } finally {
       setIsConnecting(false)
@@ -123,6 +145,7 @@ export function WalletSettings({
     if (isConnecting) return
 
     setIsConnecting(true)
+    setWalletFeedback(null)
 
     try {
       // Step 1: Update database FIRST (ensures source of truth is updated)
@@ -135,6 +158,7 @@ export function WalletSettings({
 
       // Step 3: Notify parent component for immediate UI update
       onAddressChange?.('')
+      setWalletFeedback(null)
 
       toast.success('Wallet disconnected successfully')
     } catch (error) {
@@ -143,16 +167,36 @@ export function WalletSettings({
       // Provide specific error messages
       if (error instanceof Error) {
         if (error.message.includes('Not authenticated')) {
+          setWalletFeedback({
+            variant: 'destructive',
+            title: 'Session expired',
+            detail: 'Please refresh and try again.',
+          })
           toast.error('Session expired. Please refresh and try again.')
         } else if (
           error.message.includes('network') ||
           error.message.includes('fetch')
         ) {
+          setWalletFeedback({
+            variant: 'destructive',
+            title: 'Network error',
+            detail: 'Check your connection and try again.',
+          })
           toast.error('Network error. Check your connection and try again.')
         } else {
+          setWalletFeedback({
+            variant: 'destructive',
+            title: 'Disconnect failed',
+            detail: error.message,
+          })
           toast.error(`Disconnect failed: ${error.message}`)
         }
       } else {
+        setWalletFeedback({
+          variant: 'destructive',
+          title: 'Failed to disconnect wallet',
+          detail: 'Please try again.',
+        })
         toast.error('Failed to disconnect wallet. Please try again.')
       }
 
@@ -224,6 +268,21 @@ export function WalletSettings({
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
+          {walletFeedback && (
+            <Alert
+              variant={
+                walletFeedback.variant === 'destructive'
+                  ? 'destructive'
+                  : 'default'
+              }
+            >
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>{walletFeedback.title}</AlertTitle>
+              {walletFeedback.detail ? (
+                <AlertDescription>{walletFeedback.detail}</AlertDescription>
+              ) : null}
+            </Alert>
+          )}
           {isOwnProfile && (
             <Alert className="border-info/50 bg-info">
               <AlertCircle className="h-4 w-4 text-info-foreground" />

--- a/components/tipping/TipButton.test.tsx
+++ b/components/tipping/TipButton.test.tsx
@@ -141,4 +141,24 @@ describe('TipButton auth-first CTA', () => {
     await user.click(screen.getByRole('button', { name: /Tip Author/i }))
     expect(screen.getByRole('button', { name: 'Send Tip' })).toBeInTheDocument()
   })
+
+  it('shows inline alert for invalid tip amount when wallet is connected', async () => {
+    mockIsAuthenticated.mockReturnValue(true)
+    mockIsConnected.mockReturnValue(true)
+    const user = userEvent.setup({ delay: null })
+    render(
+      <TipButton
+        articleId={'articles:abc' as never}
+        authorName="Author"
+        authorStellarAddress="GABC"
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /Tip Author/i }))
+    const customInput = screen.getByPlaceholderText('0.00')
+    await user.type(customInput, '0')
+    await user.click(screen.getByRole('button', { name: 'Send Tip' }))
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/valid amount/i)
+  })
 })

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -85,6 +85,10 @@ export function TipButton({
   const [isLoading, setIsLoading] = useState(false)
   const [tipFlowStep, setTipFlowStep] = useState<TipFlowStep | null>(null)
   const [tipFailure, setTipFailure] = useState<TipFailureMessage | null>(null)
+  const [tipFormError, setTipFormError] = useState<TipFailureMessage | null>(
+    null
+  )
+  const [tipSuccess, setTipSuccess] = useState<string | null>(null)
   const [tipMessage, setTipMessage] = useState('')
 
   const convex = useConvex()
@@ -123,6 +127,8 @@ export function TipButton({
     }
     setIsOpen(open)
     setTipFailure(null)
+    setTipFormError(null)
+    if (!open) setTipSuccess(null)
   }
 
   const handleSignInToTip = () => {
@@ -150,18 +156,25 @@ export function TipButton({
       customAmount,
       message: tipMessage,
     })
-    if (!validation.ok) return
+    if (!validation.ok) {
+      setTipFormError({ title: validation.message })
+      toast.error(validation.message)
+      return
+    }
     const amountCents = validation.amountCents
 
     if (!isConnected || !publicKey) {
-      toast.error('Please connect your Stellar wallet to send tips')
+      const message = 'Please connect your Stellar wallet to send tips'
+      setTipFormError({ title: message })
+      toast.error(message)
       return
     }
 
     if (!authorStellarAddress) {
-      toast.error(
+      const message =
         'Author has not set up their Stellar wallet for receiving tips'
-      )
+      setTipFormError({ title: message })
+      toast.error(message)
       return
     }
 
@@ -173,9 +186,9 @@ export function TipButton({
     try {
       const cooldown = await convex.query(api.tips.canTip, {})
       if (!cooldown.allowed) {
-        toast.error('Slow down', {
-          description: `Please wait ${cooldown.waitSec}s before tipping again.`,
-        })
+        const detail = `Please wait ${cooldown.waitSec}s before tipping again.`
+        setTipFormError({ title: 'Slow down', detail })
+        toast.error('Slow down', { description: detail })
         return
       }
     } catch (err) {
@@ -186,6 +199,8 @@ export function TipButton({
     }
 
     setTipFailure(null)
+    setTipFormError(null)
+    setTipSuccess(null)
     setIsLoading(true)
 
     try {
@@ -221,29 +236,33 @@ export function TipButton({
 
       clearPendingTipIntent()
       setTipFailure(null)
-      setIsOpen(false)
-      setSelectedAmount(null)
-      setCustomAmount('')
-      setTipMessage('')
+      setTipFormError(null)
+      const successMessage = `Successfully tipped ${authorName} $${(amountCents / 100).toFixed(2)} via Stellar!`
+      setTipSuccess(successMessage)
 
-      toast.success(
-        `Successfully tipped ${authorName} $${(amountCents / 100).toFixed(2)} via Stellar!`,
-        {
-          description: receipt.transactionHash
-            ? `Transaction: ${receipt.transactionHash.slice(0, 8)}...`
-            : undefined,
-          action: receipt.transactionHash
-            ? {
-                label: 'View',
-                onClick: () =>
-                  window.open(
-                    `https://stellar.expert/explorer/testnet/tx/${receipt.transactionHash}`,
-                    '_blank'
-                  ),
-              }
-            : undefined,
-        }
-      )
+      toast.success(successMessage, {
+        description: receipt.transactionHash
+          ? `Transaction: ${receipt.transactionHash.slice(0, 8)}...`
+          : undefined,
+        action: receipt.transactionHash
+          ? {
+              label: 'View',
+              onClick: () =>
+                window.open(
+                  `https://stellar.expert/explorer/testnet/tx/${receipt.transactionHash}`,
+                  '_blank'
+                ),
+            }
+          : undefined,
+      })
+
+      window.setTimeout(() => {
+        setIsOpen(false)
+        setTipSuccess(null)
+        setSelectedAmount(null)
+        setCustomAmount('')
+        setTipMessage('')
+      }, 3000)
     } catch (error) {
       console.error('Stellar tip error:', error)
       setTipFailure(formatTipFailureMessage(error))
@@ -263,6 +282,7 @@ export function TipButton({
     try {
       const connected = await connect()
       if (connected) {
+        setTipFormError(null)
         toast.success('Wallet connected successfully!')
       }
     } catch (error) {
@@ -278,9 +298,33 @@ export function TipButton({
         return
       }
 
+      setTipFormError({ title: message })
       toast.error(message)
     }
   }
+
+  const inlineTipAlert = tipSuccess ? (
+    <Alert className="border-success/50 bg-success/10 text-success-foreground">
+      <AlertTitle>Tip sent</AlertTitle>
+      <AlertDescription>{tipSuccess}</AlertDescription>
+    </Alert>
+  ) : tipFailure ? (
+    <Alert variant="destructive">
+      <AlertCircle className="h-4 w-4" />
+      <AlertTitle>{tipFailure.title}</AlertTitle>
+      {tipFailure.detail ? (
+        <AlertDescription>{tipFailure.detail}</AlertDescription>
+      ) : null}
+    </Alert>
+  ) : tipFormError ? (
+    <Alert variant="destructive">
+      <AlertCircle className="h-4 w-4" />
+      <AlertTitle>{tipFormError.title}</AlertTitle>
+      {tipFormError.detail ? (
+        <AlertDescription>{tipFormError.detail}</AlertDescription>
+      ) : null}
+    </Alert>
+  ) : null
 
   return (
     <>
@@ -313,15 +357,7 @@ export function TipButton({
             </DialogDescription>
           </DialogHeader>
 
-          {tipFailure && (
-            <Alert variant="destructive">
-              <AlertCircle className="h-4 w-4" />
-              <AlertTitle>{tipFailure.title}</AlertTitle>
-              {tipFailure.detail ? (
-                <AlertDescription>{tipFailure.detail}</AlertDescription>
-              ) : null}
-            </Alert>
-          )}
+          {inlineTipAlert}
 
           {!isAuthenticated ? (
             <div className="p-3 bg-muted border border-border rounded-lg text-sm text-muted-foreground">
@@ -478,7 +514,11 @@ export function TipButton({
               <button
                 type="button"
                 onClick={handleTip}
-                disabled={isLoading || (!selectedAmount && !customAmount)}
+                disabled={
+                  isLoading ||
+                  !!tipSuccess ||
+                  (!selectedAmount && !customAmount)
+                }
                 className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
               >
                 {isLoading ? (

--- a/hooks/useStaleLoading.ts
+++ b/hooks/useStaleLoading.ts
@@ -1,0 +1,46 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+type UseStaleLoadingOptions = {
+  timeoutMs?: number
+}
+
+export function useStaleLoading(
+  isLoading: boolean,
+  { timeoutMs = 10_000 }: UseStaleLoadingOptions = {}
+) {
+  const [isStale, setIsStale] = useState(false)
+  const timeoutIdRef = useRef<number | null>(null)
+
+  const reset = useCallback(() => {
+    setIsStale(false)
+  }, [])
+
+  useEffect(() => {
+    if (!isLoading) {
+      if (timeoutIdRef.current !== null) {
+        window.clearTimeout(timeoutIdRef.current)
+        timeoutIdRef.current = null
+      }
+      setIsStale(false)
+      return
+    }
+
+    if (isStale) return
+
+    timeoutIdRef.current = window.setTimeout(() => {
+      setIsStale(true)
+    }, timeoutMs)
+
+    return () => {
+      if (timeoutIdRef.current !== null) {
+        window.clearTimeout(timeoutIdRef.current)
+        timeoutIdRef.current = null
+      }
+    }
+  }, [isLoading, isStale, timeoutMs])
+
+  return { isStale, reset }
+}
+

--- a/hooks/useStaleLoading.ts
+++ b/hooks/useStaleLoading.ts
@@ -43,4 +43,3 @@ export function useStaleLoading(
 
   return { isStale, reset }
 }
-

--- a/lib/articles/tocActiveSection.test.ts
+++ b/lib/articles/tocActiveSection.test.ts
@@ -1,9 +1,6 @@
 /** @vitest-environment jsdom */
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import {
-  ACTIVE_HEADING_TOP_OFFSET_PX,
-  pickActiveId,
-} from './tocActiveSection'
+import { ACTIVE_HEADING_TOP_OFFSET_PX, pickActiveId } from './tocActiveSection'
 
 function mockHeading(id: string, top: number) {
   const el = document.createElement('h2')

--- a/lib/articles/tocActiveSection.test.ts
+++ b/lib/articles/tocActiveSection.test.ts
@@ -1,0 +1,90 @@
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  ACTIVE_HEADING_TOP_OFFSET_PX,
+  pickActiveId,
+} from './tocActiveSection'
+
+function mockHeading(id: string, top: number) {
+  const el = document.createElement('h2')
+  el.id = id
+  vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+    top,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    width: 0,
+    height: 0,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect)
+  return el
+}
+
+describe('pickActiveId', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns null when ids is empty', () => {
+    expect(pickActiveId([])).toBeNull()
+  })
+
+  it('returns null when no heading elements exist in the DOM', () => {
+    vi.spyOn(document, 'getElementById').mockReturnValue(null)
+    expect(pickActiveId(['a', 'b'])).toBeNull()
+  })
+
+  it('returns the first heading when all are below the offset', () => {
+    const a = mockHeading('intro', 200)
+    const b = mockHeading('body', 400)
+    vi.spyOn(document, 'getElementById').mockImplementation((id) => {
+      if (id === 'intro') return a
+      if (id === 'body') return b
+      return null
+    })
+
+    expect(pickActiveId(['intro', 'body'])).toBe('intro')
+  })
+
+  it('returns the last heading at or above the offset threshold', () => {
+    const a = mockHeading('intro', 40)
+    const b = mockHeading('middle', 80)
+    const c = mockHeading('deep', 120)
+    vi.spyOn(document, 'getElementById').mockImplementation((id) => {
+      if (id === 'intro') return a
+      if (id === 'middle') return b
+      if (id === 'deep') return c
+      return null
+    })
+
+    expect(pickActiveId(['intro', 'middle', 'deep'])).toBe('middle')
+  })
+
+  it('skips missing DOM nodes and still resolves active section', () => {
+    const b = mockHeading('middle', 50)
+    vi.spyOn(document, 'getElementById').mockImplementation((id) => {
+      if (id === 'missing') return null
+      if (id === 'middle') return b
+      return null
+    })
+
+    expect(pickActiveId(['missing', 'middle'])).toBe('middle')
+  })
+
+  it('respects a custom offset', () => {
+    const a = mockHeading('intro', 150)
+    vi.spyOn(document, 'getElementById').mockReturnValue(a)
+
+    expect(pickActiveId(['intro'], 100)).toBe('intro')
+    expect(pickActiveId(['intro'], 200)).toBe('intro')
+  })
+
+  it('uses the default offset constant', () => {
+    const atThreshold = mockHeading('section', ACTIVE_HEADING_TOP_OFFSET_PX)
+    vi.spyOn(document, 'getElementById').mockReturnValue(atThreshold)
+
+    expect(pickActiveId(['section'])).toBe('section')
+  })
+})

--- a/lib/articles/tocActiveSection.ts
+++ b/lib/articles/tocActiveSection.ts
@@ -1,0 +1,26 @@
+/** Below fixed nav (h-16) + thin progress strip; aligns with prose scroll-margin. */
+export const ACTIVE_HEADING_TOP_OFFSET_PX = 96
+
+/**
+ * Returns the id of the heading that is currently "active" for TOC highlighting:
+ * the last heading whose top edge is at or above the scroll offset threshold,
+ * or the first heading found if none have crossed the threshold yet.
+ */
+export function pickActiveId(
+  ids: string[],
+  offsetPx = ACTIVE_HEADING_TOP_OFFSET_PX
+): string | null {
+  let active: string | null = null
+  let firstFound: string | null = null
+
+  for (const id of ids) {
+    const el = document.getElementById(id)
+    if (!el) continue
+    if (firstFound == null) firstFound = id
+    if (el.getBoundingClientRect().top <= offsetPx) {
+      active = id
+    }
+  }
+
+  return active ?? firstFound
+}

--- a/lib/editor/publish-feedback.test.ts
+++ b/lib/editor/publish-feedback.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PUBLISH_EMPTY_CONTENT_FEEDBACK,
+  publishErrorFeedback,
+} from './publish-feedback'
+
+describe('publish-feedback', () => {
+  it('defines empty content feedback', () => {
+    expect(PUBLISH_EMPTY_CONTENT_FEEDBACK.title).toMatch(/content/i)
+  })
+
+  it('maps errors to destructive feedback', () => {
+    expect(publishErrorFeedback(new Error('Offline')).detail).toBe('Offline')
+    expect(publishErrorFeedback('x').detail).toBe('Unknown error')
+  })
+})

--- a/lib/editor/publish-feedback.ts
+++ b/lib/editor/publish-feedback.ts
@@ -1,0 +1,17 @@
+import type { FlowFeedback } from '@/lib/feedback/flow-feedback'
+
+export const PUBLISH_EMPTY_CONTENT_FEEDBACK: FlowFeedback = {
+  variant: 'default',
+  title: 'Add content before publishing',
+  detail: 'Write something in the editor, then try again.',
+}
+
+export function publishErrorFeedback(error: unknown): FlowFeedback {
+  const message =
+    error instanceof Error ? error.message : 'Unknown error'
+  return {
+    variant: 'destructive',
+    title: 'Failed to publish',
+    detail: message,
+  }
+}

--- a/lib/editor/publish-feedback.ts
+++ b/lib/editor/publish-feedback.ts
@@ -7,8 +7,7 @@ export const PUBLISH_EMPTY_CONTENT_FEEDBACK: FlowFeedback = {
 }
 
 export function publishErrorFeedback(error: unknown): FlowFeedback {
-  const message =
-    error instanceof Error ? error.message : 'Unknown error'
+  const message = error instanceof Error ? error.message : 'Unknown error'
   return {
     variant: 'destructive',
     title: 'Failed to publish',

--- a/lib/feedback/flow-feedback.ts
+++ b/lib/feedback/flow-feedback.ts
@@ -6,7 +6,10 @@ export type FlowFeedback = {
   detail?: string
 }
 
-export function truncateFeedbackMessage(message: string, maxLength = 120): string {
+export function truncateFeedbackMessage(
+  message: string,
+  maxLength = 120
+): string {
   if (message.length <= maxLength) return message
   return `${message.slice(0, maxLength - 1)}…`
 }

--- a/lib/feedback/flow-feedback.ts
+++ b/lib/feedback/flow-feedback.ts
@@ -1,0 +1,12 @@
+export type FlowFeedbackVariant = 'destructive' | 'default'
+
+export type FlowFeedback = {
+  variant: FlowFeedbackVariant
+  title: string
+  detail?: string
+}
+
+export function truncateFeedbackMessage(message: string, maxLength = 120): string {
+  if (message.length <= maxLength) return message
+  return `${message.slice(0, maxLength - 1)}…`
+}

--- a/lib/tip/signInToTip.test.ts
+++ b/lib/tip/signInToTip.test.ts
@@ -1,11 +1,6 @@
 import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
 import { describe, expect, it, vi } from 'vitest'
-import { toast } from 'sonner'
 import { validateTipAmountForm, signInToTip } from './signInToTip'
-
-vi.mock('sonner', () => ({
-  toast: { error: vi.fn() },
-}))
 
 const mockRedirect = vi.hoisted(() => vi.fn())
 
@@ -21,6 +16,9 @@ describe('signInToTip', () => {
       customAmount: '',
     })
     expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.message).toMatch(/valid amount/i)
+    }
     signInToTip(
       router,
       '/article',
@@ -31,13 +29,11 @@ describe('signInToTip', () => {
       }
     )
     expect(mockRedirect).not.toHaveBeenCalled()
-    expect(toast.error).toHaveBeenCalled()
   })
 
   it('redirects with valid amount', () => {
     const router = { replace: vi.fn() } as unknown as AppRouterInstance
     mockRedirect.mockClear()
-    vi.mocked(toast.error).mockClear()
 
     signInToTip(
       router,
@@ -61,5 +57,8 @@ describe('signInToTip', () => {
       message: 'x'.repeat(501),
     })
     expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.message).toMatch(/500 characters/)
+    }
   })
 })

--- a/lib/tip/signInToTip.ts
+++ b/lib/tip/signInToTip.ts
@@ -1,5 +1,4 @@
 import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
-import { toast } from 'sonner'
 import { TIP_MIN_CENTS, TIP_MAX_CENTS, TIP_MAX_USD } from '@/lib/constants'
 import { redirectToLoginForTip } from '@/lib/tip/redirectToLoginForTip'
 import type { PendingTipIntent } from '@/lib/tip/pendingTipIntent'
@@ -12,7 +11,7 @@ export type TipAmountFormState = {
 
 export type ValidateTipAmountResult =
   | { ok: true; amountCents: number }
-  | { ok: false }
+  | { ok: false; message: string }
 
 export function validateTipAmountForm({
   selectedAmount,
@@ -22,18 +21,24 @@ export function validateTipAmountForm({
   const amountCents = selectedAmount || parseFloat(customAmount) * 100
 
   if (!amountCents || amountCents < TIP_MIN_CENTS) {
-    toast.error('Please select or enter a valid amount')
-    return { ok: false }
+    return {
+      ok: false,
+      message: 'Please select or enter a valid amount',
+    }
   }
 
   if (amountCents > TIP_MAX_CENTS) {
-    toast.error(`Maximum tip amount is $${TIP_MAX_USD.toFixed(2)}`)
-    return { ok: false }
+    return {
+      ok: false,
+      message: `Maximum tip amount is $${TIP_MAX_USD.toFixed(2)}`,
+    }
   }
 
   if (message !== undefined && message.length > 500) {
-    toast.error('Message must be 500 characters or less')
-    return { ok: false }
+    return {
+      ok: false,
+      message: 'Message must be 500 characters or less',
+    }
   }
 
   return { ok: true, amountCents }


### PR DESCRIPTION
## Summary

Improves the article reading experience with accessible loading states (including slow-load recovery), clearer share feedback when popups or clipboard APIs fail, scroll-synced table of contents highlighting, and a more reliable reading progress bar. Reuses the same loading pattern on profile and write routes.

## Changes

### Accessible loading with stale recovery (`LoadingRegion`, `useStaleLoading`)
- Adds `LoadingRegion`: skeleton fallback, `aria-busy`, and `aria-live` announcements (“Loading article.” / “article loaded.”).
- After 10s of loading, shows a stale state with **Try again** (router refresh + reset timer) and **Reload page**.
- Adds `useStaleLoading` hook to drive the stale timeout.
- Wired on:
  - Article page (`/[username]/[slug]`) while Convex article query is pending
  - Profile page while user profile loads (fixes loading check to `user === undefined` vs falsy)
  - Write page while auth session resolves
- Skeletons use `aria-hidden` inside `LoadingRegion` so screen readers get status text, not duplicate structure.

### Share fallbacks (`ShareButtons`)
- Transient error and “Copied!” feedback with auto-dismiss timers.
- Copy link: Clipboard API when available, `document.execCommand('copy')` fallback for older/non-secure contexts.
- Native Web Share: ignores user cancel (`AbortError`); surfaces other failures inline.
- Popup-blocked detection for Twitter/LinkedIn/Facebook: inline error + persistent fallback panel with direct `<a target="_blank">` links and copy button (dismissible).
- Used on article display and publish success panel.

### Table of contents — active section (`ArticleTableOfContents`, `tocActiveSection`)
- Highlights the current section while scrolling via `pickActiveId()` (last heading above nav offset, or first heading).
- Scroll/resize updates throttled with `requestAnimationFrame`; `MutationObserver` waits until heading elements exist in `.article-content`.
- Active link uses `aria-current="location"` and visual highlight; click smooth-scrolls to heading.
- Sticky sidebar on large screens when 3+ H2 headings (`tocHeadings.length >= 3`).
- Unit tests for `pickActiveId` edge cases.

### Reading progress bar (`ReadingProgressBar`)
- Detects nested scroll containers when window scroll is zero but an inner pane scrolls.
- Throttles updates with rAF; listens to `visualViewport` resize and `ResizeObserver` on document for layout changes.
- Avoids redundant state updates when progress unchanged.

### In-flow status on article engagement (tip UI)
- `TipButton` / `HighlightTipButton`: inline form validation errors and success messaging in the dialog (alongside toasts).
- Shared `flow-feedback` helpers (`truncateFeedbackMessage`) and publish error feedback utilities for consistent copy length.

### Also on branch (minor)
- Earnings withdrawal success/error alerts on dashboard + dialog error passthrough (small follow-up to withdrawal UX).


## Testing

- `bun run test:once components/articles/ShareButtons.test.tsx lib/articles/tocActiveSection.test.ts components/tipping/TipButton.test.tsx components/highlights/HighlightTipButton.test.tsx components/dashboard/WithdrawalDialog.test.tsx components/stellar/WalletSettings.test.tsx components/editor/EditorActionBar.test.tsx lib/editor/publish-feedback.test.ts lib/tip/signInToTip.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run test:once`
- `bun run build`
- GitHub checks on `93f3710`: `Required`, `Build`, `Lint, Typecheck & Test`, `Dependency Audit`, `PR Hygiene Required`, `PR title`, `Commit subjects`, Vercel, and Vercel Preview Comments all pass.

## Notes

- Updated this branch with latest `development` after PR #195 landed. Final branch divergence is `0 11` against `origin/development`, and GitHub reports `mergeStateStatus: CLEAN`.
- Review fix added in `93f3710`: copy feedback now clears when a popup-blocked share action shows the fallback panel, with regression coverage in `components/articles/ShareButtons.test.tsx`.
- Manual preview QA passed per Pragya on 2026-06-03 for the ENG-149 checklist: loading stale recovery, share fallback, active ToC, reading progress, article/highlight tip feedback, editor feedback, withdrawal/wallet feedback, responsive behavior, and auth boundaries.
- Separate known issue, not treated as an ENG-149 blocker: deleting a non-tipped highlight may still appear stale until refresh. The prior PR #192 delete-refresh fix is present in this branch, so this may be a stale preview tab or a separate uncovered delete-state path.
