### PR TITLE
refactor(navigation): move theme toggle to nav end and add mobile menu access

### DIFF
--- a/components/landing/Navigation.tsx
+++ b/components/landing/Navigation.tsx
@@ -402,8 +402,6 @@ export default function Navigation() {
 
             <div className="w-px h-5 bg-border mx-2" />
 
-            <ThemeToggle />
-
             <Link
               href="/login"
               className="focus-ring px-3 py-1.5 text-[13px] font-medium text-muted-foreground hover:text-foreground rounded-lg hover:bg-muted/60 transition-all duration-200"
@@ -418,6 +416,8 @@ export default function Navigation() {
               Try on Testnet
               <ArrowRight className="w-3.5 h-3.5 shrink-0 text-brand-foreground/80" />
             </Link>
+
+            <ThemeToggle />
           </div>
 
           <Sheet open={isOpen} onOpenChange={setIsOpen}>
@@ -493,6 +493,10 @@ export default function Navigation() {
                     Try on Testnet
                     <ArrowRight className="w-3.5 h-3.5 shrink-0 text-brand-foreground/80" />
                   </Link>
+                </div>
+
+                <div className="flex justify-end pt-3 border-t border-border">
+                  <ThemeToggle />
                 </div>
               </div>
             </SheetContent>

--- a/components/layout/AppNavigation.tsx
+++ b/components/layout/AppNavigation.tsx
@@ -77,8 +77,6 @@ export default function AppNavigation() {
               <span>Guide</span>
             </Link>
 
-            <ThemeToggle />
-
             {isAuthenticated ? (
               <>
                 <Link
@@ -129,6 +127,8 @@ export default function AppNavigation() {
                 </Link>
               </>
             )}
+
+            <ThemeToggle />
           </div>
 
           <Sheet open={menuOpen} onOpenChange={setMenuOpen}>
@@ -232,6 +232,10 @@ export default function AppNavigation() {
                     </Link>
                   </div>
                 )}
+
+                <div className="flex justify-end pt-3 mt-2 border-t border-border">
+                  <ThemeToggle />
+                </div>
               </div>
             </SheetContent>
           </Sheet>


### PR DESCRIPTION
## Summary

Repositions the dark/light theme toggle to the right end of the desktop nav on both the app and landing headers, and adds the same toggle to the mobile hamburger menus so it is available below the `md` breakpoint.

## Changes

- **App nav** (`AppNavigation.tsx`): move `ThemeToggle` after Sign Out / Get Started on desktop; add toggle at the bottom of the mobile sheet (right-aligned, below a divider).
- **Landing nav** (`Navigation.tsx`): move `ThemeToggle` after Try on Testnet on desktop; add toggle at the bottom of the mobile sheet.
<img width="1220" height="715" alt="Screenshot 2026-06-04 at 6 06 15 PM" src="https://github.com/user-attachments/assets/c91efb69-0883-44c1-821e-52275a3a1407" />
<img width="1222" height="716" alt="Screenshot 2026-06-04 at 6 03 37 PM" src="https://github.com/user-attachments/assets/29bc63f2-6517-4b1b-a11f-da8a139485cf" />


