### PR TITLE
feat(articles): article-first reader layout (ENG-245)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ IMPROVEMENTS_MOSCOW.md
 docs/tranche-2.md
 docs/tranche-2-evidence.md
 docs/contract-evidence.md
+docs/eng-245-pr198-evidence.md
 docs/tipping-verification-plan.md
 docs/final-gtm-plan.md
 

--- a/app/[username]/[slug]/page.tsx
+++ b/app/[username]/[slug]/page.tsx
@@ -1,9 +1,7 @@
 'use client'
 
-import nextDynamic from 'next/dynamic'
 import { notFound } from 'next/navigation'
-import { use, useState, useMemo } from 'react'
-import { ArticleTipActions } from '@/components/tipping/ArticleTipActions'
+import { use, useMemo } from 'react'
 import {
   useArticleBySlug,
   useArticleHighlightTipStatsOptional,
@@ -11,33 +9,13 @@ import {
 } from '@/hooks/convex'
 import ArticleDisplay from '@/components/articles/ArticleDisplay'
 import { ArticlePageLoadingSkeleton } from '@/components/articles/ArticlePageLoadingSkeleton'
+import { ArticleReaderSupport } from '@/components/articles/ArticleReaderSupport'
+import { ArticleDetailsPanel } from '@/components/articles/ArticleDetailsPanel'
 import AppNavigation from '@/components/layout/AppNavigation'
 import { SiteFooter } from '@/components/layout/SiteFooter'
-import { TipStats } from '@/components/tipping/TipStats'
-import { NftSidebarSkeleton } from '@/components/articles/ArticleEngagementSkeleton'
-
-const NFTIntegration = nextDynamic(
-  () =>
-    import('@/components/nft/NFTIntegration').then((mod) => ({
-      default: mod.NFTIntegration,
-    })),
-  { ssr: false, loading: () => <NftSidebarSkeleton /> }
-)
-import {
-  DollarSign,
-  Trophy,
-  Heart,
-  MessageSquare,
-  ChevronDown,
-  Archive,
-} from 'lucide-react'
-import { ArweaveStatus } from '@/components/articles/ArweaveStatus'
-import { HighlightNotes } from '@/components/highlights/HighlightNotes'
-import { HighlightHeatmap } from '@/components/highlights/HighlightHeatmap'
 import { useAuth } from '@/components/providers/AuthContext'
 import type { Id } from '@/types/convex'
 import type { ArticleForDisplay } from '@/types/index'
-import { cn } from '@/lib/utils'
 import { ErrorBoundary } from '@/components/error/ErrorBoundary'
 import {
   ArticleDisplaySectionFallback,
@@ -45,7 +23,6 @@ import {
 } from '@/components/error/SectionErrorFallback'
 import { ReadingProgressBar } from '@/components/articles/ReadingProgressBar'
 import { extractH2HeadingsFromTiptapJson } from '@/lib/tiptap/headings'
-import { ArticleTableOfContents } from '@/components/articles/ArticleTableOfContents'
 import { LoadingRegion } from '@/components/a11y/LoadingRegion'
 import { useStaleLoading } from '@/hooks/useStaleLoading'
 import { useRouter } from 'next/navigation'
@@ -59,7 +36,6 @@ interface ArticlePageProps {
 
 export default function ArticlePage({ params }: ArticlePageProps) {
   const { username, slug } = use(params)
-  const [showHighlightsPanel, setShowHighlightsPanel] = useState(false)
   const { user } = useAuth()
   const router = useRouter()
 
@@ -75,7 +51,6 @@ export default function ArticlePage({ params }: ArticlePageProps) {
     [article?.content]
   )
 
-  // Build lookup map for tip badges
   const tipsByHighlight = useMemo(() => {
     if (!highlightTipStats?.topHighlights) return {}
     return Object.fromEntries(
@@ -86,12 +61,10 @@ export default function ArticlePage({ params }: ArticlePageProps) {
     )
   }, [highlightTipStats])
 
-  // Check if article exists (null means not found, undefined means loading)
   if (article === null) {
     notFound()
   }
 
-  // Show loading while article is being fetched
   if (article === undefined) {
     return (
       <div className="min-h-screen bg-background">
@@ -140,163 +113,42 @@ export default function ArticlePage({ params }: ArticlePageProps) {
       <AppNavigation />
       <ReadingProgressBar />
       <main className="flex-1 pt-20 w-full">
-        <div className="max-w-7xl mx-auto px-4 py-8">
-          <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
-            {/* Main Article Content */}
-            <div className="lg:col-span-8">
-              <ErrorBoundary fallback={<ArticleDisplaySectionFallback />}>
-                <ArticleDisplay
-                  article={articleForDisplay}
-                  tocHeadings={tocHeadings}
+        <div className="max-w-4xl mx-auto px-4 py-8">
+          <ErrorBoundary fallback={<ArticleDisplaySectionFallback />}>
+            <ArticleDisplay
+              article={articleForDisplay}
+              tocHeadings={tocHeadings}
+              authorStellarAddress={article.author.stellarAddress}
+              readerSupport={
+                <ArticleReaderSupport
+                  articleId={article._id}
+                  articleSlug={article.slug}
+                  authorName={
+                    article.author.name || article.author.username
+                  }
                   authorStellarAddress={article.author.stellarAddress}
                 />
-              </ErrorBoundary>
-            </div>
+              }
+            />
+          </ErrorBoundary>
 
-            {/* Engagement Sidebar */}
-            <div className="lg:col-span-4 flex flex-col gap-6">
-              <ErrorBoundary fallback={<ArticleSidebarSectionFallback />}>
-                {tocHeadings.length >= 3 && (
-                  <div className="sticky top-24 z-10 w-full self-start bg-background lg:max-h-[calc(100dvh-7rem)] lg:overflow-y-auto">
-                    <ArticleTableOfContents headings={tocHeadings} />
-                  </div>
-                )}
-                <div className="space-y-6">
-                  {/* Tip Section */}
-                  <div className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-[var(--card-padding)]">
-                    <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-                      <Heart className="w-5 h-5 text-red-500" />
-                      Support the Author
-                    </h3>
-                    <ArticleTipActions
-                      articleId={article._id}
-                      articleSlug={article.slug}
-                      authorName={
-                        article.author.name || article.author.username
-                      }
-                      authorStellarAddress={article.author.stellarAddress}
-                    />
-                    <div className="mt-4 pt-4 border-t">
-                      <TipStats articleId={article._id} />
-                    </div>
-                  </div>
-
-                  {/* NFT Section */}
-                  <div className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-[var(--card-padding)]">
-                    <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-                      <Trophy className="w-5 h-5 text-purple-500" />
-                      NFT Collection
-                    </h3>
-                    <NFTIntegration
-                      articleId={article._id}
-                      articleTitle={article.title}
-                      articleSlug={article.slug}
-                      authorId={article.author.id}
-                      currentUserId={user?._id as Id<'users'> | undefined}
-                    />
-                  </div>
-
-                  {/* Highlight Heatmap Section */}
-                  <HighlightHeatmap
-                    articleId={article._id}
-                    isAuthor={user?._id === article.author.id}
-                  />
-
-                  {/* Highlight Notes Section */}
-                  <div className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border">
-                    <button
-                      onClick={() =>
-                        setShowHighlightsPanel(!showHighlightsPanel)
-                      }
-                      className="w-full p-[var(--card-padding)] flex items-center justify-between hover:bg-muted transition-colors"
-                    >
-                      <h3 className="text-lg font-semibold flex items-center gap-2">
-                        <MessageSquare className="w-5 h-5 text-blue-500" />
-                        Highlight Notes
-                        {highlights &&
-                          highlights.filter((h) => h.note).length > 0 && (
-                            <span className="ml-2 px-2 py-0.5 bg-primary/15 text-primary text-sm rounded-full">
-                              {highlights.filter((h) => h.note).length}
-                            </span>
-                          )}
-                      </h3>
-                      <ChevronDown
-                        className={cn(
-                          'w-4 h-4 transform transition-transform',
-                          showHighlightsPanel ? 'rotate-180' : ''
-                        )}
-                      />
-                    </button>
-
-                    {showHighlightsPanel && (
-                      <div className="border-t">
-                        <HighlightNotes
-                          highlights={highlights || []}
-                          currentUserId={user?._id as Id<'users'> | undefined}
-                          tipsByHighlight={tipsByHighlight}
-                          onNoteClick={(highlight) => {
-                            // Scroll to highlight in article
-                            const element = document.querySelector(
-                              `[data-highlight-id="${highlight._id}"]`
-                            )
-                            element?.scrollIntoView({
-                              behavior: 'smooth',
-                              block: 'center',
-                            })
-                          }}
-                          className="max-h-[500px] overflow-y-auto"
-                        />
-                      </div>
-                    )}
-                  </div>
-
-                  {/* Article Stats */}
-                  {article.tipStats && (
-                    <div className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-[var(--card-padding)]">
-                      <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-                        <DollarSign className="w-5 h-5 text-green-500" />
-                        Article Stats
-                      </h3>
-                      <div className="space-y-3">
-                        <div className="flex justify-between">
-                          <span className="text-muted-foreground">
-                            Total Tips
-                          </span>
-                          <span className="font-semibold">
-                            {article.tipStats.count || 0}
-                          </span>
-                        </div>
-                        <div className="flex justify-between">
-                          <span className="text-muted-foreground">
-                            Total Earned
-                          </span>
-                          <span className="font-semibold">
-                            ${(article.tipStats.total || 0).toFixed(2)}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  )}
-
-                  {/* Arweave Permanent Storage */}
-                  {article.arweaveStatus && (
-                    <div className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-[var(--card-padding)]">
-                      <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-                        <Archive className="w-5 h-5 text-blue-500" />
-                        Permanent Storage
-                      </h3>
-                      <ArweaveStatus
-                        status={article.arweaveStatus}
-                        txId={article.arweaveTxId}
-                        url={article.arweaveUrl}
-                        timestamp={article.arweaveTimestamp}
-                      />
-                    </div>
-                  )}
-                </div>
-              </ErrorBoundary>
-            </div>
-          </div>
+          <ErrorBoundary fallback={<ArticleSidebarSectionFallback />}>
+            <ArticleDetailsPanel
+              articleId={article._id}
+              articleTitle={article.title}
+              articleSlug={article.slug}
+              authorId={article.author.id}
+              currentUserId={user?._id as Id<'users'> | undefined}
+              tocHeadings={tocHeadings}
+              highlights={highlights}
+              tipsByHighlight={tipsByHighlight}
+              tipStats={article.tipStats}
+              arweaveStatus={article.arweaveStatus}
+              arweaveTxId={article.arweaveTxId}
+              arweaveUrl={article.arweaveUrl}
+              arweaveTimestamp={article.arweaveTimestamp}
+            />
+          </ErrorBoundary>
         </div>
       </main>
       <SiteFooter variant="default" />
@@ -304,6 +156,5 @@ export default function ArticlePage({ params }: ArticlePageProps) {
   )
 }
 
-// Configure dynamic behavior for production
 export const dynamic = 'force-dynamic'
 export const dynamicParams = true

--- a/app/[username]/[slug]/page.tsx
+++ b/app/[username]/[slug]/page.tsx
@@ -123,9 +123,7 @@ export default function ArticlePage({ params }: ArticlePageProps) {
                 <ArticleReaderSupport
                   articleId={article._id}
                   articleSlug={article.slug}
-                  authorName={
-                    article.author.name || article.author.username
-                  }
+                  authorName={article.author.name || article.author.username}
                   authorStellarAddress={article.author.stellarAddress}
                 />
               }

--- a/components/articles/ArticleDetailsPanel.tsx
+++ b/components/articles/ArticleDetailsPanel.tsx
@@ -68,7 +68,11 @@ export function ArticleDetailsPanel({
   const noteCount = highlights?.filter((h) => h.note).length ?? 0
 
   return (
-    <Accordion type="single" collapsible className="mt-8 border-t border-border">
+    <Accordion
+      type="single"
+      collapsible
+      className="mt-8 border-t border-border"
+    >
       <AccordionItem value="article-details" className="border-none">
         <AccordionTrigger className="text-muted-foreground hover:text-foreground hover:no-underline">
           Article details

--- a/components/articles/ArticleDetailsPanel.tsx
+++ b/components/articles/ArticleDetailsPanel.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import nextDynamic from 'next/dynamic'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion'
+import { ArticleTableOfContents } from '@/components/articles/ArticleTableOfContents'
+import { HighlightHeatmap } from '@/components/highlights/HighlightHeatmap'
+import { HighlightNotes } from '@/components/highlights/HighlightNotes'
+import { ArweaveStatus } from '@/components/articles/ArweaveStatus'
+import { NftSidebarSkeleton } from '@/components/articles/ArticleEngagementSkeleton'
+import { Archive, DollarSign, MessageSquare, Trophy } from 'lucide-react'
+import type { Id } from '@/types/convex'
+import type { TocHeading } from '@/lib/tiptap/headings'
+import type { Doc } from '@/convex/_generated/dataModel'
+
+const NFTIntegration = nextDynamic(
+  () =>
+    import('@/components/nft/NFTIntegration').then((mod) => ({
+      default: mod.NFTIntegration,
+    })),
+  { ssr: false, loading: () => <NftSidebarSkeleton /> }
+)
+
+interface ArticleDetailsPanelProps {
+  articleId: Id<'articles'>
+  articleTitle: string
+  articleSlug: string
+  authorId: Id<'users'>
+  currentUserId?: Id<'users'>
+  tocHeadings: TocHeading[]
+  highlights: Doc<'highlights'>[] | undefined
+  tipsByHighlight: Record<string, { count: number; totalUsd: number }>
+  tipStats?: { count?: number; total?: number } | null
+  arweaveStatus?: string | null
+  arweaveTxId?: string | null
+  arweaveUrl?: string | null
+  arweaveTimestamp?: number | null
+}
+
+function DetailsSection({ children }: { children: React.ReactNode }) {
+  return (
+    <section className="border-t border-border pt-6 first:border-t-0 first:pt-0">
+      {children}
+    </section>
+  )
+}
+
+export function ArticleDetailsPanel({
+  articleId,
+  articleTitle,
+  articleSlug,
+  authorId,
+  currentUserId,
+  tocHeadings,
+  highlights,
+  tipsByHighlight,
+  tipStats,
+  arweaveStatus,
+  arweaveTxId,
+  arweaveUrl,
+  arweaveTimestamp,
+}: ArticleDetailsPanelProps) {
+  const showToc = tocHeadings.length >= 3
+  const noteCount = highlights?.filter((h) => h.note).length ?? 0
+
+  return (
+    <Accordion type="single" collapsible className="mt-8 border-t border-border">
+      <AccordionItem value="article-details" className="border-none">
+        <AccordionTrigger className="text-muted-foreground hover:text-foreground hover:no-underline">
+          Article details
+        </AccordionTrigger>
+        <AccordionContent>
+          <div className="space-y-0">
+            {showToc && (
+              <DetailsSection>
+                <ArticleTableOfContents headings={tocHeadings} embedded />
+              </DetailsSection>
+            )}
+
+            <DetailsSection>
+              <h4 className="text-sm font-medium flex items-center gap-2 mb-4">
+                <Trophy className="w-4 h-4 text-purple-500" />
+                NFT Collection
+              </h4>
+              <NFTIntegration
+                articleId={articleId}
+                articleTitle={articleTitle}
+                articleSlug={articleSlug}
+                authorId={authorId}
+                currentUserId={currentUserId}
+                embedded
+              />
+            </DetailsSection>
+
+            <DetailsSection>
+              <HighlightHeatmap
+                articleId={articleId}
+                isAuthor={currentUserId === authorId}
+                embedded
+              />
+            </DetailsSection>
+
+            <DetailsSection>
+              <h4 className="text-sm font-medium flex items-center gap-2 mb-4">
+                <MessageSquare className="w-4 h-4 text-blue-500" />
+                Highlight Notes
+                {noteCount > 0 && (
+                  <span className="px-2 py-0.5 bg-primary/15 text-primary text-xs rounded-full">
+                    {noteCount}
+                  </span>
+                )}
+              </h4>
+              <HighlightNotes
+                highlights={highlights || []}
+                currentUserId={currentUserId}
+                tipsByHighlight={tipsByHighlight}
+                onNoteClick={(highlight) => {
+                  const element = document.querySelector(
+                    `[data-highlight-id="${highlight._id}"]`
+                  )
+                  element?.scrollIntoView({
+                    behavior: 'smooth',
+                    block: 'center',
+                  })
+                }}
+                className="max-h-[500px] overflow-y-auto"
+              />
+            </DetailsSection>
+
+            {tipStats && (
+              <DetailsSection>
+                <h4 className="text-sm font-medium flex items-center gap-2 mb-4">
+                  <DollarSign className="w-4 h-4 text-green-500" />
+                  Article Stats
+                </h4>
+                <div className="space-y-3">
+                  <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Total Tips</span>
+                    <span className="font-semibold">{tipStats.count || 0}</span>
+                  </div>
+                  <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Total Earned</span>
+                    <span className="font-semibold">
+                      ${(tipStats.total || 0).toFixed(2)}
+                    </span>
+                  </div>
+                </div>
+              </DetailsSection>
+            )}
+
+            {arweaveStatus && (
+              <DetailsSection>
+                <h4 className="text-sm font-medium flex items-center gap-2 mb-4">
+                  <Archive className="w-4 h-4 text-blue-500" />
+                  Permanent Storage
+                </h4>
+                <ArweaveStatus
+                  status={arweaveStatus}
+                  txId={arweaveTxId ?? undefined}
+                  url={arweaveUrl ?? undefined}
+                  timestamp={arweaveTimestamp ?? undefined}
+                />
+              </DetailsSection>
+            )}
+          </div>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  )
+}

--- a/components/articles/ArticleDisplay.tsx
+++ b/components/articles/ArticleDisplay.tsx
@@ -31,6 +31,7 @@ interface ArticleDisplayProps {
   authorStellarAddress?: string | null
   showHighlights?: boolean
   tocHeadings?: TocHeading[]
+  readerSupport?: React.ReactNode
 }
 
 export default function ArticleDisplay({
@@ -38,6 +39,7 @@ export default function ArticleDisplay({
   authorStellarAddress: _authorStellarAddress,
   showHighlights = true,
   tocHeadings = [],
+  readerSupport,
 }: ArticleDisplayProps) {
   const [currentUrl, setCurrentUrl] = useState('')
 
@@ -105,6 +107,8 @@ export default function ArticleDisplay({
           </div>
         )}
       </header>
+
+      {readerSupport}
 
       <div className="article-content">
         {showHighlights ? (

--- a/components/articles/ArticlePageLoadingSkeleton.tsx
+++ b/components/articles/ArticlePageLoadingSkeleton.tsx
@@ -6,7 +6,11 @@ export function ArticlePageLoadingSkeleton() {
       <div className="max-w-4xl mx-auto px-4 py-8">
         <Skeleton className="h-96 w-full rounded-lg mb-8" />
         <Skeleton className="h-8 w-3/4 mb-4" />
-        <Skeleton className="h-4 w-1/2 mb-8" />
+        <Skeleton className="h-4 w-1/2 mb-6" />
+        <div className="flex items-center justify-between gap-4 py-4 border-y border-border mb-8">
+          <Skeleton className="h-9 w-28" />
+          <Skeleton className="h-4 w-40" />
+        </div>
         <div className="space-y-3">
           <Skeleton className="h-4 w-full" />
           <Skeleton className="h-4 w-full" />

--- a/components/articles/ArticleReaderSupport.tsx
+++ b/components/articles/ArticleReaderSupport.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { ArticleTipActions } from '@/components/tipping/ArticleTipActions'
+import { TipStats } from '@/components/tipping/TipStats'
+import type { Id } from '@/types/convex'
+
+interface ArticleReaderSupportProps {
+  articleId: Id<'articles'>
+  articleSlug: string
+  authorName: string
+  authorStellarAddress?: string | null
+}
+
+export function ArticleReaderSupport({
+  articleId,
+  articleSlug,
+  authorName,
+  authorStellarAddress,
+}: ArticleReaderSupportProps) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-4 py-4 border-y border-border">
+      <ArticleTipActions
+        articleId={articleId}
+        articleSlug={articleSlug}
+        authorName={authorName}
+        authorStellarAddress={authorStellarAddress}
+      />
+      <TipStats articleId={articleId} />
+    </div>
+  )
+}

--- a/components/articles/ArticleTableOfContents.tsx
+++ b/components/articles/ArticleTableOfContents.tsx
@@ -112,7 +112,9 @@ export function ArticleTableOfContents({
     >
       <h3
         id={TOC_HEADING_ID}
-        className={embedded ? 'text-sm font-medium mb-3' : 'text-lg font-semibold mb-3'}
+        className={
+          embedded ? 'text-sm font-medium mb-3' : 'text-lg font-semibold mb-3'
+        }
       >
         On this page
       </h3>

--- a/components/articles/ArticleTableOfContents.tsx
+++ b/components/articles/ArticleTableOfContents.tsx
@@ -12,6 +12,7 @@ const TOC_LINK_CLASS =
 
 interface ArticleTableOfContentsProps {
   headings: TocHeading[]
+  embedded?: boolean
 }
 
 function getHeadingElements(ids: string[]): HTMLElement[] {
@@ -22,6 +23,7 @@ function getHeadingElements(ids: string[]): HTMLElement[] {
 
 export function ArticleTableOfContents({
   headings,
+  embedded = false,
 }: ArticleTableOfContentsProps) {
   const enabled = headings.length >= 3
   const [activeId, setActiveId] = useState<string | null>(null)
@@ -101,8 +103,17 @@ export function ArticleTableOfContents({
   if (!enabled) return null
 
   return (
-    <div className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-[var(--card-padding)]">
-      <h3 id={TOC_HEADING_ID} className="text-lg font-semibold mb-3">
+    <div
+      className={
+        embedded
+          ? undefined
+          : 'bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-[var(--card-padding)]'
+      }
+    >
+      <h3
+        id={TOC_HEADING_ID}
+        className={embedded ? 'text-sm font-medium mb-3' : 'text-lg font-semibold mb-3'}
+      >
         On this page
       </h3>
       <nav aria-labelledby={TOC_HEADING_ID}>

--- a/components/dashboard/WithdrawalDialog.test.tsx
+++ b/components/dashboard/WithdrawalDialog.test.tsx
@@ -51,7 +51,7 @@ describe('WithdrawalDialog', () => {
       })
       expect(onOpenChange).toHaveBeenCalledWith(false)
     })
-  }, 10_000)
+  })
 
   it('uses saved Stellar address without manual entry', async () => {
     const user = userEvent.setup({ delay: null })

--- a/components/highlights/HighlightHeatmap.tsx
+++ b/components/highlights/HighlightHeatmap.tsx
@@ -11,7 +11,13 @@ interface HighlightHeatmapProps {
   articleId: Id<'articles'>
   isAuthor?: boolean
   className?: string
+  embedded?: boolean
 }
+
+const heatmapShellClass = (embedded: boolean) =>
+  embedded
+    ? ''
+    : 'bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-[var(--card-padding)]'
 
 type HeatmapWindow = 'all' | '7d' | '30d'
 
@@ -19,6 +25,7 @@ export function HighlightHeatmap({
   articleId,
   isAuthor = false,
   className,
+  embedded = false,
 }: HighlightHeatmapProps) {
   const [window, setWindow] = useState<HeatmapWindow>('all')
 
@@ -35,12 +42,7 @@ export function HighlightHeatmap({
   // Loading state
   if (stats === undefined) {
     return (
-      <div
-        className={cn(
-          'bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-[var(--card-padding)]',
-          className
-        )}
-      >
+      <div className={cn(heatmapShellClass(embedded), className)}>
         <div className="animate-pulse space-y-4">
           <div className="h-6 bg-muted rounded w-1/2" />
           <div className="h-20 bg-muted rounded"></div>
@@ -55,14 +57,14 @@ export function HighlightHeatmap({
   // Empty state - No tips yet
   if (!stats || stats.totalTips === 0) {
     return (
-      <div
-        className={cn(
-          'bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-[var(--card-padding)]',
-          className
-        )}
-      >
+      <div className={cn(heatmapShellClass(embedded), className)}>
         <div className="flex items-center justify-between gap-3 mb-4">
-          <h3 className="text-lg font-semibold flex items-center gap-2">
+          <h3
+            className={cn(
+              'font-semibold flex items-center gap-2',
+              embedded ? 'text-sm font-medium' : 'text-lg font-semibold'
+            )}
+          >
             <Flame className="w-5 h-5 text-orange-500" />
             Highlight Heatmap
           </h3>
@@ -144,14 +146,14 @@ export function HighlightHeatmap({
   )
 
   return (
-    <div
-      className={cn(
-        'bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-[var(--card-padding)]',
-        className
-      )}
-    >
+    <div className={cn(heatmapShellClass(embedded), className)}>
       <div className="flex items-center justify-between gap-3 mb-4">
-        <h3 className="text-lg font-semibold flex items-center gap-2">
+        <h3
+          className={cn(
+            'flex items-center gap-2',
+            embedded ? 'text-sm font-medium' : 'text-lg font-semibold'
+          )}
+        >
           <Flame className="w-5 h-5 text-orange-500" />
           Highlight Heatmap
         </h3>

--- a/components/layout/AppNavigation.test.tsx
+++ b/components/layout/AppNavigation.test.tsx
@@ -33,7 +33,7 @@ describe('AppNavigation mobile menu', () => {
   })
 
   it('opens a dialog when the menu toggle is clicked', async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup({ delay: null })
     render(<AppNavigation />)
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()

--- a/components/nft/NFTIntegration.tsx
+++ b/components/nft/NFTIntegration.tsx
@@ -25,6 +25,7 @@ interface NFTIntegrationProps {
   articleSlug: string
   authorId: Id<'users'>
   currentUserId?: Id<'users'>
+  embedded?: boolean
 }
 
 export function NFTIntegration({
@@ -33,6 +34,7 @@ export function NFTIntegration({
   articleSlug,
   authorId,
   currentUserId,
+  embedded = false,
 }: NFTIntegrationProps) {
   const [showTransferModal, setShowTransferModal] = useState(false)
   const transferTriggerRef = useRef<HTMLButtonElement>(null)
@@ -62,17 +64,21 @@ export function NFTIntegration({
     ? (nftStatus.totalTips / nftStatus.tipThreshold) * 100
     : 0
 
+  const Shell = embedded ? 'div' : Card
+  const Header = embedded ? 'div' : CardHeader
+  const Content = embedded ? 'div' : CardContent
+
   if (isLoading) {
     return (
-      <Card className="w-full">
-        <CardHeader>
+      <Shell className="w-full">
+        <Header className={embedded ? 'space-y-2' : undefined}>
           <Skeleton className="h-8 w-32" />
           <Skeleton className="h-4 w-64 mt-2" />
-        </CardHeader>
-        <CardContent>
+        </Header>
+        <Content>
           <Skeleton className="h-24 w-full" />
-        </CardContent>
-      </Card>
+        </Content>
+      </Shell>
     )
   }
 
@@ -82,12 +88,13 @@ export function NFTIntegration({
 
   return (
     <div className="space-y-6">
-      {/* NFT Status Card */}
-      <Card className="w-full">
-        <CardHeader>
+      <Shell className="w-full">
+        <Header className={embedded ? 'space-y-2 mb-4' : undefined}>
           <div className="flex items-center justify-between">
             <div>
-              <CardTitle className="flex items-center gap-2">
+              <CardTitle
+                className={`flex items-center gap-2 ${embedded ? 'text-sm font-medium' : ''}`}
+              >
                 NFT Status
                 {nftStatus.isMinted && (
                   <NFTBadge rarity={nftStatus.rarity || 'common'} size="sm" />
@@ -105,8 +112,8 @@ export function NFTIntegration({
               </Badge>
             )}
           </div>
-        </CardHeader>
-        <CardContent>
+        </Header>
+        <Content>
           <Tabs defaultValue="overview" className="w-full">
             <TabsList className="grid w-full grid-cols-3">
               <TabsTrigger value="overview">Overview</TabsTrigger>
@@ -265,8 +272,8 @@ export function NFTIntegration({
               )}
             </TabsContent>
           </Tabs>
-        </CardContent>
-      </Card>
+        </Content>
+      </Shell>
 
       {/* Transfer Modal */}
       {nftStatus.isMinted && nftStatus.owner && (

--- a/components/tipping/TipButton.test.tsx
+++ b/components/tipping/TipButton.test.tsx
@@ -64,7 +64,7 @@ describe('TipButton auth-first CTA', () => {
     mockIsConnected.mockReturnValue(false)
   })
 
-  it('shows Sign in to tip when signed out', { timeout: 10_000 }, async () => {
+  it('shows Sign in to tip when signed out', async () => {
     const user = userEvent.setup({ delay: null })
     render(
       <TipButton

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -44,6 +44,8 @@ import {
   type TipFailureMessage,
 } from '@/lib/stellar/tip-error-messages'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 import { signInToTip, validateTipAmountForm } from '@/lib/tip/signInToTip'
 import { applyPendingAmountFields } from '@/lib/tip/applyPendingTipFormState'
 import { clearPendingTipIntent } from '@/lib/tip/pendingTipIntent'
@@ -330,13 +332,10 @@ export function TipButton({
     <>
       <Dialog open={isOpen} onOpenChange={handleOpenChange}>
         <DialogTrigger asChild>
-          <button
-            type="button"
-            className={`focus-ring inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 transition-all transform hover:scale-105 shadow-lg ${className}`}
-          >
+          <Button variant="outline" className={cn('gap-2', className)}>
             <Coins className="w-4 h-4" />
-            <span className="font-medium">Tip Author</span>
-          </button>
+            Tip Author
+          </Button>
         </DialogTrigger>
         <DialogContent
           className="top-auto bottom-0 left-1/2 max-h-[min(90dvh,calc(100%-2rem))] max-w-md translate-x-[-50%] translate-y-0 gap-4 overflow-y-auto rounded-b-none rounded-t-xl border border-border bg-popover p-6 shadow-xl data-[state=closed]:slide-out-to-bottom-[48%] data-[state=open]:slide-in-from-bottom-[48%] sm:top-[50%] sm:bottom-auto sm:max-h-[min(90dvh,100%)] sm:translate-y-[-50%] sm:rounded-xl sm:data-[state=closed]:slide-out-to-left-1/2 sm:data-[state=closed]:slide-out-to-top-[48%] sm:data-[state=open]:slide-in-from-left-1/2 sm:data-[state=open]:slide-in-from-top-[48%]"
@@ -472,46 +471,47 @@ export function TipButton({
           )}
 
           <div className="flex gap-3">
-            <button
+            <Button
               type="button"
+              variant="outline"
               onClick={() => handleOpenChange(false)}
               disabled={isLoading}
-              className="focus-ring flex-1 px-4 py-2 border border-input bg-background text-foreground rounded-lg hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex-1"
             >
               Cancel
-            </button>
+            </Button>
 
             {!isAuthenticated ? (
-              <button
+              <Button
                 type="button"
                 onClick={handleSignInToTip}
                 disabled={isLoading || (!selectedAmount && !customAmount)}
-                className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                className="flex-1 gap-2"
               >
                 <Heart className="w-4 h-4" />
-                <span>Sign in to tip</span>
-              </button>
+                Sign in to tip
+              </Button>
             ) : !isConnected ? (
-              <button
+              <Button
                 type="button"
                 onClick={handleConnectWallet}
                 disabled={isLoading || isWalletLoading}
-                className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-blue-500 to-blue-600 text-white rounded-lg hover:from-blue-600 hover:to-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                className="flex-1 gap-2"
               >
                 {isWalletLoading ? (
                   <>
                     <Loader2 className="w-4 h-4 animate-spin" />
-                    <span>Connecting</span>
+                    Connecting
                   </>
                 ) : (
                   <>
                     <Wallet className="w-4 h-4" />
-                    <span>Connect Wallet</span>
+                    Connect Wallet
                   </>
                 )}
-              </button>
+              </Button>
             ) : (
-              <button
+              <Button
                 type="button"
                 onClick={handleTip}
                 disabled={
@@ -519,24 +519,22 @@ export function TipButton({
                   !!tipSuccess ||
                   (!selectedAmount && !customAmount)
                 }
-                className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                className="flex-1 gap-2"
               >
                 {isLoading ? (
                   <>
                     <Loader2 className="w-4 h-4 animate-spin" />
-                    <span>
-                      {tipFlowStep
-                        ? tipFlowProgressLabel(tipFlowStep)
-                        : 'Awaiting signature'}
-                    </span>
+                    {tipFlowStep
+                      ? tipFlowProgressLabel(tipFlowStep)
+                      : 'Awaiting signature'}
                   </>
                 ) : (
                   <>
                     <Heart className="w-4 h-4" />
-                    <span>{tipFailure ? 'Retry' : 'Send Tip'}</span>
+                    {tipFailure ? 'Retry' : 'Send Tip'}
                   </>
                 )}
-              </button>
+              </Button>
             )}
           </div>
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,7 +24,8 @@ export default defineConfig({
           exclude: ['node_modules', '.next', 'convex/**'],
           environment: 'node',
           setupFiles: ['./vitest.setup.ts'],
-          testTimeout: 10_000,
+          // UI interaction tests can exceed 10s when the full suite runs in parallel.
+          testTimeout: 30_000,
         },
       },
     ],


### PR DESCRIPTION
## Summary

Refactors the published article page into an article-first, single-column reader layout. Monetization and secondary modules no longer compete with the reading experience as a full right sidebar.

## Changes

- Remove the 8+4 sidebar grid from `app/[username]/[slug]/page.tsx` in favor of a centered `max-w-4xl` single-column layout
- Add `ArticleReaderSupport`, a compact horizontal support bar with Tip Author and tip stats placed after the author byline, before the article body
- Add `ArticleDetailsPanel`, a collapsed accordion for NFT, heatmap, highlight notes, article stats, permanent storage, and TOC
- Add `readerSupport` slot to `ArticleDisplay` for Medium-style engagement placement
- Restyle `TipButton` from yellow-orange gradient to restrained shadcn `Button` variants
- Add `embedded` prop to `ArticleTableOfContents`, `HighlightHeatmap`, and `NFTIntegration` to avoid stacked card chrome inside the details panel
- Update `ArticlePageLoadingSkeleton` to match the new support bar placement

## Testing

- `bun run format:check` via CI Lint, Typecheck & Test - passed
- `bun run lint` via CI Lint, Typecheck & Test - passed
- `bun run typecheck` via CI Lint, Typecheck & Test - passed
- `bun run test:once` via CI Lint, Typecheck & Test - passed
- `bun run build` via CI Build - passed
- PR Hygiene Required - passed
- Vercel preview deployment - passed
- Manual preview smoke for `/pragya/test-article-4` - passed

## Notes

- Preview URL: https://quilltip-85vpx34cx-pragya-sharmas-projects-a6320130.vercel.app
- Manual smoke confirmed the article body is dominant above the fold, support is consolidated into one compact area, article details are collapsed by default and open cleanly, tip dialog states still work, responsive layout does not overflow, browser console/network are clean, and article routes from browse/profile use the new reader layout.
- Existing older article data was not deleted by this PR. Public browse/profile lists may only show listing-ready published rows because of existing discovery filtering outside the ENG-245 layout change.
- No contract, Stellar transaction, Convex schema, or Arweave behavior changes are included in this PR.