### PR TITLE
feat(editor): publish readiness excerpt in more menu (ENG-247)

### DIFF
--- a/components/editor/EditorActionBar.test.tsx
+++ b/components/editor/EditorActionBar.test.tsx
@@ -1,9 +1,15 @@
 /** @vitest-environment jsdom */
-import { act, render, screen } from '@testing-library/react'
-import { describe, expect, it, vi, afterEach } from 'vitest'
+import { act, render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
 import type { Editor } from '@tiptap/react'
 import { EditorActionBar } from '@/components/editor/EditorActionBar'
 import { AUTO_SAVE_GUIDANCE } from '@/lib/autosave'
+
+const useIsMobileMock = vi.hoisted(() => vi.fn(() => false))
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => useIsMobileMock(),
+}))
 
 function makeStubEditor(): Editor {
   return {
@@ -36,6 +42,10 @@ const baseProps = {
 }
 
 describe('EditorActionBar autosave status', () => {
+  beforeEach(() => {
+    useIsMobileMock.mockReturnValue(false)
+  })
+
   afterEach(() => {
     vi.useRealTimers()
   })
@@ -175,5 +185,43 @@ describe('EditorActionBar publish requirements', () => {
     )
     expect(screen.queryByText(/excerpt of at least/)).not.toBeInTheDocument()
     expect(screen.getAllByText('Published').length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('EditorActionBar excerpt menu', () => {
+  it('expands excerpt textarea inside the more menu', () => {
+    const onExcerptChange = vi.fn()
+    const onExcerptOpenChange = vi.fn()
+
+    render(
+      <EditorActionBar
+        {...baseProps}
+        excerpt=""
+        onExcerptChange={onExcerptChange}
+        excerptOpen={false}
+        onExcerptOpenChange={onExcerptOpenChange}
+        moreMenuOpen
+        onMoreMenuOpenChange={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByText('Add excerpt'))
+    expect(onExcerptOpenChange).toHaveBeenCalledWith(true)
+  })
+
+  it('shows Edit excerpt when excerpt text exists', () => {
+    render(
+      <EditorActionBar
+        {...baseProps}
+        excerpt="A short summary for the article."
+        onExcerptChange={vi.fn()}
+        excerptOpen={false}
+        onExcerptOpenChange={vi.fn()}
+        moreMenuOpen
+        onMoreMenuOpenChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Edit excerpt')).toBeInTheDocument()
   })
 })

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -14,6 +14,7 @@ import {
   Loader2,
 } from 'lucide-react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import { cn } from '@/lib/utils'
 import { AUTO_SAVE_GUIDANCE } from '@/lib/autosave'
 import { truncateFeedbackMessage } from '@/lib/feedback/flow-feedback'
 import { estimateReadingMinutes } from '@/lib/reading-time'
@@ -66,6 +67,7 @@ interface EditorActionBarProps {
   isPublishing: boolean
   canPublish: boolean
   publishBlockReason?: string | null
+  onBlockReasonClick?: () => void
   lastSavedAt?: Date | null
   onDelete?: () => void
   isDeleting?: boolean
@@ -164,6 +166,7 @@ export function EditorActionBar({
   isPublishing,
   canPublish,
   publishBlockReason = null,
+  onBlockReasonClick,
   lastSavedAt,
   onDelete,
   isDeleting = false,
@@ -415,7 +418,11 @@ export function EditorActionBar({
         <div
           id={publishBlockReasonId}
           role="status"
-          className="border-t border-border bg-muted/50 px-4 py-2 text-xs text-muted-foreground"
+          className={cn(
+            'border-t border-border bg-muted/50 px-4 py-2 text-xs text-muted-foreground',
+            onBlockReasonClick && 'cursor-pointer hover:bg-muted'
+          )}
+          onClick={onBlockReasonClick}
         >
           {publishBlockReason}
         </div>

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -414,19 +414,30 @@ export function EditorActionBar({
         </p>
       )}
 
-      {publishBlockReason && !isPublished && (
-        <div
-          id={publishBlockReasonId}
-          role="status"
-          className={cn(
-            'border-t border-border bg-muted/50 px-4 py-2 text-xs text-muted-foreground',
-            onBlockReasonClick && 'cursor-pointer hover:bg-muted'
-          )}
-          onClick={onBlockReasonClick}
-        >
-          {publishBlockReason}
-        </div>
-      )}
+      {publishBlockReason &&
+        !isPublished &&
+        (onBlockReasonClick ? (
+          <button
+            type="button"
+            id={publishBlockReasonId}
+            onClick={onBlockReasonClick}
+            className={cn(
+              'w-full border-t border-border bg-muted/50 px-4 py-2 text-left text-xs text-muted-foreground',
+              'cursor-pointer hover:bg-muted',
+              focusRing
+            )}
+          >
+            {publishBlockReason}
+          </button>
+        ) : (
+          <div
+            id={publishBlockReasonId}
+            role="status"
+            className="border-t border-border bg-muted/50 px-4 py-2 text-xs text-muted-foreground"
+          >
+            {publishBlockReason}
+          </div>
+        ))}
     </div>
   )
 }

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -22,10 +22,7 @@ import {
   AlignLeft,
 } from 'lucide-react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-import {
-  Collapsible,
-  CollapsibleContent,
-} from '@/components/ui/collapsible'
+import { Collapsible, CollapsibleContent } from '@/components/ui/collapsible'
 import { Textarea } from '@/components/ui/textarea'
 import { cn } from '@/lib/utils'
 import { AUTO_SAVE_GUIDANCE } from '@/lib/autosave'
@@ -176,7 +173,10 @@ function MoreMenu({
           {onExcerptChange && onExcerptOpenChange && (
             <>
               <DropdownMenu.Separator className="h-px bg-border my-1" />
-              <Collapsible open={excerptOpen} onOpenChange={onExcerptOpenChange}>
+              <Collapsible
+                open={excerptOpen}
+                onOpenChange={onExcerptOpenChange}
+              >
                 <DropdownMenu.Item
                   className="px-4 py-2.5 text-sm text-foreground outline-none flex cursor-pointer items-center justify-between gap-2 hover:bg-muted focus:bg-muted data-[highlighted]:bg-muted"
                   onSelect={(e) => {

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -1,6 +1,12 @@
 'use client'
 
-import { useEffect, useId, useState, type ReactNode } from 'react'
+import {
+  useEffect,
+  useId,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from 'react'
 import { Editor } from '@tiptap/react'
 import { formatDistanceToNow } from 'date-fns'
 import {
@@ -12,12 +18,21 @@ import {
   Clock,
   LetterText,
   Loader2,
+  ChevronDown,
+  AlignLeft,
 } from 'lucide-react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import {
+  Collapsible,
+  CollapsibleContent,
+} from '@/components/ui/collapsible'
+import { Textarea } from '@/components/ui/textarea'
 import { cn } from '@/lib/utils'
 import { AUTO_SAVE_GUIDANCE } from '@/lib/autosave'
 import { truncateFeedbackMessage } from '@/lib/feedback/flow-feedback'
 import { estimateReadingMinutes } from '@/lib/reading-time'
+import { MIN_LISTING_EXCERPT_CHARS } from '@/convex/lib/articleListingReady'
+import { useIsMobile } from '@/hooks/use-mobile'
 
 function draftStatusTitle(
   lastSavedAt: Date | null | undefined,
@@ -72,24 +87,59 @@ interface EditorActionBarProps {
   onDelete?: () => void
   isDeleting?: boolean
   hasUnsavedChanges?: boolean
+  excerpt?: string
+  onExcerptChange?: (value: string) => void
+  excerptOpen?: boolean
+  onExcerptOpenChange?: (open: boolean) => void
+  excerptTextareaRef?: RefObject<HTMLTextAreaElement | null>
+  moreMenuOpen?: boolean
+  onMoreMenuOpenChange?: (open: boolean) => void
+  excerptMaxChars?: number
 }
 
 const RELATIVE_TIME_INTERVAL_MS = 30_000
+const DEFAULT_EXCERPT_MAX_CHARS = 500
 
 function MoreMenu({
   editor,
   onDelete,
   isDeleting = false,
+  excerpt = '',
+  onExcerptChange,
+  excerptOpen = false,
+  onExcerptOpenChange,
+  excerptTextareaRef,
+  moreMenuOpen,
+  onMoreMenuOpenChange,
+  excerptMaxChars = DEFAULT_EXCERPT_MAX_CHARS,
+  isActive = true,
 }: {
   editor: Editor | null
   onDelete?: () => void
   isDeleting?: boolean
+  excerpt?: string
+  onExcerptChange?: (value: string) => void
+  excerptOpen?: boolean
+  onExcerptOpenChange?: (open: boolean) => void
+  excerptTextareaRef?: RefObject<HTMLTextAreaElement | null>
+  moreMenuOpen?: boolean
+  onMoreMenuOpenChange?: (open: boolean) => void
+  excerptMaxChars?: number
+  isActive?: boolean
 }) {
   const focusRing =
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+  const excerptLabel = excerpt.trim() ? 'Edit excerpt' : 'Add excerpt'
+  const menuOpen = isActive && Boolean(moreMenuOpen)
 
   return (
-    <DropdownMenu.Root>
+    <DropdownMenu.Root
+      open={menuOpen}
+      onOpenChange={(open) => {
+        if (!isActive) return
+        onMoreMenuOpenChange?.(open)
+      }}
+    >
       <DropdownMenu.Trigger asChild>
         <button
           type="button"
@@ -102,7 +152,10 @@ function MoreMenu({
       </DropdownMenu.Trigger>
       <DropdownMenu.Portal>
         <DropdownMenu.Content
-          className="bg-card rounded-lg shadow-lg border border-border py-1 z-50 min-w-[180px]"
+          className={cn(
+            'bg-card rounded-lg shadow-lg border border-border py-1 z-50',
+            excerptOpen ? 'min-w-[280px]' : 'min-w-[180px]'
+          )}
           sideOffset={4}
           align="end"
         >
@@ -120,6 +173,65 @@ function MoreMenu({
             <Clock className="w-4 h-4 shrink-0" />~
             {estimateReadingMinutes(editor?.getText() ?? '')} min read
           </DropdownMenu.Item>
+          {onExcerptChange && onExcerptOpenChange && (
+            <>
+              <DropdownMenu.Separator className="h-px bg-border my-1" />
+              <Collapsible open={excerptOpen} onOpenChange={onExcerptOpenChange}>
+                <DropdownMenu.Item
+                  className="px-4 py-2.5 text-sm text-foreground outline-none flex cursor-pointer items-center justify-between gap-2 hover:bg-muted focus:bg-muted data-[highlighted]:bg-muted"
+                  onSelect={(e) => {
+                    e.preventDefault()
+                    const next = !excerptOpen
+                    onExcerptOpenChange(next)
+                    if (next) {
+                      window.setTimeout(
+                        () => excerptTextareaRef?.current?.focus(),
+                        0
+                      )
+                    }
+                  }}
+                >
+                  <span className="flex min-w-0 items-center gap-2">
+                    <AlignLeft className="w-4 h-4 shrink-0" />
+                    <span>{excerptLabel}</span>
+                  </span>
+                  <ChevronDown
+                    className={cn(
+                      'h-3.5 w-3.5 shrink-0 transition-transform',
+                      excerptOpen && 'rotate-180'
+                    )}
+                  />
+                </DropdownMenu.Item>
+                <CollapsibleContent>
+                  <div
+                    id="field-excerpt"
+                    className="space-y-2 border-t border-border px-3 pb-3 pt-2"
+                    onPointerDown={(e) => e.stopPropagation()}
+                  >
+                    <p className="text-[11px] leading-snug text-muted-foreground">
+                      Required for publishing. Shown on article cards and in the
+                      publish preview (at least {MIN_LISTING_EXCERPT_CHARS}{' '}
+                      characters).
+                    </p>
+                    <Textarea
+                      ref={excerptTextareaRef}
+                      id="article-excerpt"
+                      value={excerpt}
+                      onChange={(e) => onExcerptChange(e.target.value)}
+                      placeholder="Brief description of your article"
+                      rows={3}
+                      maxLength={excerptMaxChars}
+                      className="resize-none text-sm"
+                    />
+                    <p className="text-[11px] tabular-nums text-muted-foreground">
+                      {Math.min(excerpt.length, excerptMaxChars)}/
+                      {excerptMaxChars}
+                    </p>
+                  </div>
+                </CollapsibleContent>
+              </Collapsible>
+            </>
+          )}
           {onDelete && (
             <>
               <DropdownMenu.Separator className="h-px bg-border my-1" />
@@ -171,10 +283,24 @@ export function EditorActionBar({
   onDelete,
   isDeleting = false,
   hasUnsavedChanges = false,
+  excerpt,
+  onExcerptChange,
+  excerptOpen,
+  onExcerptOpenChange,
+  excerptTextareaRef,
+  moreMenuOpen,
+  onMoreMenuOpenChange,
+  excerptMaxChars,
 }: EditorActionBarProps) {
   const publishBlockReasonId = useId()
   const [relativeTick, setRelativeTick] = useState(0)
   const shortcuts = useUndoRedoShortcuts()
+  const isMobile = useIsMobile()
+
+  const handleMoreMenuOpenChange = (open: boolean) => {
+    onMoreMenuOpenChange?.(open)
+    if (!open) onExcerptOpenChange?.(false)
+  }
 
   const canUndo = editor?.can().undo ?? false
   const canRedo = editor?.can().redo ?? false
@@ -334,6 +460,15 @@ export function EditorActionBar({
               editor={editor}
               onDelete={onDelete}
               isDeleting={isDeleting}
+              excerpt={excerpt}
+              onExcerptChange={onExcerptChange}
+              excerptOpen={excerptOpen}
+              onExcerptOpenChange={onExcerptOpenChange}
+              excerptTextareaRef={excerptTextareaRef}
+              moreMenuOpen={moreMenuOpen}
+              onMoreMenuOpenChange={handleMoreMenuOpenChange}
+              excerptMaxChars={excerptMaxChars}
+              isActive={isMobile}
             />
           </div>
         </div>
@@ -401,6 +536,15 @@ export function EditorActionBar({
             editor={editor}
             onDelete={onDelete}
             isDeleting={isDeleting}
+            excerpt={excerpt}
+            onExcerptChange={onExcerptChange}
+            excerptOpen={excerptOpen}
+            onExcerptOpenChange={onExcerptOpenChange}
+            excerptTextareaRef={excerptTextareaRef}
+            moreMenuOpen={moreMenuOpen}
+            onMoreMenuOpenChange={handleMoreMenuOpenChange}
+            excerptMaxChars={excerptMaxChars}
+            isActive={!isMobile}
           />
         </div>
       </div>

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -1041,7 +1041,9 @@ export function WriteEditorWorkspace() {
         error={error?.message ?? null}
         isPublished={publishStatus.published}
         isPublishing={isPublishing}
-        canPublish={!!editor && !editor.isEmpty && !isPublishing && !publishListingError}
+        canPublish={
+          !!editor && !editor.isEmpty && !isPublishing && !publishListingError
+        }
         publishBlockReason={publishListingError}
         onBlockReasonClick={
           publishListingError?.includes('excerpt')

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -1041,8 +1041,19 @@ export function WriteEditorWorkspace() {
         error={error?.message ?? null}
         isPublished={publishStatus.published}
         isPublishing={isPublishing}
-        canPublish={!!editor && !editor.isEmpty && !isPublishing}
+        canPublish={!!editor && !editor.isEmpty && !isPublishing && !publishListingError}
         publishBlockReason={publishListingError}
+        onBlockReasonClick={
+          publishListingError?.includes('excerpt')
+            ? () => {
+                document
+                  .getElementById('field-excerpt')
+                  ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                setExcerptOpen(true)
+                window.setTimeout(() => excerptTextareaRef.current?.focus(), 0)
+              }
+            : undefined
+        }
         lastSavedAt={lastSavedAt ?? undefined}
         onDelete={handleRequestDelete}
         isDeleting={isDeleting}
@@ -1358,9 +1369,9 @@ export function WriteEditorWorkspace() {
               aria-invalid={!!titleError}
               aria-describedby={titleError ? ARTICLE_TITLE_ERROR_ID : undefined}
               className={cn(
-                'w-full resize-none overflow-hidden bg-transparent py-2 text-3xl font-semibold leading-snug text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                'w-full resize-none overflow-hidden bg-transparent py-2 text-3xl font-semibold leading-snug text-foreground placeholder:text-muted-foreground/50 focus:outline-none',
                 titleError
-                  ? 'rounded-md border border-destructive px-2 focus-visible:ring-destructive'
+                  ? 'rounded-md border border-destructive px-2'
                   : 'border border-transparent'
               )}
             />
@@ -1438,7 +1449,7 @@ export function WriteEditorWorkspace() {
                     setExcerpt(e.target.value)
                     setHasUnsavedChanges(true)
                   }}
-                  placeholder="Brief description of your article (optional)"
+                  placeholder="Brief description of your article"
                   rows={3}
                   maxLength={EXCERPT_MAX_CHARS}
                   className="resize-none"

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -27,13 +27,7 @@ import { toast } from 'sonner'
 import Image from 'next/image'
 import { EDITOR_PROSE_CLASS, UPLOAD_CONTROL_FOCUS_RING } from '@/lib/constants'
 import { mutationWithTimeout } from '@/lib/convexMutationWithTimeout'
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible'
-import { Textarea } from '@/components/ui/textarea'
-import { AlertCircle, ChevronDown, Loader2, X } from 'lucide-react'
+import { AlertCircle, Loader2, X } from 'lucide-react'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import {
   AlertDialog,
@@ -147,6 +141,7 @@ export function WriteEditorWorkspace() {
   /** When true, user dismissed recovery (Not now / Esc); keep local backup until Restore/Discard. */
   const recoveryDeferredRef = useRef(false)
   const [excerptOpen, setExcerptOpen] = useState(false)
+  const [moreMenuOpen, setMoreMenuOpen] = useState(false)
   const excerptTextareaRef = useRef<HTMLTextAreaElement>(null)
   const tagsInputRef = useRef<HTMLInputElement>(null)
   const coverChangeButtonRef = useRef<HTMLButtonElement>(null)
@@ -1048,9 +1043,7 @@ export function WriteEditorWorkspace() {
         onBlockReasonClick={
           publishListingError?.includes('excerpt')
             ? () => {
-                document
-                  .getElementById('field-excerpt')
-                  ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                setMoreMenuOpen(true)
                 setExcerptOpen(true)
                 window.setTimeout(() => excerptTextareaRef.current?.focus(), 0)
               }
@@ -1060,6 +1053,17 @@ export function WriteEditorWorkspace() {
         onDelete={handleRequestDelete}
         isDeleting={isDeleting}
         hasUnsavedChanges={hasUnsavedChanges}
+        excerpt={excerpt}
+        onExcerptChange={(value) => {
+          setExcerpt(value)
+          setHasUnsavedChanges(true)
+        }}
+        excerptOpen={excerptOpen}
+        onExcerptOpenChange={setExcerptOpen}
+        excerptTextareaRef={excerptTextareaRef}
+        moreMenuOpen={moreMenuOpen}
+        onMoreMenuOpenChange={setMoreMenuOpen}
+        excerptMaxChars={EXCERPT_MAX_CHARS}
       />
       {publishSuccessVisible ? (
         <div className="mx-auto w-full max-w-4xl px-4 pt-4 sm:px-6">
@@ -1163,9 +1167,7 @@ export function WriteEditorWorkspace() {
                 el?.focus()
               }}
               onFocusExcerpt={() => {
-                document
-                  .getElementById('field-excerpt')
-                  ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                setMoreMenuOpen(true)
                 setExcerptOpen(true)
                 window.setTimeout(() => excerptTextareaRef.current?.focus(), 0)
               }}
@@ -1394,70 +1396,6 @@ export function WriteEditorWorkspace() {
                   {savedArticleForLink.slug}
                 </p>
               )}
-          </div>
-
-          <div id="field-excerpt" className="mb-4">
-            <Collapsible open={excerptOpen} onOpenChange={setExcerptOpen}>
-              <div className="flex items-start justify-between gap-4">
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="text-xs font-medium text-muted-foreground">
-                      Excerpt
-                    </span>
-                    <span className="text-[11px] tabular-nums text-muted-foreground">
-                      {Math.min(excerpt.length, EXCERPT_MAX_CHARS)}/
-                      {EXCERPT_MAX_CHARS}
-                    </span>
-                  </div>
-                  <p className="mt-0.5 text-xs text-muted-foreground">
-                    Required for publishing. Shown on article cards and in the
-                    publish preview (at least 10 characters).
-                  </p>
-                  {!excerptOpen && excerpt.trim().length > 0 && (
-                    <p className="mt-2 line-clamp-2 whitespace-pre-wrap break-words text-sm text-foreground/80">
-                      {excerpt.trim()}
-                    </p>
-                  )}
-                </div>
-
-                <CollapsibleTrigger asChild>
-                  <button
-                    type="button"
-                    className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
-                    onClick={() => {
-                      if (!excerptOpen) {
-                        window.setTimeout(
-                          () => excerptTextareaRef.current?.focus(),
-                          0
-                        )
-                      }
-                    }}
-                    aria-label={excerptOpen ? 'Hide excerpt' : 'Add excerpt'}
-                  >
-                    <span>{excerptOpen ? 'Hide' : 'Add excerpt'}</span>
-                    <ChevronDown
-                      className={`h-3.5 w-3.5 transition-transform ${excerptOpen ? 'rotate-180' : ''}`}
-                    />
-                  </button>
-                </CollapsibleTrigger>
-              </div>
-
-              <CollapsibleContent className="mt-3">
-                <Textarea
-                  ref={excerptTextareaRef}
-                  id="article-excerpt"
-                  value={excerpt}
-                  onChange={(e) => {
-                    setExcerpt(e.target.value)
-                    setHasUnsavedChanges(true)
-                  }}
-                  placeholder="Brief description of your article"
-                  rows={3}
-                  maxLength={EXCERPT_MAX_CHARS}
-                  className="resize-none"
-                />
-              </CollapsibleContent>
-            </Collapsible>
           </div>
 
           {editor && (


### PR DESCRIPTION
## Summary

Improves the write editor publish-readiness flow by moving excerpt editing into the action bar more menu, surfacing clear publish block reasons, and fixing duplicate dropdown rendering on mobile/desktop.

Closes ENG-247.

## Changes

- Move excerpt editing from the main editor body into the three-dots more menu as a collapsible "Add excerpt" / "Edit excerpt" panel with character count and helper text
- Show a publish block reason banner when title or excerpt fails listing-ready checks; clicking an excerpt-related reason opens the more menu and focuses the excerpt field
- Disable Publish when listing-ready validation fails (`getListingReadyPublishError`)
- Fix duplicate more-menu dropdowns caused by mobile and desktop menus sharing one open state
- Add `EditorActionBar` tests for excerpt menu behavior and publish block reason display
- Merge latest `development` and resolve ENG-246 editor toolbar conflicts without dropping the PR changes

## Testing

- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test:once -- components/editor/EditorActionBar.test.tsx` (17 tests passed)
- [x] `bun run test:once -- convex/lib/articleListingReady.test.ts convex/lib/articleTitle.test.ts convex/articles.publishListingReady.test.ts convex/articles.publishTitle.test.ts` (27 tests passed)
- [x] `bun run test:once` (110 files, 616 tests passed)
- [x] `NEXT_PUBLIC_CONVEX_URL=https://example.convex.cloud bun run build`

## Notes

- Excerpt remains required for publishing (minimum 10 characters per listing-ready rules)
- Publish confirm dialog still previews excerpt before final publish
- Local ENG-247 QA checklist/evidence stayed local-only and was not committed
- Manual preview checks should use the Vercel preview linked from this PR

<img width="1225" height="719" alt="247_2" src="https://github.com/user-attachments/assets/4727e1e9-4cbc-4644-92e1-88559b976e8a" />
<img width="1221" height="717" alt="247_1" src="https://github.com/user-attachments/assets/625f5ae8-787a-473d-986c-c3245c99189e" />
