### PR TITLE
feat: prepare ENG-236 settlement evidence run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,11 +65,13 @@ docs/tranche-2-evidence.md
 docs/contract-evidence.md
 docs/eng-245-pr198-evidence.md
 docs/eng-235-batch-evidence.local.*
+docs/eng-236-batch-evidence.local.*
 docs/tipping-verification-plan.md
 docs/final-gtm-plan.md
 
 # local operator inputs
 scripts/eng-235-batch-input.local.json
+scripts/eng-236-batch-input.local.json
 
 .agents/*
 certificates

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:e2e:eng-224": "playwright test e2e/eng-224-console.spec.ts",
     "eng-224:console-baseline": "node scripts/eng-224-console-baseline.mjs",
     "eng-235:batch-evidence": "bun scripts/eng-235-batch-evidence-runner.ts",
+    "eng-236:batch-evidence": "bun scripts/eng-236-batch-evidence-runner.ts",
     "test:debug": "vitest --inspect-brk --no-file-parallelism",
     "test:coverage": "vitest run --coverage --coverage.reporter=text"
   },

--- a/scripts/eng-236-batch-evidence-runner.test.ts
+++ b/scripts/eng-236-batch-evidence-runner.test.ts
@@ -1,0 +1,423 @@
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type {
+  ArticleBatchTipParams,
+  HighlightBatchTipParams,
+} from '../lib/stellar/types'
+
+import {
+  buildBatchEvidenceHelpText,
+  buildBatchEvidenceTemplate,
+  buildStellarExpertTransactionUrl,
+  loadBatchEvidenceInput,
+  parseCliArgs,
+  runBatchEvidence,
+  type BatchEvidenceRunnerDependencies,
+} from './eng-236-batch-evidence-runner'
+
+const CONTRACT_ID = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC'
+const TIPPER_PUBLIC_KEY =
+  'GDKYMGH5YDTOVWBDQ2BH6IQCSVI33JHBWZ2GZQAV66JRJITTDAVBAHTN'
+const AUTHOR_PUBLIC_KEY =
+  'GAK6Z5YFAV5UQKW2UM7IKK65QJ3OQN6HTUWX3DZGHJ63T4CRXQK3Q6YB'
+const SECOND_AUTHOR_PUBLIC_KEY =
+  'GCBWQNDQ4K4N276QKCQKZVXXWMQZVGHKXJ2DT2VBBXPAF3LD7JFLJQHP'
+
+const realEnv = process.env
+
+afterEach(() => {
+  process.env = realEnv
+  vi.restoreAllMocks()
+})
+
+async function withTempDir(): Promise<string> {
+  return mkdtemp(path.join(tmpdir(), 'eng-236-runner-test-'))
+}
+
+function makeInputFile(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify(
+    {
+      tipperPublicKey: TIPPER_PUBLIC_KEY,
+      batches: [
+        {
+          id: 'article-smoke',
+          tipType: 'article',
+          tips: [
+            {
+              articleId: 'article-one',
+              authorAddress: AUTHOR_PUBLIC_KEY,
+              amountCents: 100,
+            },
+            {
+              articleId: 'article-two',
+              authorAddress: SECOND_AUTHOR_PUBLIC_KEY,
+              amountCents: 250,
+            },
+          ],
+        },
+        {
+          id: 'highlight-smoke',
+          tipType: 'highlight',
+          tips: [
+            {
+              highlightId: 'highlight-one',
+              articleId: 'article-one',
+              authorAddress: AUTHOR_PUBLIC_KEY,
+              amountCents: 125,
+            },
+          ],
+        },
+      ],
+      ...overrides,
+    },
+    null,
+    2
+  )
+}
+
+function makeDependencies(
+  overrides: Partial<BatchEvidenceRunnerDependencies> = {}
+): BatchEvidenceRunnerDependencies {
+  return {
+    buildArticleBatchTipTransaction: vi.fn(
+      async (_tipper: string, tips: ArticleBatchTipParams[]) => ({
+        xdr: 'article-prepared-xdr',
+        stroops: 350_000_000,
+        authorReceived: 341_250_000,
+        platformFee: 8_750_000,
+        items: tips.map((tip) => {
+          const stroops = tip.amountCents === 100 ? 100_000_000 : 250_000_000
+          return {
+            ...tip,
+            stroops,
+            authorReceived: Math.floor(stroops * 0.975),
+            platformFee: stroops - Math.floor(stroops * 0.975),
+          }
+        }),
+      })
+    ),
+    buildHighlightBatchTipTransaction: vi.fn(
+      async (_tipper: string, tips: HighlightBatchTipParams[]) => ({
+        xdr: 'highlight-prepared-xdr',
+        stroops: 125_000_000,
+        authorReceived: 121_875_000,
+        platformFee: 3_125_000,
+        items: tips.map((tip) => ({
+          ...tip,
+          stroops: 125_000_000,
+          authorReceived: 121_875_000,
+          platformFee: 3_125_000,
+        })),
+      })
+    ),
+    signPreparedXdr: vi.fn(async (xdr) => `signed-${xdr}`),
+    submitSignedBatchTransaction: vi.fn(async (signedXdr) => ({
+      transactionHash: `${signedXdr}-hash`,
+    })),
+    now: () => new Date('2026-06-10T12:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+describe('ENG-236 batch evidence runner', () => {
+  it('builds a local template that covers article and highlight batch inputs', () => {
+    const template = buildBatchEvidenceTemplate()
+
+    expect(template.tipperPublicKey).toBe('<TESTNET tipper public key>')
+    expect(template.batches).toHaveLength(2)
+    expect(template.batches[0]).toMatchObject({
+      id: 'article-batch-smoke',
+      tipType: 'article',
+      tips: [
+        {
+          articleId: '<article id>',
+          authorAddress: '<author Stellar public key>',
+          amountCents: 100,
+        },
+      ],
+    })
+    expect(template.batches[1]).toMatchObject({
+      id: 'highlight-batch-smoke',
+      tipType: 'highlight',
+      tips: [
+        {
+          highlightId: '<highlight id>',
+          articleId: '<article id>',
+          authorAddress: '<author Stellar public key>',
+          amountCents: 100,
+        },
+      ],
+    })
+  })
+
+  it('loads and validates local batch evidence input', async () => {
+    const dir = await withTempDir()
+    const inputPath = path.join(dir, 'input.json')
+
+    try {
+      await writeFile(inputPath, makeInputFile(), 'utf8')
+
+      const input = await loadBatchEvidenceInput(inputPath)
+
+      expect(input.tipperPublicKey).toBe(TIPPER_PUBLIC_KEY)
+      expect(input.batches).toHaveLength(2)
+      expect(input.batches[0]?.tipType).toBe('article')
+      expect(input.batches[1]?.tipType).toBe('highlight')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects malformed batch evidence input before network work', async () => {
+    const dir = await withTempDir()
+    const inputPath = path.join(dir, 'input.json')
+
+    try {
+      await writeFile(
+        inputPath,
+        makeInputFile({ tipperPublicKey: 'not-a-stellar-account' }),
+        'utf8'
+      )
+
+      await expect(loadBatchEvidenceInput(inputPath)).rejects.toThrow(
+        'tipperPublicKey must be a Stellar public key'
+      )
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('runs dry-run batches without requiring a secret or submitting', async () => {
+    const dir = await withTempDir()
+    const inputPath = path.join(dir, 'input.json')
+    const outputPath = path.join(dir, 'evidence.local.jsonl')
+    const deps = makeDependencies()
+
+    try {
+      await writeFile(inputPath, makeInputFile(), 'utf8')
+
+      const result = await runBatchEvidence({
+        inputPath,
+        outputPath,
+        dryRun: true,
+        contractId: CONTRACT_ID,
+        deps,
+      })
+
+      expect(result).toHaveLength(2)
+      expect(deps.buildArticleBatchTipTransaction).toHaveBeenCalledWith(
+        TIPPER_PUBLIC_KEY,
+        [
+          {
+            articleId: 'article-one',
+            authorAddress: AUTHOR_PUBLIC_KEY,
+            amountCents: 100,
+          },
+          {
+            articleId: 'article-two',
+            authorAddress: SECOND_AUTHOR_PUBLIC_KEY,
+            amountCents: 250,
+          },
+        ]
+      )
+      expect(deps.buildHighlightBatchTipTransaction).toHaveBeenCalledWith(
+        TIPPER_PUBLIC_KEY,
+        [
+          {
+            highlightId: 'highlight-one',
+            articleId: 'article-one',
+            authorAddress: AUTHOR_PUBLIC_KEY,
+            amountCents: 125,
+          },
+        ]
+      )
+      expect(deps.signPreparedXdr).not.toHaveBeenCalled()
+      expect(deps.submitSignedBatchTransaction).not.toHaveBeenCalled()
+
+      const lines = (await readFile(outputPath, 'utf8')).trim().split('\n')
+      expect(lines).toHaveLength(2)
+      expect(JSON.parse(lines[0] ?? '{}')).toMatchObject({
+        issue: 'ENG-236',
+        dryRun: true,
+        batchId: 'article-smoke',
+        tipType: 'article',
+        batchSize: 2,
+        contractId: CONTRACT_ID,
+        tipperPublicKey: TIPPER_PUBLIC_KEY,
+        transactionHash: null,
+        stellarExpertUrl: null,
+      })
+      expect(JSON.parse(lines[1] ?? '{}')).toMatchObject({
+        issue: 'ENG-236',
+        dryRun: true,
+        batchId: 'highlight-smoke',
+        tipType: 'highlight',
+        batchSize: 1,
+        contractId: CONTRACT_ID,
+        tipperPublicKey: TIPPER_PUBLIC_KEY,
+        transactionHash: null,
+        stellarExpertUrl: null,
+      })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('records item-level evidence for ENG-236 storage spot checks', async () => {
+    const dir = await withTempDir()
+    const inputPath = path.join(dir, 'input.json')
+    const outputPath = path.join(dir, 'evidence.local.jsonl')
+    const deps = makeDependencies()
+
+    try {
+      await writeFile(inputPath, makeInputFile(), 'utf8')
+
+      const result = await runBatchEvidence({
+        inputPath,
+        outputPath,
+        dryRun: true,
+        contractId: CONTRACT_ID,
+        deps,
+      })
+
+      expect(result[0]).toMatchObject({
+        issue: 'ENG-236',
+        batchId: 'article-smoke',
+        tipType: 'article',
+        batchSize: 2,
+        items: [
+          {
+            articleId: 'article-one',
+            authorAddress: AUTHOR_PUBLIC_KEY,
+            amountCents: 100,
+            stroops: 100_000_000,
+            authorReceived: 97_500_000,
+            platformFee: 2_500_000,
+          },
+          {
+            articleId: 'article-two',
+            authorAddress: SECOND_AUTHOR_PUBLIC_KEY,
+            amountCents: 250,
+            stroops: 250_000_000,
+            authorReceived: 243_750_000,
+            platformFee: 6_250_000,
+          },
+        ],
+      })
+      expect(result[1]).toMatchObject({
+        issue: 'ENG-236',
+        batchId: 'highlight-smoke',
+        tipType: 'highlight',
+        batchSize: 1,
+        items: [
+          {
+            highlightId: 'highlight-one',
+            articleId: 'article-one',
+            authorAddress: AUTHOR_PUBLIC_KEY,
+            amountCents: 125,
+            stroops: 125_000_000,
+            authorReceived: 121_875_000,
+            platformFee: 3_125_000,
+          },
+        ],
+      })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('uses ENG-236 local input and evidence paths by default', () => {
+    expect(parseCliArgs(['--write-template'])).toMatchObject({
+      writeTemplate: true,
+      templatePath: 'scripts/eng-236-batch-input.local.json',
+      outputPath: 'docs/eng-236-batch-evidence.local.jsonl',
+    })
+  })
+
+  it('shows issue-specific operator commands in help text', () => {
+    const helpText = buildBatchEvidenceHelpText()
+
+    expect(helpText).toContain('ENG-236 local batch evidence runner')
+    expect(helpText).toContain(
+      'bun run eng-236:batch-evidence -- --write-template'
+    )
+    expect(helpText).toContain('scripts/eng-236-batch-input.local.json')
+  })
+
+  it('signs and submits each batch when dry-run is disabled', async () => {
+    const dir = await withTempDir()
+    const inputPath = path.join(dir, 'input.json')
+    const outputPath = path.join(dir, 'evidence.local.jsonl')
+    const deps = makeDependencies()
+
+    try {
+      await writeFile(inputPath, makeInputFile(), 'utf8')
+
+      await runBatchEvidence({
+        inputPath,
+        outputPath,
+        dryRun: false,
+        contractId: CONTRACT_ID,
+        secretKey: 'S'.repeat(56),
+        deps,
+      })
+
+      expect(deps.signPreparedXdr).toHaveBeenCalledTimes(2)
+      expect(deps.submitSignedBatchTransaction).toHaveBeenCalledTimes(2)
+
+      const lines = (await readFile(outputPath, 'utf8')).trim().split('\n')
+      expect(JSON.parse(lines[0] ?? '{}')).toMatchObject({
+        dryRun: false,
+        transactionHash: 'signed-article-prepared-xdr-hash',
+        stellarExpertUrl:
+          'https://stellar.expert/explorer/testnet/tx/signed-article-prepared-xdr-hash',
+      })
+      expect(JSON.parse(lines[1] ?? '{}')).toMatchObject({
+        dryRun: false,
+        transactionHash: 'signed-highlight-prepared-xdr-hash',
+        stellarExpertUrl:
+          'https://stellar.expert/explorer/testnet/tx/signed-highlight-prepared-xdr-hash',
+      })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('requires an operator secret for live submission', async () => {
+    const dir = await withTempDir()
+    const inputPath = path.join(dir, 'input.json')
+    const outputPath = path.join(dir, 'evidence.local.jsonl')
+
+    try {
+      await writeFile(inputPath, makeInputFile(), 'utf8')
+
+      await expect(
+        runBatchEvidence({
+          inputPath,
+          outputPath,
+          dryRun: false,
+          contractId: CONTRACT_ID,
+          deps: makeDependencies(),
+        })
+      ).rejects.toThrow('ENG236_TIPPER_SECRET_KEY is required')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('Stellar Expert evidence links', () => {
+  it('uses the testnet explorer for TESTNET evidence', () => {
+    expect(buildStellarExpertTransactionUrl('abc123', 'TESTNET')).toBe(
+      'https://stellar.expert/explorer/testnet/tx/abc123'
+    )
+  })
+
+  it('uses the public explorer for MAINNET evidence', () => {
+    expect(buildStellarExpertTransactionUrl('abc123', 'MAINNET')).toBe(
+      'https://stellar.expert/explorer/public/tx/abc123'
+    )
+  })
+})

--- a/scripts/eng-236-batch-evidence-runner.ts
+++ b/scripts/eng-236-batch-evidence-runner.ts
@@ -1,0 +1,506 @@
+import { appendFile, mkdir, readFile, writeFile } from 'fs/promises'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { z } from 'zod'
+
+import { StellarClient } from '../lib/stellar/client'
+import { STELLAR_CONFIG } from '../lib/stellar/config'
+import { loadStellarSdk } from '../lib/stellar/sdk-loader'
+import type {
+  ArticleBatchTipParams,
+  ArticleBatchTipQuote,
+  BatchTipTransactionResult,
+  HighlightBatchTipParams,
+  HighlightBatchTipQuote,
+} from '../lib/stellar/types'
+
+const ISSUE_ID = 'ENG-236'
+const DEFAULT_TEMPLATE_PATH = 'scripts/eng-236-batch-input.local.json'
+const DEFAULT_EVIDENCE_PATH = 'docs/eng-236-batch-evidence.local.jsonl'
+const SUBMISSION_MAX_ATTEMPTS = 30
+const SUBMISSION_RETRY_DELAY_MS = 1_000
+
+const stellarAccountSchema = z
+  .string()
+  .regex(/^G[A-Z2-7]{55}$/, 'must be a Stellar public key')
+
+const articleTipSchema = z.object({
+  articleId: z.string().min(1, 'articleId is required'),
+  authorAddress: stellarAccountSchema,
+  amountCents: z.number().int().positive('amountCents must be positive'),
+})
+
+const highlightTipSchema = articleTipSchema.extend({
+  highlightId: z.string().min(1, 'highlightId is required'),
+})
+
+const articleBatchSchema = z.object({
+  id: z.string().min(1).optional(),
+  tipType: z.literal('article'),
+  tips: z
+    .array(articleTipSchema)
+    .min(1, 'article batch needs at least one tip'),
+})
+
+const highlightBatchSchema = z.object({
+  id: z.string().min(1).optional(),
+  tipType: z.literal('highlight'),
+  tips: z
+    .array(highlightTipSchema)
+    .min(1, 'highlight batch needs at least one tip'),
+})
+
+const batchEvidenceInputSchema = z.object({
+  tipperPublicKey: stellarAccountSchema,
+  batches: z
+    .array(
+      z.discriminatedUnion('tipType', [
+        articleBatchSchema,
+        highlightBatchSchema,
+      ])
+    )
+    .min(1, 'at least one batch is required'),
+})
+
+export type BatchEvidenceInput = z.infer<typeof batchEvidenceInputSchema>
+export type BatchEvidenceBatch = BatchEvidenceInput['batches'][number]
+export type BatchEvidenceItem = ArticleBatchTipQuote | HighlightBatchTipQuote
+
+export type BatchEvidenceLine = {
+  issue: typeof ISSUE_ID
+  recordedAt: string
+  network: string
+  dryRun: boolean
+  batchId: string
+  tipType: BatchEvidenceBatch['tipType']
+  batchSize: number
+  contractId: string
+  tipperPublicKey: string
+  transactionHash: string | null
+  stellarExpertUrl: string | null
+  stroops: number
+  authorReceived: number
+  platformFee: number
+  items: BatchEvidenceItem[]
+}
+
+export type BatchSubmitResult = {
+  transactionHash: string
+}
+
+export type BatchEvidenceRunnerDependencies = {
+  buildArticleBatchTipTransaction: (
+    tipperPublicKey: string,
+    tips: ArticleBatchTipParams[]
+  ) => Promise<BatchTipTransactionResult<ArticleBatchTipQuote>>
+  buildHighlightBatchTipTransaction: (
+    tipperPublicKey: string,
+    tips: HighlightBatchTipParams[]
+  ) => Promise<BatchTipTransactionResult<HighlightBatchTipQuote>>
+  signPreparedXdr: (
+    xdr: string,
+    secretKey: string,
+    expectedPublicKey: string
+  ) => Promise<string>
+  submitSignedBatchTransaction: (
+    signedXdr: string
+  ) => Promise<BatchSubmitResult>
+  now: () => Date
+}
+
+export type RunBatchEvidenceOptions = {
+  inputPath: string
+  outputPath?: string
+  dryRun: boolean
+  contractId?: string
+  secretKey?: string
+  deps?: BatchEvidenceRunnerDependencies
+}
+
+type CliOptions = {
+  inputPath?: string
+  outputPath: string
+  dryRun: boolean
+  writeTemplate: boolean
+  templatePath: string
+  help: boolean
+}
+
+export function buildBatchEvidenceTemplate(): BatchEvidenceInput {
+  return {
+    tipperPublicKey: '<TESTNET tipper public key>',
+    batches: [
+      {
+        id: 'article-batch-smoke',
+        tipType: 'article',
+        tips: [
+          {
+            articleId: '<article id>',
+            authorAddress: '<author Stellar public key>',
+            amountCents: 100,
+          },
+        ],
+      },
+      {
+        id: 'highlight-batch-smoke',
+        tipType: 'highlight',
+        tips: [
+          {
+            highlightId: '<highlight id>',
+            articleId: '<article id>',
+            authorAddress: '<author Stellar public key>',
+            amountCents: 100,
+          },
+        ],
+      },
+    ],
+  }
+}
+
+export async function writeBatchEvidenceTemplate(
+  templatePath = DEFAULT_TEMPLATE_PATH
+): Promise<void> {
+  await mkdir(path.dirname(templatePath), { recursive: true })
+  await writeFile(
+    templatePath,
+    `${JSON.stringify(buildBatchEvidenceTemplate(), null, 2)}\n`,
+    'utf8'
+  )
+}
+
+export async function loadBatchEvidenceInput(
+  inputPath: string
+): Promise<BatchEvidenceInput> {
+  let raw: string
+  try {
+    raw = await readFile(inputPath, 'utf8')
+  } catch (error) {
+    throw new Error(
+      `Could not read batch evidence input at ${inputPath}: ${formatError(error)}`
+    )
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error) {
+    throw new Error(
+      `Batch evidence input must be valid JSON: ${formatError(error)}`
+    )
+  }
+
+  const result = batchEvidenceInputSchema.safeParse(parsed)
+  if (!result.success) {
+    const issue = result.error.issues[0]
+    const location = issue?.path.join('.') || 'input'
+    const message = issue?.message || 'invalid input'
+    throw new Error(`${location} ${message}`)
+  }
+
+  return result.data
+}
+
+export function buildStellarExpertTransactionUrl(
+  transactionHash: string,
+  network: string
+): string {
+  const explorerNetwork = network === 'MAINNET' ? 'public' : 'testnet'
+  return `https://stellar.expert/explorer/${explorerNetwork}/tx/${transactionHash}`
+}
+
+export async function signPreparedXdr(
+  xdr: string,
+  secretKey: string,
+  expectedPublicKey: string
+): Promise<string> {
+  const StellarSdk = await loadStellarSdk()
+  const keypair = StellarSdk.Keypair.fromSecret(secretKey)
+
+  if (keypair.publicKey() !== expectedPublicKey) {
+    throw new Error(
+      'ENG236_TIPPER_SECRET_KEY does not match input tipperPublicKey'
+    )
+  }
+
+  const transaction = StellarSdk.TransactionBuilder.fromXDR(
+    xdr,
+    STELLAR_CONFIG.NETWORK_PASSPHRASE
+  )
+  transaction.sign(keypair)
+
+  return transaction.toXDR()
+}
+
+export async function submitSignedBatchTransaction(
+  signedXdr: string
+): Promise<BatchSubmitResult> {
+  const StellarSdk = await loadStellarSdk()
+  const sorobanServer = new StellarSdk.rpc.Server(
+    STELLAR_CONFIG.SOROBAN_RPC_URL
+  )
+  const transaction = StellarSdk.TransactionBuilder.fromXDR(
+    signedXdr,
+    STELLAR_CONFIG.NETWORK_PASSPHRASE
+  )
+
+  const submission = await sorobanServer.sendTransaction(transaction)
+  if (submission.status !== 'PENDING') {
+    throw new Error(
+      `Batch transaction submission failed with status ${submission.status}: ${formatRpcError(submission.errorResult)}`
+    )
+  }
+
+  for (let attempt = 0; attempt < SUBMISSION_MAX_ATTEMPTS; attempt++) {
+    const result = await sorobanServer.getTransaction(submission.hash)
+
+    if (result.status === 'SUCCESS') {
+      return { transactionHash: submission.hash }
+    }
+
+    if (result.status === 'FAILED') {
+      throw new Error(
+        `Batch transaction failed on TESTNET: ${formatRpcError(result)}`
+      )
+    }
+
+    await delay(SUBMISSION_RETRY_DELAY_MS)
+  }
+
+  throw new Error(
+    `Batch transaction timeout: ${submission.hash} was not confirmed after ${SUBMISSION_MAX_ATTEMPTS} attempts`
+  )
+}
+
+export async function runBatchEvidence(
+  options: RunBatchEvidenceOptions
+): Promise<BatchEvidenceLine[]> {
+  const input = await loadBatchEvidenceInput(options.inputPath)
+  const outputPath = options.outputPath ?? DEFAULT_EVIDENCE_PATH
+  const contractId = options.contractId ?? STELLAR_CONFIG.TIPPING_CONTRACT_ID
+  const secretKey = options.secretKey ?? process.env.ENG236_TIPPER_SECRET_KEY
+  const deps = options.deps ?? createDefaultDependencies()
+
+  if (!contractId) {
+    throw new Error('NEXT_PUBLIC_TIPPING_CONTRACT_ID is required')
+  }
+
+  if (!options.dryRun && !secretKey) {
+    throw new Error('ENG236_TIPPER_SECRET_KEY is required for live submission')
+  }
+
+  await mkdir(path.dirname(outputPath), { recursive: true })
+
+  const lines: BatchEvidenceLine[] = []
+  for (const [index, batch] of input.batches.entries()) {
+    const built =
+      batch.tipType === 'article'
+        ? await deps.buildArticleBatchTipTransaction(
+            input.tipperPublicKey,
+            batch.tips
+          )
+        : await deps.buildHighlightBatchTipTransaction(
+            input.tipperPublicKey,
+            batch.tips
+          )
+
+    let transactionHash: string | null = null
+    if (!options.dryRun) {
+      const signedXdr = await deps.signPreparedXdr(
+        built.xdr,
+        secretKey as string,
+        input.tipperPublicKey
+      )
+      const submitted = await deps.submitSignedBatchTransaction(signedXdr)
+      transactionHash = submitted.transactionHash
+    }
+
+    const line: BatchEvidenceLine = {
+      issue: ISSUE_ID,
+      recordedAt: deps.now().toISOString(),
+      network: STELLAR_CONFIG.NETWORK,
+      dryRun: options.dryRun,
+      batchId: batch.id ?? `${batch.tipType}-${index + 1}`,
+      tipType: batch.tipType,
+      batchSize: batch.tips.length,
+      contractId,
+      tipperPublicKey: input.tipperPublicKey,
+      transactionHash,
+      stellarExpertUrl: transactionHash
+        ? buildStellarExpertTransactionUrl(
+            transactionHash,
+            STELLAR_CONFIG.NETWORK
+          )
+        : null,
+      stroops: built.stroops,
+      authorReceived: built.authorReceived,
+      platformFee: built.platformFee,
+      items: built.items,
+    }
+
+    await appendFile(outputPath, `${JSON.stringify(line)}\n`, 'utf8')
+    lines.push(line)
+  }
+
+  return lines
+}
+
+export function parseCliArgs(args: string[]): CliOptions {
+  const options: CliOptions = {
+    outputPath: DEFAULT_EVIDENCE_PATH,
+    dryRun: false,
+    writeTemplate: false,
+    templatePath: DEFAULT_TEMPLATE_PATH,
+    help: false,
+  }
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+    if (!arg) continue
+
+    switch (arg) {
+      case '--help':
+      case '-h':
+        options.help = true
+        break
+      case '--dry-run':
+        options.dryRun = true
+        break
+      case '--write-template':
+        options.writeTemplate = true
+        break
+      case '--input':
+        options.inputPath = readOptionValue(args, index, arg)
+        index++
+        break
+      case '--output':
+        options.outputPath = readOptionValue(args, index, arg)
+        index++
+        break
+      case '--template':
+        options.templatePath = readOptionValue(args, index, arg)
+        index++
+        break
+      default:
+        throw new Error(`Unknown option: ${arg}`)
+    }
+  }
+
+  return options
+}
+
+async function main(): Promise<void> {
+  const options = parseCliArgs(process.argv.slice(2))
+
+  if (options.help) {
+    console.log(buildBatchEvidenceHelpText())
+    return
+  }
+
+  if (options.writeTemplate) {
+    await writeBatchEvidenceTemplate(options.templatePath)
+    console.log(`Wrote ${ISSUE_ID} input template to ${options.templatePath}`)
+    return
+  }
+
+  if (!options.inputPath) {
+    throw new Error(
+      `Missing required --input path. Generate a local template first with: bun run eng-236:batch-evidence -- --write-template`
+    )
+  }
+
+  const lines = await runBatchEvidence({
+    inputPath: options.inputPath,
+    outputPath: options.outputPath,
+    dryRun: options.dryRun,
+  })
+
+  for (const line of lines) {
+    const tx = line.transactionHash ?? 'dry-run'
+    console.log(
+      `${line.batchId}: ${line.tipType} batch size ${line.batchSize} recorded (${tx})`
+    )
+    if (line.stellarExpertUrl) {
+      console.log(`  ${line.stellarExpertUrl}`)
+    }
+  }
+  console.log(
+    `Appended ${lines.length} ${ISSUE_ID} evidence line(s) to ${options.outputPath}`
+  )
+}
+
+function createDefaultDependencies(): BatchEvidenceRunnerDependencies {
+  const client = new StellarClient()
+
+  return {
+    buildArticleBatchTipTransaction:
+      client.buildArticleBatchTipTransaction.bind(client),
+    buildHighlightBatchTipTransaction:
+      client.buildHighlightBatchTipTransaction.bind(client),
+    signPreparedXdr,
+    submitSignedBatchTransaction,
+    now: () => new Date(),
+  }
+}
+
+function readOptionValue(
+  args: string[],
+  index: number,
+  optionName: string
+): string {
+  const value = args[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${optionName} requires a value`)
+  }
+  return value
+}
+
+function formatRpcError(error: unknown): string {
+  if (error === undefined || error === null) return 'no error details'
+  if (typeof error === 'string') return error
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return String(error)
+  }
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export function buildBatchEvidenceHelpText(): string {
+  return [
+    `${ISSUE_ID} local batch evidence runner`,
+    '',
+    'Prepare local input:',
+    '  bun run eng-236:batch-evidence -- --write-template',
+    '',
+    'Dry-run build and evidence shape:',
+    `  bun run eng-236:batch-evidence -- --input ${DEFAULT_TEMPLATE_PATH} --dry-run`,
+    '',
+    'Live TESTNET submission:',
+    `  ENG236_TIPPER_SECRET_KEY=<local TESTNET secret> bun run eng-236:batch-evidence -- --input ${DEFAULT_TEMPLATE_PATH}`,
+    '',
+    'Options:',
+    '  --write-template        Write a local input template',
+    '  --template <path>       Template output path',
+    '  --input <path>          Local JSON input path',
+    '  --output <path>         Evidence JSONL output path',
+    '  --dry-run               Build transactions and append evidence without signing/submitting',
+    '  --help                  Show this help',
+  ].join('\n')
+}
+
+const scriptPath = process.argv[1] ? path.resolve(process.argv[1]) : ''
+const currentPath = fileURLToPath(import.meta.url)
+
+if (scriptPath === currentPath) {
+  main().catch((error) => {
+    console.error(formatError(error))
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
## Summary

Adds ENG-236-specific batch evidence tooling for a controlled TESTNET tester run without changing the ENG-235 runner. Linear: ENG-236.

## Changes

- Adds `eng-236:batch-evidence` and an ENG-236 runner with article/highlight batch support.
- Records item-level evidence so representative article/highlight storage getters can be checked after live submission.
- Ignores ENG-236 local input and evidence outputs.

## Testing

- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run test:once`
- `bun run build` (sandbox font fetch failed; rerun with network access passed)
- `bun run test:once scripts/eng-235-batch-evidence-runner.test.ts`
- `bun run test:once scripts/eng-236-batch-evidence-runner.test.ts`
- `bun run eng-235:batch-evidence -- --help`
- `bun run eng-236:batch-evidence -- --help`

## Notes

- A controlled tester run against TESTNET processed 100 live batch transactions: 50 article batches, 50 highlight batches, 200 total tips, and 100 Stellar Expert links.
- This proves the batch path can process article and highlight settlement batches on TESTNET; new-user onboarding evidence is follow-up scope.
- Representative storage checks passed for one article tip and one highlight tip via contract getters; full links/counts are in ignored local evidence docs.
- No secrets or private evidence files are included in this PR.
