### PR TITLE
feat(navigation): unify navigation and brand identity across public and app surfaces (ENG-248)

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { LegalLinks } from '@/components/legal/LegalLinks'
+import { Logo } from '@/components/ui/Logo'
 import { AUTH_FOOTER_LINKS } from '@/lib/copy/footer-links'
 
 /**
@@ -20,13 +21,7 @@ export default function AuthLayout({
       {/* Navigation Header */}
       <header className="absolute top-0 left-0 right-0 z-10">
         <nav className="container mx-auto px-6 py-6">
-          <Link
-            href="/"
-            className="inline-flex items-center text-2xl font-bold text-brand-blue hover:text-brand-accent transition-colors"
-          >
-            <span className="font-handwritten text-3xl mr-2">Q</span>
-            Quilltip
-          </Link>
+          <Logo />
         </nav>
       </header>
 
@@ -36,9 +31,7 @@ export default function AuthLayout({
           {/* Logo and Welcome Message */}
           <div className="text-center mb-8">
             <div className="inline-flex items-center justify-center mb-4">
-              <span className="text-5xl font-handwritten text-brand-blue">
-                Q
-              </span>
+              <Logo href={null} size="lg" />
             </div>
             <h1 className="text-3xl font-bold text-foreground">
               Welcome to Quilltip

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -18,13 +18,6 @@ export default function AuthLayout({
 }) {
   return (
     <div className="min-h-screen bg-gradient-to-br from-brand-cream to-background dark:from-background dark:to-muted">
-      {/* Navigation Header */}
-      <header className="absolute top-0 left-0 right-0 z-10">
-        <nav className="container mx-auto px-6 py-6">
-          <Logo />
-        </nav>
-      </header>
-
       {/* Auth Form Container */}
       <main className="flex min-h-screen items-center justify-center px-6 py-20">
         <div className="w-full max-w-md">

--- a/app/guide/page.tsx
+++ b/app/guide/page.tsx
@@ -1,17 +1,13 @@
 'use client'
 
-import { useAuth } from '@/components/providers/AuthContext'
-import Navigation from '@/components/landing/Navigation'
-import AppNavigation from '@/components/layout/AppNavigation'
+import { SiteHeader } from '@/components/layout/SiteHeader'
 import { WalletGuide } from '@/components/guide/WalletGuide'
 import { SiteFooter } from '@/components/layout/SiteFooter'
 
 export default function GuidePage() {
-  const { isAuthenticated } = useAuth()
-
   return (
     <div className="flex min-h-screen flex-col bg-background">
-      {isAuthenticated ? <AppNavigation /> : <Navigation />}
+      <SiteHeader />
       <div className="flex-1 pt-24 pb-16 px-4">
         <WalletGuide />
       </div>

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -1,0 +1,88 @@
+/** @vitest-environment jsdom */
+import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import HomePage from './page'
+
+const useAuthMock = vi.fn()
+
+vi.mock('@/components/providers/AuthContext', () => ({
+  useAuth: () => useAuthMock(),
+}))
+
+vi.mock('@/components/layout/AppNavigation', () => ({
+  default: () => <nav data-testid="app-navigation" />,
+}))
+
+vi.mock('@/components/landing/Navigation', () => ({
+  default: () => <nav data-testid="public-navigation" />,
+}))
+
+vi.mock('@/components/landing/HeroSection', () => ({
+  default: () => <div data-testid="hero-section" />,
+}))
+
+vi.mock('next/dynamic', () => ({
+  default: () => () => <div data-testid="landing-below-fold" />,
+}))
+
+vi.mock('@/components/landing/useLandingHashScroll', () => ({
+  useLandingHashScroll: () => {},
+}))
+
+vi.mock('@/components/onboarding/OnboardingDialog', () => ({
+  OnboardingDialog: () => null,
+}))
+
+vi.mock('@/components/articles/HomeRecentArticlesSection', () => ({
+  HomeRecentArticlesSection: () => null,
+}))
+
+vi.mock('@/components/error/ErrorBoundary', () => ({
+  ErrorBoundary: ({ children }: { children: ReactNode }) => children,
+}))
+
+describe('HomePage loading states', () => {
+  beforeEach(() => {
+    useAuthMock.mockReset()
+  })
+
+  it('shows the public landing while auth is bootstrapping for guests', () => {
+    useAuthMock.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: true,
+    })
+
+    render(<HomePage />)
+
+    expect(screen.getByTestId('public-navigation')).toBeInTheDocument()
+    expect(screen.queryByTestId('app-navigation')).not.toBeInTheDocument()
+  })
+
+  it('shows the signed-in loading shell when authenticated profile is loading', () => {
+    useAuthMock.mockReturnValue({
+      user: null,
+      isAuthenticated: true,
+      isLoading: true,
+    })
+
+    render(<HomePage />)
+
+    expect(screen.getByTestId('app-navigation')).toBeInTheDocument()
+    expect(screen.queryByTestId('public-navigation')).not.toBeInTheDocument()
+  })
+
+  it('shows the public landing for resolved guests', () => {
+    useAuthMock.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+    })
+
+    render(<HomePage />)
+
+    expect(screen.getByTestId('public-navigation')).toBeInTheDocument()
+    expect(screen.queryByTestId('app-navigation')).not.toBeInTheDocument()
+  })
+})

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -68,7 +68,7 @@ export default function HomePage() {
   const hasWallet = !!user?.stellarAddress
   const showOnboarding = isAuthenticated && user && !user.onboardingCompleted
 
-  if (isLoading) {
+  if (isAuthenticated && isLoading) {
     return <HomeLoadingShell />
   }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import dynamic from 'next/dynamic'
 import { useAuth } from '@/components/providers/AuthContext'
-import Navigation from '@/components/landing/Navigation'
 import AppNavigation from '@/components/layout/AppNavigation'
 import HeroSection from '@/components/landing/HeroSection'
+
+import dynamic from 'next/dynamic'
 
 const LandingBelowFold = dynamic(
   () => import('@/components/landing/LandingBelowFold'),
@@ -17,6 +17,38 @@ import { ErrorBoundary } from '@/components/error/ErrorBoundary'
 import { DashboardRecentArticlesFallback } from '@/components/error/SectionErrorFallback'
 import Link from 'next/link'
 import { PenSquare, BookOpen, Wallet, TrendingUp } from 'lucide-react'
+import Navigation from '@/components/landing/Navigation'
+
+function HomeLoadingShell() {
+  return (
+    <div className="min-h-screen bg-background">
+      <AppNavigation />
+      <div className="pt-24 pb-8 max-w-6xl mx-auto px-4 animate-pulse">
+        <div className="mb-8 space-y-3">
+          <div className="h-9 w-64 rounded-lg bg-muted" />
+          <div className="h-5 w-80 rounded-lg bg-muted" />
+        </div>
+        <div className="grid md:grid-cols-3 gap-6 mb-12">
+          {[0, 1, 2].map((key) => (
+            <div
+              key={key}
+              className="h-40 rounded-[var(--card-radius)] bg-muted"
+            />
+          ))}
+        </div>
+        <div className="h-7 w-40 rounded-lg bg-muted mb-6" />
+        <div className="grid gap-4 md:grid-cols-2">
+          {[0, 1].map((key) => (
+            <div
+              key={key}
+              className="h-28 rounded-[var(--card-radius)] bg-muted"
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
 
 function PublicLandingPage() {
   useLandingHashScroll()
@@ -31,10 +63,14 @@ function PublicLandingPage() {
 }
 
 export default function HomePage() {
-  const { user, isAuthenticated } = useAuth()
+  const { user, isAuthenticated, isLoading } = useAuth()
 
   const hasWallet = !!user?.stellarAddress
   const showOnboarding = isAuthenticated && user && !user.onboardingCompleted
+
+  if (isLoading) {
+    return <HomeLoadingShell />
+  }
 
   if (isAuthenticated && user) {
     return (

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -3,6 +3,11 @@
 import Link from 'next/link'
 import { ArrowRight, Zap } from 'lucide-react'
 import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
+import {
+  HERO_START_READING,
+  HERO_START_WRITING,
+  HERO_WALLET_SETUP,
+} from '@/lib/copy/nav-cta'
 import { LandingProductProof } from '@/components/landing/LandingProductProof'
 import { motion, AnimatePresence } from 'motion/react'
 import { useEffect, useState, useCallback, useRef } from 'react'
@@ -216,7 +221,7 @@ export default function HeroSection() {
               href="/articles"
               className="focus-ring group inline-flex w-full items-center justify-center gap-2 rounded-lg bg-brand px-6 py-2.5 text-[13px] font-medium text-brand-foreground transition-all duration-200 hover:bg-brand-hover hover:shadow-lg sm:w-auto"
             >
-              Start Reading
+              {HERO_START_READING}
               <ArrowRight className="w-3.5 h-3.5 transition-transform duration-200 group-hover:translate-x-0.5" />
             </Link>
             <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[12px] sm:text-[13px]">
@@ -224,7 +229,7 @@ export default function HeroSection() {
                 href="/register"
                 className="focus-ring rounded-sm text-muted-foreground transition-colors hover:text-foreground"
               >
-                Start Writing
+                {HERO_START_WRITING}
               </Link>
               <span className="text-border" aria-hidden>
                 ·
@@ -233,7 +238,7 @@ export default function HeroSection() {
                 href="/guide"
                 className="focus-ring rounded-sm text-muted-foreground transition-colors hover:text-foreground"
               >
-                Testnet wallet setup
+                {HERO_WALLET_SETUP}
               </Link>
             </div>
           </motion.div>

--- a/components/landing/Navigation.test.tsx
+++ b/components/landing/Navigation.test.tsx
@@ -15,6 +15,7 @@ vi.mock('motion/react', () => ({
   motion: {
     nav: (props: HTMLAttributes<HTMLElement>) => <nav {...props} />,
     div: (props: HTMLAttributes<HTMLDivElement>) => <div {...props} />,
+    span: (props: HTMLAttributes<HTMLSpanElement>) => <span {...props} />,
   },
   AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
 }))

--- a/components/landing/Navigation.tsx
+++ b/components/landing/Navigation.tsx
@@ -20,6 +20,7 @@ import {
 import { motion, AnimatePresence } from 'motion/react'
 import { LucideIcon } from 'lucide-react'
 import { ThemeToggle } from '@/components/theme/ThemeToggle'
+import { Logo } from '@/components/ui/Logo'
 import {
   Sheet,
   SheetContent,
@@ -30,6 +31,7 @@ import {
   handleLandingHashClick,
   scrollToLandingSection,
 } from '@/lib/landing/scroll-to-section'
+import { NAV_SIGN_IN, NAV_TRY_ON_TESTNET } from '@/lib/copy/nav-cta'
 
 const MOBILE_MENU_CLOSE_MS = 280
 
@@ -257,22 +259,7 @@ export default function Navigation() {
     >
       <div className="container mx-auto max-w-7xl px-6">
         <div className="flex items-center justify-between h-16">
-          {/* Logo */}
-          <Link
-            href="/"
-            className="focus-ring flex items-center gap-3 group rounded-lg"
-          >
-            <motion.div
-              className="w-9 h-9 bg-gradient-to-br from-brand-blue to-brand-accent rounded-xl flex items-center justify-center shadow-sm"
-              whileHover={{ scale: 1.05 }}
-              transition={{ type: 'spring', stiffness: 400, damping: 10 }}
-            >
-              <PenTool className="w-[18px] h-[18px] text-brand-foreground" />
-            </motion.div>
-            <span className="text-[22px] font-semibold text-foreground tracking-tight">
-              Quilltip
-            </span>
-          </Link>
+          <Logo animated />
 
           {/* Desktop Navigation */}
           <div className="hidden md:flex items-center gap-1" ref={navRef}>
@@ -406,14 +393,14 @@ export default function Navigation() {
               href="/login"
               className="focus-ring px-3 py-1.5 text-[13px] font-medium text-muted-foreground hover:text-foreground rounded-lg hover:bg-muted/60 transition-all duration-200"
             >
-              Sign In
+              {NAV_SIGN_IN}
             </Link>
 
             <Link
               href="/register"
               className="focus-ring inline-flex items-center gap-1.5 bg-brand text-brand-foreground px-4 py-1.5 rounded-lg text-[13px] font-medium hover:bg-brand-hover transition-all duration-200 ml-1"
             >
-              Try on Testnet
+              {NAV_TRY_ON_TESTNET}
               <ArrowRight className="w-3.5 h-3.5 shrink-0 text-brand-foreground/80" />
             </Link>
 
@@ -483,14 +470,14 @@ export default function Navigation() {
                     className="focus-ring block rounded-lg text-foreground hover:bg-muted text-sm font-medium transition-colors py-2 px-1"
                     onClick={() => setIsOpen(false)}
                   >
-                    Sign In
+                    {NAV_SIGN_IN}
                   </Link>
                   <Link
                     href="/register"
                     className="focus-ring inline-flex w-full items-center justify-center gap-1.5 bg-brand text-brand-foreground px-5 py-2.5 rounded-lg hover:bg-brand-hover transition-colors text-sm font-medium"
                     onClick={() => setIsOpen(false)}
                   >
-                    Try on Testnet
+                    {NAV_TRY_ON_TESTNET}
                     <ArrowRight className="w-3.5 h-3.5 shrink-0 text-brand-foreground/80" />
                   </Link>
                 </div>

--- a/components/layout/AppNavigation.test.tsx
+++ b/components/layout/AppNavigation.test.tsx
@@ -4,6 +4,9 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import AppNavigation from '@/components/layout/AppNavigation'
+import { NAV_SIGN_IN, NAV_TRY_ON_TESTNET } from '@/lib/copy/nav-cta'
+
+const mockUseAuth = vi.fn()
 
 vi.mock('next/link', () => ({
   default: (props: { href: string; children: ReactNode }) => (
@@ -16,20 +19,30 @@ vi.mock('next/navigation', () => ({
 }))
 
 vi.mock('@/components/providers/AuthContext', () => ({
-  useAuth: () => ({
-    user: null,
-    isAuthenticated: false,
-    signOut: vi.fn(),
-  }),
+  useAuth: () => mockUseAuth(),
 }))
 
 vi.mock('@/components/theme/ThemeToggle', () => ({
   ThemeToggle: () => <button type="button">Theme</button>,
 }))
 
+vi.mock('motion/react', () => ({
+  motion: {
+    span: (props: { children: ReactNode; className?: string }) => (
+      <span className={props.className}>{props.children}</span>
+    ),
+  },
+}))
+
 describe('AppNavigation mobile menu', () => {
   beforeEach(() => {
     document.body.style.pointerEvents = ''
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      signOut: vi.fn(),
+    })
   })
 
   it('opens a dialog when the menu toggle is clicked', async () => {
@@ -44,7 +57,7 @@ describe('AppNavigation mobile menu', () => {
     expect(
       screen.getByRole('heading', { name: 'Navigation menu' })
     ).toBeInTheDocument()
-  })
+  }, 15000)
 
   it('closes the dialog when Escape is pressed', async () => {
     const user = userEvent.setup()
@@ -105,5 +118,55 @@ describe('AppNavigation mobile menu', () => {
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
     expect(trigger).toHaveFocus()
+  })
+})
+
+describe('AppNavigation auth CTAs', () => {
+  beforeEach(() => {
+    document.body.style.pointerEvents = ''
+  })
+
+  it('hides signed-out CTAs while auth is loading', () => {
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: true,
+      signOut: vi.fn(),
+    })
+
+    render(<AppNavigation />)
+
+    expect(screen.queryByText(NAV_SIGN_IN)).not.toBeInTheDocument()
+    expect(screen.queryByText(NAV_TRY_ON_TESTNET)).not.toBeInTheDocument()
+  })
+
+  it('shows signed-out CTAs when auth has resolved for guests', () => {
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      signOut: vi.fn(),
+    })
+
+    render(<AppNavigation />)
+
+    expect(screen.getByText(NAV_SIGN_IN)).toBeInTheDocument()
+    expect(screen.getByText(NAV_TRY_ON_TESTNET)).toBeInTheDocument()
+  })
+
+  it('shows authenticated links when signed in', () => {
+    mockUseAuth.mockReturnValue({
+      user: { username: 'writer' },
+      isAuthenticated: true,
+      isLoading: false,
+      signOut: vi.fn(),
+    })
+
+    render(<AppNavigation />)
+
+    expect(screen.getByText('Write')).toBeInTheDocument()
+    expect(screen.getByText('Profile')).toBeInTheDocument()
+    expect(screen.queryByText(NAV_SIGN_IN)).not.toBeInTheDocument()
+    expect(screen.queryByText(NAV_TRY_ON_TESTNET)).not.toBeInTheDocument()
   })
 })

--- a/components/layout/AppNavigation.tsx
+++ b/components/layout/AppNavigation.tsx
@@ -12,6 +12,7 @@ import {
   BookOpen,
   HelpCircle,
   Menu,
+  ArrowRight,
 } from 'lucide-react'
 import { usePathname } from 'next/navigation'
 import { ThemeToggle } from '@/components/theme/ThemeToggle'
@@ -21,9 +22,15 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet'
+import { Logo } from '@/components/ui/Logo'
+import { NAV_SIGN_IN, NAV_TRY_ON_TESTNET } from '@/lib/copy/nav-cta'
+
+function AuthActionsSkeleton() {
+  return <div className="h-9 w-24 rounded-lg bg-muted animate-pulse" aria-hidden />
+}
 
 export default function AppNavigation() {
-  const { user, isAuthenticated, signOut } = useAuth()
+  const { user, isAuthenticated, isLoading, signOut } = useAuth()
   const pathname = usePathname()
   const [menuOpen, setMenuOpen] = useState(false)
 
@@ -31,104 +38,194 @@ export default function AppNavigation() {
 
   const closeMenu = () => setMenuOpen(false)
 
-  const desktopLinkClass = (active: boolean) =>
-    `focus-ring flex items-center gap-2 px-3 py-1.5 rounded-lg transition ${
+  const desktopLinkClass = (
+    active: boolean,
+    options?: { largeScreenOnly?: boolean }
+  ) =>
+    `${options?.largeScreenOnly ? 'hidden lg:flex ' : ''}focus-ring inline-flex shrink-0 whitespace-nowrap items-center gap-2 px-3 py-1.5 rounded-lg transition ${
       active
         ? 'bg-primary text-primary-foreground'
         : 'text-muted-foreground hover:text-foreground'
     }`
+
+  const desktopSignOutClass =
+    'focus-ring inline-flex shrink-0 whitespace-nowrap items-center gap-2 px-3 py-1.5 rounded-lg text-muted-foreground hover:text-destructive transition'
 
   const mobileLinkClass = (active: boolean) =>
     `focus-ring flex items-center gap-2 px-3 py-2 rounded-lg transition text-sm font-medium ${
       active ? 'bg-muted text-primary' : 'text-foreground hover:bg-muted'
     }`
 
+  const renderDesktopAuthActions = () => {
+    if (isLoading) {
+      return <AuthActionsSkeleton />
+    }
+
+    if (isAuthenticated) {
+      return (
+        <>
+          <Link
+            href="/write"
+            className={desktopLinkClass(isActive('/write'))}
+          >
+            <PenSquare className="w-4 h-4 shrink-0" />
+            <span>Write</span>
+          </Link>
+          <Link
+            href="/drafts"
+            className={desktopLinkClass(isActive('/drafts'), {
+              largeScreenOnly: true,
+            })}
+          >
+            <FileText className="w-4 h-4 shrink-0" />
+            <span>Drafts</span>
+          </Link>
+          <Link
+            href="/profile"
+            className={desktopLinkClass(
+              pathname === `/${user?.username}` || pathname === '/profile',
+              { largeScreenOnly: true }
+            )}
+          >
+            <User className="w-4 h-4 shrink-0" />
+            <span>Profile</span>
+          </Link>
+          <button
+            type="button"
+            onClick={() => signOut()}
+            className={desktopSignOutClass}
+          >
+            <LogOut className="w-4 h-4 shrink-0" />
+            <span>Sign Out</span>
+          </button>
+        </>
+      )
+    }
+
+    return (
+      <>
+        <Link
+          href="/login"
+          className="focus-ring shrink-0 whitespace-nowrap px-3 py-1.5 text-[13px] font-medium text-muted-foreground hover:text-foreground rounded-lg hover:bg-muted/60 transition-all duration-200"
+        >
+          {NAV_SIGN_IN}
+        </Link>
+        <Link
+          href="/register"
+          className="focus-ring inline-flex shrink-0 whitespace-nowrap items-center gap-1.5 bg-brand text-brand-foreground px-4 py-1.5 rounded-lg text-[13px] font-medium hover:bg-brand-hover transition-all duration-200"
+        >
+          {NAV_TRY_ON_TESTNET}
+          <ArrowRight className="w-3.5 h-3.5 shrink-0 text-brand-foreground/80" />
+        </Link>
+      </>
+    )
+  }
+
+  const renderMobileAuthActions = () => {
+    if (isLoading) {
+      return (
+        <div className="pt-2 mt-2 border-t border-border">
+          <AuthActionsSkeleton />
+        </div>
+      )
+    }
+
+    if (isAuthenticated) {
+      return (
+        <>
+          <Link
+            href="/write"
+            className={mobileLinkClass(isActive('/write'))}
+            onClick={closeMenu}
+          >
+            <PenSquare className="w-4 h-4 shrink-0" />
+            <span>Write</span>
+          </Link>
+          <Link
+            href="/drafts"
+            className={mobileLinkClass(isActive('/drafts'))}
+            onClick={closeMenu}
+          >
+            <FileText className="w-4 h-4 shrink-0" />
+            <span>Drafts</span>
+          </Link>
+          <Link
+            href="/profile"
+            className={mobileLinkClass(
+              pathname === `/${user?.username}` || pathname === '/profile'
+            )}
+            onClick={closeMenu}
+          >
+            <User className="w-4 h-4 shrink-0" />
+            <span>Profile</span>
+          </Link>
+          <button
+            type="button"
+            onClick={() => {
+              closeMenu()
+              signOut()
+            }}
+            className="focus-ring flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium text-foreground hover:bg-muted hover:text-destructive transition text-left"
+          >
+            <LogOut className="w-4 h-4 shrink-0" />
+            <span>Sign Out</span>
+          </button>
+        </>
+      )
+    }
+
+    return (
+      <div className="flex flex-col gap-2 pt-2 border-t border-border mt-2">
+        <Link
+          href="/login"
+          className="focus-ring rounded-lg px-3 py-2 text-sm font-medium text-foreground hover:bg-muted transition"
+          onClick={closeMenu}
+        >
+          {NAV_SIGN_IN}
+        </Link>
+        <Link
+          href="/register"
+          className="focus-ring inline-flex w-full items-center justify-center gap-1.5 bg-brand text-brand-foreground px-5 py-2.5 rounded-lg hover:bg-brand-hover transition-colors text-sm font-medium"
+          onClick={closeMenu}
+        >
+          {NAV_TRY_ON_TESTNET}
+          <ArrowRight className="w-3.5 h-3.5 shrink-0 text-brand-foreground/80" />
+        </Link>
+      </div>
+    )
+  }
+
   return (
     <nav className="fixed top-0 w-full bg-background/95 backdrop-blur-md z-50 border-b border-border">
       <div className="container mx-auto px-4">
         <div className="flex items-center justify-between h-16">
-          <Link
-            href="/"
-            className="focus-ring flex items-center space-x-2 rounded-md"
-            onClick={closeMenu}
-          >
-            <span className="text-3xl font-handwritten text-foreground">
-              Quilltip
-            </span>
-          </Link>
+          <div className="flex min-w-0 items-center gap-8">
+            <Logo onClick={closeMenu} className="shrink-0" />
 
-          <div className="hidden md:flex items-center space-x-6">
-            <Link href="/" className={desktopLinkClass(isActive('/'))}>
-              <Home className="w-4 h-4" />
-              <span>Home</span>
-            </Link>
-            <Link
-              href="/articles"
-              className={desktopLinkClass(isActive('/articles'))}
-            >
-              <BookOpen className="w-4 h-4" />
-              <span>Articles</span>
-            </Link>
-            <Link
-              href="/guide"
-              className={desktopLinkClass(isActive('/guide'))}
-            >
-              <HelpCircle className="w-4 h-4" />
-              <span>Guide</span>
-            </Link>
+            <div className="hidden md:flex min-w-0 items-center gap-4 lg:gap-6">
+              <Link href="/" className={desktopLinkClass(isActive('/'))}>
+                <Home className="w-4 h-4 shrink-0" />
+                <span>Home</span>
+              </Link>
+              <Link
+                href="/articles"
+                className={desktopLinkClass(isActive('/articles'))}
+              >
+                <BookOpen className="w-4 h-4 shrink-0" />
+                <span>Articles</span>
+              </Link>
+              <Link
+                href="/guide"
+                className={desktopLinkClass(isActive('/guide'))}
+              >
+                <HelpCircle className="w-4 h-4 shrink-0" />
+                <span>Guide</span>
+              </Link>
 
-            {isAuthenticated ? (
-              <>
-                <Link
-                  href="/write"
-                  className={desktopLinkClass(isActive('/write'))}
-                >
-                  <PenSquare className="w-4 h-4" />
-                  <span>Write</span>
-                </Link>
-                <Link
-                  href="/drafts"
-                  className={desktopLinkClass(isActive('/drafts'))}
-                >
-                  <FileText className="w-4 h-4" />
-                  <span>Drafts</span>
-                </Link>
-                <Link
-                  href="/profile"
-                  className={desktopLinkClass(
-                    pathname === `/${user?.username}` || pathname === '/profile'
-                  )}
-                >
-                  <User className="w-4 h-4" />
-                  <span>Profile</span>
-                </Link>
-                <button
-                  type="button"
-                  onClick={() => signOut()}
-                  className="focus-ring flex items-center gap-2 px-3 py-1.5 rounded-lg text-muted-foreground hover:text-destructive transition"
-                >
-                  <LogOut className="w-4 h-4" />
-                  <span>Sign Out</span>
-                </button>
-              </>
-            ) : (
-              <>
-                <Link
-                  href="/login"
-                  className="focus-ring rounded-md text-muted-foreground hover:text-foreground transition"
-                >
-                  Sign In
-                </Link>
-                <Link
-                  href="/register"
-                  className="focus-ring bg-primary text-primary-foreground px-4 py-2 rounded-lg hover:bg-primary/90 transition"
-                >
-                  Get Started
-                </Link>
-              </>
-            )}
+              {renderDesktopAuthActions()}
 
-            <ThemeToggle />
+              <ThemeToggle />
+            </div>
           </div>
 
           <Sheet open={menuOpen} onOpenChange={setMenuOpen}>
@@ -173,65 +270,7 @@ export default function AppNavigation() {
                   <span>Guide</span>
                 </Link>
 
-                {isAuthenticated ? (
-                  <>
-                    <Link
-                      href="/write"
-                      className={mobileLinkClass(isActive('/write'))}
-                      onClick={closeMenu}
-                    >
-                      <PenSquare className="w-4 h-4 shrink-0" />
-                      <span>Write</span>
-                    </Link>
-                    <Link
-                      href="/drafts"
-                      className={mobileLinkClass(isActive('/drafts'))}
-                      onClick={closeMenu}
-                    >
-                      <FileText className="w-4 h-4 shrink-0" />
-                      <span>Drafts</span>
-                    </Link>
-                    <Link
-                      href="/profile"
-                      className={mobileLinkClass(
-                        pathname === `/${user?.username}` ||
-                          pathname === '/profile'
-                      )}
-                      onClick={closeMenu}
-                    >
-                      <User className="w-4 h-4 shrink-0" />
-                      <span>Profile</span>
-                    </Link>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        closeMenu()
-                        signOut()
-                      }}
-                      className="focus-ring flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium text-foreground hover:bg-muted hover:text-destructive transition text-left"
-                    >
-                      <LogOut className="w-4 h-4 shrink-0" />
-                      <span>Sign Out</span>
-                    </button>
-                  </>
-                ) : (
-                  <div className="flex flex-col gap-2 pt-2 border-t border-border mt-2">
-                    <Link
-                      href="/login"
-                      className="focus-ring rounded-lg px-3 py-2 text-sm font-medium text-foreground hover:bg-muted transition"
-                      onClick={closeMenu}
-                    >
-                      Sign In
-                    </Link>
-                    <Link
-                      href="/register"
-                      className="focus-ring bg-primary text-primary-foreground px-4 py-2.5 rounded-lg hover:bg-primary/90 transition text-center text-sm font-medium"
-                      onClick={closeMenu}
-                    >
-                      Get Started
-                    </Link>
-                  </div>
-                )}
+                {renderMobileAuthActions()}
 
                 <div className="flex justify-end pt-3 mt-2 border-t border-border">
                   <ThemeToggle />

--- a/components/layout/AppNavigation.tsx
+++ b/components/layout/AppNavigation.tsx
@@ -26,7 +26,9 @@ import { Logo } from '@/components/ui/Logo'
 import { NAV_SIGN_IN, NAV_TRY_ON_TESTNET } from '@/lib/copy/nav-cta'
 
 function AuthActionsSkeleton() {
-  return <div className="h-9 w-24 rounded-lg bg-muted animate-pulse" aria-hidden />
+  return (
+    <div className="h-9 w-24 rounded-lg bg-muted animate-pulse" aria-hidden />
+  )
 }
 
 export default function AppNavigation() {
@@ -64,10 +66,7 @@ export default function AppNavigation() {
     if (isAuthenticated) {
       return (
         <>
-          <Link
-            href="/write"
-            className={desktopLinkClass(isActive('/write'))}
-          >
+          <Link href="/write" className={desktopLinkClass(isActive('/write'))}>
             <PenSquare className="w-4 h-4 shrink-0" />
             <span>Write</span>
           </Link>

--- a/components/layout/InfoPageLayout.tsx
+++ b/components/layout/InfoPageLayout.tsx
@@ -1,8 +1,6 @@
 'use client'
 
-import { useAuth } from '@/components/providers/AuthContext'
-import Navigation from '@/components/landing/Navigation'
-import AppNavigation from '@/components/layout/AppNavigation'
+import { SiteHeader } from '@/components/layout/SiteHeader'
 import { SiteFooter } from '@/components/layout/SiteFooter'
 
 type InfoPageLayoutProps = {
@@ -16,11 +14,9 @@ export function InfoPageLayout({
   description,
   children,
 }: InfoPageLayoutProps) {
-  const { isAuthenticated } = useAuth()
-
   return (
     <div className="flex min-h-screen flex-col bg-background">
-      {isAuthenticated ? <AppNavigation /> : <Navigation />}
+      <SiteHeader />
       <div className="flex-1 pt-24 pb-16 px-4">
         <div className="mx-auto max-w-3xl">
           <header className="mb-10 border-b border-border pb-8">

--- a/components/layout/SiteFooter.tsx
+++ b/components/layout/SiteFooter.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { Heart, PenTool } from 'lucide-react'
+import { Heart } from 'lucide-react'
 import { Reveal } from '@/components/landing/Reveal'
 import { FooterNav } from '@/components/layout/FooterNav'
+import { Logo } from '@/components/ui/Logo'
 import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
 import { cn } from '@/lib/utils'
 
@@ -22,13 +23,8 @@ export function SiteFooter({ variant = 'default' }: SiteFooterProps) {
         <div className="container mx-auto max-w-7xl px-8 relative z-10">
           <div className="py-16">
             <Reveal className="text-center">
-              <div className="flex items-center gap-3 mb-4 justify-center">
-                <div className="w-9 h-9 bg-card rounded-lg border border-border flex items-center justify-center shadow-sm">
-                  <PenTool className="w-5 h-5 text-foreground" />
-                </div>
-                <h3 className="text-2xl font-display font-medium tracking-[-0.01em]">
-                  Quilltip
-                </h3>
+              <div className="flex justify-center mb-4">
+                <Logo href={null} variant="onDark" size="lg" />
               </div>
               <p className="text-spotlight-muted text-[15px] leading-relaxed max-w-2xl mx-auto">
                 {TESTNET_PRACTICE_NOTE}

--- a/components/layout/SiteHeader.tsx
+++ b/components/layout/SiteHeader.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useAuth } from '@/components/providers/AuthContext'
+import Navigation from '@/components/landing/Navigation'
+import AppNavigation from '@/components/layout/AppNavigation'
+
+export function SiteHeader() {
+  const { isAuthenticated, isLoading } = useAuth()
+
+  if (isLoading) {
+    return <AppNavigation />
+  }
+
+  if (isAuthenticated) {
+    return <AppNavigation />
+  }
+
+  return <Navigation />
+}

--- a/components/legal/LegalPageLayout.tsx
+++ b/components/legal/LegalPageLayout.tsx
@@ -1,9 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useAuth } from '@/components/providers/AuthContext'
-import Navigation from '@/components/landing/Navigation'
-import AppNavigation from '@/components/layout/AppNavigation'
+import { SiteHeader } from '@/components/layout/SiteHeader'
 import { Button } from '@/components/ui/button'
 import { SiteFooter } from '@/components/layout/SiteFooter'
 import type { LegalSection } from '@/lib/copy/legal-shared'
@@ -24,11 +22,9 @@ export function LegalPageLayout({
   sections,
   alternatePolicy,
 }: LegalPageLayoutProps) {
-  const { isAuthenticated } = useAuth()
-
   return (
     <div className="flex min-h-screen flex-col bg-background">
-      {isAuthenticated ? <AppNavigation /> : <Navigation />}
+      <SiteHeader />
       <div className="flex-1 pt-24 pb-16 px-4">
         <article className="mx-auto max-w-3xl">
           <header className="mb-10 border-b border-border pb-8">

--- a/components/providers/AuthContext.tsx
+++ b/components/providers/AuthContext.tsx
@@ -1,5 +1,14 @@
 'use client'
 
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+import { useRouter } from 'next/navigation'
 import { useAuthActions } from '@convex-dev/auth/react'
 import { useConvexAuth } from 'convex/react'
 import { Value } from 'convex/values'
@@ -19,12 +28,67 @@ interface AuthContextType {
   signOut: () => Promise<void>
 }
 
+type AuthSessionContextValue = {
+  isSigningOut: boolean
+  beginSignOut: () => void
+  endSignOut: () => void
+}
+
+const AuthSessionContext = createContext<AuthSessionContextValue | null>(null)
+
+export function AuthSessionProvider({ children }: { children: ReactNode }) {
+  const [isSigningOut, setIsSigningOut] = useState(false)
+
+  const value = useMemo(
+    () => ({
+      isSigningOut,
+      beginSignOut: () => setIsSigningOut(true),
+      endSignOut: () => setIsSigningOut(false),
+    }),
+    [isSigningOut]
+  )
+
+  return (
+    <AuthSessionContext.Provider value={value}>
+      {children}
+      {isSigningOut ? (
+        <div
+          className="fixed inset-0 z-[100] bg-background"
+          role="status"
+          aria-live="polite"
+          aria-label="Signing out"
+        />
+      ) : null}
+    </AuthSessionContext.Provider>
+  )
+}
+
+function useAuthSession(): AuthSessionContextValue {
+  const context = useContext(AuthSessionContext)
+  if (!context) {
+    throw new Error('useAuth must be used within AuthSessionProvider')
+  }
+  return context
+}
+
 export function useAuth(): AuthContextType {
-  const { signIn, signOut } = useAuthActions()
+  const router = useRouter()
+  const { beginSignOut, endSignOut } = useAuthSession()
+  const { signIn, signOut: convexSignOut } = useAuthActions()
   const { isAuthenticated, isLoading: authLoading } = useConvexAuth()
   const userQuery = useCurrentUser()
 
   const isLoading = authLoading || (isAuthenticated && userQuery === undefined)
+
+  const signOut = useCallback(async () => {
+    beginSignOut()
+    try {
+      router.replace('/login')
+      await convexSignOut()
+    } finally {
+      endSignOut()
+    }
+  }, [beginSignOut, convexSignOut, endSignOut, router])
 
   return {
     user: userQuery === undefined ? null : userQuery,

--- a/components/providers/Providers.tsx
+++ b/components/providers/Providers.tsx
@@ -10,6 +10,7 @@ import {
   WalletActivationProvider,
   useWalletActivation,
 } from './WalletActivationContext'
+import { AuthSessionProvider } from './AuthContext'
 
 const LazyWalletProvider = dynamic(
   () =>
@@ -45,16 +46,18 @@ function WalletBoundary({ children }: { children: React.ReactNode }) {
 export default function Providers({ children }: ProvidersProps) {
   return (
     <ConvexAuthProvider client={convex}>
-      <ThemeProvider>
-        <WalletActivationProvider>
-          <ErrorBoundary fallback={WalletErrorFallback}>
-            <WalletBoundary>
-              {children}
-              <Toaster />
-            </WalletBoundary>
-          </ErrorBoundary>
-        </WalletActivationProvider>
-      </ThemeProvider>
+      <AuthSessionProvider>
+        <ThemeProvider>
+          <WalletActivationProvider>
+            <ErrorBoundary fallback={WalletErrorFallback}>
+              <WalletBoundary>
+                {children}
+                <Toaster />
+              </WalletBoundary>
+            </ErrorBoundary>
+          </WalletActivationProvider>
+        </ThemeProvider>
+      </AuthSessionProvider>
     </ConvexAuthProvider>
   )
 }

--- a/components/ui/Logo.test.tsx
+++ b/components/ui/Logo.test.tsx
@@ -5,7 +5,11 @@ import { describe, expect, it, vi } from 'vitest'
 import { Logo } from '@/components/ui/Logo'
 
 vi.mock('next/link', () => ({
-  default: (props: { href: string; children: ReactNode; 'aria-label'?: string }) => (
+  default: (props: {
+    href: string
+    children: ReactNode
+    'aria-label'?: string
+  }) => (
     <a href={props.href} aria-label={props['aria-label']}>
       {props.children}
     </a>
@@ -24,7 +28,10 @@ describe('Logo', () => {
   it('renders a home link with the Quilltip wordmark', () => {
     render(<Logo />)
 
-    expect(screen.getByRole('link', { name: 'Quilltip' })).toHaveAttribute('href', '/')
+    expect(screen.getByRole('link', { name: 'Quilltip' })).toHaveAttribute(
+      'href',
+      '/'
+    )
     expect(screen.getByText('Quilltip')).toBeInTheDocument()
   })
 

--- a/components/ui/Logo.test.tsx
+++ b/components/ui/Logo.test.tsx
@@ -1,0 +1,43 @@
+/** @vitest-environment jsdom */
+import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { Logo } from '@/components/ui/Logo'
+
+vi.mock('next/link', () => ({
+  default: (props: { href: string; children: ReactNode; 'aria-label'?: string }) => (
+    <a href={props.href} aria-label={props['aria-label']}>
+      {props.children}
+    </a>
+  ),
+}))
+
+vi.mock('motion/react', () => ({
+  motion: {
+    span: (props: { children: ReactNode; className?: string }) => (
+      <span className={props.className}>{props.children}</span>
+    ),
+  },
+}))
+
+describe('Logo', () => {
+  it('renders a home link with the Quilltip wordmark', () => {
+    render(<Logo />)
+
+    expect(screen.getByRole('link', { name: 'Quilltip' })).toHaveAttribute('href', '/')
+    expect(screen.getByText('Quilltip')).toBeInTheDocument()
+  })
+
+  it('renders as a static div when href is null', () => {
+    render(<Logo href={null} />)
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(screen.getByText('Quilltip')).toBeInTheDocument()
+  })
+
+  it('can hide the wordmark', () => {
+    render(<Logo showText={false} />)
+
+    expect(screen.queryByText('Quilltip')).not.toBeInTheDocument()
+  })
+})

--- a/components/ui/Logo.tsx
+++ b/components/ui/Logo.tsx
@@ -1,37 +1,21 @@
 'use client'
 
 import Link from 'next/link'
-
-/** Quill / pen nib outline: oval with hole and two tines */
-function QuillIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden
-    >
-      <path d="M12 5c-2.5 0-4 1.8-4 4s1 4 4 5c3-1 4-2.5 4-5s-1.5-4-4-4z" />
-      <circle cx="12" cy="8.5" r="1.25" />
-    </svg>
-  )
-}
+import { PenTool } from 'lucide-react'
+import { motion } from 'motion/react'
 
 export interface LogoProps {
-  /** Link to home. Omit to render as div (e.g. in footer) */
-  href?: string
-  /** 'dark' = dark icon + dark text (light bg). 'light' = light icon + light text (dark bg) */
-  variant?: 'dark' | 'light'
-  /** Show text "QuillTip" next to icon */
+  /** Link target. Omit for home (`/`). Pass `null` for a static, non-link lockup. */
+  href?: string | null
+  /** `default` for light backgrounds; `onDark` for spotlight/dark footer surfaces. */
+  variant?: 'default' | 'onDark'
+  /** Show "Quilltip" wordmark next to icon. */
   showText?: boolean
-  /** Size of the icon box */
-  iconSize?: 'sm' | 'md' | 'lg'
-  /** Optional class for the container */
+  size?: 'sm' | 'md' | 'lg'
+  /** Spring hover scale on the icon box (landing nav only). */
+  animated?: boolean
   className?: string
+  onClick?: () => void
 }
 
 const iconSizeClasses = {
@@ -53,42 +37,63 @@ const textSizeClasses = {
 }
 
 export function Logo({
-  href = '/',
-  variant = 'dark',
+  href,
+  variant = 'default',
   showText = true,
-  iconSize = 'md',
+  size = 'md',
+  animated = false,
   className = '',
+  onClick,
 }: LogoProps) {
-  const isDark = variant === 'dark'
-  const boxBg = isDark ? 'bg-neutral-900' : 'bg-neutral-700'
-  const iconColor = 'text-white'
-  const textColor = isDark ? 'text-neutral-900' : 'text-white'
-  const textFont = isDark ? 'font-semibold' : 'font-medium'
+  const isOnDark = variant === 'onDark'
+  const iconBoxClass = isOnDark
+    ? 'bg-card border border-border shadow-sm'
+    : 'bg-gradient-to-br from-brand-blue to-brand-accent shadow-sm'
+  const iconColor = isOnDark ? 'text-foreground' : 'text-brand-foreground'
+  const textColor = isOnDark ? 'text-spotlight-foreground' : 'text-foreground'
+  const textFont = isOnDark ? 'font-medium font-display' : 'font-semibold'
+
+  const iconBox = (
+    <span
+      className={`${iconSizeClasses[size]} ${iconBoxClass} rounded-xl flex items-center justify-center shrink-0`}
+    >
+      <PenTool className={`${iconInnerClasses[size]} ${iconColor}`} aria-hidden />
+    </span>
+  )
 
   const content = (
     <>
-      <span
-        className={`${iconSizeClasses[iconSize]} ${boxBg} rounded-xl flex items-center justify-center shrink-0 ${isDark ? 'shadow-sm' : 'shadow-lg'}`}
-      >
-        <QuillIcon className={`${iconInnerClasses[iconSize]} ${iconColor}`} />
-      </span>
+      {animated ? (
+        <motion.span
+          className={`${iconSizeClasses[size]} ${iconBoxClass} rounded-xl flex items-center justify-center shrink-0`}
+          whileHover={{ scale: 1.05 }}
+          transition={{ type: 'spring', stiffness: 400, damping: 10 }}
+        >
+          <PenTool className={`${iconInnerClasses[size]} ${iconColor}`} aria-hidden />
+        </motion.span>
+      ) : (
+        iconBox
+      )}
       {showText && (
         <span
-          className={`${textSizeClasses[iconSize]} ${textFont} ${textColor} tracking-tight`}
+          className={`${textSizeClasses[size]} ${textFont} ${textColor} tracking-tight`}
         >
-          QuillTip
+          Quilltip
         </span>
       )}
     </>
   )
 
   const sharedClass = `inline-flex items-center gap-3 ${className}`
+  const linkHref = href === undefined ? '/' : href
 
-  if (href) {
+  if (linkHref !== null) {
     return (
       <Link
-        href={href}
-        className={`${sharedClass} hover:opacity-90 transition-opacity`}
+        href={linkHref}
+        onClick={onClick}
+        className={`${sharedClass} focus-ring rounded-lg hover:opacity-90 transition-opacity`}
+        aria-label="Quilltip"
       >
         {content}
       </Link>

--- a/components/ui/Logo.tsx
+++ b/components/ui/Logo.tsx
@@ -57,7 +57,10 @@ export function Logo({
     <span
       className={`${iconSizeClasses[size]} ${iconBoxClass} rounded-xl flex items-center justify-center shrink-0`}
     >
-      <PenTool className={`${iconInnerClasses[size]} ${iconColor}`} aria-hidden />
+      <PenTool
+        className={`${iconInnerClasses[size]} ${iconColor}`}
+        aria-hidden
+      />
     </span>
   )
 
@@ -69,7 +72,10 @@ export function Logo({
           whileHover={{ scale: 1.05 }}
           transition={{ type: 'spring', stiffness: 400, damping: 10 }}
         >
-          <PenTool className={`${iconInnerClasses[size]} ${iconColor}`} aria-hidden />
+          <PenTool
+            className={`${iconInnerClasses[size]} ${iconColor}`}
+            aria-hidden
+          />
         </motion.span>
       ) : (
         iconBox

--- a/lib/copy/nav-cta.test.ts
+++ b/lib/copy/nav-cta.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import {
+  HERO_START_READING,
+  HERO_START_WRITING,
+  HERO_WALLET_SETUP,
+  NAV_SIGN_IN,
+  NAV_TRY_ON_TESTNET,
+} from '@/lib/copy/nav-cta'
+
+describe('nav-cta vocabulary', () => {
+  it('exports the approved navigation labels', () => {
+    expect(NAV_SIGN_IN).toBe('Sign In')
+    expect(NAV_TRY_ON_TESTNET).toBe('Try on Testnet')
+  })
+
+  it('exports the approved landing hero labels', () => {
+    expect(HERO_START_READING).toBe('Start Reading')
+    expect(HERO_START_WRITING).toBe('Start Writing')
+    expect(HERO_WALLET_SETUP).toBe('Testnet wallet setup')
+  })
+})

--- a/lib/copy/nav-cta.ts
+++ b/lib/copy/nav-cta.ts
@@ -1,0 +1,13 @@
+/**
+ * Approved navigation and landing hero CTA labels.
+ *
+ * Navigation CTAs use the same vocabulary on public and app surfaces.
+ * Hero CTAs are route-specific actions and stay distinct from nav labels.
+ */
+
+export const NAV_SIGN_IN = 'Sign In'
+export const NAV_TRY_ON_TESTNET = 'Try on Testnet'
+
+export const HERO_START_READING = 'Start Reading'
+export const HERO_START_WRITING = 'Start Writing'
+export const HERO_WALLET_SETUP = 'Testnet wallet setup'


### PR DESCRIPTION
## Summary

Unifies Quilltip navigation and brand identity so signed-out, signed-in, and loading states share the same logo, CTA labels, and header entry point. Adds `SiteHeader` to pick the correct nav by auth state, refactors `AppNavigation` and landing `Navigation` around a shared `Logo` component, and smooths sign-out transitions with `AuthSessionProvider`.



## Changes

- Add `SiteHeader` to render landing `Navigation` for signed-out users and `AppNavigation` for signed-in or loading sessions
- Introduce shared `Logo` component with size, variant, and optional animation support; use it in both navs and the auth layout
- Centralize nav CTA copy in `lib/copy/nav-cta.ts` (`Sign In`, `Try on Testnet`)
- Refactor `AppNavigation` to use the shared logo, shared CTAs, auth action skeleton, and improved mobile sheet menu
- Update landing `Navigation` to use the shared `Logo` and aligned CTA labels
- Wire `SiteHeader` into guide, info, and legal page layouts
- Add `AuthSessionProvider` with a full-screen sign-out overlay to prevent nav flicker during logout
- Update auth layout to use the shared `Logo` lockup
- Extend unit tests for `Logo`, `AppNavigation`, and landing `Navigation` mobile menu behavior

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run format`
- [x] `bun run test:once` (632/632 passed)
- [x] `bun run build`


## Notes

- No route or backend changes; this is navigation/branding and auth UX only.
- Cleared stale `.next` cache locally when typecheck referenced removed dashboard routes from an old build artifact.
<img width="1223" height="721" alt="1" src="https://github.com/user-attachments/assets/7d3662e7-2cd3-42ca-9758-3dc06a1abe6a" />
<img width="1221" height="719" alt="2" src="https://github.com/user-attachments/assets/44d9ba68-589e-49ff-bbce-abae615fbae0" />
<img width="1222" height="715" alt="3" src="https://github.com/user-attachments/assets/03e61866-b968-4aed-88c2-d046e6a34959" />

<img width="1220" height="715" alt="4" src="https://github.com/user-attachments/assets/3f43aae6-5094-47bd-8848-a70b1a73682f" />
<img width="1221" height="718" alt="5" src="https://github.com/user-attachments/assets/580c917f-1288-4168-a922-37264df65f3d" />
