### PR TITLE
feat(articles): polish browse discovery with feed layout and filters (ENG-250)

### DIFF
--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -113,9 +113,10 @@ export default function ArticlesPage() {
           view={view}
           sort={sort}
           activeTag={tag}
+          activeAuthor={author}
         />
 
-        {(tag || author || urlSearch) && (
+        {(tag || author) && (
           <div className="mb-6 flex items-center gap-2 flex-wrap">
             <span className="text-sm text-muted-foreground">Filtering by:</span>
             {tag && (
@@ -153,26 +154,6 @@ export default function ArticlesPage() {
                   }}
                   className="ml-2 hover:text-primary-foreground/80"
                   aria-label="Remove author filter"
-                >
-                  ×
-                </button>
-              </span>
-            )}
-            {urlSearch && (
-              <span className="inline-flex items-center px-3 py-1 rounded-full text-sm bg-brand-blue text-white">
-                Search: &ldquo;{urlSearch}&rdquo;
-                <button
-                  onClick={() => {
-                    router.push(
-                      buildArticlesBrowseHref({
-                        search: '',
-                        page: 1,
-                        sourceParams: searchParams,
-                      })
-                    )
-                  }}
-                  className="ml-2 hover:text-primary-foreground/80"
-                  aria-label="Remove search filter"
                 >
                   ×
                 </button>

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -6,7 +6,12 @@ import AppNavigation from '@/components/layout/AppNavigation'
 import { SiteFooter } from '@/components/layout/SiteFooter'
 import SearchInput from '@/components/articles/SearchInput'
 import { ArticlesBrowseContent } from '@/components/articles/ArticlesBrowseContent'
+import { ArticlesBrowseDiscoveryHeader } from '@/components/articles/ArticlesBrowseDiscoveryHeader'
 import { buildArticlesBrowseHref } from '@/lib/articles/buildArticlesBrowseHref'
+import {
+  parseBrowseSort,
+  parseBrowseView,
+} from '@/lib/articles/browseDiscovery'
 import {
   buildArticlesBrowseScrollStorageKey,
   writeBrowseScrollY,
@@ -36,7 +41,6 @@ export default function ArticlesPage() {
 
   useEffect(() => {
     const onPageHide = () => {
-      // If we already saved right before a click navigation, don't overwrite it.
       if (didSaveOnNavigateRef.current) return
       writeBrowseScrollY(scrollStorageKey, window.scrollY)
     }
@@ -55,8 +59,9 @@ export default function ArticlesPage() {
   const tag = searchParams?.get('tag') || undefined
   const author = searchParams?.get('author') || undefined
   const urlSearch = searchParams?.get('search') || undefined
+  const view = parseBrowseView(searchParams?.get('view'))
+  const sort = parseBrowseSort(searchParams?.get('sort'))
 
-  // Sync searchTerm with URL parameter
   useEffect(() => {
     setSearchTerm(urlSearch || '')
   }, [urlSearch])
@@ -80,7 +85,6 @@ export default function ArticlesPage() {
       <AppNavigation />
 
       <main className="flex-1 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12 w-full">
-        {/* Page Header */}
         <div className="mb-8">
           <h1 className="text-4xl font-bold text-foreground mb-2">
             All Articles
@@ -90,7 +94,6 @@ export default function ArticlesPage() {
           </p>
         </div>
 
-        {/* Search Input */}
         <div className="mb-6 max-w-md">
           <label
             htmlFor="articles-browse-search"
@@ -106,9 +109,14 @@ export default function ArticlesPage() {
           />
         </div>
 
-        {/* Active Filters */}
+        <ArticlesBrowseDiscoveryHeader
+          view={view}
+          sort={sort}
+          activeTag={tag}
+        />
+
         {(tag || author || urlSearch) && (
-          <div className="mb-6 flex items-center gap-2">
+          <div className="mb-6 flex items-center gap-2 flex-wrap">
             <span className="text-sm text-muted-foreground">Filtering by:</span>
             {tag && (
               <span className="inline-flex items-center px-3 py-1 rounded-full text-sm bg-brand-blue text-white">
@@ -184,6 +192,8 @@ export default function ArticlesPage() {
           tag={tag}
           author={author}
           urlSearch={urlSearch}
+          view={view}
+          sort={sort}
           scrollStorageKey={scrollStorageKey}
           onArticleNavigate={saveBrowseScrollPosition}
         />

--- a/components/articles/ArticleCard.tsx
+++ b/components/articles/ArticleCard.tsx
@@ -4,12 +4,19 @@ import { formatDistanceToNow } from 'date-fns'
 import { ArticleForDisplay } from '@/types/index'
 import { ArticleAuthorByline } from '@/components/articles/ArticleAuthorByline'
 import { TagFilterLink } from '@/components/articles/TagFilterLink'
+import type { BrowseView } from '@/lib/articles/browseDiscovery'
 
 interface ArticleCardProps {
   article: ArticleForDisplay
   priority?: boolean
   onArticleNavigate?: () => void
   tagLinkAuthor?: string
+  view?: BrowseView
+}
+
+function formatReadTime(minutes?: number): string | null {
+  if (!minutes || minutes < 1) return null
+  return `${minutes} min read`
 }
 
 export default function ArticleCard({
@@ -17,14 +24,24 @@ export default function ArticleCard({
   priority,
   onArticleNavigate,
   tagLinkAuthor,
+  view = 'latest',
 }: ArticleCardProps) {
   const publishedDate = article.publishedAt
     ? formatDistanceToNow(new Date(article.publishedAt), { addSuffix: true })
     : null
+  const readTimeLabel = formatReadTime(article.readTime)
+  const tipCount = article.tipCount ?? 0
+
+  const metaParts = [
+    readTimeLabel,
+    publishedDate,
+    view === 'featured' && tipCount > 0
+      ? `${tipCount} tip${tipCount === 1 ? '' : 's'}`
+      : null,
+  ].filter((part): part is string => Boolean(part))
 
   return (
-    <article className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border ring-1 ring-border/60 hover:shadow-md transition-shadow duration-200">
-      {/* Cover Image */}
+    <article className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border ring-1 ring-border/60 hover:shadow-md transition-shadow duration-200 flex flex-col h-full">
       {article.coverImage && (
         <Link
           href={`/${article.author.username}/${article.slug}`}
@@ -46,8 +63,7 @@ export default function ArticleCard({
         </Link>
       )}
 
-      <div className="p-[var(--card-padding)]">
-        {/* Title */}
+      <div className="p-[var(--card-padding)] flex flex-col flex-1">
         <Link
           href={`/${article.author.username}/${article.slug}`}
           scroll={false}
@@ -60,16 +76,14 @@ export default function ArticleCard({
           </h2>
         </Link>
 
-        {/* Excerpt */}
         {article.excerpt && (
-          <p className="text-muted-foreground mb-4 line-clamp-3">
+          <p className="text-muted-foreground mb-4 line-clamp-3 flex-1">
             {article.excerpt}
           </p>
         )}
 
-        {/* Tags */}
         {article.tags.length > 0 && (
-          <div className="flex flex-wrap gap-2 mb-4">
+          <div className="flex flex-wrap gap-2 mb-4 min-h-[28px]">
             {article.tags.slice(0, 3).map((tag) => (
               <TagFilterLink key={tag.id} tag={tag.name} author={tagLinkAuthor}>
                 {tag.name}
@@ -83,15 +97,13 @@ export default function ArticleCard({
           </div>
         )}
 
-        {/* Author Info */}
-        <div className="flex items-center justify-between pt-4 border-t border-border">
+        <div className="flex items-end justify-between gap-3 pt-4 border-t border-border mt-auto">
           <ArticleAuthorByline author={article.author} size="sm" showHandle />
 
-          {/* Published Date */}
-          {publishedDate && (
-            <span className="text-xs text-muted-foreground">
-              {publishedDate}
-            </span>
+          {metaParts.length > 0 && (
+            <p className="text-xs text-muted-foreground text-right shrink-0">
+              {metaParts.join(' · ')}
+            </p>
           )}
         </div>
       </div>

--- a/components/articles/ArticleFeedRow.tsx
+++ b/components/articles/ArticleFeedRow.tsx
@@ -1,10 +1,12 @@
 import Link from 'next/link'
 import Image from 'next/image'
 import { format } from 'date-fns'
+import { Bookmark, MoreHorizontal } from 'lucide-react'
 import { ArticleForDisplay } from '@/types/index'
 import { canLinkAuthorProfile } from '@/components/articles/ArticleAuthorByline'
 import { TagFilterLink } from '@/components/articles/TagFilterLink'
 import { UserAvatar } from '@/components/ui/user-avatar'
+import { Button } from '@/components/ui/button'
 import {
   formatReadTime,
   getFeedRowContextLabel,
@@ -139,8 +141,8 @@ export default function ArticleFeedRow({
         )}
       </div>
 
-      {(primaryTag || readTimeLabel || contextLabel) && (
-        <div className="mt-4 flex flex-wrap items-center gap-x-3 gap-y-2 text-[13px] text-muted-foreground">
+      <div className="mt-4 flex items-center justify-between gap-4">
+        <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2 text-[13px] text-muted-foreground">
           {primaryTag && (
             <TagFilterLink
               tag={primaryTag.name}
@@ -153,7 +155,28 @@ export default function ArticleFeedRow({
           {readTimeLabel && <span>{readTimeLabel}</span>}
           {contextLabel && <span>{contextLabel}</span>}
         </div>
-      )}
+
+        <div className="flex shrink-0 items-center gap-0.5 text-muted-foreground">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-9 w-9 rounded-full text-muted-foreground hover:text-foreground"
+            aria-label={`Save ${article.title}`}
+          >
+            <Bookmark className="h-5 w-5" aria-hidden />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-9 w-9 rounded-full text-muted-foreground hover:text-foreground"
+            aria-label={`More options for ${article.title}`}
+          >
+            <MoreHorizontal className="h-5 w-5" aria-hidden />
+          </Button>
+        </div>
+      </div>
     </article>
   )
 }

--- a/components/articles/ArticleFeedRow.tsx
+++ b/components/articles/ArticleFeedRow.tsx
@@ -58,7 +58,7 @@ export default function ArticleFeedRow({
   const publishedDateTime =
     article.publishedAt instanceof Date
       ? article.publishedAt.toISOString()
-      : article.publishedAt ?? undefined
+      : (article.publishedAt ?? undefined)
 
   return (
     <article className="py-8 first:pt-6 last:pb-6">

--- a/components/articles/ArticleFeedRow.tsx
+++ b/components/articles/ArticleFeedRow.tsx
@@ -1,0 +1,159 @@
+import Link from 'next/link'
+import Image from 'next/image'
+import { format } from 'date-fns'
+import { ArticleForDisplay } from '@/types/index'
+import { canLinkAuthorProfile } from '@/components/articles/ArticleAuthorByline'
+import { TagFilterLink } from '@/components/articles/TagFilterLink'
+import { UserAvatar } from '@/components/ui/user-avatar'
+import {
+  formatReadTime,
+  getFeedRowContextLabel,
+} from '@/lib/articles/feedRowStatus'
+import type { BrowseView } from '@/lib/articles/browseDiscovery'
+import { cn } from '@/lib/utils'
+
+interface ArticleFeedRowProps {
+  article: ArticleForDisplay
+  priority?: boolean
+  onArticleNavigate?: () => void
+  tagLinkAuthor?: string
+  view?: BrowseView
+}
+
+function formatPublishedDate(publishedAt: Date | string | null): string | null {
+  if (!publishedAt) return null
+  const date = publishedAt instanceof Date ? publishedAt : new Date(publishedAt)
+  if (Number.isNaN(date.getTime())) return null
+  return format(date, 'MMM d')
+}
+
+function MetadataSeparator() {
+  return (
+    <span className="text-muted-foreground/70" aria-hidden>
+      ·
+    </span>
+  )
+}
+
+export default function ArticleFeedRow({
+  article,
+  priority,
+  onArticleNavigate,
+  tagLinkAuthor,
+  view = 'latest',
+}: ArticleFeedRowProps) {
+  const articleHref = `/${article.author.username}/${article.slug}`
+  const publishedLabel = formatPublishedDate(article.publishedAt)
+  const readTimeLabel = formatReadTime(article.readTime)
+  const contextLabel = getFeedRowContextLabel(view, article)
+  const displayName = article.author.name || article.author.username
+  const linkableAuthor = canLinkAuthorProfile(article.author)
+  const primaryTag = article.tags[0]
+  const handle = article.author.username
+
+  const navigate = () => onArticleNavigate?.()
+
+  const publishedDateTime =
+    article.publishedAt instanceof Date
+      ? article.publishedAt.toISOString()
+      : article.publishedAt ?? undefined
+
+  return (
+    <article className="py-8 first:pt-6 last:pb-6">
+      <div className="mb-3 flex min-w-0 items-center gap-2 text-[13px] leading-none text-muted-foreground">
+        <UserAvatar
+          src={article.author.avatar}
+          alt={displayName}
+          name={displayName}
+          className="h-5 w-5 shrink-0"
+        />
+        <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1">
+          {linkableAuthor ? (
+            <Link
+              href={`/${article.author.username}`}
+              className="focus-ring truncate rounded-sm font-medium text-foreground hover:underline"
+            >
+              {displayName}
+            </Link>
+          ) : (
+            <span className="truncate font-medium text-foreground">
+              {displayName}
+            </span>
+          )}
+          {handle && handle !== 'unknown' && (
+            <>
+              <MetadataSeparator />
+              <span className="truncate">@{handle}</span>
+            </>
+          )}
+          {publishedLabel && (
+            <>
+              <MetadataSeparator />
+              <time dateTime={publishedDateTime}>{publishedLabel}</time>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-start gap-4 sm:gap-6">
+        <div className="min-w-0 flex-1">
+          <Link
+            href={articleHref}
+            scroll={false}
+            className="focus-ring rounded-md"
+            onPointerDown={navigate}
+            onClick={navigate}
+          >
+            <h2 className="text-xl font-bold leading-snug text-foreground line-clamp-3 sm:text-2xl sm:leading-tight hover:text-brand-blue transition-colors">
+              {article.title}
+            </h2>
+          </Link>
+
+          {article.excerpt && (
+            <p className="mt-2 text-sm leading-relaxed text-muted-foreground line-clamp-2 sm:text-base">
+              {article.excerpt}
+            </p>
+          )}
+        </div>
+
+        {article.coverImage && (
+          <Link
+            href={articleHref}
+            scroll={false}
+            className={cn(
+              'focus-ring relative shrink-0 overflow-hidden bg-muted',
+              'h-[72px] w-[72px] rounded-sm sm:h-[112px] sm:w-[112px]'
+            )}
+            onPointerDown={navigate}
+            onClick={navigate}
+          >
+            <Image
+              src={article.coverImage}
+              alt={article.title}
+              fill
+              sizes="(max-width: 640px) 72px, 112px"
+              priority={priority}
+              className="object-cover"
+            />
+          </Link>
+        )}
+      </div>
+
+      {(primaryTag || readTimeLabel || contextLabel) && (
+        <div className="mt-4 flex flex-wrap items-center gap-x-3 gap-y-2 text-[13px] text-muted-foreground">
+          {primaryTag && (
+            <TagFilterLink
+              tag={primaryTag.name}
+              author={tagLinkAuthor}
+              className="px-3 py-1.5 text-[13px] bg-muted/80"
+            >
+              {primaryTag.name}
+            </TagFilterLink>
+          )}
+          {readTimeLabel && <span>{readTimeLabel}</span>}
+          {contextLabel && <span>{contextLabel}</span>}
+        </div>
+      )}
+    </article>
+  )
+}

--- a/components/articles/ArticleFeedSkeleton.tsx
+++ b/components/articles/ArticleFeedSkeleton.tsx
@@ -1,0 +1,40 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+export function ArticleFeedRowSkeleton() {
+  return (
+    <div className="py-8 first:pt-6 last:pb-6" aria-hidden>
+      <div className="mb-3 flex items-center gap-2">
+        <Skeleton className="h-5 w-5 rounded-full" />
+        <Skeleton className="h-3.5 w-32" />
+        <Skeleton className="h-3.5 w-16" />
+        <Skeleton className="h-3.5 w-12" />
+      </div>
+
+      <div className="flex items-start gap-4 sm:gap-6">
+        <div className="min-w-0 flex-1 space-y-2">
+          <Skeleton className="h-7 w-full sm:h-8" />
+          <Skeleton className="h-7 w-4/5 sm:h-8" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-3/4" />
+        </div>
+        <Skeleton className="h-[72px] w-[72px] shrink-0 rounded-sm sm:h-[112px] sm:w-[112px]" />
+      </div>
+
+      <div className="mt-4 flex items-center gap-3">
+        <Skeleton className="h-7 w-24 rounded-full" />
+        <Skeleton className="h-3.5 w-16" />
+        <Skeleton className="h-3.5 w-20" />
+      </div>
+    </div>
+  )
+}
+
+export function ArticleFeedSkeleton({ count = 6 }: { count?: number }) {
+  return (
+    <div className="max-w-3xl mx-auto divide-y divide-border">
+      {Array.from({ length: count }).map((_, i) => (
+        <ArticleFeedRowSkeleton key={i} />
+      ))}
+    </div>
+  )
+}

--- a/components/articles/ArticleFeedSkeleton.tsx
+++ b/components/articles/ArticleFeedSkeleton.tsx
@@ -20,10 +20,15 @@ export function ArticleFeedRowSkeleton() {
         <Skeleton className="h-[72px] w-[72px] shrink-0 rounded-sm sm:h-[112px] sm:w-[112px]" />
       </div>
 
-      <div className="mt-4 flex items-center gap-3">
-        <Skeleton className="h-7 w-24 rounded-full" />
-        <Skeleton className="h-3.5 w-16" />
-        <Skeleton className="h-3.5 w-20" />
+      <div className="mt-4 flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-7 w-24 rounded-full" />
+          <Skeleton className="h-3.5 w-16" />
+        </div>
+        <div className="flex items-center gap-0.5">
+          <Skeleton className="h-9 w-9 rounded-full" />
+          <Skeleton className="h-9 w-9 rounded-full" />
+        </div>
       </div>
     </div>
   )

--- a/components/articles/ArticleGrid.tsx
+++ b/components/articles/ArticleGrid.tsx
@@ -1,4 +1,5 @@
 import ArticleCard from './ArticleCard'
+import ArticleFeedRow from './ArticleFeedRow'
 import { ArticleForDisplay } from '@/types/index'
 import Link from 'next/link'
 import { BookOpen } from 'lucide-react'
@@ -85,6 +86,23 @@ export default function ArticleGrid({
               </Button>
             )}
         </div>
+      </div>
+    )
+  }
+
+  if (variant === 'articles') {
+    return (
+      <div className="max-w-3xl mx-auto divide-y divide-border">
+        {articles.map((article, index) => (
+          <ArticleFeedRow
+            key={article.id}
+            article={article}
+            priority={index === 0}
+            onArticleNavigate={onArticleNavigate}
+            tagLinkAuthor={tagLinkAuthor}
+            view={view}
+          />
+        ))}
       </div>
     )
   }

--- a/components/articles/ArticleGrid.tsx
+++ b/components/articles/ArticleGrid.tsx
@@ -2,19 +2,32 @@ import ArticleCard from './ArticleCard'
 import { ArticleForDisplay } from '@/types/index'
 import Link from 'next/link'
 import { BookOpen } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { BrowseView } from '@/lib/articles/browseDiscovery'
+
+export type ArticleGridEmptyState = {
+  hasSearch: boolean
+  hasFilters: boolean
+  onClearSearch?: () => void
+  onClearAll?: () => void
+}
 
 interface ArticleGridProps {
   articles: ArticleForDisplay[]
   variant?: 'home' | 'articles'
+  view?: BrowseView
   onArticleNavigate?: () => void
   tagLinkAuthor?: string
+  emptyState?: ArticleGridEmptyState
 }
 
 export default function ArticleGrid({
   articles,
   variant = 'articles',
+  view = 'latest',
   onArticleNavigate,
   tagLinkAuthor,
+  emptyState,
 }: ArticleGridProps) {
   if (articles.length === 0) {
     if (variant === 'home') {
@@ -49,27 +62,28 @@ export default function ArticleGrid({
 
     return (
       <div className="text-center py-12">
-        <div className="max-w-sm mx-auto">
-          <svg
-            className="mx-auto h-12 w-12 text-muted-foreground mb-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9.5a2 2 0 00-2-2h-2"
-            />
-          </svg>
+        <div className="max-w-sm mx-auto rounded-[var(--card-radius)] border border-border bg-card px-6 py-10 shadow-[var(--card-shadow)]">
+          <BookOpen className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
           <h3 className="text-lg font-medium text-foreground mb-1">
             No articles found
           </h3>
-          <p className="text-muted-foreground">
-            Try adjusting your search or filters to find what you&apos;re
-            looking for.
+          <p className="text-muted-foreground mb-6">
+            {emptyState?.hasSearch
+              ? 'No articles match your search. Try a different term or clear your search.'
+              : "Try adjusting your search or filters to find what you're looking for."}
           </p>
+          {emptyState?.hasSearch && emptyState.onClearSearch && (
+            <Button type="button" onClick={emptyState.onClearSearch}>
+              Clear search
+            </Button>
+          )}
+          {!emptyState?.hasSearch &&
+            emptyState?.hasFilters &&
+            emptyState.onClearAll && (
+              <Button type="button" onClick={emptyState.onClearAll}>
+                Clear filters
+              </Button>
+            )}
         </div>
       </div>
     )
@@ -84,6 +98,7 @@ export default function ArticleGrid({
           priority={index === 0}
           onArticleNavigate={onArticleNavigate}
           tagLinkAuthor={tagLinkAuthor}
+          view={view}
         />
       ))}
     </div>

--- a/components/articles/ArticlesBrowseContent.tsx
+++ b/components/articles/ArticlesBrowseContent.tsx
@@ -6,7 +6,7 @@ import { useListArticles } from '@/hooks/convex'
 import { mapListArticlesToDisplay } from '@/lib/articles/mapListArticleToDisplay'
 import ArticleGrid from '@/components/articles/ArticleGrid'
 import Pagination from '@/components/articles/Pagination'
-import { ArticleGridSkeleton } from '@/components/articles/ArticleCardSkeleton'
+import { ArticleFeedSkeleton } from '@/components/articles/ArticleFeedSkeleton'
 import { buildArticlesBrowseHref } from '@/lib/articles/buildArticlesBrowseHref'
 import { readBrowseScrollY } from '@/lib/articles/browseListScrollStorage'
 import { getBrowseContextMessage } from '@/components/articles/ArticlesBrowseDiscoveryHeader'
@@ -71,7 +71,7 @@ export function ArticlesBrowseContent({
   }, [scrollStorageKey, listReady])
 
   if (result === undefined) {
-    return <ArticleGridSkeleton count={9} />
+    return <ArticleFeedSkeleton count={6} />
   }
 
   const articles = mapListArticlesToDisplay(result.articles)

--- a/components/articles/ArticlesBrowseContent.tsx
+++ b/components/articles/ArticlesBrowseContent.tsx
@@ -9,6 +9,8 @@ import Pagination from '@/components/articles/Pagination'
 import { ArticleGridSkeleton } from '@/components/articles/ArticleCardSkeleton'
 import { buildArticlesBrowseHref } from '@/lib/articles/buildArticlesBrowseHref'
 import { readBrowseScrollY } from '@/lib/articles/browseListScrollStorage'
+import { getBrowseContextMessage } from '@/components/articles/ArticlesBrowseDiscoveryHeader'
+import type { BrowseSort, BrowseView } from '@/lib/articles/browseDiscovery'
 
 function buildPagination(result: {
   page: number
@@ -33,6 +35,8 @@ export function ArticlesBrowseContent({
   tag,
   author,
   urlSearch,
+  view,
+  sort,
   scrollStorageKey,
   onArticleNavigate,
 }: {
@@ -40,6 +44,8 @@ export function ArticlesBrowseContent({
   tag?: string
   author?: string
   urlSearch?: string
+  view: BrowseView
+  sort: BrowseSort
   scrollStorageKey: string
   onArticleNavigate?: () => void
 }) {
@@ -51,6 +57,8 @@ export function ArticlesBrowseContent({
     tag,
     author,
     search: urlSearch,
+    view,
+    sort,
   })
 
   const listReady = result !== undefined
@@ -68,6 +76,7 @@ export function ArticlesBrowseContent({
 
   const articles = mapListArticlesToDisplay(result.articles)
   const pagination = buildPagination(result)
+  const contextMessage = getBrowseContextMessage(view, result.browseMeta)
 
   const handlePageChange = (page: number) => {
     router.push(
@@ -78,9 +87,40 @@ export function ArticlesBrowseContent({
     )
   }
 
+  const handleClearSearch = () => {
+    router.push(
+      buildArticlesBrowseHref({
+        search: '',
+        page: 1,
+        sourceParams: searchParams,
+      })
+    )
+  }
+
+  const handleClearAll = () => {
+    router.push('/articles')
+  }
+
+  const hasSearch = Boolean(urlSearch?.trim())
+  const hasFilters = Boolean(tag || author || hasSearch)
+
   return (
     <>
-      <ArticleGrid articles={articles} onArticleNavigate={onArticleNavigate} />
+      {contextMessage && (
+        <p className="mb-4 text-sm text-muted-foreground">{contextMessage}</p>
+      )}
+
+      <ArticleGrid
+        articles={articles}
+        onArticleNavigate={onArticleNavigate}
+        view={view}
+        emptyState={{
+          hasSearch,
+          hasFilters,
+          onClearSearch: handleClearSearch,
+          onClearAll: handleClearAll,
+        }}
+      />
 
       {pagination.totalPages > 1 && (
         <div className="mt-12">

--- a/components/articles/ArticlesBrowseDiscoveryHeader.tsx
+++ b/components/articles/ArticlesBrowseDiscoveryHeader.tsx
@@ -1,9 +1,8 @@
 'use client'
 
-import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Sparkles, Clock, TrendingUp } from 'lucide-react'
-import { useBrowseTags } from '@/hooks/convex'
+import { useBrowseAuthors, useBrowseTags } from '@/hooks/convex'
 import { buildArticlesBrowseHref } from '@/lib/articles/buildArticlesBrowseHref'
 import {
   BROWSE_SORTS,
@@ -33,16 +32,19 @@ type ArticlesBrowseDiscoveryHeaderProps = {
   view: BrowseView
   sort: BrowseSort
   activeTag?: string
+  activeAuthor?: string
 }
 
 export function ArticlesBrowseDiscoveryHeader({
   view,
   sort,
   activeTag,
+  activeAuthor,
 }: ArticlesBrowseDiscoveryHeaderProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
   const browseTags = useBrowseTags()
+  const browseAuthors = useBrowseAuthors()
 
   const handleViewChange = (nextView: BrowseView) => {
     router.push(
@@ -64,86 +66,112 @@ export function ArticlesBrowseDiscoveryHeader({
     )
   }
 
+  const handleAuthorChange = (username: string) => {
+    router.push(
+      buildArticlesBrowseHref({
+        author: username,
+        page: 1,
+        sourceParams: searchParams,
+      })
+    )
+  }
+
   const tags = browseTags ?? []
+  const authors = browseAuthors ?? []
 
   return (
-    <div className="mb-6 space-y-4">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div
-          className="inline-flex w-full sm:w-auto rounded-full border border-border bg-muted/40 p-1"
-          role="tablist"
-          aria-label="Browse articles by"
-        >
-          {VIEW_TABS.map((tab) => {
-            const isActive = view === tab.id
-            const Icon = tab.icon
-            return (
-              <button
-                key={tab.id}
-                type="button"
-                role="tab"
-                aria-selected={isActive}
-                onClick={() => handleViewChange(tab.id)}
-                className={cn(
-                  'focus-ring inline-flex flex-1 sm:flex-none items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition-colors min-h-[40px]',
-                  isActive
-                    ? 'bg-foreground text-background shadow-sm'
-                    : 'text-muted-foreground hover:text-foreground'
-                )}
-              >
-                <Icon className="h-4 w-4 shrink-0" aria-hidden />
-                {tab.label}
-              </button>
-            )
-          })}
+    <div className="mb-6 border-b border-border">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div className="-mb-px flex-1 overflow-x-auto">
+          <div
+            className="flex min-w-max items-center gap-0.5"
+            role="tablist"
+            aria-label="Browse articles"
+          >
+            {VIEW_TABS.map((tab) => {
+              const isActive = view === tab.id
+              const Icon = tab.icon
+              return (
+                <button
+                  key={tab.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  onClick={() => handleViewChange(tab.id)}
+                  className={cn(
+                    'focus-ring inline-flex items-center gap-1.5 border-b-2 px-3 py-2.5 text-sm font-medium whitespace-nowrap transition-colors min-h-[44px]',
+                    isActive
+                      ? 'border-foreground text-foreground'
+                      : 'border-transparent text-muted-foreground hover:border-border hover:text-foreground'
+                  )}
+                >
+                  <Icon className="h-4 w-4 shrink-0" aria-hidden />
+                  {tab.label}
+                </button>
+              )
+            })}
+
+            {tags.length > 0 && (
+              <>
+                <span
+                  className="mx-2 h-4 w-px shrink-0 bg-border self-center"
+                  aria-hidden
+                />
+                {tags.map(({ tag }) => (
+                  <TagFilterLink
+                    key={tag}
+                    tag={tag}
+                    className={cn(
+                      'my-1 shrink-0',
+                      activeTag === tag &&
+                        'bg-foreground text-background hover:bg-foreground/90 hover:text-background'
+                    )}
+                  />
+                ))}
+              </>
+            )}
+          </div>
         </div>
 
-        {view === 'latest' && (
-          <label className="flex items-center gap-2 text-sm text-muted-foreground shrink-0">
-            <span>Sort by</span>
-            <select
-              className="h-9 rounded-md border border-border bg-background px-2 text-foreground"
-              value={sort}
-              onChange={(e) => handleSortChange(e.target.value as BrowseSort)}
-              aria-label="Sort articles by"
-            >
-              {BROWSE_SORTS.map((option) => (
-                <option key={option} value={option}>
-                  {SORT_LABELS[option]}
-                </option>
-              ))}
-            </select>
-          </label>
-        )}
-      </div>
+        <div className="flex shrink-0 flex-wrap items-center gap-3 pb-3">
+          {authors.length > 0 && (
+            <label className="flex items-center gap-2 text-sm text-muted-foreground">
+              <span className="sr-only sm:not-sr-only">Author</span>
+              <select
+                className="h-9 max-w-[11rem] truncate rounded-md border border-border bg-background px-2 text-foreground sm:max-w-[14rem]"
+                value={activeAuthor ?? ''}
+                onChange={(e) => handleAuthorChange(e.target.value)}
+                aria-label="Filter articles by author"
+              >
+                <option value="">All authors</option>
+                {authors.map((author) => (
+                  <option key={author.username} value={author.username}>
+                    {author.name?.trim() || `@${author.username}`}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
 
-      {tags.length > 0 && (
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-sm text-muted-foreground shrink-0">Topics</span>
-          {tags.map(({ tag }) => (
-            <TagFilterLink
-              key={tag}
-              tag={tag}
-              className={cn(
-                activeTag === tag &&
-                  'bg-foreground text-background hover:bg-foreground/90 hover:text-background'
-              )}
-            />
-          ))}
-          {activeTag && (
-            <Link
-              href={buildArticlesBrowseHref({
-                tag: '',
-                page: 1,
-                sourceParams: searchParams,
-              })}
-              className="text-sm text-brand-blue hover:text-brand-accent underline"
-            >
-              Clear topic
-            </Link>
+          {view === 'latest' && (
+            <label className="flex items-center gap-2 text-sm text-muted-foreground">
+              <span className="sr-only sm:not-sr-only">Sort by</span>
+              <select
+                className="h-9 rounded-md border border-border bg-background px-2 text-foreground"
+                value={sort}
+                onChange={(e) => handleSortChange(e.target.value as BrowseSort)}
+                aria-label="Sort articles by"
+              >
+                {BROWSE_SORTS.map((option) => (
+                  <option key={option} value={option}>
+                    {SORT_LABELS[option]}
+                  </option>
+                ))}
+              </select>
+            </label>
           )}
         </div>
-      )}
+      </div>
     </div>
   )
 }

--- a/components/articles/ArticlesBrowseDiscoveryHeader.tsx
+++ b/components/articles/ArticlesBrowseDiscoveryHeader.tsx
@@ -82,10 +82,10 @@ export function ArticlesBrowseDiscoveryHeader({
 
   return (
     <div className="mb-6 space-y-4 border-b border-border pb-4">
-      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-        <div className="-mb-px flex-1 overflow-x-auto">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex-1 overflow-x-auto">
           <div
-            className="flex min-w-max items-center gap-0.5"
+            className="inline-flex min-w-max items-center gap-0.5 rounded-full bg-muted p-1"
             role="tablist"
             aria-label="Browse articles"
           >
@@ -100,10 +100,10 @@ export function ArticlesBrowseDiscoveryHeader({
                   aria-selected={isActive}
                   onClick={() => handleViewChange(tab.id)}
                   className={cn(
-                    'focus-ring inline-flex items-center gap-1.5 border-b-2 px-3 py-2.5 text-sm font-medium whitespace-nowrap transition-colors min-h-[44px]',
+                    'focus-ring inline-flex items-center gap-1.5 rounded-full px-3 py-2 text-sm font-medium whitespace-nowrap transition-colors min-h-[36px]',
                     isActive
-                      ? 'border-foreground text-foreground'
-                      : 'border-transparent text-muted-foreground hover:border-border hover:text-foreground'
+                      ? 'bg-primary text-primary-foreground shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground'
                   )}
                 >
                   <Icon className="h-4 w-4 shrink-0" aria-hidden />

--- a/components/articles/ArticlesBrowseDiscoveryHeader.tsx
+++ b/components/articles/ArticlesBrowseDiscoveryHeader.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Sparkles, Clock, TrendingUp } from 'lucide-react'
 import { useBrowseAuthors, useBrowseTags } from '@/hooks/convex'
@@ -80,7 +81,7 @@ export function ArticlesBrowseDiscoveryHeader({
   const authors = browseAuthors ?? []
 
   return (
-    <div className="mb-6 border-b border-border">
+    <div className="mb-6 space-y-4 border-b border-border pb-4">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
         <div className="-mb-px flex-1 overflow-x-auto">
           <div
@@ -110,30 +111,10 @@ export function ArticlesBrowseDiscoveryHeader({
                 </button>
               )
             })}
-
-            {tags.length > 0 && (
-              <>
-                <span
-                  className="mx-2 h-4 w-px shrink-0 bg-border self-center"
-                  aria-hidden
-                />
-                {tags.map(({ tag }) => (
-                  <TagFilterLink
-                    key={tag}
-                    tag={tag}
-                    className={cn(
-                      'my-1 shrink-0',
-                      activeTag === tag &&
-                        'bg-foreground text-background hover:bg-foreground/90 hover:text-background'
-                    )}
-                  />
-                ))}
-              </>
-            )}
           </div>
         </div>
 
-        <div className="flex shrink-0 flex-wrap items-center gap-3 pb-3">
+        <div className="flex shrink-0 flex-wrap items-center gap-3">
           {authors.length > 0 && (
             <label className="flex items-center gap-2 text-sm text-muted-foreground">
               <span className="sr-only sm:not-sr-only">Author</span>
@@ -172,6 +153,34 @@ export function ArticlesBrowseDiscoveryHeader({
           )}
         </div>
       </div>
+
+      {tags.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm text-muted-foreground shrink-0">Topics</span>
+          {tags.map(({ tag }) => (
+            <TagFilterLink
+              key={tag}
+              tag={tag}
+              className={cn(
+                activeTag === tag &&
+                  'bg-foreground text-background hover:bg-foreground/90 hover:text-background'
+              )}
+            />
+          ))}
+          {activeTag && (
+            <Link
+              href={buildArticlesBrowseHref({
+                tag: '',
+                page: 1,
+                sourceParams: searchParams,
+              })}
+              className="text-sm text-brand-blue hover:text-brand-accent underline"
+            >
+              Clear topic
+            </Link>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/components/articles/ArticlesBrowseDiscoveryHeader.tsx
+++ b/components/articles/ArticlesBrowseDiscoveryHeader.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { Sparkles, Clock, TrendingUp } from 'lucide-react'
+import { useBrowseTags } from '@/hooks/convex'
+import { buildArticlesBrowseHref } from '@/lib/articles/buildArticlesBrowseHref'
+import {
+  BROWSE_SORTS,
+  type BrowseSort,
+  type BrowseView,
+} from '@/lib/articles/browseDiscovery'
+import { TagFilterLink } from '@/components/articles/TagFilterLink'
+import { cn } from '@/lib/utils'
+
+const VIEW_TABS: {
+  id: BrowseView
+  label: string
+  icon: typeof Clock
+}[] = [
+  { id: 'featured', label: 'Featured', icon: Sparkles },
+  { id: 'latest', label: 'Latest', icon: Clock },
+  { id: 'trending', label: 'Trending', icon: TrendingUp },
+]
+
+const SORT_LABELS: Record<BrowseSort, string> = {
+  newest: 'Newest',
+  oldest: 'Oldest',
+  most_tipped: 'Most tipped',
+}
+
+type ArticlesBrowseDiscoveryHeaderProps = {
+  view: BrowseView
+  sort: BrowseSort
+  activeTag?: string
+}
+
+export function ArticlesBrowseDiscoveryHeader({
+  view,
+  sort,
+  activeTag,
+}: ArticlesBrowseDiscoveryHeaderProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const browseTags = useBrowseTags()
+
+  const handleViewChange = (nextView: BrowseView) => {
+    router.push(
+      buildArticlesBrowseHref({
+        view: nextView,
+        page: 1,
+        sourceParams: searchParams,
+      })
+    )
+  }
+
+  const handleSortChange = (nextSort: BrowseSort) => {
+    router.push(
+      buildArticlesBrowseHref({
+        sort: nextSort,
+        page: 1,
+        sourceParams: searchParams,
+      })
+    )
+  }
+
+  const tags = browseTags ?? []
+
+  return (
+    <div className="mb-6 space-y-4">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div
+          className="inline-flex w-full sm:w-auto rounded-full border border-border bg-muted/40 p-1"
+          role="tablist"
+          aria-label="Browse articles by"
+        >
+          {VIEW_TABS.map((tab) => {
+            const isActive = view === tab.id
+            const Icon = tab.icon
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                onClick={() => handleViewChange(tab.id)}
+                className={cn(
+                  'focus-ring inline-flex flex-1 sm:flex-none items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition-colors min-h-[40px]',
+                  isActive
+                    ? 'bg-foreground text-background shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                <Icon className="h-4 w-4 shrink-0" aria-hidden />
+                {tab.label}
+              </button>
+            )
+          })}
+        </div>
+
+        {view === 'latest' && (
+          <label className="flex items-center gap-2 text-sm text-muted-foreground shrink-0">
+            <span>Sort by</span>
+            <select
+              className="h-9 rounded-md border border-border bg-background px-2 text-foreground"
+              value={sort}
+              onChange={(e) => handleSortChange(e.target.value as BrowseSort)}
+              aria-label="Sort articles by"
+            >
+              {BROWSE_SORTS.map((option) => (
+                <option key={option} value={option}>
+                  {SORT_LABELS[option]}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+      </div>
+
+      {tags.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm text-muted-foreground shrink-0">Topics</span>
+          {tags.map(({ tag }) => (
+            <TagFilterLink
+              key={tag}
+              tag={tag}
+              className={cn(
+                activeTag === tag &&
+                  'bg-foreground text-background hover:bg-foreground/90 hover:text-background'
+              )}
+            />
+          ))}
+          {activeTag && (
+            <Link
+              href={buildArticlesBrowseHref({
+                tag: '',
+                page: 1,
+                sourceParams: searchParams,
+              })}
+              className="text-sm text-brand-blue hover:text-brand-accent underline"
+            >
+              Clear topic
+            </Link>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function getBrowseContextMessage(
+  view: BrowseView,
+  browseMeta?: {
+    featuredFallback?: boolean
+    trendingFallback?: boolean
+  }
+): string | null {
+  if (browseMeta?.featuredFallback) {
+    return 'No reader-supported stories yet. Showing recently published articles.'
+  }
+  if (browseMeta?.trendingFallback) {
+    return 'No engagement signals yet. Showing recently published articles.'
+  }
+  if (view === 'featured') {
+    return 'Reader-supported stories with the most tips.'
+  }
+  if (view === 'trending') {
+    return 'Trending by tips and highlights.'
+  }
+  return null
+}

--- a/components/articles/TagFilterLink.tsx
+++ b/components/articles/TagFilterLink.tsx
@@ -30,11 +30,13 @@ export function TagFilterLink({
       aria-label={`Filter by tag ${tag}`}
       className={[
         'focus-ring inline-flex items-center rounded-full',
-        'text-xs px-2 py-1 bg-muted text-foreground',
+        'text-xs px-2.5 py-1 bg-muted text-foreground',
         'hover:bg-muted/80 hover:text-foreground',
         'transition-colors',
         className,
-      ].join(' ')}
+      ]
+        .filter(Boolean)
+        .join(' ')}
     >
       {children ?? tag}
     </Link>

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -16,6 +16,7 @@ import type * as crons from "../crons.js";
 import type * as highlightTips from "../highlightTips.js";
 import type * as highlights from "../highlights.js";
 import type * as http from "../http.js";
+import type * as lib_articleBrowseSort from "../lib/articleBrowseSort.js";
 import type * as lib_articleListing from "../lib/articleListing.js";
 import type * as lib_articleListingReady from "../lib/articleListingReady.js";
 import type * as lib_articleSearch from "../lib/articleSearch.js";
@@ -55,6 +56,7 @@ declare const fullApi: ApiFromModules<{
   highlightTips: typeof highlightTips;
   highlights: typeof highlights;
   http: typeof http;
+  "lib/articleBrowseSort": typeof lib_articleBrowseSort;
   "lib/articleListing": typeof lib_articleListing;
   "lib/articleListingReady": typeof lib_articleListingReady;
   "lib/articleSearch": typeof lib_articleSearch;

--- a/convex/articles.listArticles.test.ts
+++ b/convex/articles.listArticles.test.ts
@@ -483,4 +483,319 @@ describe('listArticles', () => {
       expect(res.articles[0]!.title).toBe(title)
     })
   })
+
+  it('sorts by oldest when sort=oldest', async () => {
+    const t = convexTest(schema, modules)
+    await t.run(async (ctx) => {
+      const now = Date.now()
+      const u = await ctx.db.insert('users', {
+        email: 'sort@x.test',
+        username: 'sortwriter',
+        createdAt: now,
+        updatedAt: now,
+      })
+      await ctx.db.insert('articles', {
+        slug: 'older',
+        title: 'Older',
+        excerpt: listingExcerpt,
+        content: emptyDoc,
+        published: true,
+        publishedAt: now,
+        authorId: u,
+        authorUsername: 'sortwriter',
+        tags: [],
+        searchContent: 'Older',
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      await ctx.db.insert('articles', {
+        slug: 'newer',
+        title: 'Newer',
+        excerpt: listingExcerpt,
+        content: emptyDoc,
+        published: true,
+        publishedAt: now + 1000,
+        authorId: u,
+        authorUsername: 'sortwriter',
+        tags: [],
+        searchContent: 'Newer',
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      const res = await ctx.runQuery(api.articles.listArticles, {
+        sort: 'oldest',
+        page: 1,
+        limit: 10,
+      })
+      expect(res.articles.map((a) => a.slug)).toEqual(['older', 'newer'])
+    })
+  })
+
+  it('featured view returns tipped articles and sets fallback meta when none', async () => {
+    const t = convexTest(schema, modules)
+    await t.run(async (ctx) => {
+      const now = Date.now()
+      const u = await ctx.db.insert('users', {
+        email: 'feat@x.test',
+        username: 'featwriter',
+        createdAt: now,
+        updatedAt: now,
+      })
+      const tippedId = await ctx.db.insert('articles', {
+        slug: 'tipped',
+        title: 'Tipped',
+        excerpt: listingExcerpt,
+        content: emptyDoc,
+        published: true,
+        publishedAt: now,
+        authorId: u,
+        authorUsername: 'featwriter',
+        tags: [],
+        searchContent: 'Tipped',
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 3,
+        totalTipsUsd: 1,
+        createdAt: now,
+        updatedAt: now,
+      })
+      await ctx.db.insert('articles', {
+        slug: 'plain',
+        title: 'Plain',
+        excerpt: listingExcerpt,
+        content: emptyDoc,
+        published: true,
+        publishedAt: now + 1000,
+        authorId: u,
+        authorUsername: 'featwriter',
+        tags: [],
+        searchContent: 'Plain',
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      const featured = await ctx.runQuery(api.articles.listArticles, {
+        view: 'featured',
+        page: 1,
+        limit: 10,
+      })
+      expect(featured.total).toBe(1)
+      expect(featured.articles[0]!._id).toBe(tippedId)
+      expect(featured.browseMeta?.featuredFallback).toBeUndefined()
+
+      const noTipsUser = await ctx.db.insert('users', {
+        email: 'notipped@x.test',
+        username: 'notipped',
+        createdAt: now,
+        updatedAt: now,
+      })
+      await ctx.db.insert('articles', {
+        slug: 'recent',
+        title: 'Recent',
+        excerpt: listingExcerpt,
+        content: emptyDoc,
+        published: true,
+        publishedAt: now + 3000,
+        authorId: noTipsUser,
+        authorUsername: 'notipped',
+        tags: [],
+        searchContent: 'Recent',
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      const fallback = await ctx.runQuery(api.articles.listArticles, {
+        view: 'featured',
+        author: 'notipped',
+        page: 1,
+        limit: 10,
+      })
+      expect(fallback.browseMeta?.featuredFallback).toBe(true)
+      expect(fallback.articles[0]!.slug).toBe('recent')
+    })
+  })
+
+  it('trending view orders by engagement and falls back when scores are zero', async () => {
+    const t = convexTest(schema, modules)
+    await t.run(async (ctx) => {
+      const now = Date.now()
+      const u = await ctx.db.insert('users', {
+        email: 'trend@x.test',
+        username: 'trendwriter',
+        createdAt: now,
+        updatedAt: now,
+      })
+      await ctx.db.insert('articles', {
+        slug: 'quiet',
+        title: 'Quiet',
+        excerpt: listingExcerpt,
+        content: emptyDoc,
+        published: true,
+        publishedAt: now + 2000,
+        authorId: u,
+        authorUsername: 'trendwriter',
+        tags: [],
+        searchContent: 'Quiet',
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      const hotId = await ctx.db.insert('articles', {
+        slug: 'hot',
+        title: 'Hot',
+        excerpt: listingExcerpt,
+        content: emptyDoc,
+        published: true,
+        publishedAt: now,
+        authorId: u,
+        authorUsername: 'trendwriter',
+        tags: [],
+        searchContent: 'Hot',
+        viewCount: 0,
+        highlightCount: 1,
+        tipCount: 1,
+        totalTipsUsd: 1,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      const trending = await ctx.runQuery(api.articles.listArticles, {
+        view: 'trending',
+        page: 1,
+        limit: 10,
+      })
+      expect(trending.articles[0]!._id).toBe(hotId)
+
+      const fallbackUser = await ctx.db.insert('users', {
+        email: 'flat@x.test',
+        username: 'flatwriter',
+        createdAt: now,
+        updatedAt: now,
+      })
+      await ctx.db.insert('articles', {
+        slug: 'flat-old',
+        title: 'Flat Old',
+        excerpt: listingExcerpt,
+        content: emptyDoc,
+        published: true,
+        publishedAt: now,
+        authorId: fallbackUser,
+        authorUsername: 'flatwriter',
+        tags: [],
+        searchContent: 'Flat Old',
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      await ctx.db.insert('articles', {
+        slug: 'flat-new',
+        title: 'Flat New',
+        excerpt: listingExcerpt,
+        content: emptyDoc,
+        published: true,
+        publishedAt: now + 5000,
+        authorId: fallbackUser,
+        authorUsername: 'flatwriter',
+        tags: [],
+        searchContent: 'Flat New',
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      const fallback = await ctx.runQuery(api.articles.listArticles, {
+        view: 'trending',
+        author: 'flatwriter',
+        page: 1,
+        limit: 10,
+      })
+      expect(fallback.browseMeta?.trendingFallback).toBe(true)
+      expect(fallback.articles[0]!.slug).toBe('flat-new')
+    })
+  })
+})
+
+describe('listBrowseTags', () => {
+  it('returns tags ordered by article count', async () => {
+    const t = convexTest(schema, modules)
+    await t.run(async (ctx) => {
+      const now = Date.now()
+      const u = await ctx.db.insert('users', {
+        email: 'chips@x.test',
+        username: 'chipwriter',
+        createdAt: now,
+        updatedAt: now,
+      })
+      const a1 = await ctx.db.insert('articles', {
+        slug: 'one',
+        title: 'One',
+        excerpt: listingExcerpt,
+        content: emptyDoc,
+        published: true,
+        publishedAt: now,
+        authorId: u,
+        authorUsername: 'chipwriter',
+        tags: ['rust', 'web'],
+        searchContent: 'One',
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      const a2 = await ctx.db.insert('articles', {
+        slug: 'two',
+        title: 'Two',
+        excerpt: listingExcerpt,
+        content: emptyDoc,
+        published: true,
+        publishedAt: now + 1,
+        authorId: u,
+        authorUsername: 'chipwriter',
+        tags: ['rust'],
+        searchContent: 'Two',
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      const doc1 = await ctx.db.get(a1)
+      const doc2 = await ctx.db.get(a2)
+      if (doc1) await replaceTagLinksForArticle(ctx, doc1)
+      if (doc2) await replaceTagLinksForArticle(ctx, doc2)
+
+      const tags = await ctx.runQuery(api.articles.listBrowseTags, { limit: 5 })
+      expect(tags[0]).toEqual({ tag: 'rust', articleCount: 2 })
+      expect(tags[1]).toEqual({ tag: 'web', articleCount: 1 })
+    })
+  })
 })

--- a/convex/articles.listArticles.test.ts
+++ b/convex/articles.listArticles.test.ts
@@ -741,6 +741,82 @@ describe('listArticles', () => {
   })
 })
 
+describe('listBrowseAuthors', () => {
+  it('returns authors ordered by published article count', async () => {
+    const t = convexTest(schema, modules)
+    await t.run(async (ctx) => {
+      const now = Date.now()
+      const prolific = await ctx.db.insert('users', {
+        email: 'prolific@x.test',
+        username: 'prolific',
+        name: 'Prolific Writer',
+        createdAt: now,
+        updatedAt: now,
+      })
+      const quiet = await ctx.db.insert('users', {
+        email: 'quiet@x.test',
+        username: 'quiet',
+        name: 'Quiet Writer',
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      for (let i = 0; i < 2; i++) {
+        await ctx.db.insert('articles', {
+          slug: `prolific-${i}`,
+          title: `Prolific ${i}`,
+          excerpt: listingExcerpt,
+          content: emptyDoc,
+          published: true,
+          publishedAt: now + i,
+          authorId: prolific,
+          authorUsername: 'prolific',
+          tags: [],
+          searchContent: `Prolific ${i}`,
+          viewCount: 0,
+          highlightCount: 0,
+          tipCount: 0,
+          totalTipsUsd: 0,
+          createdAt: now,
+          updatedAt: now,
+        })
+      }
+
+      await ctx.db.insert('articles', {
+        slug: 'quiet-one',
+        title: 'Quiet one',
+        excerpt: listingExcerpt,
+        content: emptyDoc,
+        published: true,
+        publishedAt: now,
+        authorId: quiet,
+        authorUsername: 'quiet',
+        tags: [],
+        searchContent: 'Quiet one',
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      const authors = await ctx.runQuery(api.articles.listBrowseAuthors, {
+        limit: 5,
+      })
+      expect(authors[0]).toMatchObject({
+        username: 'prolific',
+        name: 'Prolific Writer',
+        articleCount: 2,
+      })
+      expect(authors[1]).toMatchObject({
+        username: 'quiet',
+        articleCount: 1,
+      })
+    })
+  })
+})
+
 describe('listBrowseTags', () => {
   it('returns tags ordered by article count', async () => {
     const t = convexTest(schema, modules)

--- a/convex/articles.ts
+++ b/convex/articles.ts
@@ -277,6 +277,49 @@ export const listBrowseTags = query({
   },
 })
 
+export const listBrowseAuthors = query({
+  args: {
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = Math.min(Math.max(args.limit ?? 20, 1), 50)
+    const rows = await ctx.db
+      .query('articles')
+      .withIndex('by_published_date', (q) => q.eq('published', true))
+      .order('desc')
+      .collect()
+
+    const counts = new Map<Id<'users'>, number>()
+    for (const article of rows) {
+      if (!isArticleListingReady(article)) continue
+      counts.set(article.authorId, (counts.get(article.authorId) ?? 0) + 1)
+    }
+
+    const sorted = [...counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, limit)
+
+    const authors: {
+      username: string
+      name: string | null
+      articleCount: number
+    }[] = []
+
+    for (const [authorId, articleCount] of sorted) {
+      const user = await ctx.db.get(authorId)
+      const username = user?.username?.trim()
+      if (!user || !username) continue
+      authors.push({
+        username,
+        name: user.name ?? null,
+        articleCount,
+      })
+    }
+
+    return authors
+  },
+})
+
 // Get article by slug
 export const getArticleBySlug = query({
   args: {

--- a/convex/articles.ts
+++ b/convex/articles.ts
@@ -86,11 +86,13 @@ const browseSortValidator = v.union(
   v.literal('most_tipped')
 )
 
-function paginateBrowseArticles<T extends {
-  publishedAt?: number
-  tipCount?: number
-  highlightCount?: number
-}>(
+function paginateBrowseArticles<
+  T extends {
+    publishedAt?: number
+    tipCount?: number
+    highlightCount?: number
+  },
+>(
   articles: T[],
   view: BrowseView,
   sort: BrowseSort,

--- a/convex/articles.ts
+++ b/convex/articles.ts
@@ -23,6 +23,11 @@ import {
 } from './lib/articleListingReady'
 import { searchListingArticles } from './lib/articleSearch'
 import {
+  sortArticlesForBrowse,
+  type BrowseSort,
+  type BrowseView,
+} from './lib/articleBrowseSort'
+import {
   extractTextFromTiptapJson,
   tiptapJsonHasNonEmptyText,
 } from './lib/tiptapContent'
@@ -69,6 +74,40 @@ function validateArticleInput(args: {
   }
 }
 
+const browseViewValidator = v.union(
+  v.literal('latest'),
+  v.literal('trending'),
+  v.literal('featured')
+)
+
+const browseSortValidator = v.union(
+  v.literal('newest'),
+  v.literal('oldest'),
+  v.literal('most_tipped')
+)
+
+function paginateBrowseArticles<T extends {
+  publishedAt?: number
+  tipCount?: number
+  highlightCount?: number
+}>(
+  articles: T[],
+  view: BrowseView,
+  sort: BrowseSort,
+  offset: number,
+  limit: number
+) {
+  const { articles: sorted, meta } = sortArticlesForBrowse(articles, view, sort)
+  const total = sorted.length
+  const slice = sorted.slice(offset, offset + limit)
+  return {
+    slice,
+    total,
+    totalPages: total === 0 ? 0 : Math.ceil(total / limit),
+    browseMeta: meta,
+  }
+}
+
 // List articles with pagination and filters
 export const listArticles = query({
   args: {
@@ -77,11 +116,15 @@ export const listArticles = query({
     tag: v.optional(v.string()),
     author: v.optional(v.string()),
     search: v.optional(v.string()),
+    view: v.optional(browseViewValidator),
+    sort: v.optional(browseSortValidator),
   },
   handler: async (ctx, args) => {
     const page = Math.max(args.page || 1, 1)
     const limit = Math.min(Math.max(args.limit || 10, 1), 50)
     const offset = (page - 1) * limit
+    const view: BrowseView = args.view ?? 'latest'
+    const sort: BrowseSort = args.sort ?? 'newest'
 
     const tag = args.tag?.trim() || undefined
     const searchRaw = args.search?.trim()
@@ -114,8 +157,13 @@ export const listArticles = query({
         authorId,
         filterTag: tag,
       })
-      const total = rows.length
-      const slice = rows.slice(offset, offset + limit)
+      const { slice, total, totalPages, browseMeta } = paginateBrowseArticles(
+        rows,
+        view,
+        sort,
+        offset,
+        limit
+      )
       const enrichedArticles = await Promise.all(
         slice.map(async (article) => ({
           ...stripWriterNotes(article),
@@ -127,7 +175,8 @@ export const listArticles = query({
         total,
         page,
         limit,
-        totalPages: total === 0 ? 0 : Math.ceil(total / limit),
+        totalPages,
+        browseMeta,
       }
     }
 
@@ -152,10 +201,15 @@ export const listArticles = query({
         (a): a is NonNullable<typeof a> =>
           a?.published === true && isArticleListingReady(a)
       )
-      const total = articles.length
-      const pageSlice = articles.slice(offset, offset + limit)
+      const { slice, total, totalPages, browseMeta } = paginateBrowseArticles(
+        articles,
+        view,
+        sort,
+        offset,
+        limit
+      )
       const enrichedArticles = await Promise.all(
-        pageSlice.map(async (article) => ({
+        slice.map(async (article) => ({
           ...stripWriterNotes(article),
           author: await enrichWithUser(ctx, article.authorId),
         }))
@@ -165,7 +219,8 @@ export const listArticles = query({
         total,
         page,
         limit,
-        totalPages: total === 0 ? 0 : Math.ceil(total / limit),
+        totalPages,
+        browseMeta,
       }
     }
 
@@ -180,8 +235,13 @@ export const listArticles = query({
 
     let rows = await rowsQuery.collect()
     rows = rows.filter(isArticleListingReady)
-    const total = rows.length
-    const slice = rows.slice(offset, offset + limit)
+    const { slice, total, totalPages, browseMeta } = paginateBrowseArticles(
+      rows,
+      view,
+      sort,
+      offset,
+      limit
+    )
     const enrichedArticles = await Promise.all(
       slice.map(async (article) => ({
         ...stripWriterNotes(article),
@@ -193,8 +253,27 @@ export const listArticles = query({
       total,
       page,
       limit,
-      totalPages: total === 0 ? 0 : Math.ceil(total / limit),
+      totalPages,
+      browseMeta,
     }
+  },
+})
+
+export const listBrowseTags = query({
+  args: {
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = Math.min(Math.max(args.limit ?? 12, 1), 30)
+    const links = await ctx.db.query('articleTagLinks').collect()
+    const counts = new Map<string, number>()
+    for (const link of links) {
+      counts.set(link.tag, (counts.get(link.tag) ?? 0) + 1)
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .slice(0, limit)
+      .map(([tag, articleCount]) => ({ tag, articleCount }))
   },
 })
 

--- a/convex/lib/articleBrowseSort.test.ts
+++ b/convex/lib/articleBrowseSort.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { engagementScore, sortArticlesForBrowse } from './articleBrowseSort'
+
+type Row = {
+  id: string
+  publishedAt?: number
+  tipCount?: number
+  highlightCount?: number
+}
+
+function row(
+  id: string,
+  publishedAt: number,
+  tipCount = 0,
+  highlightCount = 0
+): Row {
+  return { id, publishedAt, tipCount, highlightCount }
+}
+
+describe('engagementScore', () => {
+  it('weights tips more than highlights', () => {
+    expect(engagementScore({ tipCount: 1 })).toBe(3)
+    expect(engagementScore({ highlightCount: 1 })).toBe(1)
+  })
+})
+
+describe('sortArticlesForBrowse', () => {
+  const articles = [
+    row('old', 100, 0, 0),
+    row('new', 200, 0, 0),
+    row('tipped', 150, 2, 0),
+  ]
+
+  it('sorts latest by newest', () => {
+    const { articles: sorted } = sortArticlesForBrowse(articles, 'latest', 'newest')
+    expect(sorted.map((a) => a.id)).toEqual(['new', 'tipped', 'old'])
+  })
+
+  it('sorts latest by oldest', () => {
+    const { articles: sorted } = sortArticlesForBrowse(articles, 'latest', 'oldest')
+    expect(sorted.map((a) => a.id)).toEqual(['old', 'tipped', 'new'])
+  })
+
+  it('sorts latest by most tipped', () => {
+    const { articles: sorted } = sortArticlesForBrowse(
+      articles,
+      'latest',
+      'most_tipped'
+    )
+    expect(sorted.map((a) => a.id)).toEqual(['tipped', 'new', 'old'])
+  })
+
+  it('featured returns tipped articles first', () => {
+    const { articles: sorted, meta } = sortArticlesForBrowse(
+      articles,
+      'featured',
+      'newest'
+    )
+    expect(sorted.map((a) => a.id)).toEqual(['tipped'])
+    expect(meta.featuredFallback).toBeUndefined()
+  })
+
+  it('featured falls back to latest when no tips', () => {
+    const noTips = [row('old', 100), row('new', 200)]
+    const { articles: sorted, meta } = sortArticlesForBrowse(
+      noTips,
+      'featured',
+      'newest'
+    )
+    expect(sorted.map((a) => a.id)).toEqual(['new', 'old'])
+    expect(meta.featuredFallback).toBe(true)
+  })
+
+  it('trending sorts by engagement score', () => {
+    const mixed = [
+      row('low', 300, 0, 1),
+      row('high', 100, 1, 0),
+      row('mid', 200, 0, 2),
+    ]
+    const { articles: sorted } = sortArticlesForBrowse(mixed, 'trending', 'newest')
+    expect(sorted.map((a) => a.id)).toEqual(['high', 'mid', 'low'])
+  })
+
+  it('trending falls back when all scores are zero', () => {
+    const noEngagement = [row('old', 100), row('new', 200)]
+    const { articles: sorted, meta } = sortArticlesForBrowse(
+      noEngagement,
+      'trending',
+      'newest'
+    )
+    expect(sorted.map((a) => a.id)).toEqual(['new', 'old'])
+    expect(meta.trendingFallback).toBe(true)
+  })
+})

--- a/convex/lib/articleBrowseSort.test.ts
+++ b/convex/lib/articleBrowseSort.test.ts
@@ -32,12 +32,20 @@ describe('sortArticlesForBrowse', () => {
   ]
 
   it('sorts latest by newest', () => {
-    const { articles: sorted } = sortArticlesForBrowse(articles, 'latest', 'newest')
+    const { articles: sorted } = sortArticlesForBrowse(
+      articles,
+      'latest',
+      'newest'
+    )
     expect(sorted.map((a) => a.id)).toEqual(['new', 'tipped', 'old'])
   })
 
   it('sorts latest by oldest', () => {
-    const { articles: sorted } = sortArticlesForBrowse(articles, 'latest', 'oldest')
+    const { articles: sorted } = sortArticlesForBrowse(
+      articles,
+      'latest',
+      'oldest'
+    )
     expect(sorted.map((a) => a.id)).toEqual(['old', 'tipped', 'new'])
   })
 
@@ -77,7 +85,11 @@ describe('sortArticlesForBrowse', () => {
       row('high', 100, 1, 0),
       row('mid', 200, 0, 2),
     ]
-    const { articles: sorted } = sortArticlesForBrowse(mixed, 'trending', 'newest')
+    const { articles: sorted } = sortArticlesForBrowse(
+      mixed,
+      'trending',
+      'newest'
+    )
     expect(sorted.map((a) => a.id)).toEqual(['high', 'mid', 'low'])
   })
 

--- a/convex/lib/articleBrowseSort.ts
+++ b/convex/lib/articleBrowseSort.ts
@@ -1,0 +1,91 @@
+export type BrowseView = 'latest' | 'trending' | 'featured'
+export type BrowseSort = 'newest' | 'oldest' | 'most_tipped'
+
+export type BrowseSortableArticle = {
+  publishedAt?: number
+  tipCount?: number
+  highlightCount?: number
+}
+
+export type BrowseSortMeta = {
+  featuredFallback?: boolean
+  trendingFallback?: boolean
+}
+
+export function engagementScore(article: BrowseSortableArticle): number {
+  return (article.tipCount ?? 0) * 3 + (article.highlightCount ?? 0)
+}
+
+function comparePublishedAtDesc(
+  a: BrowseSortableArticle,
+  b: BrowseSortableArticle
+): number {
+  return (b.publishedAt ?? 0) - (a.publishedAt ?? 0)
+}
+
+function comparePublishedAtAsc(
+  a: BrowseSortableArticle,
+  b: BrowseSortableArticle
+): number {
+  return (a.publishedAt ?? 0) - (b.publishedAt ?? 0)
+}
+
+function sortByLatest<T extends BrowseSortableArticle>(
+  articles: T[],
+  sort: BrowseSort
+): T[] {
+  const copy = [...articles]
+  if (sort === 'oldest') {
+    copy.sort(comparePublishedAtAsc)
+    return copy
+  }
+  if (sort === 'most_tipped') {
+    copy.sort((a, b) => {
+      const tipDiff = (b.tipCount ?? 0) - (a.tipCount ?? 0)
+      if (tipDiff !== 0) return tipDiff
+      return comparePublishedAtDesc(a, b)
+    })
+    return copy
+  }
+  copy.sort(comparePublishedAtDesc)
+  return copy
+}
+
+export function sortArticlesForBrowse<T extends BrowseSortableArticle>(
+  articles: T[],
+  view: BrowseView,
+  sort: BrowseSort
+): { articles: T[]; meta: BrowseSortMeta } {
+  const meta: BrowseSortMeta = {}
+
+  if (view === 'latest') {
+    return { articles: sortByLatest(articles, sort), meta }
+  }
+
+  if (view === 'featured') {
+    const tipped = articles.filter((a) => (a.tipCount ?? 0) > 0)
+    if (tipped.length === 0) {
+      meta.featuredFallback = true
+      return { articles: sortByLatest(articles, 'newest'), meta }
+    }
+    const sorted = [...tipped].sort((a, b) => {
+      const tipDiff = (b.tipCount ?? 0) - (a.tipCount ?? 0)
+      if (tipDiff !== 0) return tipDiff
+      return comparePublishedAtDesc(a, b)
+    })
+    return { articles: sorted, meta }
+  }
+
+  const scored = [...articles].sort((a, b) => {
+    const scoreDiff = engagementScore(b) - engagementScore(a)
+    if (scoreDiff !== 0) return scoreDiff
+    return comparePublishedAtDesc(a, b)
+  })
+
+  if (scored.every((a) => engagementScore(a) === 0)) {
+    meta.trendingFallback = true
+    return { articles: sortByLatest(articles, 'newest'), meta }
+  }
+
+  return { articles: scored, meta }
+}

--- a/hooks/convex/index.ts
+++ b/hooks/convex/index.ts
@@ -1,6 +1,7 @@
 export { useCurrentUser, useUserByUsername, useUserStats } from './useUsers'
 export {
   useListArticles,
+  useBrowseTags,
   useArticleBySlug,
   useArticleById,
   useUserDrafts,

--- a/hooks/convex/index.ts
+++ b/hooks/convex/index.ts
@@ -2,6 +2,7 @@ export { useCurrentUser, useUserByUsername, useUserStats } from './useUsers'
 export {
   useListArticles,
   useBrowseTags,
+  useBrowseAuthors,
   useArticleBySlug,
   useArticleById,
   useUserDrafts,

--- a/hooks/convex/useArticles.ts
+++ b/hooks/convex/useArticles.ts
@@ -22,6 +22,10 @@ export function useBrowseTags(limit = 12) {
   return useQuery(api.articles.listBrowseTags, { limit })
 }
 
+export function useBrowseAuthors(limit = 20) {
+  return useQuery(api.articles.listBrowseAuthors, { limit })
+}
+
 export function useArticleBySlug(
   username: string | null | undefined,
   slug: string | null | undefined

--- a/hooks/convex/useArticles.ts
+++ b/hooks/convex/useArticles.ts
@@ -2,16 +2,24 @@ import { useQuery } from 'convex/react'
 import { api } from '@/convex/_generated/api'
 import type { Id } from '@/types/convex'
 
+import type { BrowseSort, BrowseView } from '@/lib/articles/browseDiscovery'
+
 export type ListArticlesArgs = {
   page?: number
   limit?: number
   tag?: string
   author?: string
   search?: string
+  view?: BrowseView
+  sort?: BrowseSort
 }
 
 export function useListArticles(args: ListArticlesArgs | 'skip') {
   return useQuery(api.articles.listArticles, args === 'skip' ? 'skip' : args)
+}
+
+export function useBrowseTags(limit = 12) {
+  return useQuery(api.articles.listBrowseTags, { limit })
 }
 
 export function useArticleBySlug(

--- a/lib/articles/browseDiscovery.ts
+++ b/lib/articles/browseDiscovery.ts
@@ -1,0 +1,17 @@
+export const BROWSE_VIEWS = ['latest', 'trending', 'featured'] as const
+export type BrowseView = (typeof BROWSE_VIEWS)[number]
+export const DEFAULT_BROWSE_VIEW: BrowseView = 'latest'
+
+export const BROWSE_SORTS = ['newest', 'oldest', 'most_tipped'] as const
+export type BrowseSort = (typeof BROWSE_SORTS)[number]
+export const DEFAULT_BROWSE_SORT: BrowseSort = 'newest'
+
+export function parseBrowseView(value: string | null | undefined): BrowseView {
+  if (value === 'trending' || value === 'featured') return value
+  return DEFAULT_BROWSE_VIEW
+}
+
+export function parseBrowseSort(value: string | null | undefined): BrowseSort {
+  if (value === 'oldest' || value === 'most_tipped') return value
+  return DEFAULT_BROWSE_SORT
+}

--- a/lib/articles/buildArticlesBrowseHref.test.ts
+++ b/lib/articles/buildArticlesBrowseHref.test.ts
@@ -5,9 +5,9 @@ import {
 } from './buildArticlesBrowseHref'
 
 describe('pickArticlesBrowseParams', () => {
-  it('keeps only tag, page, search, and author', () => {
+  it('keeps only browse query keys', () => {
     const source = new URLSearchParams(
-      'page=2&tag=rust&search=foo&author=alice&nftOwnedPage=3&tab=earnings'
+      'page=2&tag=rust&search=foo&author=alice&view=trending&sort=oldest&nftOwnedPage=3&tab=earnings'
     )
     const picked = pickArticlesBrowseParams(source)
     expect(Object.fromEntries(picked)).toEqual({
@@ -15,6 +15,8 @@ describe('pickArticlesBrowseParams', () => {
       page: '2',
       search: 'foo',
       author: 'alice',
+      view: 'trending',
+      sort: 'oldest',
     })
   })
 
@@ -78,5 +80,25 @@ describe('buildArticlesBrowseHref', () => {
         page: 2,
       })
     ).toBe('/articles?tag=rust&page=2')
+  })
+
+  it('sets view and sort when non-default', () => {
+    expect(
+      buildArticlesBrowseHref({
+        view: 'trending',
+        sort: 'oldest',
+        page: 1,
+      })
+    ).toBe('/articles?view=trending&sort=oldest')
+  })
+
+  it('omits default view and sort from href', () => {
+    expect(
+      buildArticlesBrowseHref({
+        view: 'latest',
+        sort: 'newest',
+        page: 1,
+      })
+    ).toBe('/articles')
   })
 })

--- a/lib/articles/buildArticlesBrowseHref.ts
+++ b/lib/articles/buildArticlesBrowseHref.ts
@@ -1,8 +1,17 @@
+import {
+  DEFAULT_BROWSE_SORT,
+  DEFAULT_BROWSE_VIEW,
+  type BrowseSort,
+  type BrowseView,
+} from './browseDiscovery'
+
 export const ARTICLES_BROWSE_QUERY_KEYS = [
   'tag',
   'page',
   'search',
   'author',
+  'view',
+  'sort',
 ] as const
 
 export type ArticlesBrowseQueryKey = (typeof ARTICLES_BROWSE_QUERY_KEYS)[number]
@@ -23,6 +32,8 @@ export function buildArticlesBrowseHref(options: {
   page?: number
   search?: string
   author?: string
+  view?: BrowseView | ''
+  sort?: BrowseSort | ''
   sourceParams?: URLSearchParams | null
 }): string {
   const params = options.sourceParams
@@ -45,6 +56,22 @@ export function buildArticlesBrowseHref(options: {
     const trimmed = options.author.trim()
     if (trimmed) params.set('author', trimmed)
     else params.delete('author')
+  }
+
+  if (options.view !== undefined) {
+    if (options.view && options.view !== DEFAULT_BROWSE_VIEW) {
+      params.set('view', options.view)
+    } else {
+      params.delete('view')
+    }
+  }
+
+  if (options.sort !== undefined) {
+    if (options.sort && options.sort !== DEFAULT_BROWSE_SORT) {
+      params.set('sort', options.sort)
+    } else {
+      params.delete('sort')
+    }
   }
 
   if (options.page !== undefined) {

--- a/lib/articles/feedRowStatus.test.ts
+++ b/lib/articles/feedRowStatus.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatReadTime,
+  getFeedRowContextLabel,
+  getFeedRowStatusLabel,
+} from './feedRowStatus'
+
+describe('getFeedRowContextLabel', () => {
+  it('returns Reader-supported on featured view with tips', () => {
+    expect(getFeedRowContextLabel('featured', { tipCount: 3 })).toBe(
+      'Reader-supported'
+    )
+  })
+
+  it('returns null on featured when there are no tips', () => {
+    expect(getFeedRowContextLabel('featured', { tipCount: 0 })).toBeNull()
+  })
+
+  it('returns Trending when engagement exists on trending view', () => {
+    expect(getFeedRowContextLabel('trending', { tipCount: 1 })).toBe(
+      'Trending'
+    )
+    expect(getFeedRowContextLabel('trending', { highlightCount: 2 })).toBe(
+      'Trending'
+    )
+  })
+
+  it('returns null on latest view', () => {
+    expect(getFeedRowContextLabel('latest', { tipCount: 5 })).toBeNull()
+  })
+})
+
+describe('getFeedRowStatusLabel', () => {
+  it('delegates to getFeedRowContextLabel', () => {
+    expect(getFeedRowStatusLabel('featured', { tipCount: 1 })).toBe(
+      'Reader-supported'
+    )
+  })
+})
+
+describe('formatReadTime', () => {
+  it('formats minutes', () => {
+    expect(formatReadTime(7)).toBe('7 min read')
+  })
+
+  it('returns null for missing or zero values', () => {
+    expect(formatReadTime(0)).toBeNull()
+    expect(formatReadTime(undefined)).toBeNull()
+  })
+})

--- a/lib/articles/feedRowStatus.test.ts
+++ b/lib/articles/feedRowStatus.test.ts
@@ -17,9 +17,7 @@ describe('getFeedRowContextLabel', () => {
   })
 
   it('returns Trending when engagement exists on trending view', () => {
-    expect(getFeedRowContextLabel('trending', { tipCount: 1 })).toBe(
-      'Trending'
-    )
+    expect(getFeedRowContextLabel('trending', { tipCount: 1 })).toBe('Trending')
     expect(getFeedRowContextLabel('trending', { highlightCount: 2 })).toBe(
       'Trending'
     )

--- a/lib/articles/feedRowStatus.ts
+++ b/lib/articles/feedRowStatus.ts
@@ -1,0 +1,40 @@
+import type { BrowseView } from '@/lib/articles/browseDiscovery'
+
+type FeedRowArticle = {
+  tipCount?: number
+  highlightCount?: number
+}
+
+export function getFeedRowContextLabel(
+  view: BrowseView,
+  article: FeedRowArticle
+): string | null {
+  const tipCount = article.tipCount ?? 0
+  const highlightCount = article.highlightCount ?? 0
+
+  if (view === 'featured' && tipCount > 0) {
+    return 'Reader-supported'
+  }
+
+  if (view === 'trending') {
+    const engagement = tipCount * 3 + highlightCount
+    if (engagement > 0) {
+      return 'Trending'
+    }
+  }
+
+  return null
+}
+
+/** @deprecated Use getFeedRowContextLabel */
+export function getFeedRowStatusLabel(
+  view: BrowseView,
+  article: FeedRowArticle
+): string | null {
+  return getFeedRowContextLabel(view, article)
+}
+
+export function formatReadTime(minutes?: number): string | null {
+  if (!minutes || minutes < 1) return null
+  return `${minutes} min read`
+}

--- a/lib/articles/mapListArticleToDisplay.ts
+++ b/lib/articles/mapListArticleToDisplay.ts
@@ -29,6 +29,8 @@ export function mapListArticleRowToDisplay(
       name: tagName,
       slug: tagName.toLowerCase().replace(/\s+/g, '-'),
     })),
+    readTime: article.readTime,
+    tipCount: article.tipCount,
   }
 }
 

--- a/lib/articles/mapListArticleToDisplay.ts
+++ b/lib/articles/mapListArticleToDisplay.ts
@@ -31,6 +31,7 @@ export function mapListArticleRowToDisplay(
     })),
     readTime: article.readTime,
     tipCount: article.tipCount,
+    highlightCount: article.highlightCount,
   }
 }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -20,6 +20,8 @@ export interface ArticleForDisplay {
     name: string
     slug: string
   }>
+  readTime?: number
+  tipCount?: number
   content?: JSONContent
   tipStats?: ArticleBySlug['tipStats']
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -22,6 +22,7 @@ export interface ArticleForDisplay {
   }>
   readTime?: number
   tipCount?: number
+  highlightCount?: number
   content?: JSONContent
   tipStats?: ArticleBySlug['tipStats']
 }


### PR DESCRIPTION
## Summary

Polishes the `/articles` browse experience with featured, latest, and trending views, richer filtering, and a Medium-style feed layout. Adds author and topic discovery controls, backend browse sorting, and regression tests for the new discovery flows.



## Changes

- Add `ArticlesBrowseDiscoveryHeader` with Featured / Latest / Trending tabs, author filter, sort controls, and a dedicated Topics row
- Introduce `ArticleFeedRow` and `ArticleFeedSkeleton` for the browse feed layout, with context labels and row actions
- Extend `ArticleGrid` and `ArticlesBrowseContent` to support feed vs card presentation
- Expand Convex `listArticles` with browse views (`featured`, `latest`, `trending`), sort options, author filtering, and browse tag/author helpers
- Add browse discovery URL helpers and query param parsing (`view`, `sort`, `tag`, `author`)
- Update `TagFilterLink` and article card tag behavior for browse filtering
- Add unit and Convex tests for browse sorting, feed row status, href building, and `listArticles` browse behavior

## Testing

- [x] `bun run lint`
- [x] `b run typecheck`
- [x] `bun run format`
- [x] `bun run test:once` (673 tests passed)
- [x] `bun run build`


## Notes

- Rebased onto latest `development` before opening this PR
- Featured and trending views include fallback messaging when engagement signals are unavailable
- Browse feed uses list-style rows on `/articles`; existing card/grid behavior remains available where appropriate
<img width="1221" height="717" alt="2_" src="https://github.com/user-attachments/assets/11d4831e-4024-434a-a444-4ef4a66007c7" />
<img width="1220" height="716" alt="1_" src="https://github.com/user-attachments/assets/2ceb00de-6fb6-4792-a898-785c6ce5f2b0" />
