### PR TITLE
feat(auth): reduce account creation friction with intent-based signup (ENG-254)

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -20,8 +20,8 @@ export default function AuthLayout({
     <div className="min-h-screen bg-gradient-to-br from-brand-cream to-background dark:from-background dark:to-muted">
       <AuthShellHeader />
 
-      <main className="flex min-h-screen items-center justify-center px-6 pb-20 pt-24">
-        <div className="w-full max-w-md">
+      <main className="flex min-h-screen items-start justify-center px-6 pb-20 pt-28 sm:pt-32">
+        <div className="w-full max-w-md mt-8">
           <div className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-8">
             {children}
           </div>

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { LegalLinks } from '@/components/legal/LegalLinks'
-import { Logo } from '@/components/ui/Logo'
+import { AuthShellHeader } from '@/components/auth/AuthShellHeader'
 import { AUTH_FOOTER_LINKS } from '@/lib/copy/footer-links'
 
 /**
@@ -18,23 +18,10 @@ export default function AuthLayout({
 }) {
   return (
     <div className="min-h-screen bg-gradient-to-br from-brand-cream to-background dark:from-background dark:to-muted">
-      {/* Auth Form Container */}
-      <main className="flex min-h-screen items-center justify-center px-6 py-20">
-        <div className="w-full max-w-md">
-          {/* Logo and Welcome Message */}
-          <div className="text-center mb-8">
-            <div className="inline-flex items-center justify-center mb-4">
-              <Logo href={null} size="lg" />
-            </div>
-            <h1 className="text-3xl font-bold text-foreground">
-              Welcome to Quilltip
-            </h1>
-            <p className="mt-2 text-muted-foreground">
-              Where your words find their worth
-            </p>
-          </div>
+      <AuthShellHeader />
 
-          {/* Auth Form Card */}
+      <main className="flex min-h-screen items-center justify-center px-6 pb-20 pt-24">
+        <div className="w-full max-w-md">
           <div className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-8">
             {children}
           </div>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react'
 import LoginForm from '@/components/auth/LoginForm'
 import { AuthReturnLinks } from '@/components/auth/AuthReturnLinks'
+import { AuthIntentHeading } from '@/components/auth/AuthIntentHeading'
 
 /**
  * Login Page
@@ -12,14 +13,9 @@ import { AuthReturnLinks } from '@/components/auth/AuthReturnLinks'
 export default function LoginPage() {
   return (
     <div className="space-y-6">
-      <div className="text-center">
-        <h2 className="text-2xl font-bold text-foreground">
-          Sign in to your account
-        </h2>
-        <p className="mt-2 text-sm text-muted-foreground">
-          Welcome back! Please enter your details.
-        </p>
-      </div>
+      <Suspense fallback={null}>
+        <AuthIntentHeading variant="login" />
+      </Suspense>
 
       <Suspense fallback={null}>
         <LoginForm />

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react'
 import RegisterForm from '@/components/auth/RegisterForm'
 import { AuthReturnLinks } from '@/components/auth/AuthReturnLinks'
+import { AuthIntentHeading } from '@/components/auth/AuthIntentHeading'
 
 /**
  * Registration Page
@@ -12,14 +13,9 @@ import { AuthReturnLinks } from '@/components/auth/AuthReturnLinks'
 export default function RegisterPage() {
   return (
     <div className="space-y-6">
-      <div className="text-center">
-        <h2 className="text-2xl font-bold text-foreground">
-          Create your account
-        </h2>
-        <p className="mt-2 text-sm text-muted-foreground">
-          Join Quilltip and start sharing your stories with the world.
-        </p>
-      </div>
+      <Suspense fallback={null}>
+        <AuthIntentHeading variant="register" />
+      </Suspense>
 
       <Suspense fallback={null}>
         <RegisterForm />

--- a/components/auth/AuthIntentHeading.tsx
+++ b/components/auth/AuthIntentHeading.tsx
@@ -11,7 +11,10 @@ interface AuthIntentHeadingProps {
   variant: 'login' | 'register'
 }
 
-function getCopy(variant: AuthIntentHeadingProps['variant'], returnPath: string): AuthPageCopy {
+function getCopy(
+  variant: AuthIntentHeadingProps['variant'],
+  returnPath: string
+): AuthPageCopy {
   return variant === 'register'
     ? getRegisterCopy(returnPath)
     : getLoginCopy(returnPath)
@@ -29,7 +32,9 @@ export function AuthIntentHeading({ variant }: AuthIntentHeadingProps) {
   )
 }
 
-export function useAuthPageCopy(variant: AuthIntentHeadingProps['variant']): AuthPageCopy {
+export function useAuthPageCopy(
+  variant: AuthIntentHeadingProps['variant']
+): AuthPageCopy {
   const returnPath = useAuthReturnPath()
   return getCopy(variant, returnPath)
 }

--- a/components/auth/AuthIntentHeading.tsx
+++ b/components/auth/AuthIntentHeading.tsx
@@ -1,28 +1,15 @@
 'use client'
 
 import { useAuthReturnPath } from '@/components/auth/useAuthReturnPath'
-import {
-  getLoginCopy,
-  getRegisterCopy,
-  type AuthPageCopy,
-} from '@/lib/copy/auth-intent'
+import { getAuthPageCopy, type AuthPageVariant } from '@/lib/copy/auth-intent'
 
 interface AuthIntentHeadingProps {
-  variant: 'login' | 'register'
-}
-
-function getCopy(
-  variant: AuthIntentHeadingProps['variant'],
-  returnPath: string
-): AuthPageCopy {
-  return variant === 'register'
-    ? getRegisterCopy(returnPath)
-    : getLoginCopy(returnPath)
+  variant: AuthPageVariant
 }
 
 export function AuthIntentHeading({ variant }: AuthIntentHeadingProps) {
   const returnPath = useAuthReturnPath()
-  const { heading, subtitle } = getCopy(variant, returnPath)
+  const { heading, subtitle } = getAuthPageCopy(variant, returnPath)
 
   return (
     <div className="text-center">
@@ -30,11 +17,4 @@ export function AuthIntentHeading({ variant }: AuthIntentHeadingProps) {
       <p className="mt-2 text-sm text-muted-foreground">{subtitle}</p>
     </div>
   )
-}
-
-export function useAuthPageCopy(
-  variant: AuthIntentHeadingProps['variant']
-): AuthPageCopy {
-  const returnPath = useAuthReturnPath()
-  return getCopy(variant, returnPath)
 }

--- a/components/auth/AuthIntentHeading.tsx
+++ b/components/auth/AuthIntentHeading.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useAuthReturnPath } from '@/components/auth/useAuthReturnPath'
+import {
+  getLoginCopy,
+  getRegisterCopy,
+  type AuthPageCopy,
+} from '@/lib/copy/auth-intent'
+
+interface AuthIntentHeadingProps {
+  variant: 'login' | 'register'
+}
+
+function getCopy(variant: AuthIntentHeadingProps['variant'], returnPath: string): AuthPageCopy {
+  return variant === 'register'
+    ? getRegisterCopy(returnPath)
+    : getLoginCopy(returnPath)
+}
+
+export function AuthIntentHeading({ variant }: AuthIntentHeadingProps) {
+  const returnPath = useAuthReturnPath()
+  const { heading, subtitle } = getCopy(variant, returnPath)
+
+  return (
+    <div className="text-center">
+      <h2 className="text-2xl font-bold text-foreground">{heading}</h2>
+      <p className="mt-2 text-sm text-muted-foreground">{subtitle}</p>
+    </div>
+  )
+}
+
+export function useAuthPageCopy(variant: AuthIntentHeadingProps['variant']): AuthPageCopy {
+  const returnPath = useAuthReturnPath()
+  return getCopy(variant, returnPath)
+}

--- a/components/auth/AuthShellHeader.tsx
+++ b/components/auth/AuthShellHeader.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { Logo } from '@/components/ui/Logo'
+import { ThemeToggle } from '@/components/theme/ThemeToggle'
+
+export function AuthShellHeader() {
+  return (
+    <header className="fixed top-0 left-0 right-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur-md">
+      <div className="mx-auto flex h-16 max-w-5xl items-center justify-between px-6">
+        <Logo animated />
+        <ThemeToggle />
+      </div>
+    </header>
+  )
+}

--- a/components/auth/LoginForm.test.tsx
+++ b/components/auth/LoginForm.test.tsx
@@ -50,6 +50,8 @@ describe('LoginForm', () => {
     expect(
       screen.getByRole('button', { name: /sign in and continue writing/i })
     ).toBeInTheDocument()
+    // React may invoke initial render twice; the old nested hook path exceeded this.
+    expect(mockUseAuthReturnPath.mock.calls.length).toBeLessThanOrEqual(2)
   })
 
   it('shows redirecting message and navigates to the return path on successful sign in', async () => {

--- a/components/auth/LoginForm.test.tsx
+++ b/components/auth/LoginForm.test.tsx
@@ -43,6 +43,15 @@ describe('LoginForm', () => {
     mockSignIn.mockResolvedValue(undefined)
   })
 
+  it('uses write-intent submit label when return path is the editor', () => {
+    mockUseAuthReturnPath.mockReturnValue('/write')
+    render(<LoginForm />)
+
+    expect(
+      screen.getByRole('button', { name: /sign in and continue writing/i })
+    ).toBeInTheDocument()
+  })
+
   it('shows redirecting message and navigates to the return path on successful sign in', async () => {
     const user = userEvent.setup({ delay: null })
 
@@ -54,7 +63,7 @@ describe('LoginForm', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(/signed in successfully! redirecting to dashboard/i)
+        screen.getByText(/signed in successfully! taking you to articles/i)
       ).toBeInTheDocument()
     })
 

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { useAuthActions } from '@convex-dev/auth/react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useAuthReturnPath } from '@/components/auth/useAuthReturnPath'
+import { useAuthPageCopy } from '@/components/auth/AuthIntentHeading'
 import { readPendingTipIntent } from '@/lib/tip/pendingTipIntent'
 import { getSafeRedirectPath } from '@/lib/navigation/walletProfileDestination'
 import { useForm } from 'react-hook-form'
@@ -34,6 +35,7 @@ export default function LoginForm() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const returnToPath = useAuthReturnPath()
+  const copy = useAuthPageCopy('login')
   const redirectParam = searchParams.get('redirect')
   const postLoginPath =
     redirectParam != null && redirectParam !== ''
@@ -101,7 +103,7 @@ export default function LoginForm() {
               aria-hidden="true"
               className="h-4 w-4 shrink-0 text-success-foreground"
             />
-            <span>Signed in successfully! Redirecting to dashboard...</span>
+            <span>{copy.successMessage}</span>
           </p>
         </div>
       </div>
@@ -185,10 +187,10 @@ export default function LoginForm() {
         {isLoading ? (
           <>
             <Loader2 className="h-4 w-4 animate-spin" />
-            Signing in...
+            {copy.submitLoadingLabel}
           </>
         ) : (
-          'Sign in'
+          copy.submitLabel
         )}
       </Button>
     </form>

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { useAuthActions } from '@convex-dev/auth/react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useAuthReturnPath } from '@/components/auth/useAuthReturnPath'
-import { useAuthPageCopy } from '@/components/auth/AuthIntentHeading'
+import { getLoginCopy } from '@/lib/copy/auth-intent'
 import { readPendingTipIntent } from '@/lib/tip/pendingTipIntent'
 import { getSafeRedirectPath } from '@/lib/navigation/walletProfileDestination'
 import { useForm } from 'react-hook-form'
@@ -35,7 +35,7 @@ export default function LoginForm() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const returnToPath = useAuthReturnPath()
-  const copy = useAuthPageCopy('login')
+  const copy = getLoginCopy(returnToPath)
   const redirectParam = searchParams.get('redirect')
   const postLoginPath =
     redirectParam != null && redirectParam !== ''

--- a/components/auth/PasswordRequirements.tsx
+++ b/components/auth/PasswordRequirements.tsx
@@ -1,6 +1,5 @@
 import { Check, Circle } from 'lucide-react'
 import { getPasswordRuleStatuses } from '@/lib/validations/password-rules'
-import { cn } from '@/lib/utils'
 
 export const PASSWORD_REQUIREMENTS_ID = 'password-requirements'
 
@@ -14,6 +13,45 @@ export function PasswordRequirements({
   highlightFailures = false,
 }: PasswordRequirementsProps) {
   const rules = getPasswordRuleStatuses(password)
+  const unmetRules = rules.filter((rule) => !rule.met)
+  const hasInput = password.length > 0
+  const allMet = unmetRules.length === 0
+
+  if (allMet && hasInput) {
+    return (
+      <p
+        id={PASSWORD_REQUIREMENTS_ID}
+        aria-live="polite"
+        className="mt-2 flex items-center gap-2 text-sm text-success-foreground"
+      >
+        <Check className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span>Password meets requirements</span>
+      </p>
+    )
+  }
+
+  if (hasInput || highlightFailures) {
+    return (
+      <ul
+        id={PASSWORD_REQUIREMENTS_ID}
+        aria-live="polite"
+        className="mt-2 space-y-1"
+      >
+        {unmetRules.map((rule) => (
+          <li
+            key={rule.id}
+            className="flex items-center gap-2 text-sm text-destructive"
+          >
+            <Circle
+              className="h-3.5 w-3.5 shrink-0 text-destructive"
+              aria-hidden="true"
+            />
+            <span>{rule.label}</span>
+          </li>
+        ))}
+      </ul>
+    )
+  }
 
   return (
     <ul
@@ -24,26 +62,12 @@ export function PasswordRequirements({
       {rules.map((rule) => (
         <li
           key={rule.id}
-          className={cn(
-            'flex items-center gap-2 text-sm',
-            rule.met
-              ? 'text-success-foreground'
-              : highlightFailures
-                ? 'text-destructive'
-                : 'text-muted-foreground'
-          )}
+          className="flex items-center gap-2 text-sm text-muted-foreground"
         >
-          {rule.met ? (
-            <Check className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-          ) : (
-            <Circle
-              className={cn(
-                'h-3.5 w-3.5 shrink-0',
-                highlightFailures ? 'text-destructive' : 'text-muted-foreground'
-              )}
-              aria-hidden="true"
-            />
-          )}
+          <Circle
+            className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+            aria-hidden="true"
+          />
           <span>{rule.label}</span>
         </li>
       ))}

--- a/components/auth/PasswordRequirements.tsx
+++ b/components/auth/PasswordRequirements.tsx
@@ -3,6 +3,12 @@ import { getPasswordRuleStatuses } from '@/lib/validations/password-rules'
 
 export const PASSWORD_REQUIREMENTS_ID = 'password-requirements'
 
+// "all" keeps removals announced when satisfied rules leave the list.
+const passwordRequirementsLiveProps = {
+  'aria-live': 'polite',
+  'aria-relevant': 'all',
+} as const
+
 type PasswordRequirementsProps = {
   password: string
   highlightFailures?: boolean
@@ -21,7 +27,7 @@ export function PasswordRequirements({
     return (
       <p
         id={PASSWORD_REQUIREMENTS_ID}
-        aria-live="polite"
+        {...passwordRequirementsLiveProps}
         className="mt-2 flex items-center gap-2 text-sm text-success-foreground"
       >
         <Check className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
@@ -34,7 +40,7 @@ export function PasswordRequirements({
     return (
       <ul
         id={PASSWORD_REQUIREMENTS_ID}
-        aria-live="polite"
+        {...passwordRequirementsLiveProps}
         className="mt-2 space-y-1"
       >
         {unmetRules.map((rule) => (
@@ -56,7 +62,7 @@ export function PasswordRequirements({
   return (
     <ul
       id={PASSWORD_REQUIREMENTS_ID}
-      aria-live="polite"
+      {...passwordRequirementsLiveProps}
       className="mt-2 space-y-1"
     >
       {rules.map((rule) => (

--- a/components/auth/RegisterForm.test.tsx
+++ b/components/auth/RegisterForm.test.tsx
@@ -49,6 +49,8 @@ describe('RegisterForm accessibility', () => {
     expect(
       screen.getByRole('button', { name: /create account and start writing/i })
     ).toBeInTheDocument()
+    // React may invoke initial render twice; the old nested hook path exceeded this.
+    expect(mockUseAuthReturnPath.mock.calls.length).toBeLessThanOrEqual(2)
   })
 
   it('marks the first invalid field and associates its error on empty submit', async () => {
@@ -163,6 +165,10 @@ describe('RegisterForm accessibility', () => {
   it('shows password requirements before submit', () => {
     render(<RegisterForm />)
 
+    expect(document.getElementById('password-requirements')).toHaveAttribute(
+      'aria-relevant',
+      'all'
+    )
     expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument()
     expect(screen.getByText(/one uppercase letter/i)).toBeInTheDocument()
     expect(screen.getByText(/one lowercase letter/i)).toBeInTheDocument()

--- a/components/auth/RegisterForm.test.tsx
+++ b/components/auth/RegisterForm.test.tsx
@@ -185,9 +185,7 @@ describe('RegisterForm accessibility', () => {
 
     await user.type(passwordInput, 'word1')
 
-    expect(
-      screen.getByText(/password meets requirements/i)
-    ).toBeInTheDocument()
+    expect(screen.getByText(/password meets requirements/i)).toBeInTheDocument()
     expect(
       document.getElementById('password-requirements')?.querySelectorAll('li')
     ).toHaveLength(0)

--- a/components/auth/RegisterForm.test.tsx
+++ b/components/auth/RegisterForm.test.tsx
@@ -36,6 +36,21 @@ describe('RegisterForm accessibility', () => {
     mockUseAuthReturnPath.mockReturnValue('/profile?tab=wallet')
   })
 
+  it('does not show a full name field on the initial signup screen', () => {
+    render(<RegisterForm />)
+
+    expect(screen.queryByLabelText(/full name/i)).not.toBeInTheDocument()
+  })
+
+  it('uses write-intent submit label when return path is the editor', () => {
+    mockUseAuthReturnPath.mockReturnValue('/write')
+    render(<RegisterForm />)
+
+    expect(
+      screen.getByRole('button', { name: /create account and start writing/i })
+    ).toBeInTheDocument()
+  })
+
   it('marks the first invalid field and associates its error on empty submit', async () => {
     const user = userEvent.setup({ delay: null })
     render(<RegisterForm />)

--- a/components/auth/RegisterForm.test.tsx
+++ b/components/auth/RegisterForm.test.tsx
@@ -169,20 +169,28 @@ describe('RegisterForm accessibility', () => {
     expect(screen.getByText(/one number/i)).toBeInTheDocument()
   })
 
-  it('updates password requirements as the user types', async () => {
+  it('removes satisfied password rules instead of turning them green', async () => {
     const user = userEvent.setup({ delay: null })
     render(<RegisterForm />)
 
     const passwordInput = screen.getByLabelText(/^password$/i)
-    await user.type(passwordInput, 'Password1')
+    await user.type(passwordInput, 'Pass')
 
     const requirements = document.getElementById('password-requirements')
-    expect(requirements).toBeInTheDocument()
-    const items = requirements?.querySelectorAll('li') ?? []
-    expect(items).toHaveLength(4)
-    items.forEach((item) => {
-      expect(item).toHaveClass('text-success-foreground')
-    })
+    expect(requirements?.querySelectorAll('li')).toHaveLength(2)
+    expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument()
+    expect(screen.getByText(/one number/i)).toBeInTheDocument()
+    expect(screen.queryByText(/one uppercase letter/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/one lowercase letter/i)).not.toBeInTheDocument()
+
+    await user.type(passwordInput, 'word1')
+
+    expect(
+      screen.getByText(/password meets requirements/i)
+    ).toBeInTheDocument()
+    expect(
+      document.getElementById('password-requirements')?.querySelectorAll('li')
+    ).toHaveLength(0)
   })
 
   it('highlights unmet password rules on failed submit', async () => {

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useForm, type FieldErrors } from 'react-hook-form'
 import { useAuthReturnPath } from '@/components/auth/useAuthReturnPath'
+import { useAuthPageCopy } from '@/components/auth/AuthIntentHeading'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { parseRegisterSignInError } from '@/lib/auth/map-register-error'
 import { getFirstRegisterFieldError } from '@/lib/auth/register-form-a11y'
@@ -24,7 +25,7 @@ const PASSWORD_VALIDATION_MESSAGE = 'Password does not meet all requirements'
 /**
  * Register Form Component
  *
- * Handles user registration with email, username, password, and optional name.
+ * Handles user registration with email, username, and password.
  * Includes form validation, error handling, and loading states.
  */
 
@@ -42,6 +43,7 @@ export default function RegisterForm() {
 
   const router = useRouter()
   const returnPath = useAuthReturnPath()
+  const copy = useAuthPageCopy('register')
   const { signIn } = useAuth()
 
   const {
@@ -100,7 +102,6 @@ export default function RegisterForm() {
         password: data.password,
         flow: 'signUp',
         username: data.username,
-        ...(data.name && { name: data.name }),
       })
 
       setSuccess(true)
@@ -148,9 +149,7 @@ export default function RegisterForm() {
               aria-hidden="true"
               className="h-4 w-4 shrink-0 text-success-foreground"
             />
-            <span>
-              Account created successfully! Redirecting to dashboard...
-            </span>
+            <span>{copy.successMessage}</span>
           </p>
         </div>
       </div>
@@ -205,29 +204,6 @@ export default function RegisterForm() {
             id="username"
             autoComplete="username"
             placeholder="Choose a unique username"
-            aria-invalid={control['aria-invalid']}
-            aria-describedby={control['aria-describedby']}
-            className={control.inputClassName}
-          />
-        )}
-      </RegisterFormField>
-
-      <RegisterFormField
-        id="name"
-        label={
-          <>
-            Full Name <span className="text-muted-foreground">(optional)</span>
-          </>
-        }
-        error={errors.name?.message}
-      >
-        {(control) => (
-          <Input
-            {...registerField('name')}
-            type="text"
-            id="name"
-            autoComplete="name"
-            placeholder="Your full name"
             aria-invalid={control['aria-invalid']}
             aria-describedby={control['aria-describedby']}
             className={control.inputClassName}
@@ -326,10 +302,10 @@ export default function RegisterForm() {
         {isLoading ? (
           <>
             <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-            Creating account...
+            {copy.submitLoadingLabel}
           </>
         ) : (
-          'Create account'
+          copy.submitLabel
         )}
       </Button>
     </form>

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -4,10 +4,10 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useForm, type FieldErrors } from 'react-hook-form'
 import { useAuthReturnPath } from '@/components/auth/useAuthReturnPath'
-import { useAuthPageCopy } from '@/components/auth/AuthIntentHeading'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { parseRegisterSignInError } from '@/lib/auth/map-register-error'
 import { getFirstRegisterFieldError } from '@/lib/auth/register-form-a11y'
+import { getRegisterCopy } from '@/lib/copy/auth-intent'
 import { registerSchema, type RegisterFormData } from '@/lib/validations/auth'
 import { allPasswordRulesMet } from '@/lib/validations/password-rules'
 import { CheckCircle, Eye, EyeOff, Loader2 } from 'lucide-react'
@@ -43,7 +43,7 @@ export default function RegisterForm() {
 
   const router = useRouter()
   const returnPath = useAuthReturnPath()
-  const copy = useAuthPageCopy('register')
+  const copy = getRegisterCopy(returnPath)
   const { signIn } = useAuth()
 
   const {

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { ArrowRight, Zap } from 'lucide-react'
 import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
+import { REGISTER_FOR_WRITE_HREF } from '@/lib/auth/auth-links'
 import {
   HERO_START_READING,
   HERO_START_WRITING,
@@ -226,7 +227,7 @@ export default function HeroSection() {
             </Link>
             <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[12px] sm:text-[13px]">
               <Link
-                href="/register"
+                href={REGISTER_FOR_WRITE_HREF}
                 className="focus-ring rounded-sm text-muted-foreground transition-colors hover:text-foreground"
               >
                 {HERO_START_WRITING}

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -18,6 +18,7 @@ import { motion, AnimatePresence, useInView } from 'motion/react'
 import { LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { REGISTER_FOR_WRITE_HREF } from '@/lib/auth/auth-links'
 
 type StepVariant = 'desktop' | 'mobile'
 
@@ -487,7 +488,7 @@ export default function HowItWorksSection() {
           transition={{ duration: 0.8, delay: 0.8 }}
         >
           <Link
-            href="/register"
+            href={REGISTER_FOR_WRITE_HREF}
             className="focus-ring group inline-flex items-center justify-center gap-2 bg-card text-card-foreground px-6 py-2.5 rounded-lg text-[13px] font-medium hover:bg-muted transition-all duration-200"
           >
             Start Writing & Earning Today

--- a/lib/auth/auth-links.test.ts
+++ b/lib/auth/auth-links.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+import { REGISTER_FOR_WRITE_HREF } from '@/lib/auth/auth-links'
+
+describe('auth-links', () => {
+  it('builds register href that returns to the editor', () => {
+    expect(REGISTER_FOR_WRITE_HREF).toBe('/register?returnTo=%2Fwrite')
+  })
+})

--- a/lib/auth/auth-links.ts
+++ b/lib/auth/auth-links.ts
@@ -1,0 +1,4 @@
+import { buildRegisterHref } from '@/lib/auth/safeReturnPath'
+
+/** Register URL that returns the user to the editor after signup. */
+export const REGISTER_FOR_WRITE_HREF = buildRegisterHref('/write')

--- a/lib/auth/register-form-a11y.ts
+++ b/lib/auth/register-form-a11y.ts
@@ -4,7 +4,6 @@ import type { RegisterFormData } from '@/lib/validations/auth'
 export const REGISTER_FIELD_ORDER = [
   'email',
   'username',
-  'name',
   'password',
   'confirmPassword',
 ] as const satisfies readonly (keyof RegisterFormData)[]

--- a/lib/copy/auth-intent.test.ts
+++ b/lib/copy/auth-intent.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getAuthIntent,
+  getLoginCopy,
+  getRegisterCopy,
+} from '@/lib/copy/auth-intent'
+
+describe('getAuthIntent', () => {
+  it('detects write intent from editor paths', () => {
+    expect(getAuthIntent('/write')).toBe('write')
+    expect(getAuthIntent('/write?id=abc')).toBe('write')
+  })
+
+  it('detects read intent from article paths', () => {
+    expect(getAuthIntent('/articles')).toBe('read')
+    expect(getAuthIntent('/articles/some-slug')).toBe('read')
+  })
+
+  it('falls back to default for other paths', () => {
+    expect(getAuthIntent('/')).toBe('default')
+    expect(getAuthIntent('/profile')).toBe('default')
+  })
+})
+
+describe('getRegisterCopy', () => {
+  it('promises editor access for write intent', () => {
+    const copy = getRegisterCopy('/write')
+    expect(copy.subtitle).toMatch(/editor/i)
+    expect(copy.submitLabel).toBe('Create account and start writing')
+  })
+
+  it('uses concrete default messaging', () => {
+    const copy = getRegisterCopy('/')
+    expect(copy.subtitle).toMatch(/write, publish/i)
+    expect(copy.submitLabel).toBe('Create account')
+  })
+})
+
+describe('getLoginCopy', () => {
+  it('uses write-intent messaging for the editor', () => {
+    const copy = getLoginCopy('/write')
+    expect(copy.subtitle).toBe('Sign in to continue writing.')
+    expect(copy.submitLabel).toBe('Sign in and continue writing')
+  })
+
+  it('uses read-intent messaging for articles', () => {
+    const copy = getLoginCopy('/articles')
+    expect(copy.submitLabel).toBe('Sign in and start reading')
+  })
+})

--- a/lib/copy/auth-intent.test.ts
+++ b/lib/copy/auth-intent.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  getAuthPageCopy,
   getAuthIntent,
   getLoginCopy,
   getRegisterCopy,
@@ -46,5 +47,16 @@ describe('getLoginCopy', () => {
   it('uses read-intent messaging for articles', () => {
     const copy = getLoginCopy('/articles')
     expect(copy.submitLabel).toBe('Sign in and start reading')
+  })
+})
+
+describe('getAuthPageCopy', () => {
+  it('routes register and login variants through the shared return path', () => {
+    expect(getAuthPageCopy('register', '/write')).toBe(
+      getRegisterCopy('/write')
+    )
+    expect(getAuthPageCopy('login', '/articles')).toBe(
+      getLoginCopy('/articles')
+    )
   })
 })

--- a/lib/copy/auth-intent.ts
+++ b/lib/copy/auth-intent.ts
@@ -1,0 +1,87 @@
+export type AuthIntent = 'write' | 'read' | 'default'
+
+export interface AuthPageCopy {
+  heading: string
+  subtitle: string
+  submitLabel: string
+  submitLoadingLabel: string
+  successMessage: string
+}
+
+function getPathname(returnPath: string): string {
+  const queryIndex = returnPath.indexOf('?')
+  return queryIndex === -1 ? returnPath : returnPath.slice(0, queryIndex)
+}
+
+export function getAuthIntent(returnPath: string): AuthIntent {
+  const pathname = getPathname(returnPath)
+
+  if (pathname === '/write' || pathname.startsWith('/write/')) {
+    return 'write'
+  }
+
+  if (pathname === '/articles' || pathname.startsWith('/articles/')) {
+    return 'read'
+  }
+
+  return 'default'
+}
+
+const REGISTER_COPY: Record<AuthIntent, AuthPageCopy> = {
+  write: {
+    heading: 'Create your account',
+    subtitle: "You'll go straight to the editor after signup.",
+    submitLabel: 'Create account and start writing',
+    submitLoadingLabel: 'Creating account...',
+    successMessage:
+      'Account created successfully! Opening the editor...',
+  },
+  read: {
+    heading: 'Create your account',
+    subtitle: 'Sign up to browse articles and tip writers on testnet.',
+    submitLabel: 'Create account and start reading',
+    submitLoadingLabel: 'Creating account...',
+    successMessage:
+      'Account created successfully! Taking you to articles...',
+  },
+  default: {
+    heading: 'Create your account',
+    subtitle:
+      'Create your account to write, publish, and receive tips.',
+    submitLabel: 'Create account',
+    submitLoadingLabel: 'Creating account...',
+    successMessage: 'Account created successfully! Redirecting...',
+  },
+}
+
+const LOGIN_COPY: Record<AuthIntent, AuthPageCopy> = {
+  write: {
+    heading: 'Sign in to your account',
+    subtitle: 'Sign in to continue writing.',
+    submitLabel: 'Sign in and continue writing',
+    submitLoadingLabel: 'Signing in...',
+    successMessage: 'Signed in successfully! Opening the editor...',
+  },
+  read: {
+    heading: 'Sign in to your account',
+    subtitle: 'Sign in to browse articles and tip writers.',
+    submitLabel: 'Sign in and start reading',
+    submitLoadingLabel: 'Signing in...',
+    successMessage: 'Signed in successfully! Taking you to articles...',
+  },
+  default: {
+    heading: 'Sign in to your account',
+    subtitle: 'Welcome back! Please enter your details.',
+    submitLabel: 'Sign in',
+    submitLoadingLabel: 'Signing in...',
+    successMessage: 'Signed in successfully! Redirecting...',
+  },
+}
+
+export function getRegisterCopy(returnPath: string): AuthPageCopy {
+  return REGISTER_COPY[getAuthIntent(returnPath)]
+}
+
+export function getLoginCopy(returnPath: string): AuthPageCopy {
+  return LOGIN_COPY[getAuthIntent(returnPath)]
+}

--- a/lib/copy/auth-intent.ts
+++ b/lib/copy/auth-intent.ts
@@ -33,21 +33,18 @@ const REGISTER_COPY: Record<AuthIntent, AuthPageCopy> = {
     subtitle: "You'll go straight to the editor after signup.",
     submitLabel: 'Create account and start writing',
     submitLoadingLabel: 'Creating account...',
-    successMessage:
-      'Account created successfully! Opening the editor...',
+    successMessage: 'Account created successfully! Opening the editor...',
   },
   read: {
     heading: 'Create your account',
     subtitle: 'Sign up to browse articles and tip writers on testnet.',
     submitLabel: 'Create account and start reading',
     submitLoadingLabel: 'Creating account...',
-    successMessage:
-      'Account created successfully! Taking you to articles...',
+    successMessage: 'Account created successfully! Taking you to articles...',
   },
   default: {
     heading: 'Create your account',
-    subtitle:
-      'Create your account to write, publish, and receive tips.',
+    subtitle: 'Create your account to write, publish, and receive tips.',
     submitLabel: 'Create account',
     submitLoadingLabel: 'Creating account...',
     successMessage: 'Account created successfully! Redirecting...',

--- a/lib/copy/auth-intent.ts
+++ b/lib/copy/auth-intent.ts
@@ -1,4 +1,5 @@
 export type AuthIntent = 'write' | 'read' | 'default'
+export type AuthPageVariant = 'login' | 'register'
 
 export interface AuthPageCopy {
   heading: string
@@ -81,4 +82,13 @@ export function getRegisterCopy(returnPath: string): AuthPageCopy {
 
 export function getLoginCopy(returnPath: string): AuthPageCopy {
   return LOGIN_COPY[getAuthIntent(returnPath)]
+}
+
+export function getAuthPageCopy(
+  variant: AuthPageVariant,
+  returnPath: string
+): AuthPageCopy {
+  return variant === 'register'
+    ? getRegisterCopy(returnPath)
+    : getLoginCopy(returnPath)
 }

--- a/lib/landing/features.ts
+++ b/lib/landing/features.ts
@@ -10,6 +10,7 @@ import {
   type LucideIcon,
 } from 'lucide-react'
 import { MIN_WITHDRAWAL_USD } from '@/lib/constants'
+import { REGISTER_FOR_WRITE_HREF } from '@/lib/auth/auth-links'
 
 export interface LandingFeature {
   icon: LucideIcon
@@ -23,7 +24,7 @@ export const LANDING_FEATURES: LandingFeature[] = [
     icon: Edit3,
     title: 'Rich Editor',
     description: 'Code blocks, media embeds, and full markdown support.',
-    href: '/register',
+    href: REGISTER_FOR_WRITE_HREF,
   },
   {
     icon: DollarSign,

--- a/lib/validations/__tests__/auth.test.ts
+++ b/lib/validations/__tests__/auth.test.ts
@@ -74,18 +74,7 @@ describe('Auth Validation Schemas', () => {
       expect(result.success).toBe(false)
     })
 
-    it('accepts registration with empty name', () => {
-      const result = registerSchema.safeParse({
-        email: 'user@example.com',
-        username: 'validuser',
-        password: 'Password1',
-        confirmPassword: 'Password1',
-        name: '',
-      })
-      expect(result.success).toBe(true)
-    })
-
-    it('accepts registration with name omitted', () => {
+    it('accepts registration without profile name', () => {
       const result = registerSchema.safeParse({
         email: 'user@example.com',
         username: 'validuser',
@@ -93,33 +82,6 @@ describe('Auth Validation Schemas', () => {
         confirmPassword: 'Password1',
       })
       expect(result.success).toBe(true)
-    })
-
-    it('accepts registration with a provided name', () => {
-      const result = registerSchema.safeParse({
-        email: 'user@example.com',
-        username: 'validuser',
-        password: 'Password1',
-        confirmPassword: 'Password1',
-        name: 'Jane Doe',
-      })
-      expect(result.success).toBe(true)
-    })
-
-    it('rejects name longer than 50 characters', () => {
-      const result = registerSchema.safeParse({
-        email: 'user@example.com',
-        username: 'validuser',
-        password: 'Password1',
-        confirmPassword: 'Password1',
-        name: 'a'.repeat(51),
-      })
-      expect(result.success).toBe(false)
-      if (!result.success) {
-        expect(result.error.issues[0]?.message).toBe(
-          'Name must be at most 50 characters'
-        )
-      }
     })
 
     it('rejects empty email with a clear message', () => {

--- a/lib/validations/auth.ts
+++ b/lib/validations/auth.ts
@@ -50,12 +50,6 @@ export const registerSchema = z
         'Password must contain at least one uppercase letter, one lowercase letter, and one number'
       ),
     confirmPassword: z.string().min(1, 'Please confirm your password'),
-    name: z
-      .union([
-        z.literal(''),
-        z.string().max(50, 'Name must be at most 50 characters'),
-      ])
-      .optional(),
   })
   .refine((data) => data.password === data.confirmPassword, {
     message: "Passwords don't match",


### PR DESCRIPTION
## Summary

Reduces signup friction by streamlining the registration form, adding intent-based copy based on where the user came from, and improving password validation feedback so errors disappear as criteria are met instead of turning into a green checklist.



## Changes

- Remove the full name field from registration to shorten the signup form
- Add intent-based headings, subtitles, and submit labels for login/register based on return path (write, read, default)
- Refactor auth layout: fixed `AuthShellHeader`, intent headings on login/register pages, restored spacing above the form card
- Improve password requirements UX:
  - Show unmet rules in red while typing or after failed submit
  - Remove each rule from the list once satisfied (no green checklist)
  - Show a single success line when all requirements are met
- Update landing page CTAs to route new users through signup with appropriate return paths
- Add and update tests for auth intent copy, password validation behavior, and form accessibility

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run format`
- [x] `bun run test:once` (690 tests passed)
- [x] `bun run build`


## Notes

- Password validation behavior change: satisfied rules are removed instead of turning green, per product feedback
- No schema or backend changes; registration still uses email, username, and password only
<img width="1440" height="859" alt="4_" src="https://github.com/user-attachments/assets/f6978dd9-c4ce-4e4d-818d-01c0b7fee0b4" />
<img width="1439" height="856" alt="5_" src="https://github.com/user-attachments/assets/0e5ad44c-73f8-4a72-b0eb-eb6d4425b1a1" />
<img width="1223" height="720" alt="9_" src="https://github.com/user-attachments/assets/b8234c6f-b6d3-46be-8c19-6f9941b37732" />



