### PR TITLE
fix: align FAQ accordion layout

### DIFF
--- a/components/landing/FAQSection.test.tsx
+++ b/components/landing/FAQSection.test.tsx
@@ -74,4 +74,13 @@ describe('FAQSection accordion accessibility', () => {
       'Frequently Asked Questions'
     )
   })
+
+  it('keeps FAQ items in a single centered accordion column', () => {
+    render(<FAQSection />)
+
+    const accordion = screen.getByTestId('faq-accordion')
+    expect(accordion).toHaveClass('max-w-4xl')
+    expect(accordion).toHaveClass('space-y-3')
+    expect(accordion.className).not.toContain('grid-cols-')
+  })
 })

--- a/components/landing/FAQSection.test.tsx
+++ b/components/landing/FAQSection.test.tsx
@@ -75,12 +75,14 @@ describe('FAQSection accordion accessibility', () => {
     )
   })
 
-  it('keeps FAQ items in a single centered accordion column', () => {
+  it('keeps FAQ items in left-started desktop columns', () => {
     render(<FAQSection />)
 
     const accordion = screen.getByTestId('faq-accordion')
-    expect(accordion).toHaveClass('max-w-4xl')
-    expect(accordion).toHaveClass('space-y-3')
-    expect(accordion.className).not.toContain('grid-cols-')
+    expect(accordion).toHaveClass('grid')
+    expect(accordion).toHaveClass('grid-cols-1')
+    expect(accordion).toHaveClass('md:grid-cols-2')
+
+    expect(getTrigger(firstQuestion)).toHaveClass('justify-start')
   })
 })

--- a/components/landing/FAQSection.tsx
+++ b/components/landing/FAQSection.tsx
@@ -90,7 +90,8 @@ export default function FAQSection() {
           type="single"
           collapsible
           defaultValue="faq-0"
-          className="grid grid-cols-1 md:grid-cols-2 gap-x-16 gap-y-6"
+          data-testid="faq-accordion"
+          className="mx-auto max-w-4xl space-y-3"
         >
           {faqs.map((faq, index) => (
             <motion.div
@@ -99,11 +100,14 @@ export default function FAQSection() {
               animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
               transition={{ duration: 0.5, delay: index * 0.08 }}
             >
-              <AccordionItem value={`faq-${index}`} className="border-none">
+              <AccordionItem
+                value={`faq-${index}`}
+                className="rounded-lg border border-border/70 bg-card/70 px-4 shadow-sm"
+              >
                 <AccordionTrigger
                   showChevron={false}
                   className={cn(
-                    'group w-full flex items-start gap-4 py-2 hover:no-underline',
+                    'group w-full flex items-start gap-4 py-4 hover:no-underline',
                     faqTriggerFocusClass
                   )}
                 >
@@ -123,7 +127,7 @@ export default function FAQSection() {
                     {faq.question}
                   </span>
                 </AccordionTrigger>
-                <AccordionContent className="ml-12 text-[14px] text-muted-foreground leading-relaxed">
+                <AccordionContent className="ml-12 pr-3 text-[14px] text-muted-foreground leading-relaxed">
                   {faq.answer}
                 </AccordionContent>
               </AccordionItem>

--- a/components/landing/FAQSection.tsx
+++ b/components/landing/FAQSection.tsx
@@ -91,7 +91,7 @@ export default function FAQSection() {
           collapsible
           defaultValue="faq-0"
           data-testid="faq-accordion"
-          className="mx-auto max-w-4xl space-y-3"
+          className="grid grid-cols-1 md:grid-cols-2 gap-x-16 gap-y-6"
         >
           {faqs.map((faq, index) => (
             <motion.div
@@ -100,14 +100,11 @@ export default function FAQSection() {
               animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
               transition={{ duration: 0.5, delay: index * 0.08 }}
             >
-              <AccordionItem
-                value={`faq-${index}`}
-                className="rounded-lg border border-border/70 bg-card/70 px-4 shadow-sm"
-              >
+              <AccordionItem value={`faq-${index}`} className="border-none">
                 <AccordionTrigger
                   showChevron={false}
                   className={cn(
-                    'group w-full flex items-start gap-4 py-4 hover:no-underline',
+                    'group w-full flex justify-start items-start gap-4 py-2 hover:no-underline',
                     faqTriggerFocusClass
                   )}
                 >
@@ -127,7 +124,7 @@ export default function FAQSection() {
                     {faq.question}
                   </span>
                 </AccordionTrigger>
-                <AccordionContent className="ml-12 pr-3 text-[14px] text-muted-foreground leading-relaxed">
+                <AccordionContent className="ml-12 text-[14px] text-muted-foreground leading-relaxed">
                   {faq.answer}
                 </AccordionContent>
               </AccordionItem>


### PR DESCRIPTION
## Summary
- Preserve the desktop FAQ as a two-column accordion instead of converting it into one full-width list.
- Align each FAQ trigger from the left edge of its column so the chevron and question text stay grouped.
- Keep expanded answers directly under their own question in the same column.

## Testing
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run test:once components/landing/FAQSection.test.tsx`
- `bun run test:once`
- `bun run build` (passed with network access for Google Fonts after the sandboxed run failed on font fetches)
- Manual Vercel preview QA passed on the FAQ layout

## Notes
- No Linear issue was provided for this small visual regression fix.
- Greptile’s comment about the test guarding the wrong invariant was based on the earlier PR description. The corrected requirement is to preserve desktop two columns, so `md:grid-cols-2` is intentionally asserted.