### PR TITLE
feat(landing): reduce over-explanation and simplify launch page (ENG-258)

### DIFF
--- a/components/landing/FAQSection.test.tsx
+++ b/components/landing/FAQSection.test.tsx
@@ -16,8 +16,8 @@ vi.mock('motion/react', () => ({
 }))
 
 describe('FAQSection accordion accessibility', () => {
-  const firstQuestion = 'What is Quilltip and what problem does it solve?'
-  const secondQuestion = 'Do I need cryptocurrency to read articles?'
+  const firstQuestion = 'Do I need cryptocurrency to read articles?'
+  const secondQuestion = 'How does the tipping mechanism work?'
 
   function getTrigger(name: string) {
     return screen.getByRole('button', { name })
@@ -73,6 +73,7 @@ describe('FAQSection accordion accessibility', () => {
     expect(document.getElementById('faq-heading')).toHaveTextContent(
       'Frequently Asked Questions'
     )
+    expect(screen.getAllByRole('button')).toHaveLength(4)
   })
 
   it('keeps FAQ items in left-started desktop columns', () => {

--- a/components/landing/FAQSection.tsx
+++ b/components/landing/FAQSection.tsx
@@ -34,7 +34,7 @@ const faqs = [
   {
     question: 'What does it cost to use Quilltip as a writer or reader?',
     answer:
-      "Reading articles: completely free, no wallet needed. Tipping writers: pay only the Stellar network fee (0.05 XLM, less than $0.01) plus your chosen tip amount. Publishing articles: free, no hosting fees or subscriptions.",
+      'Reading articles: completely free, no wallet needed. Tipping writers: pay only the Stellar network fee (0.05 XLM, less than $0.01) plus your chosen tip amount. Publishing articles: free, no hosting fees or subscriptions.',
   },
 ] as const
 

--- a/components/landing/FAQSection.tsx
+++ b/components/landing/FAQSection.tsx
@@ -16,11 +16,6 @@ const faqTriggerFocusClass =
 
 const faqs = [
   {
-    question: 'What is Quilltip and what problem does it solve?',
-    answer:
-      'Quilltip lets writers earn money directly from readers without ads, subscriptions, or gatekeepers taking large cuts. Anyone can publish articles for free, readers tip writers instantly with cryptocurrency, and writers keep 97.5% of every tip. All payments happen through Stellar blockchain smart contracts in 3-5 seconds with no intermediaries. Writers own their content permanently through NFTs (digital certificates of ownership), and readers never pay to access articles - tipping is always voluntary.',
-  },
-  {
     question: 'Do I need cryptocurrency to read articles?',
     answer:
       'No. Reading articles on Quilltip is completely free — no wallet, no account, no crypto needed. You only need a Stellar wallet if you want to tip writers for content you love. Setting up a wallet takes about 2 minutes, and we have a step-by-step guide to help you.',
@@ -31,11 +26,6 @@ const faqs = [
       "Readers connect a Stellar wallet (Freighter, xBull, Albedo, or hot wallet), browse articles, and click \"Tip\" to send XLM directly to the writer's wallet. The transaction completes in 3-5 seconds through Soroban smart contracts. Writers receive funds instantly in their wallet - no withdrawal process or waiting period. Minimum tip is 0.026 XLM (approximately $0.01 USD) to ensure transaction fees don't exceed the tip value. There's no maximum limit.",
   },
   {
-    question: "What's Quilltip's business model and revenue split?",
-    answer:
-      'Writers keep 97.5% of all tips. Quilltip takes 2.5% to cover infrastructure costs (hosting, Arweave storage fees, platform development). There are no subscription fees, hosting costs, or hidden charges for writers or readers.',
-  },
-  {
     question:
       'Is Quilltip live on mainnet or testnet? When can I use it with real money?',
     answer:
@@ -44,24 +34,7 @@ const faqs = [
   {
     question: 'What does it cost to use Quilltip as a writer or reader?',
     answer:
-      "Reading articles: completely free, no wallet needed. Tipping writers: pay only the Stellar network fee (0.05 XLM, less than $0.01) plus your chosen tip amount. Publishing articles: free, no hosting fees or subscriptions. Minting article NFTs: requires reaching a tip threshold (currently 10 XLM in total tips received), then pay minimal Stellar network fee for minting (approximately 0.05 XLM). Editing published articles: free, unlimited edits. When you update an article that's been minted as an NFT, the blockchain preserves the original version while displaying your latest edits to readers.",
-  },
-  {
-    question: 'What barriers prevent mainstream users from adopting Quilltip?',
-    answer:
-      "Currently requires a Stellar wallet to tip or publish, which can intimidate non-crypto users. We're addressing this by: (1) Supporting four popular wallets through Stellar Wallet Kit for maximum compatibility, (2) Providing wallet setup guides and testnet XLM for new users, (3) Making all articles readable without any wallet, (4) Planning USDC support so users can tip with stablecoins instead of volatile XLM. Future roadmap includes social login options and custodial wallet integration.",
-  },
-  {
-    question:
-      'How does Quilltip ensure my content survives long-term, even if the platform shuts down?',
-    answer:
-      'Two-layer permanence: (1) Arweave integration stores articles on decentralized, permanent storage that exists independently of Quilltip, with no recurring storage fees. (2) Article NFTs minted on Stellar blockchain create immutable proof of ownership and authorship. If Quilltip disappears, content persists on Arweave and ownership rights exist on Stellar.',
-  },
-  {
-    question:
-      'How does Quilltip handle content moderation while remaining decentralized?',
-    answer:
-      'Quilltip removes illegal content and violations of community guidelines from the platform interface. However, once Arweave integration launches, articles are stored on a decentralized network beyond our control, meaning censorship-resistant copies may persist. This balances platform safety with writer freedom: we curate the Quilltip experience while writers retain true ownership. Think of it like a library removing a book from shelves while the book itself still exists elsewhere.',
+      "Reading articles: completely free, no wallet needed. Tipping writers: pay only the Stellar network fee (0.05 XLM, less than $0.01) plus your chosen tip amount. Publishing articles: free, no hosting fees or subscriptions.",
   },
 ] as const
 
@@ -120,7 +93,7 @@ export default function FAQSection() {
                       aria-hidden="true"
                     />
                   </div>
-                  <span className="font-semibold text-foreground text-[15px] leading-relaxed pt-1 text-left">
+                  <span className="flex-1 min-w-0 font-semibold text-foreground text-[15px] leading-relaxed pt-1 text-left">
                     {faq.question}
                   </span>
                 </AccordionTrigger>

--- a/components/landing/FeaturesSection.test.tsx
+++ b/components/landing/FeaturesSection.test.tsx
@@ -26,6 +26,8 @@ describe('FeaturesSection keyboard navigation', () => {
   it('exposes a focusable link for each core feature', () => {
     render(<FeaturesSection />)
 
+    expect(LANDING_FEATURES).toHaveLength(4)
+
     for (const feature of LANDING_FEATURES) {
       expect(
         screen.getAllByRole('link', { name: feature.title }).length

--- a/components/landing/FeaturesSection.tsx
+++ b/components/landing/FeaturesSection.tsx
@@ -43,11 +43,15 @@ export default function FeaturesSection() {
     >
       <div className="container mx-auto max-w-3xl relative z-10">
         <Reveal className="text-center mb-12">
+          <span className="inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full bg-muted/60 border border-border/60 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-4">
+            <span className="w-1.5 h-1.5 bg-success rounded-full" />
+            Live on Stellar Testnet
+          </span>
           <h2 className="font-display text-4xl lg:text-5xl font-medium tracking-[-0.01em] mb-3 leading-[1.15]">
-            <span className="text-foreground">Core Features</span>
+            <span className="text-foreground">Why Quilltip</span>
           </h2>
           <p className="text-[15px] text-muted-foreground leading-relaxed">
-            Everything writers and readers need on testnet.
+            Read for free, tip what resonates, publish and earn.
           </p>
           <p className="text-[13px] text-muted-foreground leading-relaxed mt-2 max-w-lg mx-auto">
             {TESTNET_PRACTICE_NOTE}

--- a/components/landing/HeroSection.test.tsx
+++ b/components/landing/HeroSection.test.tsx
@@ -36,16 +36,18 @@ describe('HeroSection launch CTAs', () => {
   it('shows one primary and one secondary CTA without wallet setup', () => {
     render(<HeroSection />)
 
-    expect(screen.getByRole('link', { name: HERO_START_READING })).toHaveAttribute(
-      'href',
-      '/articles'
-    )
-    expect(screen.getByRole('link', { name: HERO_START_WRITING })).toHaveAttribute(
-      'href',
-      '/register'
-    )
-    expect(screen.queryByRole('link', { name: HERO_WALLET_SETUP })).not.toBeInTheDocument()
-    expect(screen.queryByText('Live on Stellar Testnet')).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: HERO_START_READING })
+    ).toHaveAttribute('href', '/articles')
+    expect(
+      screen.getByRole('link', { name: HERO_START_WRITING })
+    ).toHaveAttribute('href', '/register')
+    expect(
+      screen.queryByRole('link', { name: HERO_WALLET_SETUP })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('Live on Stellar Testnet')
+    ).not.toBeInTheDocument()
     expect(screen.queryByText('97.5%')).not.toBeInTheDocument()
   })
 })

--- a/components/landing/HeroSection.test.tsx
+++ b/components/landing/HeroSection.test.tsx
@@ -1,0 +1,51 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import HeroSection from '@/components/landing/HeroSection'
+import {
+  HERO_START_READING,
+  HERO_START_WRITING,
+  HERO_WALLET_SETUP,
+} from '@/lib/copy/nav-cta'
+
+vi.mock('motion/react', () => ({
+  motion: {
+    div: ({ children, ...props }: { children?: React.ReactNode }) => (
+      <div {...props}>{children}</div>
+    ),
+    h1: ({ children, ...props }: { children?: React.ReactNode }) => (
+      <h1 {...props}>{children}</h1>
+    ),
+    p: ({ children, ...props }: { children?: React.ReactNode }) => (
+      <p {...props}>{children}</p>
+    ),
+  },
+}))
+
+vi.mock('next/link', () => ({
+  default: (props: { href: string; children: React.ReactNode }) => (
+    <a href={props.href}>{props.children}</a>
+  ),
+}))
+
+vi.mock('@/components/landing/LandingProductProof', () => ({
+  LandingProductProof: () => <div data-testid="landing-product-proof" />,
+}))
+
+describe('HeroSection launch CTAs', () => {
+  it('shows one primary and one secondary CTA without wallet setup', () => {
+    render(<HeroSection />)
+
+    expect(screen.getByRole('link', { name: HERO_START_READING })).toHaveAttribute(
+      'href',
+      '/articles'
+    )
+    expect(screen.getByRole('link', { name: HERO_START_WRITING })).toHaveAttribute(
+      'href',
+      '/register'
+    )
+    expect(screen.queryByRole('link', { name: HERO_WALLET_SETUP })).not.toBeInTheDocument()
+    expect(screen.queryByText('Live on Stellar Testnet')).not.toBeInTheDocument()
+    expect(screen.queryByText('97.5%')).not.toBeInTheDocument()
+  })
+})

--- a/components/landing/HeroSection.test.tsx
+++ b/components/landing/HeroSection.test.tsx
@@ -32,6 +32,10 @@ vi.mock('@/components/landing/LandingProductProof', () => ({
   LandingProductProof: () => <div data-testid="landing-product-proof" />,
 }))
 
+vi.mock('@/components/landing/LandingTippingDemo', () => ({
+  LandingTippingDemo: () => <div data-testid="landing-tipping-demo" />,
+}))
+
 describe('HeroSection launch CTAs', () => {
   it('shows one primary and one secondary CTA without wallet setup', () => {
     render(<HeroSection />)

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/lib/copy/landing-hero'
 import { HERO_START_READING, HERO_START_WRITING } from '@/lib/copy/nav-cta'
 import { LandingProductProof } from '@/components/landing/LandingProductProof'
+import { LandingTippingDemo } from '@/components/landing/LandingTippingDemo'
 import { motion } from 'motion/react'
 
 export default function HeroSection() {
@@ -41,10 +42,19 @@ export default function HeroSection() {
           </motion.p>
 
           <motion.div
-            className="mt-6 flex w-full max-w-md flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center"
+            className="mt-8 hidden w-full justify-center lg:flex"
             initial={{ opacity: 0, y: 14 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.15, ease: 'easeOut' }}
+          >
+            <LandingTippingDemo />
+          </motion.div>
+
+          <motion.div
+            className="mt-6 flex w-full max-w-md flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center"
+            initial={{ opacity: 0, y: 14 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.2, ease: 'easeOut' }}
           >
             <Link
               href="/articles"
@@ -64,7 +74,7 @@ export default function HeroSection() {
           <motion.div
             initial={{ opacity: 0, y: 14 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5, delay: 0.2, ease: 'easeOut' }}
+            transition={{ duration: 0.5, delay: 0.25, ease: 'easeOut' }}
             className="mt-8 w-full flex justify-center opacity-90"
           >
             <LandingProductProof />

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -1,163 +1,16 @@
 'use client'
 
 import Link from 'next/link'
-import { ArrowRight, Zap } from 'lucide-react'
-import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
-import { REGISTER_FOR_WRITE_HREF } from '@/lib/auth/auth-links'
+import { ArrowRight } from 'lucide-react'
 import {
-  HERO_START_READING,
-  HERO_START_WRITING,
-  HERO_WALLET_SETUP,
-} from '@/lib/copy/nav-cta'
+  LANDING_HERO_HEADLINE,
+  LANDING_HERO_SUBTITLE,
+} from '@/lib/copy/landing-hero'
+import { HERO_START_READING, HERO_START_WRITING } from '@/lib/copy/nav-cta'
 import { LandingProductProof } from '@/components/landing/LandingProductProof'
-import { motion, AnimatePresence } from 'motion/react'
-import { useEffect, useState, useCallback, useRef } from 'react'
-
-const ARTICLE_TEXT = `Writers pour their hearts into stories that shape how we think — yet most see nothing in return. The quiet revolution of open knowledge deserves better. What if readers could reward the exact words that moved them?`
-
-interface HighlightPhrase {
-  text: string
-  tip: string
-}
-
-const HIGHLIGHT_PHRASES: HighlightPhrase[] = [
-  { text: 'Writers pour their hearts', tip: '+0.25 XLM' },
-  { text: 'stories that shape how we think', tip: '+0.50 XLM' },
-  { text: 'the quiet revolution of open knowledge', tip: '+0.75 XLM' },
-  { text: 'reward the exact words that moved them', tip: '+1.00 XLM' },
-]
-
-type AnimationStep = 'idle' | 'selecting' | 'highlighted' | 'tipped'
-
-type Segment =
-  | { type: 'text'; content: string }
-  | { type: 'phrase'; content: string; phraseIndex: number }
-
-function buildSegments(text: string, phrases: HighlightPhrase[]): Segment[] {
-  const ranges: { start: number; end: number; index: number }[] = []
-  phrases.forEach((p, i) => {
-    const start = text.indexOf(p.text)
-    if (start === -1) return
-    ranges.push({ start, end: start + p.text.length, index: i })
-  })
-  ranges.sort((a, b) => a.start - b.start)
-
-  const segments: Segment[] = []
-  let cursor = 0
-  for (const r of ranges) {
-    if (r.start > cursor) {
-      segments.push({ type: 'text', content: text.slice(cursor, r.start) })
-    }
-    segments.push({
-      type: 'phrase',
-      content: text.slice(r.start, r.end),
-      phraseIndex: r.index,
-    })
-    cursor = r.end
-  }
-  if (cursor < text.length) {
-    segments.push({ type: 'text', content: text.slice(cursor) })
-  }
-  return segments
-}
-
-const SEGMENTS = buildSegments(ARTICLE_TEXT, HIGHLIGHT_PHRASES)
+import { motion } from 'motion/react'
 
 export default function HeroSection() {
-  const [activeIndex, setActiveIndex] = useState(0)
-  const [animationStep, setAnimationStep] = useState<AnimationStep>('idle')
-  const timeoutRefs = useRef<ReturnType<typeof setTimeout>[]>([])
-
-  const clearAllTimeouts = useCallback(() => {
-    timeoutRefs.current.forEach(clearTimeout)
-    timeoutRefs.current = []
-  }, [])
-
-  const addTimeout = useCallback((fn: () => void, delay: number) => {
-    const id = setTimeout(fn, delay)
-    timeoutRefs.current.push(id)
-    return id
-  }, [])
-
-  useEffect(() => {
-    clearAllTimeouts()
-    setAnimationStep('idle')
-
-    addTimeout(() => setAnimationStep('selecting'), 80)
-    addTimeout(() => setAnimationStep('highlighted'), 440)
-    addTimeout(() => setAnimationStep('tipped'), 620)
-    addTimeout(() => {
-      setAnimationStep('idle')
-      addTimeout(() => {
-        setActiveIndex((prev) => (prev + 1) % HIGHLIGHT_PHRASES.length)
-      }, 80)
-    }, 1350)
-
-    return clearAllTimeouts
-  }, [activeIndex, clearAllTimeouts, addTimeout])
-
-  const renderArticleText = () => (
-    <>
-      {SEGMENTS.map((seg, i) => {
-        if (seg.type === 'text') {
-          return <span key={i}>{seg.content}</span>
-        }
-
-        const { phraseIndex } = seg
-        const isActive = phraseIndex === activeIndex
-        const isSelecting = isActive && animationStep === 'selecting'
-        const isHighlighted =
-          isActive &&
-          (animationStep === 'highlighted' || animationStep === 'tipped')
-        const showTip = isActive && animationStep === 'tipped'
-
-        return (
-          <span key={i} className="relative inline">
-            {isSelecting && (
-              <motion.span
-                className="absolute inset-y-0 left-0 bg-info/25 rounded-[2px]"
-                initial={{ width: '0%' }}
-                animate={{ width: '100%' }}
-                transition={{ duration: 0.35, ease: 'easeOut' }}
-                style={{ zIndex: 0 }}
-              />
-            )}
-            {isHighlighted && (
-              <motion.span
-                className="absolute -inset-y-0.5 -left-0.5 -right-0.5 rounded-[3px] bg-warning/30"
-                initial={{ opacity: 0, scale: 0.98 }}
-                animate={{ opacity: 1, scale: 1 }}
-                transition={{ duration: 0.2, ease: 'easeOut' }}
-                style={{ zIndex: 0 }}
-              />
-            )}
-            <span
-              className={`relative z-10 ${isHighlighted ? 'text-foreground' : ''}`}
-            >
-              {seg.content}
-            </span>
-
-            <AnimatePresence>
-              {showTip && (
-                <motion.span
-                  key="tip"
-                  className="absolute -top-9 left-1/2 -translate-x-1/2 inline-flex items-center gap-1.5 bg-popover text-popover-foreground border border-border text-[11px] font-semibold px-3 py-1.5 rounded-full shadow-xl whitespace-nowrap"
-                  initial={{ opacity: 0, y: 6, scale: 0.9 }}
-                  animate={{ opacity: 1, y: 0, scale: 1 }}
-                  exit={{ opacity: 0, y: -4, scale: 0.9 }}
-                  transition={{ duration: 0.18, ease: 'easeOut' }}
-                >
-                  <Zap className="w-3 h-3 text-warning-foreground" />
-                  {HIGHLIGHT_PHRASES[phraseIndex]?.tip}
-                </motion.span>
-              )}
-            </AnimatePresence>
-          </span>
-        )
-      })}
-    </>
-  )
-
   return (
     <section className="relative min-h-screen flex items-start md:items-center justify-center overflow-hidden pt-16">
       <div className="absolute inset-0 bg-gradient-to-b from-background via-background to-muted/30" />
@@ -169,51 +22,26 @@ export default function HeroSection() {
           animate={{ opacity: 1 }}
           transition={{ duration: 0.5 }}
         >
-          {/* Label chip */}
-          <motion.div
-            initial={{ opacity: 0, y: 12 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.4, ease: 'easeOut' }}
-          >
-            <span className="inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full bg-muted/60 border border-border/60 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">
-              <span className="w-1.5 h-1.5 bg-success rounded-full animate-pulse" />
-              Live on Stellar Testnet
-            </span>
-          </motion.div>
-
-          {/* Headline — Fraunces */}
           <motion.h1
-            className="mt-6 font-display text-4xl sm:text-[2.75rem] lg:text-5xl font-medium tracking-[-0.01em] text-foreground leading-[1.2]"
+            className="font-display text-4xl sm:text-[2.75rem] lg:text-5xl font-medium tracking-[-0.01em] text-foreground leading-[1.2]"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.05, ease: 'easeOut' }}
           >
-            Reward the words that move you
+            {LANDING_HERO_HEADLINE}
           </motion.h1>
 
-          {/* Subtitle — Inter */}
           <motion.p
             className="mt-4 text-[15px] sm:text-base text-muted-foreground max-w-md leading-relaxed"
             initial={{ opacity: 0, y: 14 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.1, ease: 'easeOut' }}
           >
-            Browse published articles and practice tipping writers on Stellar
-            testnet with free test XLM.
+            {LANDING_HERO_SUBTITLE}
           </motion.p>
 
           <motion.div
-            initial={{ opacity: 0, y: 14 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5, delay: 0.12, ease: 'easeOut' }}
-            className="w-full flex justify-center"
-          >
-            <LandingProductProof />
-          </motion.div>
-
-          {/* CTAs */}
-          <motion.div
-            className="mt-6 flex w-full max-w-md flex-col items-center justify-center gap-3 sm:flex-row sm:gap-2.5"
+            className="mt-6 flex w-full max-w-md flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center"
             initial={{ opacity: 0, y: 14 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.15, ease: 'easeOut' }}
@@ -225,102 +53,22 @@ export default function HeroSection() {
               {HERO_START_READING}
               <ArrowRight className="w-3.5 h-3.5 transition-transform duration-200 group-hover:translate-x-0.5" />
             </Link>
-            <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[12px] sm:text-[13px]">
-              <Link
-                href={REGISTER_FOR_WRITE_HREF}
-                className="focus-ring rounded-sm text-muted-foreground transition-colors hover:text-foreground"
-              >
-                {HERO_START_WRITING}
-              </Link>
-              <span className="text-border" aria-hidden>
-                ·
-              </span>
-              <Link
-                href="/guide"
-                className="focus-ring rounded-sm text-muted-foreground transition-colors hover:text-foreground"
-              >
-                {HERO_WALLET_SETUP}
-              </Link>
-            </div>
+            <Link
+              href="/register"
+              className="focus-ring inline-flex w-full items-center justify-center rounded-lg border border-border bg-background px-6 py-2.5 text-[13px] font-medium text-foreground transition-all duration-200 hover:bg-muted sm:w-auto"
+            >
+              {HERO_START_WRITING}
+            </Link>
           </motion.div>
 
-          {/* Animation Panel — desktop only */}
           <motion.div
-            className="mt-14 hidden w-full max-w-2xl md:block"
-            initial={{ opacity: 0, y: 20 }}
+            initial={{ opacity: 0, y: 14 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.2, ease: 'easeOut' }}
+            transition={{ duration: 0.5, delay: 0.2, ease: 'easeOut' }}
+            className="mt-8 w-full flex justify-center opacity-90"
           >
-            <div className="relative bg-card rounded-xl border border-border shadow-[var(--card-shadow)] overflow-hidden">
-              {/* Browser chrome */}
-              <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border bg-muted/60">
-                <div className="flex gap-1.5">
-                  <div className="w-2 h-2 bg-border rounded-full" />
-                  <div className="w-2 h-2 bg-border rounded-full" />
-                  <div className="w-2 h-2 bg-border rounded-full" />
-                </div>
-                <div className="flex-1 flex justify-center">
-                  <div className="flex items-center gap-1.5 px-3 py-0.5 bg-card rounded-md border border-border">
-                    <span className="text-[10px] text-muted-foreground font-medium">
-                      quilltip.app/article/on-open-knowledge
-                    </span>
-                  </div>
-                </div>
-                <div className="w-10" />
-              </div>
-
-              {/* Article content */}
-              <div className="px-7 sm:px-10 py-7 sm:py-8">
-                <p className="text-[14px] sm:text-[15px] leading-[1.8] text-muted-foreground text-left">
-                  {renderArticleText()}
-                </p>
-              </div>
-            </div>
+            <LandingProductProof />
           </motion.div>
-
-          {/* Metrics Strip */}
-          <motion.div
-            className="mt-12 flex items-center justify-center gap-8 sm:gap-12"
-            initial={{ opacity: 0, y: 12 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5, delay: 0.3 }}
-          >
-            <div className="text-center">
-              <p className="text-lg sm:text-xl font-semibold text-foreground tabular-nums">
-                97.5%
-              </p>
-              <p className="text-[10px] text-muted-foreground font-medium uppercase tracking-widest mt-0.5">
-                To Authors
-              </p>
-            </div>
-            <div className="w-px h-6 bg-border" />
-            <div className="text-center">
-              <p className="text-lg sm:text-xl font-semibold text-foreground tabular-nums">
-                3s
-              </p>
-              <p className="text-[10px] text-muted-foreground font-medium uppercase tracking-widest mt-0.5">
-                Settlement
-              </p>
-            </div>
-            <div className="w-px h-6 bg-border" />
-            <div className="text-center">
-              <p className="text-lg sm:text-xl font-semibold text-foreground tabular-nums">
-                $0.01
-              </p>
-              <p className="text-[10px] text-muted-foreground font-medium uppercase tracking-widest mt-0.5">
-                Min Tip
-              </p>
-            </div>
-          </motion.div>
-
-          <motion.p
-            className="mt-6 text-[12px] text-muted-foreground max-w-md leading-relaxed"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.5, delay: 0.35 }}
-          >
-            {TESTNET_PRACTICE_NOTE}
-          </motion.p>
         </motion.div>
       </div>
     </section>

--- a/components/landing/HowItWorksSection.test.tsx
+++ b/components/landing/HowItWorksSection.test.tsx
@@ -38,22 +38,28 @@ vi.mock('next/link', () => ({
   ),
 }))
 
+vi.mock('@/components/landing/LandingTippingDemo', () => ({
+  LandingTippingDemo: () => <div data-testid="landing-tipping-demo" />,
+}))
+
 describe('HowItWorksSection step controls', () => {
   beforeEach(() => {
     isMobileViewport = false
   })
 
-  function stepsTablist(label: 'Writer steps' | 'Reader steps') {
-    const lists = screen.getAllByRole('tablist', { name: label })
+  function stepsTablist() {
+    const lists = screen.getAllByRole('tablist', {
+      name: 'How it works steps',
+    })
     const active = lists.find((el) => el.getAttribute('aria-hidden') !== 'true')
     if (!active) {
-      throw new Error(`No active tablist for ${label}`)
+      throw new Error('No active tablist for how it works steps')
     }
     return active
   }
 
-  function stepTab(label: 'Writer steps' | 'Reader steps', name: string) {
-    return within(stepsTablist(label)).getByRole('tab', { name })
+  function stepTab(name: string) {
+    return within(stepsTablist()).getByRole('tab', { name })
   }
 
   function expectPanelShows(tab: HTMLElement, text: string) {
@@ -64,14 +70,21 @@ describe('HowItWorksSection step controls', () => {
     expect(within(panel!).getByText(text)).toBeVisible()
   }
 
-  it('selects the first writer step by default on desktop', () => {
+  it('renders three launch-critical steps on desktop', () => {
     render(<HowItWorksSection />)
 
-    const signUp = stepTab('Writer steps', 'Sign Up')
-    expect(signUp).toHaveAttribute('aria-selected', 'true')
+    expect(within(stepsTablist()).getAllByRole('tab')).toHaveLength(3)
+    expect(screen.getByRole('heading', { name: 'How tipping works' })).toBeInTheDocument()
+  })
+
+  it('selects the first step by default on desktop', () => {
+    render(<HowItWorksSection />)
+
+    const browse = stepTab('Browse')
+    expect(browse).toHaveAttribute('aria-selected', 'true')
     expectPanelShows(
-      signUp,
-      'One-click registration with your email. Connect Freighter wallet to start receiving tips instantly.'
+      browse,
+      'All articles are free to read. Explore by topic, trending, or latest. No paywalls, ever.'
     )
   })
 
@@ -79,17 +92,14 @@ describe('HowItWorksSection step controls', () => {
     const user = userEvent.setup()
     render(<HowItWorksSection />)
 
-    const write = stepTab('Writer steps', 'Write')
-    await user.click(write)
+    const tip = stepTab('Tip')
+    await user.click(tip)
 
-    expect(write).toHaveAttribute('aria-selected', 'true')
-    expect(stepTab('Writer steps', 'Sign Up')).toHaveAttribute(
-      'aria-selected',
-      'false'
-    )
+    expect(tip).toHaveAttribute('aria-selected', 'true')
+    expect(stepTab('Browse')).toHaveAttribute('aria-selected', 'false')
     expectPanelShows(
-      write,
-      'Full markdown support, code blocks, media embeds, and a distraction-free writing experience.'
+      tip,
+      "Install Freighter, fund with free testnet XLM, and send tips that settle in about 3 seconds."
     )
   })
 
@@ -97,42 +107,24 @@ describe('HowItWorksSection step controls', () => {
     const user = userEvent.setup()
     render(<HowItWorksSection />)
 
-    const signUp = stepTab('Writer steps', 'Sign Up')
-    signUp.focus()
+    const browse = stepTab('Browse')
+    browse.focus()
     await user.keyboard('{ArrowRight}')
 
-    const write = stepTab('Writer steps', 'Write')
-    expect(write).toHaveFocus()
-    expect(write).toHaveAttribute('aria-selected', 'true')
+    const tip = stepTab('Tip')
+    expect(tip).toHaveFocus()
+    expect(tip).toHaveAttribute('aria-selected', 'true')
   })
 
   it('links each tab to its tabpanel', () => {
     render(<HowItWorksSection />)
 
-    const signUp = stepTab('Writer steps', 'Sign Up')
-    const panelId = signUp.getAttribute('aria-controls')
+    const browse = stepTab('Browse')
+    const panelId = browse.getAttribute('aria-controls')
     expect(panelId).toBeTruthy()
     const panel = document.getElementById(panelId!)
     expect(panel).toHaveAttribute('role', 'tabpanel')
-    expect(panel).toHaveAttribute('aria-labelledby', signUp.id)
-  })
-
-  it('resets to the first reader step when switching audience tabs', async () => {
-    const user = userEvent.setup()
-    render(<HowItWorksSection />)
-
-    await user.click(stepTab('Writer steps', 'Write'))
-    await user.click(screen.getByRole('tab', { name: 'For Readers' }))
-
-    const browse = stepTab('Reader steps', 'Browse')
-    expect(browse).toHaveAttribute('aria-selected', 'true')
-    expectPanelShows(
-      browse,
-      'All articles are free to read. Explore by topic, trending, or latest. No paywalls, ever.'
-    )
-    expect(
-      within(stepsTablist('Reader steps')).getAllByRole('tab')
-    ).toHaveLength(4)
+    expect(panel).toHaveAttribute('aria-labelledby', browse.id)
   })
 
   it('operates mobile step tabs when the mobile layout is active', async () => {
@@ -140,13 +132,13 @@ describe('HowItWorksSection step controls', () => {
     const user = userEvent.setup()
     render(<HowItWorksSection />)
 
-    const publish = stepTab('Writer steps', 'Publish')
+    const publish = stepTab('Publish & earn')
     await user.click(publish)
 
     expect(publish).toHaveAttribute('aria-selected', 'true')
     expectPanelShows(
       publish,
-      'Your article is stored permanently on Arweave. A tamper-proof record of your creative work, forever.'
+      'Use the rich editor to publish your work. Tips go directly to your wallet with near-zero fees.'
     )
   })
 })

--- a/components/landing/HowItWorksSection.test.tsx
+++ b/components/landing/HowItWorksSection.test.tsx
@@ -2,14 +2,8 @@
 import type { HTMLAttributes, ReactNode } from 'react'
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import HowItWorksSection from '@/components/landing/HowItWorksSection'
-
-let isMobileViewport = false
-
-vi.mock('@/hooks/use-mobile', () => ({
-  useIsMobile: () => isMobileViewport,
-}))
 
 vi.mock('motion/react', () => ({
   motion: {
@@ -43,101 +37,86 @@ vi.mock('@/components/landing/LandingTippingDemo', () => ({
 }))
 
 describe('HowItWorksSection step controls', () => {
-  beforeEach(() => {
-    isMobileViewport = false
-  })
-
-  function stepsTablist() {
-    const lists = screen.getAllByRole('tablist', {
-      name: 'How it works steps',
-    })
-    const active = lists.find((el) => el.getAttribute('aria-hidden') !== 'true')
-    if (!active) {
-      throw new Error('No active tablist for how it works steps')
-    }
-    return active
+  function stepsRegion() {
+    return screen.getByLabelText('How it works steps')
   }
 
-  function stepTab(name: string) {
-    return within(stepsTablist()).getByRole('tab', { name })
+  function stepTrigger(name: string) {
+    return within(stepsRegion()).getByRole('button', { name })
   }
 
-  function expectPanelShows(tab: HTMLElement, text: string) {
-    const panelId = tab.getAttribute('aria-controls')
-    expect(panelId).toBeTruthy()
-    const panel = document.getElementById(panelId!)
-    expect(panel).toBeTruthy()
-    expect(within(panel!).getByText(text)).toBeVisible()
+  function expectStepContentVisible(text: string) {
+    expect(screen.getByText(text)).toBeVisible()
   }
 
-  it('renders three launch-critical steps on desktop', () => {
+  it('renders three launch-critical steps', () => {
     render(<HowItWorksSection />)
 
-    expect(within(stepsTablist()).getAllByRole('tab')).toHaveLength(3)
-    expect(screen.getByRole('heading', { name: 'How tipping works' })).toBeInTheDocument()
+    expect(within(stepsRegion()).getAllByRole('button')).toHaveLength(3)
+    expect(
+      screen.getByRole('heading', { name: 'How tipping works' })
+    ).toBeInTheDocument()
   })
 
-  it('selects the first step by default on desktop', () => {
+  it('opens the first step by default', () => {
     render(<HowItWorksSection />)
 
-    const browse = stepTab('Browse')
-    expect(browse).toHaveAttribute('aria-selected', 'true')
-    expectPanelShows(
-      browse,
+    const browse = stepTrigger('Browse')
+    expect(browse).toHaveAttribute('aria-expanded', 'true')
+    expectStepContentVisible(
       'All articles are free to read. Explore by topic, trending, or latest. No paywalls, ever.'
     )
   })
 
-  it('activates another step on click and exposes selected state', async () => {
+  it('opens another step on click and collapses the previous one', async () => {
     const user = userEvent.setup()
     render(<HowItWorksSection />)
 
-    const tip = stepTab('Tip')
+    const tip = stepTrigger('Tip')
     await user.click(tip)
 
-    expect(tip).toHaveAttribute('aria-selected', 'true')
-    expect(stepTab('Browse')).toHaveAttribute('aria-selected', 'false')
-    expectPanelShows(
-      tip,
+    expect(tip).toHaveAttribute('aria-expanded', 'true')
+    expect(stepTrigger('Browse')).toHaveAttribute('aria-expanded', 'false')
+    expectStepContentVisible(
       "Install Freighter, fund with free testnet XLM, and send tips that settle in about 3 seconds."
     )
   })
 
-  it('moves to the next step with ArrowRight and updates focus', async () => {
+  it('toggles a step closed with Enter when it is already open', async () => {
     const user = userEvent.setup()
     render(<HowItWorksSection />)
 
-    const browse = stepTab('Browse')
+    const browse = stepTrigger('Browse')
     browse.focus()
-    await user.keyboard('{ArrowRight}')
+    await user.keyboard('{Enter}')
 
-    const tip = stepTab('Tip')
-    expect(tip).toHaveFocus()
-    expect(tip).toHaveAttribute('aria-selected', 'true')
+    expect(browse).toHaveAttribute('aria-expanded', 'false')
   })
 
-  it('links each tab to its tabpanel', () => {
+  it('links each trigger to its content panel', () => {
     render(<HowItWorksSection />)
 
-    const browse = stepTab('Browse')
+    const browse = stepTrigger('Browse')
     const panelId = browse.getAttribute('aria-controls')
     expect(panelId).toBeTruthy()
     const panel = document.getElementById(panelId!)
-    expect(panel).toHaveAttribute('role', 'tabpanel')
-    expect(panel).toHaveAttribute('aria-labelledby', browse.id)
+    expect(panel).toBeTruthy()
+    expect(
+      within(panel!).getByText(
+        'Discover articles from writers across the platform'
+      )
+    ).toBeInTheDocument()
   })
 
-  it('operates mobile step tabs when the mobile layout is active', async () => {
-    isMobileViewport = true
+  it('opens a step on mobile viewport', async () => {
     const user = userEvent.setup()
     render(<HowItWorksSection />)
 
-    const publish = stepTab('Publish & earn')
+    const publish = stepTrigger('Publish & earn')
     await user.click(publish)
 
-    expect(publish).toHaveAttribute('aria-selected', 'true')
-    expectPanelShows(
-      publish,
+    expect(publish).toHaveAttribute('aria-expanded', 'true')
+    expectStepContentVisible(
       'Use the rich editor to publish your work. Tips go directly to your wallet with near-zero fees.'
     )
   })

--- a/components/landing/HowItWorksSection.test.tsx
+++ b/components/landing/HowItWorksSection.test.tsx
@@ -32,10 +32,6 @@ vi.mock('next/link', () => ({
   ),
 }))
 
-vi.mock('@/components/landing/LandingTippingDemo', () => ({
-  LandingTippingDemo: () => <div data-testid="landing-tipping-demo" />,
-}))
-
 describe('HowItWorksSection step controls', () => {
   function stepsRegion() {
     return screen.getByLabelText('How it works steps')

--- a/components/landing/HowItWorksSection.test.tsx
+++ b/components/landing/HowItWorksSection.test.tsx
@@ -78,7 +78,7 @@ describe('HowItWorksSection step controls', () => {
     expect(tip).toHaveAttribute('aria-expanded', 'true')
     expect(stepTrigger('Browse')).toHaveAttribute('aria-expanded', 'false')
     expectStepContentVisible(
-      "Install Freighter, fund with free testnet XLM, and send tips that settle in about 3 seconds."
+      'Install Freighter, fund with free testnet XLM, and send tips that settle in about 3 seconds.'
     )
   })
 

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -2,23 +2,12 @@
 
 import Link from 'next/link'
 import { useState, useRef, type KeyboardEvent } from 'react'
-import {
-  UserPlus,
-  Edit3,
-  Globe,
-  Coins,
-  ArrowRight,
-  Sparkles,
-  BookOpen,
-  Highlighter,
-  Wallet,
-  Heart,
-} from 'lucide-react'
+import { BookOpen, Wallet, Coins, ArrowRight } from 'lucide-react'
 import { motion, AnimatePresence, useInView } from 'motion/react'
 import { LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useIsMobile } from '@/hooks/use-mobile'
-import { REGISTER_FOR_WRITE_HREF } from '@/lib/auth/auth-links'
+import { LandingTippingDemo } from '@/components/landing/LandingTippingDemo'
 
 type StepVariant = 'desktop' | 'mobile'
 
@@ -29,20 +18,12 @@ interface Step {
   detail: string
 }
 
-function stepTabId(
-  tab: 'writers' | 'readers',
-  index: number,
-  variant: StepVariant
-) {
-  return `how-it-works-${tab}-${variant}-tab-${index}`
+function stepTabId(index: number, variant: StepVariant) {
+  return `how-it-works-${variant}-tab-${index}`
 }
 
-function stepPanelId(
-  tab: 'writers' | 'readers',
-  index: number,
-  variant: StepVariant
-) {
-  return `how-it-works-${tab}-${variant}-panel-${index}`
+function stepPanelId(index: number, variant: StepVariant) {
+  return `how-it-works-${variant}-panel-${index}`
 }
 
 const stepTabFocusClass =
@@ -51,85 +32,35 @@ const stepTabFocusClass =
 const stepCardBaseClass =
   'relative rounded-2xl border overflow-hidden transition-colors duration-300 text-left w-full p-0 bg-transparent'
 
+const steps: Step[] = [
+  {
+    icon: BookOpen,
+    title: 'Browse',
+    description: 'Discover articles from writers across the platform',
+    detail:
+      'All articles are free to read. Explore by topic, trending, or latest. No paywalls, ever.',
+  },
+  {
+    icon: Wallet,
+    title: 'Tip',
+    description: 'Connect a Stellar wallet and tip your favorite passages',
+    detail:
+      "Install Freighter, fund with free testnet XLM, and send tips that settle in about 3 seconds.",
+  },
+  {
+    icon: Coins,
+    title: 'Publish & earn',
+    description: 'Write, publish, and keep 97.5% of every tip',
+    detail:
+      'Use the rich editor to publish your work. Tips go directly to your wallet with near-zero fees.',
+  },
+]
+
 export default function HowItWorksSection() {
   const ref = useRef(null)
   const isInView = useInView(ref, { once: true, margin: '-100px' })
   const isMobile = useIsMobile()
-  const [activeTab, setActiveTab] = useState<'writers' | 'readers'>('writers')
   const [activeStep, setActiveStep] = useState(0)
-
-  const writerSteps: Step[] = [
-    {
-      icon: UserPlus,
-      title: 'Sign Up',
-      description:
-        'Create your account and connect your Stellar wallet in seconds',
-      detail:
-        'One-click registration with your email. Connect Freighter wallet to start receiving tips instantly.',
-    },
-    {
-      icon: Edit3,
-      title: 'Write',
-      description:
-        'Craft compelling content with our intuitive rich text editor',
-      detail:
-        'Full markdown support, code blocks, media embeds, and a distraction-free writing experience.',
-    },
-    {
-      icon: Globe,
-      title: 'Publish',
-      description: 'Share your work with the world on the blockchain',
-      detail:
-        'Your article is stored permanently on Arweave. A tamper-proof record of your creative work, forever.',
-    },
-    {
-      icon: Coins,
-      title: 'Earn',
-      description: 'Receive instant tips from readers who value your work',
-      detail:
-        'Tips settle in 3 seconds via Stellar. You keep 97.5% of every tip — no waiting periods.',
-    },
-  ]
-
-  const readerSteps: Step[] = [
-    {
-      icon: BookOpen,
-      title: 'Browse',
-      description: 'Discover articles from writers across the platform',
-      detail:
-        'All articles are free to read. Explore by topic, trending, or latest. No paywalls, ever.',
-    },
-    {
-      icon: Highlighter,
-      title: 'Highlight',
-      description: 'Select your favorite passages and save them',
-      detail:
-        'Mark the words that resonate with you. Add colors and notes to build your personal collection.',
-    },
-    {
-      icon: Wallet,
-      title: 'Connect',
-      description: 'Set up a Stellar wallet in 2 minutes',
-      detail:
-        "Install Freighter, fund with free testnet XLM, and you're ready to tip your favorite writers.",
-    },
-    {
-      icon: Heart,
-      title: 'Tip',
-      description: 'Send micro-tips starting at $0.01',
-      detail:
-        'Tip an article or a specific highlight. 97.5% goes directly to the author — near-zero fees.',
-    },
-  ]
-
-  const steps = activeTab === 'writers' ? writerSteps : readerSteps
-  const stepsTablistLabel =
-    activeTab === 'writers' ? 'Writer steps' : 'Reader steps'
-
-  const handleTabChange = (tab: 'writers' | 'readers') => {
-    setActiveTab(tab)
-    setActiveStep(0)
-  }
 
   const handleStepTabKeyDown = (
     e: KeyboardEvent<HTMLButtonElement>,
@@ -148,7 +79,7 @@ export default function HowItWorksSection() {
     const next = (index + delta + steps.length) % steps.length
     setActiveStep(next)
     const variant: StepVariant = isMobile ? 'mobile' : 'desktop'
-    document.getElementById(stepTabId(activeTab, next, variant))?.focus()
+    document.getElementById(stepTabId(next, variant))?.focus()
   }
 
   return (
@@ -156,93 +87,27 @@ export default function HowItWorksSection() {
       id="how-it-works"
       className="py-32 px-6 bg-spotlight text-spotlight-foreground relative overflow-hidden"
     >
-      {/* Subtle background grain */}
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,_color-mix(in_oklab,var(--spotlight-foreground)_6%,transparent)_0%,_transparent_60%)]" />
 
       <div className="container mx-auto max-w-7xl relative z-10" ref={ref}>
-        {/* Section Header */}
         <motion.div
           className="mb-16"
           initial={{ opacity: 0, y: 30 }}
           animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 30 }}
           transition={{ duration: 0.8 }}
         >
-          <div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-8">
-            <div>
-              <motion.div
-                className="inline-flex items-center gap-2 px-4 py-2 bg-foreground/5 backdrop-blur-sm rounded-full border border-foreground/10 mb-6"
-                initial={{ opacity: 0, scale: 0.9 }}
-                animate={
-                  isInView
-                    ? { opacity: 1, scale: 1 }
-                    : { opacity: 0, scale: 0.9 }
-                }
-                transition={{ duration: 0.5 }}
-              >
-                <Sparkles className="w-3.5 h-3.5 text-spotlight-muted" />
-                <span className="text-[11px] font-semibold text-spotlight-muted uppercase tracking-wider">
-                  Simple Process
-                </span>
-              </motion.div>
-
-              <h2 className="font-display text-4xl lg:text-5xl font-medium tracking-[-0.01em] mb-4 leading-[1.15]">
-                <span className="text-spotlight-foreground">
-                  From idea to impact,{' '}
-                </span>
-                <span className="text-spotlight-muted italic">
-                  in four steps.
-                </span>
-              </h2>
-              <p className="text-[15px] text-spotlight-muted max-w-lg leading-relaxed">
-                Whether you write or read, Quilltip makes it simple to
-                participate in the future of publishing.
-              </p>
-            </div>
-
-            {/* Writer / Reader Toggle */}
-            <div
-              role="tablist"
-              aria-label="Audience"
-              className="inline-flex items-center bg-foreground/5 rounded-lg p-1 border border-foreground/10 shrink-0"
-            >
-              <button
-                type="button"
-                role="tab"
-                aria-selected={activeTab === 'writers'}
-                onClick={() => handleTabChange('writers')}
-                className={cn(
-                  'px-5 py-2 rounded-md text-[13px] font-medium transition-all duration-200',
-                  stepTabFocusClass,
-                  activeTab === 'writers'
-                    ? 'bg-card text-card-foreground shadow-sm'
-                    : 'text-spotlight-muted hover:text-spotlight-foreground'
-                )}
-              >
-                For Writers
-              </button>
-              <button
-                type="button"
-                role="tab"
-                aria-selected={activeTab === 'readers'}
-                onClick={() => handleTabChange('readers')}
-                className={cn(
-                  'px-5 py-2 rounded-md text-[13px] font-medium transition-all duration-200',
-                  stepTabFocusClass,
-                  activeTab === 'readers'
-                    ? 'bg-card text-card-foreground shadow-sm'
-                    : 'text-spotlight-muted hover:text-spotlight-foreground'
-                )}
-              >
-                For Readers
-              </button>
-            </div>
-          </div>
+          <h2 className="font-display text-4xl lg:text-5xl font-medium tracking-[-0.01em] mb-4 leading-[1.15] text-spotlight-foreground">
+            How tipping works
+          </h2>
+          <p className="text-[15px] text-spotlight-muted max-w-lg leading-relaxed">
+            Read for free, tip what moves you, or publish and earn — all on
+            Stellar testnet.
+          </p>
         </motion.div>
 
-        {/* Expandable Steps — Desktop */}
         <motion.div
           role="tablist"
-          aria-label={stepsTablistLabel}
+          aria-label="How it works steps"
           aria-orientation="horizontal"
           aria-hidden={isMobile}
           inert={isMobile ? true : undefined}
@@ -253,11 +118,11 @@ export default function HowItWorksSection() {
         >
           {steps.map((step, index) => {
             const isActive = activeStep === index
-            const tabId = stepTabId(activeTab, index, 'desktop')
-            const panelId = stepPanelId(activeTab, index, 'desktop')
+            const tabId = stepTabId(index, 'desktop')
+            const panelId = stepPanelId(index, 'desktop')
             return (
               <motion.div
-                key={`${activeTab}-${step.title}`}
+                key={step.title}
                 className={cn(
                   stepCardBaseClass,
                   'flex flex-col min-h-0',
@@ -378,10 +243,9 @@ export default function HowItWorksSection() {
           })}
         </motion.div>
 
-        {/* Steps — Mobile (vertical accordion) */}
         <motion.div
           role="tablist"
-          aria-label={stepsTablistLabel}
+          aria-label="How it works steps"
           aria-orientation="vertical"
           aria-hidden={!isMobile}
           inert={!isMobile ? true : undefined}
@@ -392,11 +256,11 @@ export default function HowItWorksSection() {
         >
           {steps.map((step, index) => {
             const isActive = activeStep === index
-            const tabId = stepTabId(activeTab, index, 'mobile')
-            const panelId = stepPanelId(activeTab, index, 'mobile')
+            const tabId = stepTabId(index, 'mobile')
+            const panelId = stepPanelId(index, 'mobile')
             return (
               <motion.div
-                key={`${activeTab}-${step.title}`}
+                key={step.title}
                 className={cn(
                   stepCardBaseClass,
                   isActive
@@ -480,7 +344,15 @@ export default function HowItWorksSection() {
           })}
         </motion.div>
 
-        {/* CTA */}
+        <motion.div
+          className="mt-12 flex justify-center"
+          initial={{ opacity: 0, y: 20 }}
+          animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
+          transition={{ duration: 0.6, delay: 0.5 }}
+        >
+          <LandingTippingDemo />
+        </motion.div>
+
         <motion.div
           className="mt-16 text-center"
           initial={{ opacity: 0, y: 20 }}
@@ -488,7 +360,7 @@ export default function HowItWorksSection() {
           transition={{ duration: 0.8, delay: 0.8 }}
         >
           <Link
-            href={REGISTER_FOR_WRITE_HREF}
+            href="/register"
             className="focus-ring group inline-flex items-center justify-center gap-2 bg-card text-card-foreground px-6 py-2.5 rounded-lg text-[13px] font-medium hover:bg-muted transition-all duration-200"
           >
             Start Writing & Earning Today

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -75,6 +75,7 @@ export default function HowItWorksSection() {
         </motion.div>
 
         <motion.div
+          role="group"
           aria-label="How it works steps"
           className="max-w-3xl"
           initial={{ opacity: 0, y: 20 }}

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -6,7 +6,6 @@ import { BookOpen, Wallet, Coins, ArrowRight, ChevronDown } from 'lucide-react'
 import { motion, useInView } from 'motion/react'
 import { LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { LandingTippingDemo } from '@/components/landing/LandingTippingDemo'
 import {
   Accordion,
   AccordionContent,
@@ -82,75 +81,66 @@ export default function HowItWorksSection() {
           animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
           transition={{ duration: 0.6, delay: 0.3 }}
         >
-          <Accordion
-            type="single"
-            collapsible
-            defaultValue="how-it-works-0"
-            className="space-y-3"
-          >
-            {steps.map((step, index) => (
-              <AccordionItem
-                key={step.title}
-                value={`how-it-works-${index}`}
-                className={cn(
-                  'border-none rounded-2xl border transition-colors duration-200 overflow-hidden',
-                  'border-foreground/[0.06] bg-foreground/[0.02]',
-                  'data-[state=open]:border-foreground/15 data-[state=open]:bg-foreground/[0.04]'
-                )}
+              <Accordion
+                type="single"
+                collapsible
+                defaultValue="how-it-works-0"
+                className="space-y-3"
               >
-                <div>
-                  <AccordionTrigger
-                    showChevron={false}
+                {steps.map((step, index) => (
+                  <AccordionItem
+                    key={step.title}
+                    value={`how-it-works-${index}`}
                     className={cn(
-                      'group w-full flex items-center gap-4 px-5 py-4 hover:no-underline',
-                      stepTriggerFocusClass
+                      'border-none rounded-2xl border transition-colors duration-200 overflow-hidden',
+                      'border-foreground/[0.06] bg-foreground/[0.02]',
+                      'data-[state=open]:border-foreground/15 data-[state=open]:bg-foreground/[0.04]'
                     )}
                   >
-                    <div
-                      className={cn(
-                        'w-9 h-9 rounded-full flex items-center justify-center flex-shrink-0',
-                        'bg-foreground/5 border border-foreground/[0.06]',
-                        'group-data-[state=open]:bg-foreground/10 group-data-[state=open]:border-foreground/10'
-                      )}
-                      aria-hidden="true"
-                    >
-                      <ChevronDown className="w-4 h-4 text-spotlight-muted transition-transform duration-200 group-data-[state=open]:rotate-180" />
-                    </div>
+                    <div>
+                      <AccordionTrigger
+                        showChevron={false}
+                        className={cn(
+                          'group w-full flex items-center gap-4 px-5 py-4 hover:no-underline',
+                          stepTriggerFocusClass
+                        )}
+                      >
+                        <div
+                          className={cn(
+                            'w-9 h-9 rounded-full flex items-center justify-center flex-shrink-0',
+                            'bg-foreground/5 border border-foreground/[0.06]',
+                            'group-data-[state=open]:bg-foreground/10 group-data-[state=open]:border-foreground/10'
+                          )}
+                          aria-hidden="true"
+                        >
+                          <ChevronDown className="w-4 h-4 text-spotlight-muted transition-transform duration-200 group-data-[state=open]:rotate-180" />
+                        </div>
 
-                    <div className="flex items-center gap-3 min-w-0 flex-1">
-                      <step.icon
-                        className="w-4.5 h-4.5 text-spotlight-muted flex-shrink-0"
-                        aria-hidden="true"
-                      />
-                      <span className="font-display text-lg md:text-xl font-medium tracking-tight text-spotlight-foreground truncate">
-                        {step.title}
-                      </span>
-                    </div>
-                  </AccordionTrigger>
+                        <div className="flex items-center gap-3 min-w-0 flex-1">
+                          <step.icon
+                            className="w-4.5 h-4.5 text-spotlight-muted flex-shrink-0"
+                            aria-hidden="true"
+                          />
+                          <span className="font-display text-lg md:text-xl font-medium tracking-tight text-spotlight-foreground truncate">
+                            {step.title}
+                          </span>
+                        </div>
+                      </AccordionTrigger>
 
-                  <AccordionContent className="px-5 pb-5 pt-0">
-                    <ul className="list-disc pl-5 space-y-2">
-                      <li className="text-[14px] text-spotlight-foreground/85 leading-relaxed">
-                        {step.description}
-                      </li>
-                      <li className="text-[13px] text-spotlight-muted leading-relaxed">
-                        {step.detail}
-                      </li>
-                    </ul>
-                  </AccordionContent>
-                </div>
-              </AccordionItem>
-            ))}
+                      <AccordionContent className="px-5 pb-5 pt-0">
+                        <ul className="list-disc pl-5 space-y-2">
+                          <li className="text-[14px] text-spotlight-foreground/85 leading-relaxed">
+                            {step.description}
+                          </li>
+                          <li className="text-[13px] text-spotlight-muted leading-relaxed">
+                            {step.detail}
+                          </li>
+                        </ul>
+                      </AccordionContent>
+                    </div>
+                  </AccordionItem>
+                ))}
           </Accordion>
-        </motion.div>
-
-        <motion.div
-          className="mt-12 flex justify-center"
-          initial={{ opacity: 0, y: 20 }}
-          animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
-          transition={{ duration: 0.6, delay: 0.5 }}
-        >
-          <LandingTippingDemo />
         </motion.div>
 
         <motion.div

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -81,65 +81,65 @@ export default function HowItWorksSection() {
           animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
           transition={{ duration: 0.6, delay: 0.3 }}
         >
-              <Accordion
-                type="single"
-                collapsible
-                defaultValue="how-it-works-0"
-                className="space-y-3"
+          <Accordion
+            type="single"
+            collapsible
+            defaultValue="how-it-works-0"
+            className="space-y-3"
+          >
+            {steps.map((step, index) => (
+              <AccordionItem
+                key={step.title}
+                value={`how-it-works-${index}`}
+                className={cn(
+                  'border-none rounded-2xl border transition-colors duration-200 overflow-hidden',
+                  'border-foreground/[0.06] bg-foreground/[0.02]',
+                  'data-[state=open]:border-foreground/15 data-[state=open]:bg-foreground/[0.04]'
+                )}
               >
-                {steps.map((step, index) => (
-                  <AccordionItem
-                    key={step.title}
-                    value={`how-it-works-${index}`}
+                <div>
+                  <AccordionTrigger
+                    showChevron={false}
                     className={cn(
-                      'border-none rounded-2xl border transition-colors duration-200 overflow-hidden',
-                      'border-foreground/[0.06] bg-foreground/[0.02]',
-                      'data-[state=open]:border-foreground/15 data-[state=open]:bg-foreground/[0.04]'
+                      'group w-full flex items-center gap-4 px-5 py-4 hover:no-underline',
+                      stepTriggerFocusClass
                     )}
                   >
-                    <div>
-                      <AccordionTrigger
-                        showChevron={false}
-                        className={cn(
-                          'group w-full flex items-center gap-4 px-5 py-4 hover:no-underline',
-                          stepTriggerFocusClass
-                        )}
-                      >
-                        <div
-                          className={cn(
-                            'w-9 h-9 rounded-full flex items-center justify-center flex-shrink-0',
-                            'bg-foreground/5 border border-foreground/[0.06]',
-                            'group-data-[state=open]:bg-foreground/10 group-data-[state=open]:border-foreground/10'
-                          )}
-                          aria-hidden="true"
-                        >
-                          <ChevronDown className="w-4 h-4 text-spotlight-muted transition-transform duration-200 group-data-[state=open]:rotate-180" />
-                        </div>
-
-                        <div className="flex items-center gap-3 min-w-0 flex-1">
-                          <step.icon
-                            className="w-4.5 h-4.5 text-spotlight-muted flex-shrink-0"
-                            aria-hidden="true"
-                          />
-                          <span className="font-display text-lg md:text-xl font-medium tracking-tight text-spotlight-foreground truncate">
-                            {step.title}
-                          </span>
-                        </div>
-                      </AccordionTrigger>
-
-                      <AccordionContent className="px-5 pb-5 pt-0">
-                        <ul className="list-disc pl-5 space-y-2">
-                          <li className="text-[14px] text-spotlight-foreground/85 leading-relaxed">
-                            {step.description}
-                          </li>
-                          <li className="text-[13px] text-spotlight-muted leading-relaxed">
-                            {step.detail}
-                          </li>
-                        </ul>
-                      </AccordionContent>
+                    <div
+                      className={cn(
+                        'w-9 h-9 rounded-full flex items-center justify-center flex-shrink-0',
+                        'bg-foreground/5 border border-foreground/[0.06]',
+                        'group-data-[state=open]:bg-foreground/10 group-data-[state=open]:border-foreground/10'
+                      )}
+                      aria-hidden="true"
+                    >
+                      <ChevronDown className="w-4 h-4 text-spotlight-muted transition-transform duration-200 group-data-[state=open]:rotate-180" />
                     </div>
-                  </AccordionItem>
-                ))}
+
+                    <div className="flex items-center gap-3 min-w-0 flex-1">
+                      <step.icon
+                        className="w-4.5 h-4.5 text-spotlight-muted flex-shrink-0"
+                        aria-hidden="true"
+                      />
+                      <span className="font-display text-lg md:text-xl font-medium tracking-tight text-spotlight-foreground truncate">
+                        {step.title}
+                      </span>
+                    </div>
+                  </AccordionTrigger>
+
+                  <AccordionContent className="px-5 pb-5 pt-0">
+                    <ul className="list-disc pl-5 space-y-2">
+                      <li className="text-[14px] text-spotlight-foreground/85 leading-relaxed">
+                        {step.description}
+                      </li>
+                      <li className="text-[13px] text-spotlight-muted leading-relaxed">
+                        {step.detail}
+                      </li>
+                    </ul>
+                  </AccordionContent>
+                </div>
+              </AccordionItem>
+            ))}
           </Accordion>
         </motion.div>
 

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -37,7 +37,7 @@ const steps: Step[] = [
     title: 'Tip',
     description: 'Connect a Stellar wallet and tip your favorite passages',
     detail:
-      "Install Freighter, fund with free testnet XLM, and send tips that settle in about 3 seconds.",
+      'Install Freighter, fund with free testnet XLM, and send tips that settle in about 3 seconds.',
   },
   {
     icon: Coins,

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -1,15 +1,18 @@
 'use client'
 
 import Link from 'next/link'
-import { useState, useRef, type KeyboardEvent } from 'react'
-import { BookOpen, Wallet, Coins, ArrowRight } from 'lucide-react'
-import { motion, AnimatePresence, useInView } from 'motion/react'
+import { useRef } from 'react'
+import { BookOpen, Wallet, Coins, ArrowRight, ChevronDown } from 'lucide-react'
+import { motion, useInView } from 'motion/react'
 import { LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { useIsMobile } from '@/hooks/use-mobile'
 import { LandingTippingDemo } from '@/components/landing/LandingTippingDemo'
-
-type StepVariant = 'desktop' | 'mobile'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion'
 
 interface Step {
   icon: LucideIcon
@@ -18,19 +21,8 @@ interface Step {
   detail: string
 }
 
-function stepTabId(index: number, variant: StepVariant) {
-  return `how-it-works-${variant}-tab-${index}`
-}
-
-function stepPanelId(index: number, variant: StepVariant) {
-  return `how-it-works-${variant}-panel-${index}`
-}
-
-const stepTabFocusClass =
+const stepTriggerFocusClass =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-spotlight'
-
-const stepCardBaseClass =
-  'relative rounded-2xl border overflow-hidden transition-colors duration-300 text-left w-full p-0 bg-transparent'
 
 const steps: Step[] = [
   {
@@ -59,39 +51,17 @@ const steps: Step[] = [
 export default function HowItWorksSection() {
   const ref = useRef(null)
   const isInView = useInView(ref, { once: true, margin: '-100px' })
-  const isMobile = useIsMobile()
-  const [activeStep, setActiveStep] = useState(0)
-
-  const handleStepTabKeyDown = (
-    e: KeyboardEvent<HTMLButtonElement>,
-    index: number
-  ) => {
-    if (
-      e.key !== 'ArrowRight' &&
-      e.key !== 'ArrowDown' &&
-      e.key !== 'ArrowLeft' &&
-      e.key !== 'ArrowUp'
-    ) {
-      return
-    }
-    e.preventDefault()
-    const delta = e.key === 'ArrowRight' || e.key === 'ArrowDown' ? 1 : -1
-    const next = (index + delta + steps.length) % steps.length
-    setActiveStep(next)
-    const variant: StepVariant = isMobile ? 'mobile' : 'desktop'
-    document.getElementById(stepTabId(next, variant))?.focus()
-  }
 
   return (
     <section
       id="how-it-works"
-      className="py-32 px-6 bg-spotlight text-spotlight-foreground relative overflow-hidden"
+      className="py-16 px-6 bg-spotlight text-spotlight-foreground relative overflow-hidden"
     >
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,_color-mix(in_oklab,var(--spotlight-foreground)_6%,transparent)_0%,_transparent_60%)]" />
 
       <div className="container mx-auto max-w-7xl relative z-10" ref={ref}>
         <motion.div
-          className="mb-16"
+          className="mb-8"
           initial={{ opacity: 0, y: 30 }}
           animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 30 }}
           transition={{ duration: 0.8 }}
@@ -106,242 +76,72 @@ export default function HowItWorksSection() {
         </motion.div>
 
         <motion.div
-          role="tablist"
           aria-label="How it works steps"
-          aria-orientation="horizontal"
-          aria-hidden={isMobile}
-          inert={isMobile ? true : undefined}
-          className="hidden md:flex gap-2 h-[340px]"
+          className="max-w-3xl"
           initial={{ opacity: 0, y: 20 }}
           animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
           transition={{ duration: 0.6, delay: 0.3 }}
         >
-          {steps.map((step, index) => {
-            const isActive = activeStep === index
-            const tabId = stepTabId(index, 'desktop')
-            const panelId = stepPanelId(index, 'desktop')
-            return (
-              <motion.div
+          <Accordion
+            type="single"
+            collapsible
+            defaultValue="how-it-works-0"
+            className="space-y-3"
+          >
+            {steps.map((step, index) => (
+              <AccordionItem
                 key={step.title}
+                value={`how-it-works-${index}`}
                 className={cn(
-                  stepCardBaseClass,
-                  'flex flex-col min-h-0',
-                  isActive
-                    ? 'border-foreground/15 bg-foreground/[0.04]'
-                    : 'border-foreground/[0.06] bg-foreground/[0.02]'
-                )}
-                animate={{ flex: isActive ? 3 : 1 }}
-                transition={{ duration: 0.5, ease: [0.4, 0, 0.2, 1] }}
-              >
-                <motion.button
-                  type="button"
-                  role="tab"
-                  id={tabId}
-                  aria-selected={isActive}
-                  aria-controls={panelId}
-                  tabIndex={isActive ? 0 : -1}
-                  onClick={() => setActiveStep(index)}
-                  onMouseEnter={() => setActiveStep(index)}
-                  onKeyDown={(e) => handleStepTabKeyDown(e, index)}
-                  className={cn(
-                    'block h-full w-full cursor-pointer',
-                    stepTabFocusClass,
-                    !isActive &&
-                      'hover:bg-foreground/[0.03] hover:border-foreground/10'
-                  )}
-                >
-                  <AnimatePresence mode="wait">
-                    {!isActive ? (
-                      <motion.div
-                        key="collapsed"
-                        className="h-full flex flex-col items-center justify-center gap-4 px-4"
-                        initial={{ opacity: 0 }}
-                        animate={{ opacity: 1 }}
-                        exit={{ opacity: 0 }}
-                        transition={{ duration: 0.2 }}
-                      >
-                        <div className="w-12 h-12 rounded-full border border-foreground/10 flex items-center justify-center">
-                          <step.icon className="w-5 h-5 text-spotlight-muted" />
-                        </div>
-                        <span className="text-[15px] font-medium text-spotlight-muted [writing-mode:vertical-lr] tracking-wide">
-                          {step.title}
-                        </span>
-                      </motion.div>
-                    ) : (
-                      <motion.div
-                        key="expanded-header"
-                        className="p-8 pb-0"
-                        initial={{ opacity: 0 }}
-                        animate={{ opacity: 1 }}
-                        exit={{ opacity: 0 }}
-                        transition={{ duration: 0.3, delay: 0.15 }}
-                      >
-                        <div className="flex items-center gap-4 mb-6">
-                          <div className="w-14 h-14 rounded-2xl bg-foreground/10 border border-foreground/10 flex items-center justify-center">
-                            <step.icon className="w-6 h-6 text-spotlight-foreground" />
-                          </div>
-                          <h3 className="text-3xl font-display font-medium text-spotlight-foreground tracking-tight">
-                            {step.title}
-                          </h3>
-                        </div>
-                      </motion.div>
-                    )}
-                  </AnimatePresence>
-                </motion.button>
-
-                <div
-                  role="tabpanel"
-                  id={panelId}
-                  aria-labelledby={tabId}
-                  hidden={!isActive}
-                  className={cn(
-                    'flex flex-col justify-between flex-1',
-                    isActive ? 'flex' : 'hidden'
-                  )}
-                >
-                  <AnimatePresence mode="wait">
-                    {isActive && (
-                      <motion.div
-                        key="expanded-panel"
-                        className="flex flex-col justify-between flex-1 px-8 pb-8"
-                        initial={{ opacity: 0 }}
-                        animate={{ opacity: 1 }}
-                        exit={{ opacity: 0 }}
-                        transition={{ duration: 0.3, delay: 0.15 }}
-                      >
-                        <div>
-                          <p className="text-[15px] text-spotlight-foreground/85 leading-relaxed mb-3 max-w-md">
-                            {step.description}
-                          </p>
-                          <p className="text-[13px] text-spotlight-muted leading-relaxed max-w-md">
-                            {step.detail}
-                          </p>
-                        </div>
-
-                        <div
-                          className="flex items-center gap-2"
-                          aria-hidden="true"
-                        >
-                          {steps.map((_, i) => (
-                            <div
-                              key={i}
-                              className={cn(
-                                'h-1 rounded-full transition-all duration-300',
-                                i === index
-                                  ? 'w-8 bg-spotlight-foreground'
-                                  : 'w-2 bg-spotlight-foreground/20'
-                              )}
-                            />
-                          ))}
-                        </div>
-                      </motion.div>
-                    )}
-                  </AnimatePresence>
-                </div>
-              </motion.div>
-            )
-          })}
-        </motion.div>
-
-        <motion.div
-          role="tablist"
-          aria-label="How it works steps"
-          aria-orientation="vertical"
-          aria-hidden={!isMobile}
-          inert={!isMobile ? true : undefined}
-          className="md:hidden space-y-2"
-          initial={{ opacity: 0, y: 20 }}
-          animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
-          transition={{ duration: 0.6, delay: 0.3 }}
-        >
-          {steps.map((step, index) => {
-            const isActive = activeStep === index
-            const tabId = stepTabId(index, 'mobile')
-            const panelId = stepPanelId(index, 'mobile')
-            return (
-              <motion.div
-                key={step.title}
-                className={cn(
-                  stepCardBaseClass,
-                  isActive
-                    ? 'border-foreground/15 bg-foreground/[0.04]'
-                    : 'border-foreground/[0.06] bg-foreground/[0.02]'
+                  'border-none rounded-2xl border transition-colors duration-200 overflow-hidden',
+                  'border-foreground/[0.06] bg-foreground/[0.02]',
+                  'data-[state=open]:border-foreground/15 data-[state=open]:bg-foreground/[0.04]'
                 )}
               >
-                <motion.button
-                  type="button"
-                  role="tab"
-                  id={tabId}
-                  aria-selected={isActive}
-                  aria-controls={panelId}
-                  tabIndex={isActive ? 0 : -1}
-                  onClick={() => setActiveStep(index)}
-                  onKeyDown={(e) => handleStepTabKeyDown(e, index)}
-                  className={cn(
-                    'block w-full cursor-pointer',
-                    stepTabFocusClass
-                  )}
-                >
-                  <div className="flex items-center gap-4 p-5">
+                <div>
+                  <AccordionTrigger
+                    showChevron={false}
+                    className={cn(
+                      'group w-full flex items-center gap-4 px-5 py-4 hover:no-underline',
+                      stepTriggerFocusClass
+                    )}
+                  >
                     <div
                       className={cn(
-                        'w-11 h-11 rounded-xl flex items-center justify-center transition-colors duration-300',
-                        isActive
-                          ? 'bg-foreground/10 border border-foreground/10'
-                          : 'bg-foreground/5 border border-foreground/[0.06]'
+                        'w-9 h-9 rounded-full flex items-center justify-center flex-shrink-0',
+                        'bg-foreground/5 border border-foreground/[0.06]',
+                        'group-data-[state=open]:bg-foreground/10 group-data-[state=open]:border-foreground/10'
                       )}
+                      aria-hidden="true"
                     >
-                      <step.icon
-                        className={cn(
-                          'w-5 h-5 transition-colors duration-300',
-                          isActive
-                            ? 'text-spotlight-foreground'
-                            : 'text-spotlight-muted'
-                        )}
-                      />
+                      <ChevronDown className="w-4 h-4 text-spotlight-muted transition-transform duration-200 group-data-[state=open]:rotate-180" />
                     </div>
-                    <span
-                      className={cn(
-                        'text-[15px] font-medium transition-colors duration-300',
-                        isActive
-                          ? 'text-spotlight-foreground'
-                          : 'text-spotlight-muted'
-                      )}
-                    >
-                      {step.title}
-                    </span>
-                  </div>
-                </motion.button>
 
-                <div
-                  role="tabpanel"
-                  id={panelId}
-                  aria-labelledby={tabId}
-                  hidden={!isActive}
-                >
-                  <AnimatePresence>
-                    {isActive && (
-                      <motion.div
-                        initial={{ height: 0, opacity: 0 }}
-                        animate={{ height: 'auto', opacity: 1 }}
-                        exit={{ height: 0, opacity: 0 }}
-                        transition={{ duration: 0.3, ease: 'easeOut' }}
-                      >
-                        <div className="px-5 pb-5 pl-20">
-                          <p className="text-[14px] text-spotlight-foreground/85 leading-relaxed mb-2">
-                            {step.description}
-                          </p>
-                          <p className="text-[12px] text-spotlight-muted leading-relaxed">
-                            {step.detail}
-                          </p>
-                        </div>
-                      </motion.div>
-                    )}
-                  </AnimatePresence>
+                    <div className="flex items-center gap-3 min-w-0 flex-1">
+                      <step.icon
+                        className="w-4.5 h-4.5 text-spotlight-muted flex-shrink-0"
+                        aria-hidden="true"
+                      />
+                      <span className="font-display text-lg md:text-xl font-medium tracking-tight text-spotlight-foreground truncate">
+                        {step.title}
+                      </span>
+                    </div>
+                  </AccordionTrigger>
+
+                  <AccordionContent className="px-5 pb-5 pt-0">
+                    <ul className="list-disc pl-5 space-y-2">
+                      <li className="text-[14px] text-spotlight-foreground/85 leading-relaxed">
+                        {step.description}
+                      </li>
+                      <li className="text-[13px] text-spotlight-muted leading-relaxed">
+                        {step.detail}
+                      </li>
+                    </ul>
+                  </AccordionContent>
                 </div>
-              </motion.div>
-            )
-          })}
+              </AccordionItem>
+            ))}
+          </Accordion>
         </motion.div>
 
         <motion.div

--- a/components/landing/LandingTippingDemo.tsx
+++ b/components/landing/LandingTippingDemo.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import { Zap } from 'lucide-react'
+import { motion, AnimatePresence } from 'motion/react'
+import { useEffect, useState, useCallback, useRef } from 'react'
+
+const ARTICLE_TEXT = `Writers pour their hearts into stories that shape how we think — yet most see nothing in return. The quiet revolution of open knowledge deserves better. What if readers could reward the exact words that moved them?`
+
+interface HighlightPhrase {
+  text: string
+  tip: string
+}
+
+const HIGHLIGHT_PHRASES: HighlightPhrase[] = [
+  { text: 'Writers pour their hearts', tip: '+0.25 XLM' },
+  { text: 'stories that shape how we think', tip: '+0.50 XLM' },
+  { text: 'the quiet revolution of open knowledge', tip: '+0.75 XLM' },
+  { text: 'reward the exact words that moved them', tip: '+1.00 XLM' },
+]
+
+type AnimationStep = 'idle' | 'selecting' | 'highlighted' | 'tipped'
+
+type Segment =
+  | { type: 'text'; content: string }
+  | { type: 'phrase'; content: string; phraseIndex: number }
+
+function buildSegments(text: string, phrases: HighlightPhrase[]): Segment[] {
+  const ranges: { start: number; end: number; index: number }[] = []
+  phrases.forEach((p, i) => {
+    const start = text.indexOf(p.text)
+    if (start === -1) return
+    ranges.push({ start, end: start + p.text.length, index: i })
+  })
+  ranges.sort((a, b) => a.start - b.start)
+
+  const segments: Segment[] = []
+  let cursor = 0
+  for (const r of ranges) {
+    if (r.start > cursor) {
+      segments.push({ type: 'text', content: text.slice(cursor, r.start) })
+    }
+    segments.push({
+      type: 'phrase',
+      content: text.slice(r.start, r.end),
+      phraseIndex: r.index,
+    })
+    cursor = r.end
+  }
+  if (cursor < text.length) {
+    segments.push({ type: 'text', content: text.slice(cursor) })
+  }
+  return segments
+}
+
+const SEGMENTS = buildSegments(ARTICLE_TEXT, HIGHLIGHT_PHRASES)
+
+export function LandingTippingDemo() {
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [animationStep, setAnimationStep] = useState<AnimationStep>('idle')
+  const timeoutRefs = useRef<ReturnType<typeof setTimeout>[]>([])
+
+  const clearAllTimeouts = useCallback(() => {
+    timeoutRefs.current.forEach(clearTimeout)
+    timeoutRefs.current = []
+  }, [])
+
+  const addTimeout = useCallback((fn: () => void, delay: number) => {
+    const id = setTimeout(fn, delay)
+    timeoutRefs.current.push(id)
+    return id
+  }, [])
+
+  useEffect(() => {
+    clearAllTimeouts()
+    setAnimationStep('idle')
+
+    addTimeout(() => setAnimationStep('selecting'), 80)
+    addTimeout(() => setAnimationStep('highlighted'), 440)
+    addTimeout(() => setAnimationStep('tipped'), 620)
+    addTimeout(() => {
+      setAnimationStep('idle')
+      addTimeout(() => {
+        setActiveIndex((prev) => (prev + 1) % HIGHLIGHT_PHRASES.length)
+      }, 80)
+    }, 1350)
+
+    return clearAllTimeouts
+  }, [activeIndex, clearAllTimeouts, addTimeout])
+
+  const renderArticleText = () => (
+    <>
+      {SEGMENTS.map((seg, i) => {
+        if (seg.type === 'text') {
+          return <span key={i}>{seg.content}</span>
+        }
+
+        const { phraseIndex } = seg
+        const isActive = phraseIndex === activeIndex
+        const isSelecting = isActive && animationStep === 'selecting'
+        const isHighlighted =
+          isActive &&
+          (animationStep === 'highlighted' || animationStep === 'tipped')
+        const showTip = isActive && animationStep === 'tipped'
+
+        return (
+          <span key={i} className="relative inline">
+            {isSelecting && (
+              <motion.span
+                className="absolute inset-y-0 left-0 bg-info/25 rounded-[2px]"
+                initial={{ width: '0%' }}
+                animate={{ width: '100%' }}
+                transition={{ duration: 0.35, ease: 'easeOut' }}
+                style={{ zIndex: 0 }}
+              />
+            )}
+            {isHighlighted && (
+              <motion.span
+                className="absolute -inset-y-0.5 -left-0.5 -right-0.5 rounded-[3px] bg-warning/30"
+                initial={{ opacity: 0, scale: 0.98 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ duration: 0.2, ease: 'easeOut' }}
+                style={{ zIndex: 0 }}
+              />
+            )}
+            <span
+              className={`relative z-10 ${isHighlighted ? 'text-foreground' : ''}`}
+            >
+              {seg.content}
+            </span>
+
+            <AnimatePresence>
+              {showTip && (
+                <motion.span
+                  key="tip"
+                  className="absolute -top-9 left-1/2 -translate-x-1/2 inline-flex items-center gap-1.5 bg-popover text-popover-foreground border border-border text-[11px] font-semibold px-3 py-1.5 rounded-full shadow-xl whitespace-nowrap"
+                  initial={{ opacity: 0, y: 6, scale: 0.9 }}
+                  animate={{ opacity: 1, y: 0, scale: 1 }}
+                  exit={{ opacity: 0, y: -4, scale: 0.9 }}
+                  transition={{ duration: 0.18, ease: 'easeOut' }}
+                >
+                  <Zap className="w-3 h-3 text-warning-foreground" />
+                  {HIGHLIGHT_PHRASES[phraseIndex]?.tip}
+                </motion.span>
+              )}
+            </AnimatePresence>
+          </span>
+        )
+      })}
+    </>
+  )
+
+  return (
+    <div className="hidden w-full max-w-2xl md:block">
+      <div className="relative bg-card rounded-xl border border-border shadow-[var(--card-shadow)] overflow-hidden">
+        <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border bg-muted/60">
+          <div className="flex gap-1.5">
+            <div className="w-2 h-2 bg-border rounded-full" />
+            <div className="w-2 h-2 bg-border rounded-full" />
+            <div className="w-2 h-2 bg-border rounded-full" />
+          </div>
+          <div className="flex-1 flex justify-center">
+            <div className="flex items-center gap-1.5 px-3 py-0.5 bg-card rounded-md border border-border">
+              <span className="text-[10px] text-muted-foreground font-medium">
+                quilltip.app/article/on-open-knowledge
+              </span>
+            </div>
+          </div>
+          <div className="w-10" />
+        </div>
+
+        <div className="px-7 sm:px-10 py-7 sm:py-8">
+          <p className="text-[14px] sm:text-[15px] leading-[1.8] text-muted-foreground text-left">
+            {renderArticleText()}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/landing/LandingTippingDemo.tsx
+++ b/components/landing/LandingTippingDemo.tsx
@@ -150,7 +150,7 @@ export function LandingTippingDemo() {
   )
 
   return (
-    <div className="hidden w-full max-w-2xl md:block">
+    <div className="w-full max-w-2xl">
       <div className="relative bg-card rounded-xl border border-border shadow-[var(--card-shadow)] overflow-hidden">
         <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border bg-muted/60">
           <div className="flex gap-1.5">

--- a/components/landing/Navigation.test.tsx
+++ b/components/landing/Navigation.test.tsx
@@ -75,10 +75,9 @@ describe('Navigation launch IA', () => {
   it('shows Start Writing as the primary nav action', () => {
     render(<Navigation />)
 
-    expect(screen.getByRole('link', { name: NAV_START_WRITING })).toHaveAttribute(
-      'href',
-      '/register'
-    )
+    expect(
+      screen.getByRole('link', { name: NAV_START_WRITING })
+    ).toHaveAttribute('href', '/register')
   })
 
   it('limits Product dropdown items to read, write, and tipping', async () => {
@@ -86,11 +85,21 @@ describe('Navigation launch IA', () => {
     render(<Navigation />)
 
     await user.click(screen.getByRole('button', { name: 'Toggle menu' }))
-    expect(screen.getByRole('link', { name: 'Interactive Reading' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Rich Editor' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'How tipping works' })).toBeInTheDocument()
-    expect(screen.queryByRole('link', { name: 'NFT Minting' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('link', { name: 'Permanent Storage' })).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Interactive Reading' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Rich Editor' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'How tipping works' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: 'NFT Minting' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: 'Permanent Storage' })
+    ).not.toBeInTheDocument()
   })
 
   it('limits Resources dropdown to wallet guide and FAQ', async () => {
@@ -99,9 +108,15 @@ describe('Navigation launch IA', () => {
 
     await user.click(screen.getByRole('button', { name: 'Toggle menu' }))
 
-    expect(screen.getByRole('link', { name: 'Wallet Guide' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Wallet Guide' })
+    ).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'FAQ' })).toBeInTheDocument()
-    expect(screen.queryByRole('link', { name: 'Security' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('link', { name: 'Arweave Storage' })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: 'Security' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: 'Arweave Storage' })
+    ).not.toBeInTheDocument()
   })
 })

--- a/components/landing/Navigation.test.tsx
+++ b/components/landing/Navigation.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import Navigation from '@/components/landing/Navigation'
+import { NAV_START_WRITING } from '@/lib/copy/nav-cta'
 
 vi.mock('next/link', () => ({
   default: (props: { href: string; children: ReactNode }) => (
@@ -67,5 +68,40 @@ describe('Navigation mobile menu', () => {
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
     expect(trigger).toHaveFocus()
+  })
+})
+
+describe('Navigation launch IA', () => {
+  it('shows Start Writing as the primary nav action', () => {
+    render(<Navigation />)
+
+    expect(screen.getByRole('link', { name: NAV_START_WRITING })).toHaveAttribute(
+      'href',
+      '/register'
+    )
+  })
+
+  it('limits Product dropdown items to read, write, and tipping', async () => {
+    const user = userEvent.setup()
+    render(<Navigation />)
+
+    await user.click(screen.getByRole('button', { name: 'Toggle menu' }))
+    expect(screen.getByRole('link', { name: 'Interactive Reading' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Rich Editor' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'How tipping works' })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'NFT Minting' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Permanent Storage' })).not.toBeInTheDocument()
+  })
+
+  it('limits Resources dropdown to wallet guide and FAQ', async () => {
+    const user = userEvent.setup()
+    render(<Navigation />)
+
+    await user.click(screen.getByRole('button', { name: 'Toggle menu' }))
+
+    expect(screen.getByRole('link', { name: 'Wallet Guide' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'FAQ' })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Security' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Arweave Storage' })).not.toBeInTheDocument()
   })
 })

--- a/components/landing/Navigation.tsx
+++ b/components/landing/Navigation.tsx
@@ -10,12 +10,8 @@ import {
   Highlighter,
   HelpCircle,
   FileText,
-  Shield,
   ChevronDown,
   BookOpen,
-  Coins,
-  Globe,
-  Sparkles,
 } from 'lucide-react'
 import { motion, AnimatePresence } from 'motion/react'
 import { LucideIcon } from 'lucide-react'
@@ -31,7 +27,7 @@ import {
   handleLandingHashClick,
   scrollToLandingSection,
 } from '@/lib/landing/scroll-to-section'
-import { NAV_SIGN_IN, NAV_TRY_ON_TESTNET } from '@/lib/copy/nav-cta'
+import { NAV_SIGN_IN, NAV_START_WRITING } from '@/lib/copy/nav-cta'
 
 const MOBILE_MENU_CLOSE_MS = 280
 
@@ -67,55 +63,31 @@ const navDropdowns: NavDropdown[] = [
     label: 'Product',
     featured: {
       title: 'Quilltip Platform',
-      description:
-        'Write, publish, and receive testnet tips — all on Stellar testnet.',
+      description: 'Read stories for free, tip writers, or publish your own.',
       href: '#features',
       bgClass: 'bg-gradient-to-br from-muted/70 to-muted',
       icon: PenTool,
     },
     columns: [
       {
-        heading: 'Features',
+        heading: 'Read & write',
         items: [
+          {
+            icon: Highlighter,
+            title: 'Interactive Reading',
+            description: 'Browse articles and tip passages',
+            href: '/articles',
+          },
           {
             icon: PenTool,
             title: 'Rich Editor',
-            description: 'Write with markdown & media',
-            href: '#features',
+            description: 'Publish with markdown and media',
+            href: '/register',
           },
-          {
-            icon: Highlighter,
-            title: 'Highlights',
-            description: 'Readers tip specific passages',
-            href: '#features',
-          },
-          {
-            icon: Sparkles,
-            title: 'NFT Minting',
-            description: 'Mint articles as collectibles',
-            href: '#features',
-          },
-        ],
-      },
-      {
-        heading: 'Earn',
-        items: [
           {
             icon: Zap,
-            title: 'Testnet Tips',
-            description: 'Receive tips via Stellar testnet',
-            href: '#how-it-works',
-          },
-          {
-            icon: Coins,
-            title: 'Low Fees',
-            description: '97.5% goes directly to you',
-            href: '#how-it-works',
-          },
-          {
-            icon: Globe,
-            title: 'Permanent Storage',
-            description: 'Articles stored on Arweave',
+            title: 'How tipping works',
+            description: 'Three steps to read, tip, and earn',
             href: '#how-it-works',
           },
         ],
@@ -126,8 +98,7 @@ const navDropdowns: NavDropdown[] = [
     label: 'Resources',
     featured: {
       title: 'Getting Started',
-      description:
-        'Set up a testnet wallet and practice tipping in under 5 minutes.',
+      description: 'Set up a testnet wallet and practice tipping.',
       href: '/guide',
       bgClass: 'bg-gradient-to-br from-muted/60 to-muted',
       icon: BookOpen,
@@ -147,23 +118,6 @@ const navDropdowns: NavDropdown[] = [
             title: 'FAQ',
             description: 'Common questions answered',
             href: '#faq',
-          },
-        ],
-      },
-      {
-        heading: 'Trust & Safety',
-        items: [
-          {
-            icon: Shield,
-            title: 'Security',
-            description: 'Blockchain security overview',
-            href: '#security',
-          },
-          {
-            icon: Globe,
-            title: 'Arweave Storage',
-            description: 'How permanent storage works',
-            href: '#arweave-storage',
           },
         ],
       },
@@ -400,7 +354,7 @@ export default function Navigation() {
               href="/register"
               className="focus-ring inline-flex items-center gap-1.5 bg-brand text-brand-foreground px-4 py-1.5 rounded-lg text-[13px] font-medium hover:bg-brand-hover transition-all duration-200 ml-1"
             >
-              {NAV_TRY_ON_TESTNET}
+              {NAV_START_WRITING}
               <ArrowRight className="w-3.5 h-3.5 shrink-0 text-brand-foreground/80" />
             </Link>
 
@@ -477,7 +431,7 @@ export default function Navigation() {
                     className="focus-ring inline-flex w-full items-center justify-center gap-1.5 bg-brand text-brand-foreground px-5 py-2.5 rounded-lg hover:bg-brand-hover transition-colors text-sm font-medium"
                     onClick={() => setIsOpen(false)}
                   >
-                    {NAV_TRY_ON_TESTNET}
+                    {NAV_START_WRITING}
                     <ArrowRight className="w-3.5 h-3.5 shrink-0 text-brand-foreground/80" />
                   </Link>
                 </div>

--- a/components/landing/TrustSection.tsx
+++ b/components/landing/TrustSection.tsx
@@ -1,34 +1,15 @@
 'use client'
 
-import { Shield, Globe } from 'lucide-react'
+import { Shield } from 'lucide-react'
 import { Reveal } from '@/components/landing/Reveal'
 import { LandingHashLink } from '@/components/landing/LandingHashLink'
+import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
 
-const trustTopics = [
-  {
-    id: 'security',
-    icon: Shield,
-    title: 'Security on testnet',
-    description:
-      'Quilltip never holds your funds. Tips move wallet-to-wallet on Stellar testnet through audited Soroban contracts. You approve every transaction in your own wallet app before it is sent.',
-    bullets: [
-      'Practice with free testnet XLM only — no real money at risk',
-      'Wallet apps like Freighter sign transactions locally on your device',
-      'Platform fees are enforced on-chain, not by manual transfers',
-    ],
-  },
-  {
-    id: 'arweave-storage',
-    icon: Globe,
-    title: 'Permanent storage with Arweave',
-    description:
-      'Published articles are stored on Arweave, a decentralized network designed for permanent data. Your writing survives independently of Quilltip servers.',
-    bullets: [
-      'One-time upload — no recurring hosting bills for writers',
-      'Readers access content through Quilltip while copies persist on Arweave',
-      'Optional NFT minting adds an on-chain ownership record on Stellar',
-    ],
-  },
+const trustBullets = [
+  'Tips move wallet-to-wallet on Stellar testnet through audited Soroban contracts',
+  'Wallet apps like Freighter sign transactions locally on your device',
+  'Writers keep 97.5% of every tip — fees enforced on-chain',
+  'Published articles are stored on Arweave for long-term availability',
 ] as const
 
 export default function TrustSection() {
@@ -39,48 +20,76 @@ export default function TrustSection() {
           Trust and permanence
         </h2>
         <p className="text-[15px] text-muted-foreground leading-relaxed mb-12 max-w-2xl">
-          How Quilltip protects writers and readers on testnet, and how your
-          articles stay available long term.
+          How Quilltip protects writers and readers on testnet.
         </p>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-          {trustTopics.map((topic, index) => (
-            <Reveal key={topic.id} delay={index * 0.08}>
-              <article
-                id={topic.id}
-                className="scroll-mt-24 h-full rounded-2xl border border-border bg-card p-8 shadow-sm"
-              >
-                <div className="w-11 h-11 rounded-xl bg-muted flex items-center justify-center mb-5">
-                  <topic.icon className="w-5 h-5 text-foreground" />
-                </div>
-                <h3 className="text-xl font-semibold text-foreground mb-3">
-                  <LandingHashLink
-                    href={`#${topic.id}`}
-                    className="focus-ring rounded-sm hover:underline underline-offset-2"
-                  >
-                    {topic.title}
-                  </LandingHashLink>
-                </h3>
-                <p className="text-[14px] text-muted-foreground leading-relaxed mb-5">
-                  {topic.description}
-                </p>
-                <ul className="space-y-2">
-                  {topic.bullets.map((bullet) => (
-                    <li
-                      key={bullet}
-                      className="text-[13px] text-muted-foreground leading-relaxed flex gap-2"
-                    >
-                      <span className="text-brand mt-1.5 shrink-0" aria-hidden>
-                        •
-                      </span>
-                      <span>{bullet}</span>
-                    </li>
-                  ))}
-                </ul>
-              </article>
-            </Reveal>
-          ))}
+        <div className="flex items-center justify-center gap-8 sm:gap-12 mb-12">
+          <div className="text-center">
+            <p className="text-lg sm:text-xl font-semibold text-foreground tabular-nums">
+              97.5%
+            </p>
+            <p className="text-[10px] text-muted-foreground font-medium uppercase tracking-widest mt-0.5">
+              To Authors
+            </p>
+          </div>
+          <div className="w-px h-6 bg-border" />
+          <div className="text-center">
+            <p className="text-lg sm:text-xl font-semibold text-foreground tabular-nums">
+              3s
+            </p>
+            <p className="text-[10px] text-muted-foreground font-medium uppercase tracking-widest mt-0.5">
+              Settlement
+            </p>
+          </div>
+          <div className="w-px h-6 bg-border" />
+          <div className="text-center">
+            <p className="text-lg sm:text-xl font-semibold text-foreground tabular-nums">
+              $0.01
+            </p>
+            <p className="text-[10px] text-muted-foreground font-medium uppercase tracking-widest mt-0.5">
+              Min Tip
+            </p>
+          </div>
         </div>
+
+        <Reveal>
+          <article
+            id="security"
+            className="scroll-mt-24 mx-auto rounded-2xl border border-border bg-card p-8 shadow-sm max-w-3xl"
+          >
+            <div className="w-11 h-11 rounded-xl bg-muted flex items-center justify-center mb-5">
+              <Shield className="w-5 h-5 text-foreground" />
+            </div>
+            <h3 className="text-xl font-semibold text-foreground mb-3">
+              <LandingHashLink
+                href="#security"
+                className="focus-ring rounded-sm hover:underline underline-offset-2"
+              >
+                Security on testnet
+              </LandingHashLink>
+            </h3>
+            <p className="text-[14px] text-muted-foreground leading-relaxed mb-5">
+              Quilltip never holds your funds. You approve every transaction in
+              your own wallet app before it is sent.
+            </p>
+            <ul className="space-y-2 mb-5">
+              {trustBullets.map((bullet) => (
+                <li
+                  key={bullet}
+                  className="text-[13px] text-muted-foreground leading-relaxed flex gap-2"
+                >
+                  <span className="text-brand mt-1.5 shrink-0" aria-hidden>
+                    •
+                  </span>
+                  <span>{bullet}</span>
+                </li>
+              ))}
+            </ul>
+            <p className="text-[13px] text-muted-foreground leading-relaxed">
+              {TESTNET_PRACTICE_NOTE}
+            </p>
+          </article>
+        </Reveal>
       </div>
     </section>
   )

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -34,8 +34,10 @@ const AccordionTrigger = React.forwardRef<
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        'flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline text-left',
-        showChevron && '[&[data-state=open]>svg]:rotate-180',
+        'flex flex-1 items-center py-4 text-sm font-medium transition-all hover:underline text-left',
+        showChevron
+          ? 'justify-between [&[data-state=open]>svg]:rotate-180'
+          : 'justify-start',
         className
       )}
       {...props}

--- a/e2e/home-visual.spec.ts
+++ b/e2e/home-visual.spec.ts
@@ -167,7 +167,7 @@ test.describe('landing how it works', () => {
     await expect(tip).toHaveAttribute('aria-expanded', 'true')
     await expect(
       page.getByText(
-        "Install Freighter, fund with free testnet XLM, and send tips that settle in about 3 seconds."
+        'Install Freighter, fund with free testnet XLM, and send tips that settle in about 3 seconds.'
       )
     ).toBeVisible()
   })

--- a/e2e/home-visual.spec.ts
+++ b/e2e/home-visual.spec.ts
@@ -155,16 +155,16 @@ test.describe('landing how it works', () => {
     ).toBeVisible()
   })
 
-  test('desktop step cards update selection and panel content', async ({
+  test('desktop accordion steps update selection and panel content', async ({
     page,
   }) => {
     await page.setViewportSize({ width: 1280, height: 900 })
 
-    const steps = page.getByRole('tablist', { name: 'How it works steps' })
-    const tip = steps.getByRole('tab', { name: 'Tip' })
+    const steps = page.getByLabel('How it works steps')
+    const tip = steps.getByRole('button', { name: 'Tip' })
     await tip.click()
 
-    await expect(tip).toHaveAttribute('aria-selected', 'true')
+    await expect(tip).toHaveAttribute('aria-expanded', 'true')
     await expect(
       page.getByText(
         "Install Freighter, fund with free testnet XLM, and send tips that settle in about 3 seconds."
@@ -172,31 +172,29 @@ test.describe('landing how it works', () => {
     ).toBeVisible()
   })
 
-  test('desktop step cards respond to ArrowRight keyboard navigation', async ({
+  test('desktop accordion steps toggle with Enter keyboard interaction', async ({
     page,
   }) => {
     await page.setViewportSize({ width: 1280, height: 900 })
 
-    const steps = page.getByRole('tablist', { name: 'How it works steps' })
-    const browse = steps.getByRole('tab', { name: 'Browse' })
+    const steps = page.getByLabel('How it works steps')
+    const browse = steps.getByRole('button', { name: 'Browse' })
     await browse.focus()
-    await page.keyboard.press('ArrowRight')
+    await page.keyboard.press('Enter')
 
-    const tip = steps.getByRole('tab', { name: 'Tip' })
-    await expect(tip).toBeFocused()
-    await expect(tip).toHaveAttribute('aria-selected', 'true')
+    await expect(browse).toHaveAttribute('aria-expanded', 'false')
   })
 
-  test('mobile step cards update selection and panel content', async ({
+  test('mobile accordion steps update selection and panel content', async ({
     page,
   }) => {
     await page.setViewportSize({ width: 390, height: 844 })
 
-    const steps = page.getByRole('tablist', { name: 'How it works steps' })
-    const publish = steps.getByRole('tab', { name: 'Publish & earn' })
+    const steps = page.getByLabel('How it works steps')
+    const publish = steps.getByRole('button', { name: 'Publish & earn' })
     await publish.click()
 
-    await expect(publish).toHaveAttribute('aria-selected', 'true')
+    await expect(publish).toHaveAttribute('aria-expanded', 'true')
     await expect(
       page.getByText(
         'Use the rich editor to publish your work. Tips go directly to your wallet with near-zero fees.'

--- a/e2e/home-visual.spec.ts
+++ b/e2e/home-visual.spec.ts
@@ -33,12 +33,12 @@ test.describe('home landing visual regression', () => {
   test('full page screenshot', async ({ page }) => {
     await scrollSectionIntoView(page, '#features')
     await expect(
-      page.getByRole('heading', { name: 'Core Features' })
+      page.getByRole('heading', { name: 'Why Quilltip' })
     ).toBeVisible()
 
     await scrollSectionIntoView(page, '#how-it-works')
     await expect(
-      page.getByRole('heading', { name: /From idea to impact/ })
+      page.getByRole('heading', { name: 'How tipping works' })
     ).toBeVisible()
 
     await scrollSectionIntoView(page, '#security')
@@ -80,12 +80,12 @@ test.describe('landing nav hash navigation', () => {
     await assertRevealContentVisible(page, '#features')
 
     await page.getByRole('button', { name: 'Resources' }).click()
-    await page.getByRole('link', { name: 'Security' }).click()
+    await page.getByRole('link', { name: 'FAQ' }).click()
     await page.waitForTimeout(900)
     await expect(
-      page.getByRole('heading', { name: 'Security on testnet' })
+      page.getByRole('heading', { name: 'Frequently Asked Questions' })
     ).toBeVisible()
-    await assertRevealContentVisible(page, '#security')
+    await assertRevealContentVisible(page, '#faq')
   })
 
   test('mobile menu links reveal section content', async ({ page }) => {
@@ -100,13 +100,13 @@ test.describe('landing nav hash navigation', () => {
       {
         linkName: 'Rich Editor',
         hash: '#features',
-        heading: 'Core Features',
+        heading: 'Why Quilltip',
         section: '#features',
       },
       {
-        linkName: 'Testnet Tips',
+        linkName: 'How tipping works',
         hash: '#how-it-works',
-        heading: /From idea to impact/,
+        heading: 'How tipping works',
         section: '#how-it-works',
       },
       {
@@ -114,18 +114,6 @@ test.describe('landing nav hash navigation', () => {
         hash: '#faq',
         heading: 'Frequently Asked Questions',
         section: '#faq',
-      },
-      {
-        linkName: 'Security',
-        hash: '#security',
-        heading: 'Security on testnet',
-        section: '#security',
-      },
-      {
-        linkName: 'Arweave Storage',
-        hash: '#arweave-storage',
-        heading: 'Permanent storage with Arweave',
-        section: '#arweave-storage',
       },
     ]
 
@@ -153,7 +141,7 @@ test.describe('landing nav hash navigation', () => {
     await expect(page).toHaveURL(/#features$/)
     await page.waitForTimeout(900)
     await expect(
-      page.getByRole('heading', { name: 'Core Features' })
+      page.getByRole('heading', { name: 'Why Quilltip' })
     ).toBeVisible()
     await assertRevealContentVisible(page, '#features')
   })
@@ -163,7 +151,7 @@ test.describe('landing how it works', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/#how-it-works')
     await expect(
-      page.getByRole('heading', { name: /From idea to impact/ })
+      page.getByRole('heading', { name: 'How tipping works' })
     ).toBeVisible()
   })
 
@@ -172,24 +160,14 @@ test.describe('landing how it works', () => {
   }) => {
     await page.setViewportSize({ width: 1280, height: 900 })
 
-    const writerSteps = page.getByRole('tablist', { name: 'Writer steps' })
-    const write = writerSteps.getByRole('tab', { name: 'Write' })
-    await write.click()
+    const steps = page.getByRole('tablist', { name: 'How it works steps' })
+    const tip = steps.getByRole('tab', { name: 'Tip' })
+    await tip.click()
 
-    await expect(write).toHaveAttribute('aria-selected', 'true')
+    await expect(tip).toHaveAttribute('aria-selected', 'true')
     await expect(
       page.getByText(
-        'Full markdown support, code blocks, media embeds, and a distraction-free writing experience.'
-      )
-    ).toBeVisible()
-
-    await page.getByRole('tab', { name: 'For Readers' }).click()
-    const readerSteps = page.getByRole('tablist', { name: 'Reader steps' })
-    const browse = readerSteps.getByRole('tab', { name: 'Browse' })
-    await expect(browse).toHaveAttribute('aria-selected', 'true')
-    await expect(
-      page.getByText(
-        'All articles are free to read. Explore by topic, trending, or latest. No paywalls, ever.'
+        "Install Freighter, fund with free testnet XLM, and send tips that settle in about 3 seconds."
       )
     ).toBeVisible()
   })
@@ -199,14 +177,14 @@ test.describe('landing how it works', () => {
   }) => {
     await page.setViewportSize({ width: 1280, height: 900 })
 
-    const writerSteps = page.getByRole('tablist', { name: 'Writer steps' })
-    const signUp = writerSteps.getByRole('tab', { name: 'Sign Up' })
-    await signUp.focus()
+    const steps = page.getByRole('tablist', { name: 'How it works steps' })
+    const browse = steps.getByRole('tab', { name: 'Browse' })
+    await browse.focus()
     await page.keyboard.press('ArrowRight')
 
-    const write = writerSteps.getByRole('tab', { name: 'Write' })
-    await expect(write).toBeFocused()
-    await expect(write).toHaveAttribute('aria-selected', 'true')
+    const tip = steps.getByRole('tab', { name: 'Tip' })
+    await expect(tip).toBeFocused()
+    await expect(tip).toHaveAttribute('aria-selected', 'true')
   })
 
   test('mobile step cards update selection and panel content', async ({
@@ -214,14 +192,14 @@ test.describe('landing how it works', () => {
   }) => {
     await page.setViewportSize({ width: 390, height: 844 })
 
-    const writerSteps = page.getByRole('tablist', { name: 'Writer steps' })
-    const publish = writerSteps.getByRole('tab', { name: 'Publish' })
+    const steps = page.getByRole('tablist', { name: 'How it works steps' })
+    const publish = steps.getByRole('tab', { name: 'Publish & earn' })
     await publish.click()
 
     await expect(publish).toHaveAttribute('aria-selected', 'true')
     await expect(
       page.getByText(
-        'Your article is stored permanently on Arweave. A tamper-proof record of your creative work, forever.'
+        'Use the rich editor to publish your work. Tips go directly to your wallet with near-zero fees.'
       )
     ).toBeVisible()
   })

--- a/lib/copy/landing-hero.test.ts
+++ b/lib/copy/landing-hero.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import {
+  LANDING_HERO_HEADLINE,
+  LANDING_HERO_SUBTITLE,
+} from '@/lib/copy/landing-hero'
+
+describe('landing hero copy', () => {
+  it('locks approved headline and subtitle strings', () => {
+    expect(LANDING_HERO_HEADLINE).toBe('Reward the words that move you')
+    expect(LANDING_HERO_SUBTITLE).toBe(
+      'Read published stories for free. Tip the passages that move you.'
+    )
+  })
+})

--- a/lib/copy/landing-hero.ts
+++ b/lib/copy/landing-hero.ts
@@ -1,0 +1,3 @@
+export const LANDING_HERO_HEADLINE = 'Reward the words that move you'
+export const LANDING_HERO_SUBTITLE =
+  'Read published stories for free. Tip the passages that move you.'

--- a/lib/copy/nav-cta.test.ts
+++ b/lib/copy/nav-cta.test.ts
@@ -4,6 +4,7 @@ import {
   HERO_START_WRITING,
   HERO_WALLET_SETUP,
   NAV_SIGN_IN,
+  NAV_START_WRITING,
   NAV_TRY_ON_TESTNET,
 } from '@/lib/copy/nav-cta'
 
@@ -11,6 +12,7 @@ describe('nav-cta vocabulary', () => {
   it('exports the approved navigation labels', () => {
     expect(NAV_SIGN_IN).toBe('Sign In')
     expect(NAV_TRY_ON_TESTNET).toBe('Try on Testnet')
+    expect(NAV_START_WRITING).toBe('Start Writing')
   })
 
   it('exports the approved landing hero labels', () => {

--- a/lib/copy/nav-cta.ts
+++ b/lib/copy/nav-cta.ts
@@ -10,5 +10,6 @@ export const NAV_TRY_ON_TESTNET = 'Try on Testnet'
 export const NAV_START_WRITING = 'Start Writing'
 
 export const HERO_START_READING = 'Start Reading'
+// Intentionally mirrors NAV_START_WRITING today; keep separate so hero copy can diverge by route.
 export const HERO_START_WRITING = 'Start Writing'
 export const HERO_WALLET_SETUP = 'Testnet wallet setup'

--- a/lib/copy/nav-cta.ts
+++ b/lib/copy/nav-cta.ts
@@ -7,6 +7,7 @@
 
 export const NAV_SIGN_IN = 'Sign In'
 export const NAV_TRY_ON_TESTNET = 'Try on Testnet'
+export const NAV_START_WRITING = 'Start Writing'
 
 export const HERO_START_READING = 'Start Reading'
 export const HERO_START_WRITING = 'Start Writing'

--- a/lib/landing/features.ts
+++ b/lib/landing/features.ts
@@ -2,15 +2,9 @@ import {
   Edit3,
   DollarSign,
   Shield,
-  Zap,
   MessageSquare,
-  TrendingUp,
-  Globe,
-  Sparkles,
   type LucideIcon,
 } from 'lucide-react'
-import { MIN_WITHDRAWAL_USD } from '@/lib/constants'
-import { REGISTER_FOR_WRITE_HREF } from '@/lib/auth/auth-links'
 
 export interface LandingFeature {
   icon: LucideIcon
@@ -21,10 +15,10 @@ export interface LandingFeature {
 
 export const LANDING_FEATURES: LandingFeature[] = [
   {
-    icon: Edit3,
-    title: 'Rich Editor',
-    description: 'Code blocks, media embeds, and full markdown support.',
-    href: REGISTER_FOR_WRITE_HREF,
+    icon: MessageSquare,
+    title: 'Interactive Reading',
+    description: 'Highlight passages and tip the words that move you.',
+    href: '/articles',
   },
   {
     icon: DollarSign,
@@ -34,40 +28,15 @@ export const LANDING_FEATURES: LandingFeature[] = [
     href: '#how-it-works',
   },
   {
-    icon: MessageSquare,
-    title: 'Interactive Reading',
-    description: 'Highlight passages and tip the words that move you.',
-    href: '/articles',
+    icon: Edit3,
+    title: 'Rich Editor',
+    description: 'Code blocks, media embeds, and full markdown support.',
+    href: '/register',
   },
   {
     icon: Shield,
     title: '100% Ownership',
     description: 'Your content, your rules. No platform lock-in.',
     href: '#security',
-  },
-  {
-    icon: TrendingUp,
-    title: 'Testnet Analytics',
-    description:
-      'Track testnet tip activity and audience growth as it happens.',
-    href: '/register',
-  },
-  {
-    icon: Zap,
-    title: 'Withdraw Testnet Earnings',
-    description: `Move testnet earnings to your wallet once your balance reaches $${MIN_WITHDRAWAL_USD.toFixed(0)}.`,
-    href: '#how-it-works',
-  },
-  {
-    icon: Globe,
-    title: 'Permanent Storage',
-    description: 'Articles stored forever on Arweave.',
-    href: '#arweave-storage',
-  },
-  {
-    icon: Sparkles,
-    title: 'NFT Minting',
-    description: 'Mint top articles as collectible NFTs.',
-    href: '#features',
   },
 ]

--- a/lib/landing/nav-targets.ts
+++ b/lib/landing/nav-targets.ts
@@ -2,7 +2,6 @@ export const LANDING_SECTION_IDS = [
   'features',
   'how-it-works',
   'security',
-  'arweave-storage',
   'faq',
 ] as const
 
@@ -13,5 +12,4 @@ export const LANDING_NAV_HASHES = [
   '#how-it-works',
   '#faq',
   '#security',
-  '#arweave-storage',
 ] as const

--- a/lib/landing/scroll-to-section.test.ts
+++ b/lib/landing/scroll-to-section.test.ts
@@ -9,8 +9,7 @@ describe('landing nav targets', () => {
     }
   })
 
-  it('includes security and arweave storage anchors', () => {
+  it('includes security anchor', () => {
     expect(LANDING_SECTION_IDS).toContain('security')
-    expect(LANDING_SECTION_IDS).toContain('arweave-storage')
   })
 })


### PR DESCRIPTION
## Summary

Simplifies the Quilltip landing page so first-time visitors get a clearer, shorter path to reading, tipping, and writing. Removes redundant hero animation and long FAQ copy, replaces the complex How It Works layout with an accordion, and tightens navigation and trust sections.

## Changes

- Simplify `HeroSection`: drop animated article demo, metrics strip, and wallet-setup link; keep headline, subtitle, primary/secondary CTAs, and product proof
- Refactor `HowItWorksSection` from tabbed desktop/mobile layout to a single accordion with three steps (Browse, Tip, Publish & earn)
- Add `LandingTippingDemo` to show tipping inline below How It Works
- Trim `FAQSection` from 8 questions to 4 launch-critical ones and keep FAQ columns left-aligned
- Update `FeaturesSection` and `lib/landing/features.ts` to lead with Interactive Reading and clearer testnet messaging
- Simplify `Navigation` launch IA (Product and Resources dropdowns) and streamline `TrustSection`
- Extract hero copy to `lib/copy/landing-hero.ts`
- Update unit tests, navigation tests, and `e2e/home-visual.spec.ts` for the new layout

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run format`
- [x] `bun run test:once` (697 tests passed)
- [x] `bun run build`

## Notes

- Net reduction of ~400 lines across landing components; behavior and launch CTAs are preserved
- Hero and How It Works use `/register` for the write CTA (unchanged from branch intent)
- Visual regression baselines in `e2e/home-visual.spec.ts` updated for the simplified layout

https://github.com/user-attachments/assets/c60b0d3e-6f65-437f-96ba-e0d2e3afb680

<img width="1438" height="860" alt="fin" src="https://github.com/user-attachments/assets/5b17000e-e227-4fc7-9c55-f07c71b66a2c" />
