### PR TITLE
feat: two-stage tip modal flow for article and highlight tips (ENG-256)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -677,3 +677,10 @@
     animation: var(--animate-accordion-up);
   }
 }
+
+/* Stellar Wallets Kit modal must sit above Radix dialog overlays (z-50). */
+stellar-wallets-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+}

--- a/components/highlights/HighlightTipButton.test.tsx
+++ b/components/highlights/HighlightTipButton.test.tsx
@@ -1,6 +1,7 @@
 /** @vitest-environment jsdom */
 import { act, render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const writePendingHighlightSelection = vi.fn()
 vi.mock('@/lib/highlight/pendingHighlightSelection', () => ({
@@ -22,14 +23,17 @@ vi.mock('@/lib/tip/signInToTip', async () => {
 const mockAuth = vi.hoisted(() => ({
   isAuthenticated: false,
 }))
+const mockIsConnected = vi.hoisted(() => vi.fn(() => false))
+
 vi.mock('@/components/providers/AuthContext', () => ({
   useAuth: () => ({ isAuthenticated: mockAuth.isAuthenticated }),
 }))
 
 vi.mock('@/components/providers/WalletProvider', () => ({
   useWallet: () => ({
-    isConnected: false,
-    publicKey: null,
+    isConnected: mockIsConnected(),
+    isLoading: false,
+    publicKey: mockIsConnected() ? 'GABCDEF123456789' : null,
     signTransaction: vi.fn(),
     connect: vi.fn(),
   }),
@@ -85,38 +89,79 @@ vi.mock('@/components/guide/WalletTooltip', () => ({
 
 import { HighlightTipButton } from '@/components/highlights/HighlightTipButton'
 
-describe('HighlightTipButton', () => {
-  it('shows contextual wallet setup when signed in without wallet', () => {
-    mockAuth.isAuthenticated = true
+async function openHighlightTipAndContinue(
+  user: ReturnType<typeof userEvent.setup>,
+  presetLabel = '$1'
+) {
+  await user.click(screen.getByRole('button', { name: 'Tip Highlight' }))
+  await user.click(screen.getByRole('button', { name: presetLabel }))
+  await user.click(screen.getByRole('button', { name: 'Continue' }))
+}
+
+describe('HighlightTipButton two-stage flow', () => {
+  beforeEach(() => {
+    mockAuth.isAuthenticated = false
+    mockIsConnected.mockReturnValue(false)
+    writePendingHighlightSelection.mockClear()
+    signInToTip.mockClear()
+    clearPendingTipIntent.mockClear()
+    readPendingTipIntent.mockReturnValue(null)
+  })
+
+  it('shows Continue on stage 1 without sign-in CTA', async () => {
+    const user = userEvent.setup({ delay: null })
     render(
       <HighlightTipButton
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        articleId={'articles:123' as any}
+        articleId={'articles:123' as never}
         articleSlug="my-article"
         authorName="Author"
         authorStellarAddress="GABC"
         highlightText="Some highlighted text"
         startOffset={10}
         endOffset={20}
-        resumeOpen
       />
     )
 
-    expect(screen.getByText('Connect to tip Author')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Tip Highlight' }))
+
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument()
     expect(
-      screen.getAllByRole('button', { name: /Connect wallet/i }).length
-    ).toBeGreaterThanOrEqual(1)
-    expect(
-      screen.queryByRole('link', { name: /Follow our setup guide/i })
+      screen.queryByRole('button', { name: 'Sign in to tip' })
     ).not.toBeInTheDocument()
   })
 
-  it('persists pending highlight selection before Sign in to tip', () => {
+  it('persists pending highlight selection before Sign in to tip on stage 2', async () => {
+    mockAuth.isAuthenticated = false
+    const user = userEvent.setup({ delay: null })
+    render(
+      <HighlightTipButton
+        articleId={'articles:123' as never}
+        articleSlug="my-article"
+        authorName="Author"
+        authorStellarAddress="GABC"
+        highlightText="Some highlighted text"
+        startOffset={10}
+        endOffset={20}
+      />
+    )
+
+    await openHighlightTipAndContinue(user)
+    await user.click(screen.getByRole('button', { name: 'Sign in to tip' }))
+
+    expect(writePendingHighlightSelection).toHaveBeenCalledWith({
+      articleId: 'articles:123',
+      highlightText: 'Some highlighted text',
+      startOffset: 10,
+      endOffset: 20,
+    })
+    expect(signInToTip).toHaveBeenCalled()
+  })
+
+  it('opens at checkout on resume with Sign in to tip visible', () => {
     mockAuth.isAuthenticated = false
     render(
       <HighlightTipButton
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        articleId={'articles:123' as any}
+        articleId={'articles:123' as never}
         articleSlug="my-article"
         authorName="Author"
         authorStellarAddress="GABC"
@@ -128,19 +173,18 @@ describe('HighlightTipButton', () => {
       />
     )
 
-    screen.getByRole('button', { name: 'Sign in to tip' }).click()
-
-    expect(writePendingHighlightSelection).toHaveBeenCalledWith({
-      articleId: 'articles:123',
-      highlightText: 'Some highlighted text',
-      startOffset: 10,
-      endOffset: 20,
-    })
-    expect(signInToTip).toHaveBeenCalled()
+    expect(
+      screen.getByRole('button', { name: 'Sign in to tip' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Continue' })
+    ).not.toBeInTheDocument()
+    expect(screen.getByText(/Tip amount: \$5\.00/)).toBeInTheDocument()
   })
 
-  it('restores amount from pending tip intent when opening dialog', async () => {
+  it('restores amount from pending tip intent and opens checkout', async () => {
     mockAuth.isAuthenticated = true
+    mockIsConnected.mockReturnValue(true)
     readPendingTipIntent.mockReturnValue({
       kind: 'highlight',
       articleId: 'articles:123',
@@ -153,8 +197,7 @@ describe('HighlightTipButton', () => {
 
     render(
       <HighlightTipButton
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        articleId={'articles:123' as any}
+        articleId={'articles:123' as never}
         articleSlug="my-article"
         authorName="Author"
         authorStellarAddress="GABC"
@@ -175,9 +218,34 @@ describe('HighlightTipButton', () => {
       screen.getByRole('button', { name: 'Tip Highlight' }).click()
     })
 
-    // When restored, the dialog should show the chosen amount as selected.
     expect(await screen.findByTestId('highlight-tip-dialog')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Send Tip' })).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Continue' })
+    ).not.toBeInTheDocument()
     expect(clearPendingTipIntent).toHaveBeenCalled()
     raf.mockRestore()
+  })
+
+  it('shows Connect Wallet on stage 2 when signed in without wallet', async () => {
+    mockAuth.isAuthenticated = true
+    const user = userEvent.setup({ delay: null })
+    render(
+      <HighlightTipButton
+        articleId={'articles:123' as never}
+        articleSlug="my-article"
+        authorName="Author"
+        authorStellarAddress="GABC"
+        highlightText="Some highlighted text"
+        startOffset={10}
+        endOffset={20}
+      />
+    )
+
+    await openHighlightTipAndContinue(user)
+
+    expect(
+      screen.getByRole('button', { name: 'Connect Wallet' })
+    ).toBeInTheDocument()
   })
 })

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -40,6 +40,7 @@ import {
 } from '@/lib/stellar/tip-error-messages'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { signInToTip, validateTipAmountForm } from '@/lib/tip/signInToTip'
+import { connectWalletFromOverlay } from '@/lib/wallet/connectWalletFromOverlay'
 import { applyPendingAmountFields } from '@/lib/tip/applyPendingTipFormState'
 import {
   clearPendingTipIntent,
@@ -206,14 +207,18 @@ export function HighlightTipButton({
     setTipSuccess(null)
   }
 
+  const suspendDialogForWalletRef = useRef(false)
+
   const handleOpenChange = (open: boolean) => {
     if (!open && isLoading) return
     setIsOpen(open)
     onResumeOpenChange?.(open)
     if (!open) {
-      resetModalState()
-      setSelectedAmount(null)
-      setCustomAmount('')
+      if (!suspendDialogForWalletRef.current) {
+        resetModalState()
+        setSelectedAmount(null)
+        setCustomAmount('')
+      }
     } else {
       setTipFailure(null)
       setTipFormError(null)
@@ -398,7 +403,19 @@ export function HighlightTipButton({
 
   const handleConnectWallet = async () => {
     try {
-      const connected = await connect()
+      const connected = await connectWalletFromOverlay({
+        activateWallet,
+        connect,
+        closeOverlay: () => {
+          suspendDialogForWalletRef.current = true
+          setIsOpen(false)
+        },
+        reopenOverlay: () => {
+          suspendDialogForWalletRef.current = false
+          setModalStep('checkout')
+          setIsOpen(true)
+        },
+      })
       if (connected) {
         setTipFormError(null)
         toast.success('Wallet connected successfully!')

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -7,29 +7,20 @@ import { useWallet } from '@/components/providers/WalletProvider'
 import { useWalletActivation } from '@/components/providers/WalletActivationContext'
 import { usePathname, useRouter } from 'next/navigation'
 import { toast } from 'sonner'
-import { AlertCircle, Coins, Heart, Loader2, Wallet } from 'lucide-react'
+import { AlertCircle, Coins } from 'lucide-react'
 import { api } from '@/convex/_generated/api'
 import { Id } from '@/convex/_generated/dataModel'
 import { stellarClient } from '@/lib/stellar/client'
 import {
   stellarFlowEmitter,
   type TipFlowStep,
-  tipFlowProgressLabel,
 } from '@/lib/stellar/stellar-flow-emitter'
 import {
   generateHighlightId,
-  calculateTipBreakdown,
   formatTipAmount,
 } from '@/lib/stellar/highlight-utils'
-import { TipBreakdownSummaryLine } from '@/components/tipping/TipBreakdownSummaryLine'
-import { TipUsdXlmRateLine } from '@/components/tipping/TipUsdXlmRateLine'
 import { useTipDialogXlmUsdRate } from '@/hooks/useTipDialogXlmUsdRate'
-import { useSuspendDialogModalForWallet } from '@/hooks/useSuspendDialogModalForWallet'
-import {
-  TIP_PRESETS_HIGHLIGHT,
-  TIP_MIN_USD,
-  TIP_MAX_USD,
-} from '@/lib/constants'
+import { TIP_PRESETS_HIGHLIGHT } from '@/lib/constants'
 import {
   Dialog,
   DialogContent,
@@ -39,12 +30,6 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { InstallWalletDialog } from '@/components/stellar/InstallWalletDialog'
-import { ContextualWalletSetup } from '@/components/stellar/ContextualWalletSetup'
-import { WalletTooltip } from '@/components/guide/WalletTooltip'
-import {
-  networkLabelLowercase,
-  tipFlowShortNote,
-} from '@/lib/copy/network-status'
 import {
   NO_WALLET_AVAILABLE_ERROR_CODE,
   ALBEDO_INSECURE_LOCALHOST_ERROR_CODE,
@@ -62,6 +47,9 @@ import {
   readPendingTipIntent,
 } from '@/lib/tip/pendingTipIntent'
 import { writePendingHighlightSelection } from '@/lib/highlight/pendingHighlightSelection'
+import { TipAppreciationStep } from '@/components/tipping/TipAppreciationStep'
+import { TipCheckoutStep } from '@/components/tipping/TipCheckoutStep'
+import type { TipModalStep } from '@/components/tipping/tipModalStep'
 
 interface HighlightTipButtonProps {
   articleId: Id<'articles'>
@@ -112,6 +100,9 @@ export function HighlightTipButton({
   const router = useRouter()
   const pathname = usePathname()
   const [isOpen, setIsOpen] = useState(resumeOpen)
+  const [modalStep, setModalStep] = useState<TipModalStep>(
+    resumeOpen ? 'checkout' : 'appreciation'
+  )
   const resumedRef = useRef(false)
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
   const [selectedAmount, setSelectedAmount] = useState<number | null>(null)
@@ -128,7 +119,6 @@ export function HighlightTipButton({
   const convex = useConvex()
   const createHighlightTip = useMutation(api.highlightTips.create)
   const { priceUsd: displayXlmUsdRate } = useTipDialogXlmUsdRate(isOpen)
-  const suspendDialogModalForWallet = useSuspendDialogModalForWallet()
 
   useEffect(() => {
     return stellarFlowEmitter.subscribe((event) => {
@@ -149,6 +139,7 @@ export function HighlightTipButton({
       setSelectedAmount,
       setCustomAmount
     )
+    setModalStep('checkout')
     activateWallet()
     setIsOpen(true)
     onResumeOpenChange?.(true)
@@ -161,7 +152,6 @@ export function HighlightTipButton({
   ])
 
   useEffect(() => {
-    // Only signal "visible" once the dialog is actually open (mounted).
     if (!isOpen || !resumedRef.current) return
     onResumeDialogVisible?.()
   }, [isOpen, onResumeDialogVisible])
@@ -191,9 +181,9 @@ export function HighlightTipButton({
       setSelectedAmount,
       setCustomAmount
     )
+    setModalStep('checkout')
+    activateWallet()
 
-    // Clear only after we know the dialog is open (it is, we're in this effect),
-    // and after the amount fields have been applied.
     requestAnimationFrame(() => {
       clearPendingTipIntent()
     })
@@ -206,22 +196,52 @@ export function HighlightTipButton({
     highlightText,
     selectedAmount,
     customAmount,
+    activateWallet,
   ])
 
-  const handleOpenChange = (open: boolean) => {
-    if (!open && (isLoading || suspendDialogModalForWallet)) return
-    if (open && isAuthenticated) {
-      activateWallet()
-    }
-    setIsOpen(open)
-    onResumeOpenChange?.(open)
+  const resetModalState = () => {
+    setModalStep('appreciation')
     setTipFailure(null)
     setTipFormError(null)
+    setTipSuccess(null)
+  }
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open && isLoading) return
+    setIsOpen(open)
+    onResumeOpenChange?.(open)
     if (!open) {
-      setTipSuccess(null)
+      resetModalState()
       setSelectedAmount(null)
       setCustomAmount('')
+    } else {
+      setTipFailure(null)
+      setTipFormError(null)
+      setTipSuccess(null)
     }
+  }
+
+  const handleContinue = () => {
+    const validation = validateTipAmountForm({
+      selectedAmount,
+      customAmount,
+    })
+    if (!validation.ok) {
+      setTipFormError({ title: validation.message })
+      toast.error(validation.message)
+      return
+    }
+    setTipFormError(null)
+    setModalStep('checkout')
+    if (isAuthenticated) {
+      activateWallet()
+    }
+  }
+
+  const handleBackToAppreciation = () => {
+    setModalStep('appreciation')
+    setTipFailure(null)
+    setTipFormError(null)
   }
 
   const handleSignInToTip = () => {
@@ -276,11 +296,6 @@ export function HighlightTipButton({
       return
     }
 
-    // Pre-flight cooldown check: avoids building a Stellar transaction that
-    // the server would ultimately reject, which would otherwise leave an
-    // on-chain payment with no matching DB record. This is an optimization;
-    // the createHighlightTip mutation still enforces the cooldown server-side,
-    // so any network hiccup here falls through silently to the real gate.
     try {
       const cooldown = await convex.query(api.tips.canTip, {})
       if (!cooldown.allowed) {
@@ -290,9 +305,6 @@ export function HighlightTipButton({
         return
       }
     } catch (err) {
-      // Fall through: the server-side cooldown check will catch it if needed.
-      // Logging so the failure is visible in monitoring even though we don't
-      // surface it to the user.
       console.error('[HighlightTipButton] canTip pre-flight failed', err)
     }
 
@@ -370,12 +382,10 @@ export function HighlightTipButton({
 
       window.setTimeout(() => {
         setIsOpen(false)
-        setTipSuccess(null)
+        resetModalState()
         setSelectedAmount(null)
         setCustomAmount('')
-        if (onSuccess) {
-          onSuccess()
-        }
+        onSuccess?.()
       }, 3000)
     } catch (error) {
       console.error('Highlight tip error:', error)
@@ -411,6 +421,14 @@ export function HighlightTipButton({
     }
   }
 
+  const amountValidation = validateTipAmountForm({
+    selectedAmount,
+    customAmount,
+  })
+  const checkoutAmountCents = amountValidation.ok
+    ? amountValidation.amountCents
+    : 0
+
   const inlineTipAlert = tipSuccess ? (
     <Alert className="border-success/50 bg-success/10 text-success-foreground">
       <AlertTitle>Tip sent</AlertTitle>
@@ -434,24 +452,9 @@ export function HighlightTipButton({
     </Alert>
   ) : null
 
-  const displayText =
-    highlightText.length > 60
-      ? highlightText.slice(0, 60) + '...'
-      : highlightText
-
-  const previewCents = selectedAmount || parseFloat(customAmount) * 100
-  const tipBreakdownPreview =
-    Number.isFinite(previewCents) && previewCents > 0
-      ? calculateTipBreakdown(previewCents)
-      : null
-
   return (
     <>
-      <Dialog
-        open={isOpen}
-        onOpenChange={handleOpenChange}
-        modal={!suspendDialogModalForWallet}
-      >
+      <Dialog open={isOpen} onOpenChange={handleOpenChange}>
         <DialogTrigger asChild>
           <button
             type="button"
@@ -466,201 +469,62 @@ export function HighlightTipButton({
           data-testid="highlight-tip-dialog"
           className="max-w-md max-h-[min(90dvh,calc(100%-2rem))] overflow-y-auto"
           onEscapeKeyDown={(e) => {
-            if (isLoading || suspendDialogModalForWallet) e.preventDefault()
+            if (isLoading) e.preventDefault()
           }}
           onInteractOutside={(e) => {
-            if (isLoading || suspendDialogModalForWallet) e.preventDefault()
+            if (isLoading) e.preventDefault()
           }}
         >
           <DialogHeader>
-            <DialogTitle>Tip Highlight</DialogTitle>
+            <DialogTitle>
+              {modalStep === 'appreciation' ? 'Tip this highlight' : 'Send your tip'}
+            </DialogTitle>
             <DialogDescription className="sr-only">
-              Choose an amount to tip this highlight on the Stellar network.
+              {modalStep === 'appreciation'
+                ? 'Choose an amount to tip this highlight.'
+                : 'Complete your highlight tip.'}
             </DialogDescription>
           </DialogHeader>
 
           {inlineTipAlert}
 
-          <div className="mb-4 p-3 bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800 rounded-lg">
-            <p className="text-sm text-foreground italic">
-              &ldquo;{displayText}&rdquo;
-            </p>
-          </div>
-
-          <p className="text-muted-foreground mb-4 text-sm">
-            Tip {authorName} for this specific insight. 97.5% goes directly to
-            the author!
-          </p>
-
-          {!isAuthenticated ? (
-            <div className="mb-4 p-3 bg-muted border border-border rounded-lg text-sm text-muted-foreground">
-              <p>Sign in to tip this highlight.</p>
-              <p className="mt-1">
-                You can connect your Stellar wallet after signing in.
-              </p>
-            </div>
-          ) : !isConnected ? (
-            <ContextualWalletSetup
-              mode="send"
-              recipientLabel={authorName}
-              className="mb-4"
-              onConnected={() => setTipFormError(null)}
+          {modalStep === 'appreciation' ? (
+            <TipAppreciationStep
+              variant="highlight"
+              authorName={authorName}
+              highlightText={highlightText}
+              presets={TIP_PRESETS_HIGHLIGHT}
+              selectedAmount={selectedAmount}
+              customAmount={customAmount}
+              onSelectedAmountChange={setSelectedAmount}
+              onCustomAmountChange={setCustomAmount}
+              onContinue={handleContinue}
+              onCancel={() => handleOpenChange(false)}
+              isLoading={isLoading}
+              canContinue={!!selectedAmount || !!customAmount}
+              priceUsd={displayXlmUsdRate}
+              idPrefix="highlight-tip"
             />
-          ) : null}
-
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-4">
-            {TIP_PRESETS_HIGHLIGHT.map((amount) => (
-              <button
-                key={amount.cents}
-                type="button"
-                disabled={isLoading}
-                onClick={() => {
-                  setSelectedAmount(amount.cents)
-                  setCustomAmount('')
-                }}
-                className={`focus-ring relative flex min-h-12 items-center justify-center px-4 py-3 rounded-lg border-2 transition-all disabled:opacity-50 ${
-                  selectedAmount === amount.cents
-                    ? 'border-orange-500 bg-orange-50 dark:bg-orange-950/30'
-                    : 'border-border hover:border-orange-300'
-                }`}
-              >
-                {amount.popular && (
-                  <span className="absolute -top-2 left-1/2 transform -translate-x-1/2 px-2 py-0.5 bg-orange-500 text-white text-xs rounded-full">
-                    Popular
-                  </span>
-                )}
-                <span className="font-semibold">{amount.label}</span>
-              </button>
-            ))}
-          </div>
-
-          <div className="mb-6">
-            <label
-              htmlFor="highlight-tip-custom-amount"
-              className="block text-sm font-medium text-foreground mb-2"
-            >
-              Or enter custom amount
-            </label>
-            <div className="relative">
-              <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">
-                $
-              </span>
-              <input
-                id="highlight-tip-custom-amount"
-                type="number"
-                min={TIP_MIN_USD}
-                max={TIP_MAX_USD}
-                step="0.01"
-                value={customAmount}
-                onChange={(e) => {
-                  setCustomAmount(e.target.value)
-                  setSelectedAmount(null)
-                }}
-                disabled={isLoading}
-                placeholder="0.00"
-                className="focus-ring w-full pl-8 pr-4 py-2 border border-input bg-background text-foreground rounded-lg disabled:opacity-50"
-              />
-            </div>
-            <p className="text-xs text-muted-foreground mt-1">
-              Minimum: ${TIP_MIN_USD.toFixed(2)} • Maximum: $
-              {TIP_MAX_USD.toFixed(2)}
-            </p>
-            <TipUsdXlmRateLine priceUsd={displayXlmUsdRate} />
-          </div>
-
-          {tipBreakdownPreview && (
-            <TipBreakdownSummaryLine
-              totalFormatted={formatTipAmount(previewCents)}
-              authorFormatted={tipBreakdownPreview.authorShareFormatted}
-              platformFeeFormatted={tipBreakdownPreview.platformFeeFormatted}
+          ) : (
+            <TipCheckoutStep
+              variant="highlight"
+              authorName={authorName}
+              amountCents={checkoutAmountCents}
+              isAuthenticated={isAuthenticated}
+              isConnected={isConnected}
+              isWalletLoading={isWalletLoading}
+              publicKey={publicKey}
+              isLoading={isLoading}
+              tipSuccess={tipSuccess}
+              tipFailure={tipFailure}
+              tipFlowStep={tipFlowStep}
+              onBack={handleBackToAppreciation}
+              onSignIn={handleSignInToTip}
+              onConnectWallet={handleConnectWallet}
+              onSendTip={() => void handleTip()}
+              useGradientButtons
             />
           )}
-
-          <div className="flex gap-3">
-            <button
-              type="button"
-              onClick={() => handleOpenChange(false)}
-              disabled={isLoading}
-              className="focus-ring flex-1 px-4 py-2 border border-input bg-background text-foreground rounded-lg hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              Cancel
-            </button>
-
-            {!isAuthenticated ? (
-              <button
-                type="button"
-                onClick={handleSignInToTip}
-                disabled={isLoading || (!selectedAmount && !customAmount)}
-                className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-              >
-                <Heart className="w-4 h-4" />
-                <span>Sign in to tip</span>
-              </button>
-            ) : !isConnected ? (
-              <button
-                type="button"
-                onClick={handleConnectWallet}
-                disabled={isLoading || isWalletLoading}
-                className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-blue-500 to-blue-600 text-white rounded-lg hover:from-blue-600 hover:to-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-              >
-                {isWalletLoading ? (
-                  <>
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                    <span>Connecting</span>
-                  </>
-                ) : (
-                  <>
-                    <Wallet className="w-4 h-4" />
-                    <span>Connect Wallet</span>
-                  </>
-                )}
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={() => void handleTip()}
-                disabled={
-                  isLoading ||
-                  !!tipSuccess ||
-                  (!selectedAmount && !customAmount)
-                }
-                className="focus-ring flex-1 px-4 py-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-              >
-                {isLoading ? (
-                  <>
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                    <span>
-                      {tipFlowStep
-                        ? tipFlowProgressLabel(tipFlowStep)
-                        : 'Awaiting signature'}
-                    </span>
-                  </>
-                ) : (
-                  <>
-                    <Heart className="w-4 h-4" />
-                    <span>{tipFailure ? 'Retry' : 'Send Tip'}</span>
-                  </>
-                )}
-              </button>
-            )}
-          </div>
-
-          {isConnected && publicKey && (
-            <div className="text-xs text-green-600 dark:text-green-300 text-center mt-4">
-              <p className="flex items-center justify-center gap-1">
-                <Wallet className="w-3 h-3" />
-                Connected: {publicKey.slice(0, 6)}...{publicKey.slice(-6)}
-              </p>
-            </div>
-          )}
-
-          <p className="text-xs text-muted-foreground text-center mt-2 flex items-center justify-center gap-1 flex-wrap">
-            Powered by Stellar {networkLabelLowercase()}{' '}
-            {networkLabelLowercase() === 'testnet' ? (
-              <WalletTooltip concept="testnet" />
-            ) : null}{' '}
-            • {tipFlowShortNote()}
-          </p>
         </DialogContent>
       </Dialog>
 

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -494,7 +494,9 @@ export function HighlightTipButton({
         >
           <DialogHeader>
             <DialogTitle>
-              {modalStep === 'appreciation' ? 'Tip this highlight' : 'Send your tip'}
+              {modalStep === 'appreciation'
+                ? 'Tip this highlight'
+                : 'Send your tip'}
             </DialogTitle>
             <DialogDescription className="sr-only">
               {modalStep === 'appreciation'

--- a/components/tipping/TipAmountSummary.tsx
+++ b/components/tipping/TipAmountSummary.tsx
@@ -1,0 +1,22 @@
+import { formatTipAmount } from '@/lib/stellar/highlight-utils'
+
+interface TipAmountSummaryProps {
+  amountCents: number
+  message?: string
+}
+
+export function TipAmountSummary({ amountCents, message }: TipAmountSummaryProps) {
+  return (
+    <div className="rounded-lg border border-border bg-muted/30 p-3 text-sm">
+      <p className="font-medium text-foreground">
+        Tip amount: {formatTipAmount(amountCents)}
+      </p>
+      {message ? (
+        <p className="mt-2 text-muted-foreground">
+          <span className="font-medium text-foreground">Message: </span>
+          &ldquo;{message}&rdquo;
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/components/tipping/TipAmountSummary.tsx
+++ b/components/tipping/TipAmountSummary.tsx
@@ -5,7 +5,10 @@ interface TipAmountSummaryProps {
   message?: string
 }
 
-export function TipAmountSummary({ amountCents, message }: TipAmountSummaryProps) {
+export function TipAmountSummary({
+  amountCents,
+  message,
+}: TipAmountSummaryProps) {
   return (
     <div className="rounded-lg border border-border bg-muted/30 p-3 text-sm">
       <p className="font-medium text-foreground">

--- a/components/tipping/TipAppreciationStep.tsx
+++ b/components/tipping/TipAppreciationStep.tsx
@@ -165,9 +165,7 @@ export function TipAppreciationStep({
       <TipHowItWorks
         priceUsd={priceUsd}
         totalFormatted={
-          tipBreakdownPreview
-            ? formatTipAmount(previewCents)
-            : undefined
+          tipBreakdownPreview ? formatTipAmount(previewCents) : undefined
         }
         authorFormatted={tipBreakdownPreview?.authorShareFormatted}
         platformFeeFormatted={tipBreakdownPreview?.platformFeeFormatted}

--- a/components/tipping/TipAppreciationStep.tsx
+++ b/components/tipping/TipAppreciationStep.tsx
@@ -1,0 +1,198 @@
+'use client'
+
+import { ArrowRight } from 'lucide-react'
+import {
+  calculateTipBreakdown,
+  formatTipAmount,
+} from '@/lib/stellar/highlight-utils'
+import { TIP_MIN_USD, TIP_MAX_USD } from '@/lib/constants'
+import { TipHowItWorks } from '@/components/tipping/TipHowItWorks'
+import { Button } from '@/components/ui/button'
+
+type TipPreset = {
+  readonly cents: number
+  readonly label: string
+  readonly popular: boolean
+}
+
+interface TipAppreciationStepProps {
+  variant: 'article' | 'highlight'
+  authorName: string
+  highlightText?: string
+  presets: readonly TipPreset[]
+  selectedAmount: number | null
+  customAmount: string
+  tipMessage?: string
+  onSelectedAmountChange: (cents: number | null) => void
+  onCustomAmountChange: (value: string) => void
+  onTipMessageChange?: (value: string) => void
+  onContinue: () => void
+  onCancel: () => void
+  isLoading: boolean
+  canContinue: boolean
+  priceUsd: number | null
+  idPrefix?: string
+}
+
+export function TipAppreciationStep({
+  variant,
+  authorName,
+  highlightText,
+  presets,
+  selectedAmount,
+  customAmount,
+  tipMessage = '',
+  onSelectedAmountChange,
+  onCustomAmountChange,
+  onTipMessageChange,
+  onContinue,
+  onCancel,
+  isLoading,
+  canContinue,
+  priceUsd,
+  idPrefix = 'tip',
+}: TipAppreciationStepProps) {
+  const previewCents = selectedAmount || parseFloat(customAmount) * 100
+  const tipBreakdownPreview =
+    Number.isFinite(previewCents) && previewCents > 0
+      ? calculateTipBreakdown(previewCents)
+      : null
+
+  const displayHighlightText =
+    highlightText && highlightText.length > 60
+      ? highlightText.slice(0, 60) + '...'
+      : highlightText
+
+  return (
+    <>
+      {variant === 'highlight' && displayHighlightText ? (
+        <div className="p-3 bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800 rounded-lg">
+          <p className="text-sm text-foreground italic">
+            &ldquo;{displayHighlightText}&rdquo;
+          </p>
+        </div>
+      ) : null}
+
+      <p className="text-muted-foreground text-sm">
+        {variant === 'article'
+          ? `Show your appreciation for ${authorName}'s work with a micro-tip.`
+          : `Tip ${authorName} for this insight that stood out to you.`}
+      </p>
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+        {presets.map((amount) => (
+          <button
+            key={amount.cents}
+            type="button"
+            onClick={() => {
+              onSelectedAmountChange(amount.cents)
+              onCustomAmountChange('')
+            }}
+            disabled={isLoading}
+            className={`focus-ring relative flex min-h-12 items-center justify-center px-4 py-3 rounded-lg border-2 transition-all disabled:opacity-50 ${
+              selectedAmount === amount.cents
+                ? 'border-orange-500 bg-orange-50 dark:bg-orange-950/30'
+                : 'border-border hover:border-orange-300'
+            }`}
+          >
+            {amount.popular && (
+              <span className="absolute -top-2 left-1/2 transform -translate-x-1/2 px-2 py-0.5 bg-orange-500 text-white text-xs rounded-full">
+                Popular
+              </span>
+            )}
+            <span className="font-semibold">{amount.label}</span>
+          </button>
+        ))}
+      </div>
+
+      <div>
+        <label
+          htmlFor={`${idPrefix}-custom-amount`}
+          className="block text-sm font-medium text-foreground mb-2"
+        >
+          Or enter custom amount
+        </label>
+        <div className="relative">
+          <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">
+            $
+          </span>
+          <input
+            id={`${idPrefix}-custom-amount`}
+            type="number"
+            min={TIP_MIN_USD}
+            max={TIP_MAX_USD}
+            step="0.01"
+            value={customAmount}
+            onChange={(e) => {
+              onCustomAmountChange(e.target.value)
+              onSelectedAmountChange(null)
+            }}
+            disabled={isLoading}
+            placeholder="0.00"
+            className="focus-ring w-full pl-8 pr-4 py-2 border border-input bg-background text-foreground rounded-lg disabled:opacity-50"
+          />
+        </div>
+        <p className="text-xs text-muted-foreground mt-1">
+          Minimum: ${TIP_MIN_USD.toFixed(2)} • Maximum: $
+          {TIP_MAX_USD.toFixed(2)}
+        </p>
+      </div>
+
+      {variant === 'article' && onTipMessageChange ? (
+        <div>
+          <label
+            htmlFor={`${idPrefix}-optional-message`}
+            className="block text-sm font-medium text-foreground mb-2"
+          >
+            Message to author (optional)
+          </label>
+          <textarea
+            id={`${idPrefix}-optional-message`}
+            value={tipMessage}
+            onChange={(e) => onTipMessageChange(e.target.value)}
+            disabled={isLoading}
+            maxLength={500}
+            rows={3}
+            placeholder="Say thanks or leave context for your tip..."
+            className="focus-ring w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground disabled:opacity-50"
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            {tipMessage.length}/500 characters
+          </p>
+        </div>
+      ) : null}
+
+      <TipHowItWorks
+        priceUsd={priceUsd}
+        totalFormatted={
+          tipBreakdownPreview
+            ? formatTipAmount(previewCents)
+            : undefined
+        }
+        authorFormatted={tipBreakdownPreview?.authorShareFormatted}
+        platformFeeFormatted={tipBreakdownPreview?.platformFeeFormatted}
+      />
+
+      <div className="flex gap-3">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onCancel}
+          disabled={isLoading}
+          className="flex-1"
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          onClick={onContinue}
+          disabled={isLoading || !canContinue}
+          className="flex-1 gap-2"
+        >
+          Continue
+          <ArrowRight className="w-4 h-4" />
+        </Button>
+      </div>
+    </>
+  )
+}

--- a/components/tipping/TipButton.test.tsx
+++ b/components/tipping/TipButton.test.tsx
@@ -189,10 +189,6 @@ describe('TipButton two-stage flow', () => {
     expect(
       screen.getByRole('button', { name: 'Connect Wallet' })
     ).toBeInTheDocument()
-    expect(screen.getByText('Connect to tip Author')).toBeInTheDocument()
-    expect(
-      screen.queryByRole('link', { name: /Follow our setup guide/i })
-    ).not.toBeInTheDocument()
   })
 
   it('shows Send Tip on stage 2 when signed in with wallet', async () => {

--- a/components/tipping/TipButton.test.tsx
+++ b/components/tipping/TipButton.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { TipButton } from '@/components/tipping/TipButton'
@@ -7,6 +7,7 @@ import { TipButton } from '@/components/tipping/TipButton'
 const mockRedirectToLoginForTip = vi.hoisted(() => vi.fn())
 const mockIsAuthenticated = vi.hoisted(() => vi.fn(() => false))
 const mockIsConnected = vi.hoisted(() => vi.fn(() => false))
+const mockUseArticleTipResume = vi.hoisted(() => vi.fn())
 
 vi.mock('convex/react', () => ({
   useConvex: () => ({ query: vi.fn() }),
@@ -20,7 +21,8 @@ vi.mock('@/components/providers/AuthContext', () => ({
 vi.mock('@/components/providers/WalletProvider', () => ({
   useWallet: () => ({
     isConnected: mockIsConnected(),
-    publicKey: null,
+    isLoading: false,
+    publicKey: mockIsConnected() ? 'GABCDEF123456789' : null,
     signTransaction: vi.fn(),
     connect: vi.fn(),
   }),
@@ -49,7 +51,9 @@ vi.mock('@/lib/tip/pendingTipIntent', () => ({
 }))
 
 vi.mock('@/hooks/useArticleTipResume', () => ({
-  useArticleTipResume: vi.fn(),
+  useArticleTipResume: (opts: { onResume: (intent: unknown) => void }) => {
+    mockUseArticleTipResume(opts)
+  },
 }))
 
 vi.mock('@/lib/stellar/stellar-flow-emitter', () => ({
@@ -57,14 +61,36 @@ vi.mock('@/lib/stellar/stellar-flow-emitter', () => ({
   tipFlowProgressLabel: () => 'Processing',
 }))
 
-describe('TipButton auth-first CTA', () => {
+vi.mock('@/components/stellar/InstallWalletDialog', () => ({
+  InstallWalletDialog: () => null,
+}))
+
+vi.mock('@/components/guide/WalletTooltip', () => ({
+  WalletTooltip: () => null,
+}))
+
+async function openArticleTipModal(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: /Tip Author/i }))
+}
+
+async function selectPresetAndContinue(
+  user: ReturnType<typeof userEvent.setup>,
+  label = '$1'
+) {
+  await openArticleTipModal(user)
+  await user.click(screen.getByRole('button', { name: label }))
+  await user.click(screen.getByRole('button', { name: 'Continue' }))
+}
+
+describe('TipButton two-stage flow', () => {
   beforeEach(() => {
     mockRedirectToLoginForTip.mockClear()
+    mockUseArticleTipResume.mockClear()
     mockIsAuthenticated.mockReturnValue(false)
     mockIsConnected.mockReturnValue(false)
   })
 
-  it('shows Sign in to tip when signed out', async () => {
+  it('shows Continue on stage 1 without wallet or sign-in CTAs', async () => {
     const user = userEvent.setup({ delay: null })
     render(
       <TipButton
@@ -74,14 +100,53 @@ describe('TipButton auth-first CTA', () => {
       />
     )
 
-    await user.click(screen.getByRole('button', { name: /Tip Author/i }))
-    await user.click(screen.getByRole('button', { name: '$1' }))
+    await openArticleTipModal(user)
+
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Sign in to tip' })
-    ).toBeInTheDocument()
+      screen.queryByRole('button', { name: 'Sign in to tip' })
+    ).not.toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: 'Connect Wallet' })
     ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Send Tip' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/Connect your Stellar wallet/i)
+    ).not.toBeInTheDocument()
+  })
+
+  it('disables Continue until an amount is selected', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(
+      <TipButton
+        articleId={'articles:abc' as never}
+        authorName="Author"
+        authorStellarAddress="GABC"
+      />
+    )
+
+    await openArticleTipModal(user)
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
+  })
+
+  it('shows Sign in to tip on stage 2 when signed out', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(
+      <TipButton
+        articleId={'articles:abc' as never}
+        authorName="Author"
+        authorStellarAddress="GABC"
+      />
+    )
+
+    await selectPresetAndContinue(user)
+
+    expect(
+      screen.getByRole('button', { name: 'Sign in to tip' })
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '$1' })).not.toBeInTheDocument()
   })
 
   it('redirects to login with article intent when Sign in to tip is clicked', async () => {
@@ -94,8 +159,7 @@ describe('TipButton auth-first CTA', () => {
       />
     )
 
-    await user.click(screen.getByRole('button', { name: /Tip Author/i }))
-    await user.click(screen.getByRole('button', { name: '$1' }))
+    await selectPresetAndContinue(user)
     await user.click(screen.getByRole('button', { name: 'Sign in to tip' }))
 
     expect(mockRedirectToLoginForTip).toHaveBeenCalledWith(
@@ -109,7 +173,7 @@ describe('TipButton auth-first CTA', () => {
     )
   })
 
-  it('shows Connect Wallet when signed in without wallet', async () => {
+  it('shows Connect Wallet on stage 2 when signed in without wallet', async () => {
     mockIsAuthenticated.mockReturnValue(true)
     const user = userEvent.setup({ delay: null })
     render(
@@ -120,7 +184,8 @@ describe('TipButton auth-first CTA', () => {
       />
     )
 
-    await user.click(screen.getByRole('button', { name: /Tip Author/i }))
+    await selectPresetAndContinue(user)
+
     expect(
       screen.getByRole('button', { name: 'Connect Wallet' })
     ).toBeInTheDocument()
@@ -130,7 +195,7 @@ describe('TipButton auth-first CTA', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('shows Send Tip when signed in with wallet', async () => {
+  it('shows Send Tip on stage 2 when signed in with wallet', async () => {
     mockIsAuthenticated.mockReturnValue(true)
     mockIsConnected.mockReturnValue(true)
     const user = userEvent.setup({ delay: null })
@@ -142,13 +207,12 @@ describe('TipButton auth-first CTA', () => {
       />
     )
 
-    await user.click(screen.getByRole('button', { name: /Tip Author/i }))
+    await selectPresetAndContinue(user)
+
     expect(screen.getByRole('button', { name: 'Send Tip' })).toBeInTheDocument()
   })
 
-  it('shows inline alert for invalid tip amount when wallet is connected', async () => {
-    mockIsAuthenticated.mockReturnValue(true)
-    mockIsConnected.mockReturnValue(true)
+  it('returns to stage 1 with amount preserved when Back is clicked', async () => {
     const user = userEvent.setup({ delay: null })
     render(
       <TipButton
@@ -158,11 +222,60 @@ describe('TipButton auth-first CTA', () => {
       />
     )
 
-    await user.click(screen.getByRole('button', { name: /Tip Author/i }))
+    await selectPresetAndContinue(user)
+    await user.click(screen.getByRole('button', { name: 'Back' }))
+
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '$1' })).toBeInTheDocument()
+  })
+
+  it('shows inline alert for invalid tip amount on stage 1 Continue', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(
+      <TipButton
+        articleId={'articles:abc' as never}
+        authorName="Author"
+        authorStellarAddress="GABC"
+      />
+    )
+
+    await openArticleTipModal(user)
     const customInput = screen.getByPlaceholderText('0.00')
     await user.type(customInput, '0')
-    await user.click(screen.getByRole('button', { name: 'Send Tip' }))
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
 
     expect(screen.getByRole('alert')).toHaveTextContent(/valid amount/i)
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument()
+  })
+
+  it('opens at checkout on resume after login', async () => {
+    mockIsAuthenticated.mockReturnValue(true)
+    mockIsConnected.mockReturnValue(true)
+
+    render(
+      <TipButton
+        articleId={'articles:abc' as never}
+        authorName="Author"
+        authorStellarAddress="GABC"
+      />
+    )
+
+    const onResume = mockUseArticleTipResume.mock.calls[0]![0].onResume
+
+    await act(async () => {
+      onResume({
+        kind: 'article',
+        articleId: 'articles:abc',
+        amountCents: 500,
+        message: 'Thanks!',
+      })
+    })
+
+    expect(screen.getByRole('button', { name: 'Send Tip' })).toBeInTheDocument()
+    expect(screen.getByText(/Tip amount: \$5\.00/)).toBeInTheDocument()
+    expect(screen.getByText(/Thanks!/)).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Continue' })
+    ).not.toBeInTheDocument()
   })
 })

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -105,7 +105,6 @@ export function TipButton({
       setModalStep('checkout')
       activateWallet()
       setIsOpen(true)
-      requestAnimationFrame(() => setIsOpen(true))
     },
     [activateWallet]
   )

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -7,24 +7,16 @@ import { useWallet } from '@/components/providers/WalletProvider'
 import { useWalletActivation } from '@/components/providers/WalletActivationContext'
 import { usePathname, useRouter } from 'next/navigation'
 import { toast } from 'sonner'
-import { AlertCircle, Coins, Heart, Loader2, Wallet } from 'lucide-react'
-import { WalletTooltip } from '@/components/guide/WalletTooltip'
+import { AlertCircle, Coins } from 'lucide-react'
 import { api } from '@/convex/_generated/api'
 import { Id } from '@/convex/_generated/dataModel'
 import { stellarClient } from '@/lib/stellar/client'
 import {
   stellarFlowEmitter,
   type TipFlowStep,
-  tipFlowProgressLabel,
 } from '@/lib/stellar/stellar-flow-emitter'
-import {
-  calculateTipBreakdown,
-  formatTipAmount,
-} from '@/lib/stellar/highlight-utils'
-import { TipBreakdownSummaryLine } from '@/components/tipping/TipBreakdownSummaryLine'
-import { TipUsdXlmRateLine } from '@/components/tipping/TipUsdXlmRateLine'
 import { useTipDialogXlmUsdRate } from '@/hooks/useTipDialogXlmUsdRate'
-import { TIP_PRESETS_ARTICLE, TIP_MIN_USD, TIP_MAX_USD } from '@/lib/constants'
+import { TIP_PRESETS_ARTICLE } from '@/lib/constants'
 import {
   Dialog,
   DialogContent,
@@ -34,7 +26,6 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { InstallWalletDialog } from '@/components/stellar/InstallWalletDialog'
-import { ContextualWalletSetup } from '@/components/stellar/ContextualWalletSetup'
 import {
   NO_WALLET_AVAILABLE_ERROR_CODE,
   ALBEDO_INSECURE_LOCALHOST_ERROR_CODE,
@@ -51,11 +42,9 @@ import { applyPendingAmountFields } from '@/lib/tip/applyPendingTipFormState'
 import { clearPendingTipIntent } from '@/lib/tip/pendingTipIntent'
 import type { ArticlePendingTipIntent } from '@/lib/tip/pendingTipIntent'
 import { useArticleTipResume } from '@/hooks/useArticleTipResume'
-import { useSuspendDialogModalForWallet } from '@/hooks/useSuspendDialogModalForWallet'
-import {
-  networkLabelLowercase,
-  tipFlowShortNote,
-} from '@/lib/copy/network-status'
+import { TipAppreciationStep } from '@/components/tipping/TipAppreciationStep'
+import { TipCheckoutStep } from '@/components/tipping/TipCheckoutStep'
+import type { TipModalStep } from '@/components/tipping/tipModalStep'
 
 interface TipButtonProps {
   articleId: Id<'articles'>
@@ -82,6 +71,7 @@ export function TipButton({
   const router = useRouter()
   const pathname = usePathname()
   const [isOpen, setIsOpen] = useState(false)
+  const [modalStep, setModalStep] = useState<TipModalStep>('appreciation')
   const [installDialogOpen, setInstallDialogOpen] = useState(false)
   const [selectedAmount, setSelectedAmount] = useState<number | null>(null)
   const [customAmount, setCustomAmount] = useState('')
@@ -97,7 +87,6 @@ export function TipButton({
   const convex = useConvex()
   const sendTip = useMutation(api.tips.sendTip)
   const { priceUsd: displayXlmUsdRate } = useTipDialogXlmUsdRate(isOpen)
-  const suspendDialogModalForWallet = useSuspendDialogModalForWallet()
 
   useEffect(() => {
     return stellarFlowEmitter.subscribe((event) => {
@@ -111,6 +100,7 @@ export function TipButton({
     (intent: ArticlePendingTipIntent) => {
       applyPendingAmountFields(intent, setSelectedAmount, setCustomAmount)
       if (intent.message) setTipMessage(intent.message)
+      setModalStep('checkout')
       activateWallet()
       setIsOpen(true)
       requestAnimationFrame(() => setIsOpen(true))
@@ -124,15 +114,47 @@ export function TipButton({
     onResume: applyResumeIntent,
   })
 
-  const handleOpenChange = (open: boolean) => {
-    if (!open && (isLoading || suspendDialogModalForWallet)) return
-    if (open && isAuthenticated) {
-      activateWallet()
-    }
-    setIsOpen(open)
+  const resetModalState = () => {
+    setModalStep('appreciation')
     setTipFailure(null)
     setTipFormError(null)
-    if (!open) setTipSuccess(null)
+    setTipSuccess(null)
+  }
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open && isLoading) return
+    setIsOpen(open)
+    if (!open) {
+      resetModalState()
+    } else {
+      setTipFailure(null)
+      setTipFormError(null)
+      setTipSuccess(null)
+    }
+  }
+
+  const handleContinue = () => {
+    const validation = validateTipAmountForm({
+      selectedAmount,
+      customAmount,
+      message: tipMessage,
+    })
+    if (!validation.ok) {
+      setTipFormError({ title: validation.message })
+      toast.error(validation.message)
+      return
+    }
+    setTipFormError(null)
+    setModalStep('checkout')
+    if (isAuthenticated) {
+      activateWallet()
+    }
+  }
+
+  const handleBackToAppreciation = () => {
+    setModalStep('appreciation')
+    setTipFailure(null)
+    setTipFormError(null)
   }
 
   const handleSignInToTip = () => {
@@ -182,11 +204,6 @@ export function TipButton({
       return
     }
 
-    // Pre-flight cooldown check: avoids building a Stellar transaction that
-    // the server would ultimately reject, which would otherwise leave an
-    // on-chain payment with no matching DB record. This is an optimization;
-    // the sendTip mutation still enforces the cooldown server-side, so any
-    // network hiccup here falls through silently to the real gate below.
     try {
       const cooldown = await convex.query(api.tips.canTip, {})
       if (!cooldown.allowed) {
@@ -196,9 +213,6 @@ export function TipButton({
         return
       }
     } catch (err) {
-      // Fall through: the server-side cooldown check will catch it if needed.
-      // Logging so the failure is visible in monitoring even though we don't
-      // surface it to the user.
       console.error('[TipButton] canTip pre-flight failed', err)
     }
 
@@ -262,7 +276,7 @@ export function TipButton({
 
       window.setTimeout(() => {
         setIsOpen(false)
-        setTipSuccess(null)
+        resetModalState()
         setSelectedAmount(null)
         setCustomAmount('')
         setTipMessage('')
@@ -275,12 +289,6 @@ export function TipButton({
       setTipFlowStep(null)
     }
   }
-
-  const previewCents = selectedAmount || parseFloat(customAmount) * 100
-  const tipBreakdownPreview =
-    Number.isFinite(previewCents) && previewCents > 0
-      ? calculateTipBreakdown(previewCents)
-      : null
 
   const handleConnectWallet = async () => {
     try {
@@ -307,6 +315,15 @@ export function TipButton({
     }
   }
 
+  const amountValidation = validateTipAmountForm({
+    selectedAmount,
+    customAmount,
+    message: tipMessage,
+  })
+  const checkoutAmountCents = amountValidation.ok
+    ? amountValidation.amountCents
+    : 0
+
   const inlineTipAlert = tipSuccess ? (
     <Alert className="border-success/50 bg-success/10 text-success-foreground">
       <AlertTitle>Tip sent</AlertTitle>
@@ -332,11 +349,7 @@ export function TipButton({
 
   return (
     <>
-      <Dialog
-        open={isOpen}
-        onOpenChange={handleOpenChange}
-        modal={!suspendDialogModalForWallet}
-      >
+      <Dialog open={isOpen} onOpenChange={handleOpenChange}>
         <DialogTrigger asChild>
           <Button variant="outline" className={cn('gap-2', className)}>
             <Coins className="w-4 h-4" />
@@ -346,214 +359,65 @@ export function TipButton({
         <DialogContent
           className="top-auto bottom-0 left-1/2 max-h-[min(90dvh,calc(100%-2rem))] max-w-md translate-x-[-50%] translate-y-0 gap-4 overflow-y-auto rounded-b-none rounded-t-xl border border-border bg-popover p-6 shadow-xl data-[state=closed]:slide-out-to-bottom-[48%] data-[state=open]:slide-in-from-bottom-[48%] sm:top-[50%] sm:bottom-auto sm:max-h-[min(90dvh,100%)] sm:translate-y-[-50%] sm:rounded-xl sm:data-[state=closed]:slide-out-to-left-1/2 sm:data-[state=closed]:slide-out-to-top-[48%] sm:data-[state=open]:slide-in-from-left-1/2 sm:data-[state=open]:slide-in-from-top-[48%]"
           onInteractOutside={(e) => {
-            if (isLoading || suspendDialogModalForWallet) e.preventDefault()
+            if (isLoading) e.preventDefault()
           }}
           onEscapeKeyDown={(e) => {
-            if (isLoading || suspendDialogModalForWallet) e.preventDefault()
+            if (isLoading) e.preventDefault()
           }}
         >
           <DialogHeader className="text-left">
             <DialogTitle className="text-xl font-bold">
-              Support {authorName}
+              {modalStep === 'appreciation'
+                ? `Support ${authorName}`
+                : 'Send your tip'}
             </DialogTitle>
             <DialogDescription className="text-muted-foreground">
-              Show your appreciation with a micro-tip. 97.5% goes directly to
-              the author!
+              {modalStep === 'appreciation'
+                ? 'Choose how much you would like to support this author.'
+                : `Complete your tip to ${authorName}.`}
             </DialogDescription>
           </DialogHeader>
 
           {inlineTipAlert}
 
-          {!isAuthenticated ? (
-            <div className="p-3 bg-muted border border-border rounded-lg text-sm text-muted-foreground">
-              <p>Sign in to send a tip to {authorName}.</p>
-              <p className="mt-1">
-                You can connect your Stellar wallet after signing in.
-              </p>
-            </div>
-          ) : !isConnected ? (
-            <ContextualWalletSetup
-              mode="send"
-              recipientLabel={authorName}
-              onConnected={() => setTipFormError(null)}
+          {modalStep === 'appreciation' ? (
+            <TipAppreciationStep
+              variant="article"
+              authorName={authorName}
+              presets={TIP_PRESETS_ARTICLE}
+              selectedAmount={selectedAmount}
+              customAmount={customAmount}
+              tipMessage={tipMessage}
+              onSelectedAmountChange={setSelectedAmount}
+              onCustomAmountChange={setCustomAmount}
+              onTipMessageChange={setTipMessage}
+              onContinue={handleContinue}
+              onCancel={() => handleOpenChange(false)}
+              isLoading={isLoading}
+              canContinue={!!selectedAmount || !!customAmount}
+              priceUsd={displayXlmUsdRate}
+              idPrefix="tip"
             />
-          ) : null}
-
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-            {TIP_PRESETS_ARTICLE.map((amount) => (
-              <button
-                key={amount.cents}
-                type="button"
-                onClick={() => {
-                  setSelectedAmount(amount.cents)
-                  setCustomAmount('')
-                }}
-                disabled={isLoading}
-                className={`focus-ring relative flex min-h-12 items-center justify-center px-4 py-3 rounded-lg border-2 transition-all disabled:opacity-50 ${
-                  selectedAmount === amount.cents
-                    ? 'border-orange-500 bg-orange-50 dark:bg-orange-950/30'
-                    : 'border-border hover:border-orange-300'
-                }`}
-              >
-                {amount.popular && (
-                  <span className="absolute -top-2 left-1/2 transform -translate-x-1/2 px-2 py-0.5 bg-orange-500 text-white text-xs rounded-full">
-                    Popular
-                  </span>
-                )}
-                <span className="font-semibold">{amount.label}</span>
-              </button>
-            ))}
-          </div>
-
-          <div>
-            <label
-              htmlFor="tip-custom-amount"
-              className="block text-sm font-medium text-foreground mb-2"
-            >
-              Or enter custom amount
-            </label>
-            <div className="relative">
-              <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">
-                $
-              </span>
-              <input
-                id="tip-custom-amount"
-                type="number"
-                min={TIP_MIN_USD}
-                max={TIP_MAX_USD}
-                step="0.01"
-                value={customAmount}
-                onChange={(e) => {
-                  setCustomAmount(e.target.value)
-                  setSelectedAmount(null)
-                }}
-                disabled={isLoading}
-                placeholder="0.00"
-                className="focus-ring w-full pl-8 pr-4 py-2 border border-input bg-background text-foreground rounded-lg disabled:opacity-50"
-              />
-            </div>
-            <p className="text-xs text-muted-foreground mt-1">
-              Minimum: ${TIP_MIN_USD.toFixed(2)} • Maximum: $
-              {TIP_MAX_USD.toFixed(2)}
-            </p>
-            <TipUsdXlmRateLine priceUsd={displayXlmUsdRate} />
-          </div>
-
-          <div>
-            <label
-              htmlFor="tip-optional-message"
-              className="block text-sm font-medium text-foreground mb-2"
-            >
-              Message to author (optional)
-            </label>
-            <textarea
-              id="tip-optional-message"
-              value={tipMessage}
-              onChange={(e) => setTipMessage(e.target.value)}
-              disabled={isLoading}
-              maxLength={500}
-              rows={3}
-              placeholder="Say thanks or leave context for your tip..."
-              className="focus-ring w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground disabled:opacity-50"
-            />
-            <p className="mt-1 text-xs text-muted-foreground">
-              {tipMessage.length}/500 characters
-            </p>
-          </div>
-
-          {tipBreakdownPreview && (
-            <TipBreakdownSummaryLine
-              totalFormatted={formatTipAmount(previewCents)}
-              authorFormatted={tipBreakdownPreview.authorShareFormatted}
-              platformFeeFormatted={tipBreakdownPreview.platformFeeFormatted}
+          ) : (
+            <TipCheckoutStep
+              variant="article"
+              authorName={authorName}
+              amountCents={checkoutAmountCents}
+              message={tipMessage.trim() || undefined}
+              isAuthenticated={isAuthenticated}
+              isConnected={isConnected}
+              isWalletLoading={isWalletLoading}
+              publicKey={publicKey}
+              isLoading={isLoading}
+              tipSuccess={tipSuccess}
+              tipFailure={tipFailure}
+              tipFlowStep={tipFlowStep}
+              onBack={handleBackToAppreciation}
+              onSignIn={handleSignInToTip}
+              onConnectWallet={handleConnectWallet}
+              onSendTip={handleTip}
             />
           )}
-
-          <div className="flex gap-3">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => handleOpenChange(false)}
-              disabled={isLoading}
-              className="flex-1"
-            >
-              Cancel
-            </Button>
-
-            {!isAuthenticated ? (
-              <Button
-                type="button"
-                onClick={handleSignInToTip}
-                disabled={isLoading || (!selectedAmount && !customAmount)}
-                className="flex-1 gap-2"
-              >
-                <Heart className="w-4 h-4" />
-                Sign in to tip
-              </Button>
-            ) : !isConnected ? (
-              <Button
-                type="button"
-                onClick={handleConnectWallet}
-                disabled={isLoading || isWalletLoading}
-                className="flex-1 gap-2"
-              >
-                {isWalletLoading ? (
-                  <>
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                    Connecting
-                  </>
-                ) : (
-                  <>
-                    <Wallet className="w-4 h-4" />
-                    Connect Wallet
-                  </>
-                )}
-              </Button>
-            ) : (
-              <Button
-                type="button"
-                onClick={handleTip}
-                disabled={
-                  isLoading ||
-                  !!tipSuccess ||
-                  (!selectedAmount && !customAmount)
-                }
-                className="flex-1 gap-2"
-              >
-                {isLoading ? (
-                  <>
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                    {tipFlowStep
-                      ? tipFlowProgressLabel(tipFlowStep)
-                      : 'Awaiting signature'}
-                  </>
-                ) : (
-                  <>
-                    <Heart className="w-4 h-4" />
-                    {tipFailure ? 'Retry' : 'Send Tip'}
-                  </>
-                )}
-              </Button>
-            )}
-          </div>
-
-          {isConnected && publicKey && (
-            <div className="text-xs text-green-800 dark:text-green-300 text-center">
-              <p className="flex items-center justify-center gap-1">
-                <Wallet className="w-3 h-3" />
-                Connected: {publicKey.slice(0, 6)}...{publicKey.slice(-6)}
-              </p>
-            </div>
-          )}
-
-          <p className="text-xs text-muted-foreground text-center flex items-center justify-center gap-1 flex-wrap">
-            Powered by Stellar {networkLabelLowercase()}{' '}
-            <WalletTooltip concept="stellar" />{' '}
-            {networkLabelLowercase() === 'testnet' ? (
-              <WalletTooltip concept="testnet" />
-            ) : null}{' '}
-            • {tipFlowShortNote()}
-          </p>
         </DialogContent>
       </Dialog>
 

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useConvex, useMutation } from 'convex/react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { useWallet } from '@/components/providers/WalletProvider'
@@ -38,6 +38,7 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { signInToTip, validateTipAmountForm } from '@/lib/tip/signInToTip'
+import { connectWalletFromOverlay } from '@/lib/wallet/connectWalletFromOverlay'
 import { applyPendingAmountFields } from '@/lib/tip/applyPendingTipFormState'
 import { clearPendingTipIntent } from '@/lib/tip/pendingTipIntent'
 import type { ArticlePendingTipIntent } from '@/lib/tip/pendingTipIntent'
@@ -83,6 +84,7 @@ export function TipButton({
   )
   const [tipSuccess, setTipSuccess] = useState<string | null>(null)
   const [tipMessage, setTipMessage] = useState('')
+  const suspendDialogForWalletRef = useRef(false)
 
   const convex = useConvex()
   const sendTip = useMutation(api.tips.sendTip)
@@ -125,7 +127,9 @@ export function TipButton({
     if (!open && isLoading) return
     setIsOpen(open)
     if (!open) {
-      resetModalState()
+      if (!suspendDialogForWalletRef.current) {
+        resetModalState()
+      }
     } else {
       setTipFailure(null)
       setTipFormError(null)
@@ -292,7 +296,19 @@ export function TipButton({
 
   const handleConnectWallet = async () => {
     try {
-      const connected = await connect()
+      const connected = await connectWalletFromOverlay({
+        activateWallet,
+        connect,
+        closeOverlay: () => {
+          suspendDialogForWalletRef.current = true
+          setIsOpen(false)
+        },
+        reopenOverlay: () => {
+          suspendDialogForWalletRef.current = false
+          setModalStep('checkout')
+          setIsOpen(true)
+        },
+      })
       if (connected) {
         setTipFormError(null)
         toast.success('Wallet connected successfully!')

--- a/components/tipping/TipCheckoutStep.tsx
+++ b/components/tipping/TipCheckoutStep.tsx
@@ -1,0 +1,190 @@
+'use client'
+
+import Link from 'next/link'
+import { Heart, Loader2, Wallet } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { TipAmountSummary } from '@/components/tipping/TipAmountSummary'
+import { WalletTooltip } from '@/components/guide/WalletTooltip'
+import {
+  networkLabelLowercase,
+  tipFlowShortNote,
+} from '@/lib/copy/network-status'
+import type { TipFlowStep } from '@/lib/stellar/stellar-flow-emitter'
+import { tipFlowProgressLabel } from '@/lib/stellar/stellar-flow-emitter'
+import type { TipFailureMessage } from '@/lib/stellar/tip-error-messages'
+
+interface TipCheckoutStepProps {
+  variant: 'article' | 'highlight'
+  authorName: string
+  amountCents: number
+  message?: string
+  isAuthenticated: boolean
+  isConnected: boolean
+  isWalletLoading: boolean
+  publicKey: string | null
+  isLoading: boolean
+  tipSuccess: string | null
+  tipFailure: TipFailureMessage | null
+  tipFlowStep: TipFlowStep | null
+  onBack: () => void
+  onSignIn: () => void
+  onConnectWallet: () => void
+  onSendTip: () => void
+  useGradientButtons?: boolean
+}
+
+export function TipCheckoutStep({
+  variant,
+  authorName,
+  amountCents,
+  message,
+  isAuthenticated,
+  isConnected,
+  isWalletLoading,
+  publicKey,
+  isLoading,
+  tipSuccess,
+  tipFailure,
+  tipFlowStep,
+  onBack,
+  onSignIn,
+  onConnectWallet,
+  onSendTip,
+  useGradientButtons = false,
+}: TipCheckoutStepProps) {
+  const primaryGradientClass =
+    'bg-gradient-to-r from-yellow-400 to-orange-500 text-white hover:from-yellow-500 hover:to-orange-600'
+  const connectGradientClass =
+    'bg-gradient-to-r from-blue-500 to-blue-600 text-white hover:from-blue-600 hover:to-blue-700'
+
+  const renderPrimaryButton = () => {
+    if (!isAuthenticated) {
+      return (
+        <Button
+          type="button"
+          onClick={onSignIn}
+          disabled={isLoading}
+          className={`flex-1 gap-2 ${useGradientButtons ? primaryGradientClass : ''}`}
+        >
+          <Heart className="w-4 h-4" />
+          Sign in to tip
+        </Button>
+      )
+    }
+
+    if (!isConnected) {
+      return (
+        <Button
+          type="button"
+          onClick={onConnectWallet}
+          disabled={isLoading || isWalletLoading}
+          className={`flex-1 gap-2 ${useGradientButtons ? connectGradientClass : ''}`}
+        >
+          {isWalletLoading ? (
+            <>
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Connecting
+            </>
+          ) : (
+            <>
+              <Wallet className="w-4 h-4" />
+              Connect Wallet
+            </>
+          )}
+        </Button>
+      )
+    }
+
+    return (
+      <Button
+        type="button"
+        onClick={onSendTip}
+        disabled={isLoading || !!tipSuccess}
+        className={`flex-1 gap-2 ${useGradientButtons ? primaryGradientClass : ''}`}
+      >
+        {isLoading ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" />
+            {tipFlowStep
+              ? tipFlowProgressLabel(tipFlowStep)
+              : 'Awaiting signature'}
+          </>
+        ) : (
+          <>
+            <Heart className="w-4 h-4" />
+            {tipFailure ? 'Retry' : 'Send Tip'}
+          </>
+        )}
+      </Button>
+    )
+  }
+
+  return (
+    <>
+      <TipAmountSummary amountCents={amountCents} message={message} />
+
+      {!isAuthenticated ? (
+        <div className="p-3 bg-muted border border-border rounded-lg text-sm text-muted-foreground">
+          <p>
+            Sign in to send your {formatTipLabel(variant)} to {authorName}.
+          </p>
+        </div>
+      ) : !isConnected ? (
+        <div className="p-3 bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-lg text-sm text-amber-900 dark:text-amber-100">
+          <p>
+            Connect your Stellar wallet to send your{' '}
+            {formatTipLabel(variant)} to {authorName}.
+          </p>
+          <p className="mt-1">
+            New to crypto?{' '}
+            <Link
+              href="/guide"
+              className="focus-ring rounded text-amber-700 dark:text-amber-300 underline font-medium hover:text-amber-900 dark:hover:text-amber-100"
+            >
+              Follow our setup guide
+            </Link>
+          </p>
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          Confirm and send your {formatTipLabel(variant)} to {authorName}.
+        </p>
+      )}
+
+      <div className="flex gap-3">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onBack}
+          disabled={isLoading}
+          className="flex-1"
+        >
+          Back
+        </Button>
+        {renderPrimaryButton()}
+      </div>
+
+      {isConnected && publicKey ? (
+        <div className="text-xs text-green-800 dark:text-green-300 text-center">
+          <p className="flex items-center justify-center gap-1">
+            <Wallet className="w-3 h-3" />
+            Connected: {publicKey.slice(0, 6)}...{publicKey.slice(-6)}
+          </p>
+        </div>
+      ) : null}
+
+      <p className="text-xs text-muted-foreground text-center flex items-center justify-center gap-1 flex-wrap">
+        Powered by Stellar {networkLabelLowercase()}{' '}
+        <WalletTooltip concept="stellar" />{' '}
+        {networkLabelLowercase() === 'testnet' ? (
+          <WalletTooltip concept="testnet" />
+        ) : null}{' '}
+        • {tipFlowShortNote()}
+      </p>
+    </>
+  )
+}
+
+function formatTipLabel(variant: 'article' | 'highlight'): string {
+  return variant === 'article' ? 'tip' : 'highlight tip'
+}

--- a/components/tipping/TipCheckoutStep.tsx
+++ b/components/tipping/TipCheckoutStep.tsx
@@ -132,8 +132,8 @@ export function TipCheckoutStep({
       ) : !isConnected ? (
         <div className="p-3 bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-lg text-sm text-amber-900 dark:text-amber-100">
           <p>
-            Connect your Stellar wallet to send your{' '}
-            {formatTipLabel(variant)} to {authorName}.
+            Connect your Stellar wallet to send your {formatTipLabel(variant)}{' '}
+            to {authorName}.
           </p>
           <p className="mt-1">
             New to crypto?{' '}

--- a/components/tipping/TipHowItWorks.test.tsx
+++ b/components/tipping/TipHowItWorks.test.tsx
@@ -1,0 +1,35 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { TipHowItWorks } from '@/components/tipping/TipHowItWorks'
+
+vi.mock('@/components/guide/WalletTooltip', () => ({
+  WalletTooltip: () => null,
+}))
+
+describe('TipHowItWorks', () => {
+  it('hides technical details until expanded', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(
+      <TipHowItWorks
+        priceUsd={0.12}
+        totalFormatted="$5.00"
+        authorFormatted="$4.88"
+        platformFeeFormatted="$0.12"
+      />
+    )
+
+    expect(screen.queryByText(/97\.5%/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Platform fee/)).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'How it works' }))
+
+    expect(screen.getByText(/97\.5%/)).toBeInTheDocument()
+    expect(screen.getByText(/Platform fee/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /setup guide/i })).toHaveAttribute(
+      'href',
+      '/guide'
+    )
+  })
+})

--- a/components/tipping/TipHowItWorks.tsx
+++ b/components/tipping/TipHowItWorks.tsx
@@ -46,7 +46,10 @@ export function TipHowItWorks({
         />
       </CollapsibleTrigger>
       <CollapsibleContent className="mt-2 space-y-2 rounded-lg border border-border bg-muted/30 p-3 text-sm text-muted-foreground">
-        <p>97.5% of your tip goes directly to the author. A small platform fee covers payment processing.</p>
+        <p>
+          97.5% of your tip goes directly to the author. A small platform fee
+          covers payment processing.
+        </p>
         {showBreakdown ? (
           <TipBreakdownSummaryLine
             totalFormatted={totalFormatted}

--- a/components/tipping/TipHowItWorks.tsx
+++ b/components/tipping/TipHowItWorks.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { ChevronDown } from 'lucide-react'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { WalletTooltip } from '@/components/guide/WalletTooltip'
+import { TipBreakdownSummaryLine } from '@/components/tipping/TipBreakdownSummaryLine'
+import { TipUsdXlmRateLine } from '@/components/tipping/TipUsdXlmRateLine'
+import {
+  networkLabelLowercase,
+  tipFlowShortNote,
+} from '@/lib/copy/network-status'
+import { cn } from '@/lib/utils'
+
+interface TipHowItWorksProps {
+  priceUsd: number | null
+  totalFormatted?: string
+  authorFormatted?: string
+  platformFeeFormatted?: string
+}
+
+export function TipHowItWorks({
+  priceUsd,
+  totalFormatted,
+  authorFormatted,
+  platformFeeFormatted,
+}: TipHowItWorksProps) {
+  const [open, setOpen] = useState(false)
+  const showBreakdown =
+    totalFormatted && authorFormatted && platformFeeFormatted
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger className="focus-ring flex w-full items-center justify-between rounded-lg border border-border px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted/50">
+        How it works
+        <ChevronDown
+          className={cn(
+            'h-4 w-4 shrink-0 transition-transform',
+            open && 'rotate-180'
+          )}
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2 space-y-2 rounded-lg border border-border bg-muted/30 p-3 text-sm text-muted-foreground">
+        <p>97.5% of your tip goes directly to the author. A small platform fee covers payment processing.</p>
+        {showBreakdown ? (
+          <TipBreakdownSummaryLine
+            totalFormatted={totalFormatted}
+            authorFormatted={authorFormatted}
+            platformFeeFormatted={platformFeeFormatted}
+          />
+        ) : null}
+        <TipUsdXlmRateLine priceUsd={priceUsd} />
+        <p className="flex flex-wrap items-center justify-center gap-1 text-xs">
+          Powered by Stellar {networkLabelLowercase()}{' '}
+          <WalletTooltip concept="stellar" />{' '}
+          {networkLabelLowercase() === 'testnet' ? (
+            <WalletTooltip concept="testnet" />
+          ) : null}{' '}
+          • {tipFlowShortNote()}
+        </p>
+        <p>
+          New to crypto?{' '}
+          <Link
+            href="/guide"
+            className="focus-ring rounded font-medium text-foreground underline hover:text-foreground/80"
+          >
+            Follow our setup guide
+          </Link>
+        </p>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/components/tipping/tipModalStep.ts
+++ b/components/tipping/tipModalStep.ts
@@ -1,0 +1,1 @@
+export type TipModalStep = 'appreciation' | 'checkout'

--- a/lib/wallet/connectWalletFromOverlay.test.ts
+++ b/lib/wallet/connectWalletFromOverlay.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+import { connectWalletFromOverlay } from './connectWalletFromOverlay'
+
+describe('connectWalletFromOverlay', () => {
+  it('closes overlay before connect and reopens after success', async () => {
+    const order: string[] = []
+    const activateWallet = vi.fn(() => order.push('activate'))
+    const connect = vi.fn(async () => {
+      order.push('connect')
+      return true
+    })
+    const closeOverlay = vi.fn(() => {
+      order.push('close')
+    })
+    const reopenOverlay = vi.fn(() => {
+      order.push('reopen')
+    })
+    const yieldToBrowser = vi.fn(async () => {
+      order.push('yield')
+    })
+
+    const result = await connectWalletFromOverlay({
+      activateWallet,
+      connect,
+      closeOverlay,
+      reopenOverlay,
+      yieldToBrowser,
+    })
+
+    expect(result).toBe(true)
+    expect(order).toEqual(['activate', 'close', 'yield', 'connect', 'reopen'])
+  })
+
+  it('reopens overlay when connect throws', async () => {
+    const reopenOverlay = vi.fn()
+    const connect = vi.fn(async () => {
+      throw new Error('Wallet selection cancelled')
+    })
+
+    await expect(
+      connectWalletFromOverlay({
+        activateWallet: vi.fn(),
+        connect,
+        closeOverlay: vi.fn(),
+        reopenOverlay,
+        yieldToBrowser: vi.fn(async () => {}),
+      })
+    ).rejects.toThrow('Wallet selection cancelled')
+
+    expect(reopenOverlay).toHaveBeenCalledTimes(1)
+  })
+})

--- a/lib/wallet/connectWalletFromOverlay.ts
+++ b/lib/wallet/connectWalletFromOverlay.ts
@@ -1,0 +1,33 @@
+export type ConnectWalletFromOverlayOptions = {
+  activateWallet: () => void
+  connect: () => Promise<boolean>
+  closeOverlay: () => void | Promise<void>
+  reopenOverlay: () => void | Promise<void>
+  yieldToBrowser?: () => Promise<void>
+}
+
+const defaultYieldToBrowser = () =>
+  new Promise<void>((resolve) => {
+    requestAnimationFrame(() => resolve())
+  })
+
+/**
+ * Connect a wallet while a Radix (or similar) overlay dialog is open.
+ * Closes the overlay first so the Stellar Wallets Kit modal and extension
+ * popups are not blocked by the parent dialog's focus trap / inert layer.
+ */
+export async function connectWalletFromOverlay(
+  options: ConnectWalletFromOverlayOptions
+): Promise<boolean> {
+  const yieldToBrowser = options.yieldToBrowser ?? defaultYieldToBrowser
+
+  options.activateWallet()
+  await options.closeOverlay()
+  await yieldToBrowser()
+
+  try {
+    return await options.connect()
+  } finally {
+    await options.reopenOverlay()
+  }
+}


### PR DESCRIPTION
## Summary

Restructures article and highlight tip modals into a two-step flow so tipping feels like reader appreciation first and wallet/payment mechanics second. 

## Changes

- Add shared tip step components: `TipAppreciationStep`, `TipCheckoutStep`, `TipHowItWorks`, and `TipAmountSummary`
- Refactor `TipButton` and `HighlightTipButton` to use `appreciation` → `checkout` modal steps
- Stage 1 shows amount selection, optional message (article only), and a Continue CTA
- Stage 2 handles sign in, wallet connect, and send tip with a read-only amount summary
- Move XLM conversion, fee split, testnet copy, and setup guide link behind a collapsed "How it works" disclosure
- Defer `activateWallet()` until Continue or post-login resume
- Resume flows open directly on checkout with restored amount and message
- Update unit tests for staged CTAs, resume behavior, and `TipHowItWorks` disclosure

## Testing

- [x] `bun run test:once -- components/tipping components/highlights/HighlightTipButton.test.tsx`
- [x] `bun run typecheck`
- [x] `bun run lint`


## Notes

- Backend tipping logic, Convex mutations, and Stellar transaction handling are unchanged
- Article page layout, stats, and article details accordion are out of scope
<img width="1440" height="855" alt="2" src="https://github.com/user-attachments/assets/e521ae24-2ab8-4ec2-8926-9f582b67ba32" />


https://github.com/user-attachments/assets/d33b045c-88ec-477a-a8e1-230a5ed6a699

