### PR TITLE
feat(reader): tone down tipping and NFT monetization visuals (ENG-257)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -632,6 +632,8 @@
   --popover-foreground: #f8f9fa;
   --primary: #e8eaed;
   --primary-foreground: #202124;
+  --heatmap-2: #7fb3d5;
+  --heatmap-3: #e8eaed;
   --secondary: #3c4043;
   --secondary-foreground: #f8f9fa;
   --muted: #3c4043;

--- a/app/globals.css
+++ b/app/globals.css
@@ -152,6 +152,17 @@
   --popover-foreground: #202124;
   --primary: #1a365d;
   --primary-foreground: #fefefe;
+  --heatmap-0: #e6e6c3;
+  --heatmap-1: #7fb3d5;
+  --heatmap-2: #003366;
+  --heatmap-3: #1a365d;
+  --heatmap-gradient: linear-gradient(
+    to right,
+    var(--heatmap-0),
+    var(--heatmap-1),
+    var(--heatmap-2),
+    var(--heatmap-3)
+  );
   --secondary: #f1f3f4;
   --secondary-foreground: #202124;
   --muted: #f1f3f4;
@@ -195,7 +206,8 @@
    * - Tip / upload success: bg-success text-success-foreground
    * - Pending / uploading / info: bg-info text-info-foreground
    * - Section icons / quiet stats: text-muted-foreground
-   * - Heat / NFT progress emphasis: bg-primary/50 on bg-muted track
+   * - Heat intensity bars: --heatmap-gradient (cream → sky → navy → primary)
+   * - NFT progress emphasis: bg-primary/50 on bg-muted track
    * - Errors: destructive variant
    * Wallet/NFT accent: reuse --primary (no separate monetization token).
    * See docs/design-system/monetization-status-colors.md

--- a/app/globals.css
+++ b/app/globals.css
@@ -190,6 +190,18 @@
   --info-foreground: oklch(0.48 0.17 240);
 
   /*
+   * Monetization status mapping (reader-facing tip, highlight, NFT surfaces):
+   * - Wallet not connected: bg-warning text-warning-foreground border-warning/30
+   * - Tip / upload success: bg-success text-success-foreground
+   * - Pending / uploading / info: bg-info text-info-foreground
+   * - Section icons / quiet stats: text-muted-foreground
+   * - Heat / NFT progress emphasis: bg-primary/50 on bg-muted track
+   * - Errors: destructive variant
+   * Wallet/NFT accent: reuse --primary (no separate monetization token).
+   * See docs/design-system/monetization-status-colors.md
+   */
+
+  /*
    * Landing semantic tokens
    * - brand: consistent CTA color across modes
    * - spotlight: intentionally darker section surface that still adapts in dark mode

--- a/components/articles/ArticleDetailsPanel.tsx
+++ b/components/articles/ArticleDetailsPanel.tsx
@@ -87,7 +87,7 @@ export function ArticleDetailsPanel({
 
             <DetailsSection>
               <h4 className="text-sm font-medium flex items-center gap-2 mb-4">
-                <Trophy className="w-4 h-4 text-purple-500" />
+                <Trophy className="w-4 h-4 text-muted-foreground" />
                 NFT Collection
               </h4>
               <NFTIntegration
@@ -110,7 +110,7 @@ export function ArticleDetailsPanel({
 
             <DetailsSection>
               <h4 className="text-sm font-medium flex items-center gap-2 mb-4">
-                <MessageSquare className="w-4 h-4 text-blue-500" />
+                <MessageSquare className="w-4 h-4 text-muted-foreground" />
                 Highlight Notes
                 {noteCount > 0 && (
                   <span className="px-2 py-0.5 bg-primary/15 text-primary text-xs rounded-full">
@@ -138,7 +138,7 @@ export function ArticleDetailsPanel({
             {tipStats && (
               <DetailsSection>
                 <h4 className="text-sm font-medium flex items-center gap-2 mb-4">
-                  <DollarSign className="w-4 h-4 text-green-500" />
+                  <DollarSign className="w-4 h-4 text-muted-foreground" />
                   Article Stats
                 </h4>
                 <div className="space-y-3">
@@ -159,7 +159,7 @@ export function ArticleDetailsPanel({
             {arweaveStatus && (
               <DetailsSection>
                 <h4 className="text-sm font-medium flex items-center gap-2 mb-4">
-                  <Archive className="w-4 h-4 text-blue-500" />
+                  <Archive className="w-4 h-4 text-muted-foreground" />
                   Permanent Storage
                 </h4>
                 <ArweaveStatus

--- a/components/articles/ArweaveStatus.tsx
+++ b/components/articles/ArweaveStatus.tsx
@@ -24,24 +24,22 @@ const statusConfig: Record<
   { color: string; icon: React.ReactNode; label: string }
 > = {
   pending: {
-    color:
-      'text-yellow-900 bg-yellow-50 dark:text-yellow-200 dark:bg-yellow-950/50',
+    color: 'bg-warning text-warning-foreground',
     icon: <Clock className="w-4 h-4" />,
     label: 'Uploading to Arweave',
   },
   uploaded: {
-    color: 'text-blue-900 bg-blue-50 dark:text-blue-200 dark:bg-blue-950/50',
+    color: 'bg-info text-info-foreground',
     icon: <Loader2 className="w-4 h-4 animate-spin" />,
     label: 'Confirming on Arweave',
   },
   verified: {
-    color:
-      'text-green-900 bg-green-50 dark:text-green-200 dark:bg-green-950/50',
+    color: 'bg-success text-success-foreground',
     icon: <CheckCircle className="w-4 h-4" />,
     label: 'Permanently stored',
   },
   failed: {
-    color: 'text-red-900 bg-red-50 dark:text-red-200 dark:bg-red-950/50',
+    color: 'bg-destructive/10 text-destructive',
     icon: <XCircle className="w-4 h-4" />,
     label: 'Upload failed',
   },

--- a/components/highlights/HighlightDetailsPanel.tsx
+++ b/components/highlights/HighlightDetailsPanel.tsx
@@ -309,9 +309,9 @@ export function HighlightDetailsPanel({
 
         {/* Tip Statistics */}
         {tipStats.count > 0 && (
-          <div className="px-4 py-3 border-b border-border bg-gradient-to-r from-yellow-50 to-orange-50 dark:from-yellow-950/30 dark:to-orange-950/30">
+          <div className="px-4 py-3 border-b border-border bg-muted">
             <div className="flex items-center gap-2 mb-2">
-              <TrendingUp className="w-4 h-4 text-orange-500" />
+              <TrendingUp className="w-4 h-4 text-muted-foreground" />
               <span className="text-xs font-medium text-foreground">
                 Tip Statistics
               </span>
@@ -327,7 +327,7 @@ export function HighlightDetailsPanel({
                 <div className="text-xs text-muted-foreground">
                   Total Earned
                 </div>
-                <div className="text-lg font-bold text-orange-600">
+                <div className="text-lg font-bold text-foreground">
                   {formatTipAmount(tipStats.totalCents)}
                 </div>
               </div>
@@ -402,7 +402,7 @@ export function HighlightDetailsPanel({
                 />
                 {tipStats.count === 0 && (
                   <p className="text-xs text-center text-muted-foreground mt-2">
-                    Be the first to tip this highlight!
+                    No support for this highlight yet
                   </p>
                 )}
               </div>

--- a/components/highlights/HighlightHeatmap.tsx
+++ b/components/highlights/HighlightHeatmap.tsx
@@ -6,6 +6,7 @@ import { getHeatmapColor, formatTipAmount } from '@/lib/stellar/highlight-utils'
 import { Flame, TrendingUp, Sparkles } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useMemo, useState } from 'react'
+import { Badge } from '@/components/ui/badge'
 
 interface HighlightHeatmapProps {
   articleId: Id<'articles'>
@@ -65,7 +66,7 @@ export function HighlightHeatmap({
               embedded ? 'text-sm font-medium' : 'text-lg font-semibold'
             )}
           >
-            <Flame className="w-5 h-5 text-orange-500" />
+            <Flame className="w-5 h-5 text-muted-foreground" />
             Highlight Heatmap
           </h3>
 
@@ -117,13 +118,13 @@ export function HighlightHeatmap({
             {window === 'all'
               ? isAuthor
                 ? 'No highlight tips yet'
-                : 'Be the first to tip a highlight!'
+                : 'No highlighted passages supported yet'
               : `No highlight tips in the last ${windowLabel}`}
           </p>
           <p className="text-foreground/85 text-xs">
             {isAuthor
               ? 'Readers can highlight specific phrases and tip them directly'
-              : 'Select text to highlight and add a tip to your favorite phrases'}
+              : 'Highlight a passage you valued and choose an amount to support it'}
           </p>
         </div>
 
@@ -131,8 +132,8 @@ export function HighlightHeatmap({
         {!isAuthor && (
           <div className="mt-4 p-4 rounded-lg border border-border bg-muted">
             <p className="text-sm text-foreground">
-              <strong>How it works:</strong> Select any text in the article,
-              then click the tip button to support specific phrases you love!
+              <strong>How it works:</strong> Highlight a passage you valued and
+              choose an amount to support it.
             </p>
           </div>
         )}
@@ -154,7 +155,7 @@ export function HighlightHeatmap({
             embedded ? 'text-sm font-medium' : 'text-lg font-semibold'
           )}
         >
-          <Flame className="w-5 h-5 text-orange-500" />
+          <Flame className="w-5 h-5 text-muted-foreground" />
           Highlight Heatmap
         </h3>
 
@@ -233,7 +234,7 @@ export function HighlightHeatmap({
           {stats.topHighlights.map((highlight, index: number) => {
             const intensity =
               maxAmount > 0 ? highlight.totalAmountCents / maxAmount : 0
-            const bgColor = getHeatmapColor(
+            const heatOpacity = getHeatmapColor(
               highlight.totalAmountCents,
               maxAmount
             )
@@ -241,20 +242,13 @@ export function HighlightHeatmap({
             return (
               <div
                 key={highlight.highlightId}
-                className="p-3 rounded-lg border transition-all hover:shadow-md"
-                style={{
-                  backgroundColor: `${bgColor}20`, // 20% opacity
-                  borderColor: bgColor,
-                }}
+                className="p-3 rounded-lg border border-border bg-muted/50 transition-colors hover:bg-muted/80"
               >
                 <div className="flex items-start justify-between gap-3 mb-2">
                   <div className="flex items-center gap-2">
-                    <span
-                      className="flex items-center justify-center w-6 h-6 rounded-full text-xs font-bold text-white"
-                      style={{ backgroundColor: bgColor }}
-                    >
+                    <Badge variant="secondary" className="h-6 w-6 justify-center p-0 text-xs">
                       {index + 1}
-                    </span>
+                    </Badge>
                     <span className="text-xs text-muted-foreground">
                       {highlight.tipCount} tip
                       {highlight.tipCount > 1 ? 's' : ''}
@@ -269,14 +263,10 @@ export function HighlightHeatmap({
                   &ldquo;{highlight.text}&rdquo;
                 </p>
 
-                {/* Intensity bar */}
                 <div className="mt-2 h-1.5 bg-muted rounded-full overflow-hidden">
                   <div
-                    className="h-full rounded-full transition-all"
-                    style={{
-                      width: `${intensity * 100}%`,
-                      backgroundColor: bgColor,
-                    }}
+                    className="h-full rounded-full bg-primary/50 transition-all"
+                    style={{ width: `${intensity * 100}%`, opacity: heatOpacity }}
                   />
                 </div>
               </div>
@@ -292,12 +282,7 @@ export function HighlightHeatmap({
         </p>
         <div className="flex items-center gap-2">
           <span className="text-xs text-muted-foreground">Low</span>
-          <div
-            className="flex-1 h-3 rounded-full"
-            style={{
-              background: `linear-gradient(to right, ${getHeatmapColor(0, 100)}, ${getHeatmapColor(33, 100)}, ${getHeatmapColor(66, 100)}, ${getHeatmapColor(100, 100)})`,
-            }}
-          />
+          <div className="flex-1 h-3 rounded-full bg-gradient-to-r from-primary/20 via-primary/50 to-primary" />
           <span className="text-xs text-muted-foreground">High</span>
         </div>
       </div>

--- a/components/highlights/HighlightHeatmap.tsx
+++ b/components/highlights/HighlightHeatmap.tsx
@@ -2,7 +2,11 @@
 
 import { useArticleHighlightTipStats } from '@/hooks/convex'
 import type { Id } from '@/types/convex'
-import { getHeatmapColor, formatTipAmount } from '@/lib/stellar/highlight-utils'
+import {
+  HEATMAP_GRADIENT_CSS,
+  getHeatmapColor,
+  formatTipAmount,
+} from '@/lib/stellar/highlight-utils'
 import { Flame, TrendingUp, Sparkles } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useMemo, useState } from 'react'
@@ -234,7 +238,7 @@ export function HighlightHeatmap({
           {stats.topHighlights.map((highlight, index: number) => {
             const intensity =
               maxAmount > 0 ? highlight.totalAmountCents / maxAmount : 0
-            const heatOpacity = getHeatmapColor(
+            const heatColor = getHeatmapColor(
               highlight.totalAmountCents,
               maxAmount
             )
@@ -265,8 +269,11 @@ export function HighlightHeatmap({
 
                 <div className="mt-2 h-1.5 bg-muted rounded-full overflow-hidden">
                   <div
-                    className="h-full rounded-full bg-primary/50 transition-all"
-                    style={{ width: `${intensity * 100}%`, opacity: heatOpacity }}
+                    className="h-full rounded-full transition-all"
+                    style={{
+                      width: `${intensity * 100}%`,
+                      backgroundColor: heatColor,
+                    }}
                   />
                 </div>
               </div>
@@ -282,7 +289,10 @@ export function HighlightHeatmap({
         </p>
         <div className="flex items-center gap-2">
           <span className="text-xs text-muted-foreground">Low</span>
-          <div className="flex-1 h-3 rounded-full bg-gradient-to-r from-primary/20 via-primary/50 to-primary" />
+          <div
+            className="flex-1 h-3 rounded-full"
+            style={{ background: HEATMAP_GRADIENT_CSS }}
+          />
           <span className="text-xs text-muted-foreground">High</span>
         </div>
       </div>

--- a/components/highlights/HighlightHeatmap.tsx
+++ b/components/highlights/HighlightHeatmap.tsx
@@ -250,7 +250,10 @@ export function HighlightHeatmap({
               >
                 <div className="flex items-start justify-between gap-3 mb-2">
                   <div className="flex items-center gap-2">
-                    <Badge variant="secondary" className="h-6 w-6 justify-center p-0 text-xs">
+                    <Badge
+                      variant="secondary"
+                      className="h-6 w-6 justify-center p-0 text-xs"
+                    >
                       {index + 1}
                     </Badge>
                     <span className="text-xs text-muted-foreground">

--- a/components/highlights/HighlightNotes.tsx
+++ b/components/highlights/HighlightNotes.tsx
@@ -109,7 +109,7 @@ export function HighlightNotes({
             if (!tipData?.count) return null
             return (
               <div className="mb-2">
-                <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-yellow-100 dark:bg-yellow-950/50 text-yellow-800 dark:text-yellow-200 text-xs rounded-full">
+                <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-muted text-muted-foreground text-xs rounded-full">
                   <Coins className="w-3 h-3" />
                   {tipData.count} tip{tipData.count > 1 ? 's' : ''}
                   {' · '}${tipData.totalUsd.toFixed(2)}

--- a/components/highlights/HighlightPopover.tsx
+++ b/components/highlights/HighlightPopover.tsx
@@ -4,6 +4,7 @@ import { useRef, useState, useEffect } from 'react'
 import { FocusScope } from '@radix-ui/react-focus-scope'
 import { Highlighter, MessageSquare, Lock, Globe } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
 import { HighlightTipButton } from './HighlightTipButton'
 import { Id } from '@/convex/_generated/dataModel'
 import { useClampedFixedPosition } from '@/hooks/useClampedFixedPosition'
@@ -232,13 +233,14 @@ export function HighlightPopover({
 
           <div className="flex gap-2 mb-3">
             {isAuthenticated && (
-              <button
+              <Button
+                type="button"
                 onClick={handleSaveHighlight}
-                className="highlight-action-button flex-1 bg-gradient-to-r from-blue-500 to-blue-600 text-white hover:from-blue-600 hover:to-blue-700 flex items-center justify-center"
+                className="highlight-action-button flex-1"
               >
                 <Highlighter className="w-4 h-4 mr-2" />
                 <span>Save</span>
-              </button>
+              </Button>
             )}
 
             {articleId &&

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -39,6 +39,8 @@ import {
   type TipFailureMessage,
 } from '@/lib/stellar/tip-error-messages'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 import { signInToTip, validateTipAmountForm } from '@/lib/tip/signInToTip'
 import { connectWalletFromOverlay } from '@/lib/wallet/connectWalletFromOverlay'
 import { applyPendingAmountFields } from '@/lib/tip/applyPendingTipFormState'
@@ -473,14 +475,16 @@ export function HighlightTipButton({
     <>
       <Dialog open={isOpen} onOpenChange={handleOpenChange}>
         <DialogTrigger asChild>
-          <button
+          <Button
             type="button"
-            className={`focus-ring inline-flex items-center gap-2 px-3 py-1.5 bg-gradient-to-r from-yellow-400 to-orange-500 text-white rounded-lg hover:from-yellow-500 hover:to-orange-600 transition-all transform hover:scale-105 shadow-md text-sm ${className}`}
+            variant="outline"
+            size="sm"
+            className={cn('gap-2', className)}
             title="Tip this highlight"
           >
             <Coins className="w-3.5 h-3.5" />
             <span className="font-medium">Tip Highlight</span>
-          </button>
+          </Button>
         </DialogTrigger>
         <DialogContent
           data-testid="highlight-tip-dialog"
@@ -541,7 +545,6 @@ export function HighlightTipButton({
               onSignIn={handleSignInToTip}
               onConnectWallet={handleConnectWallet}
               onSendTip={() => void handleTip()}
-              useGradientButtons
             />
           )}
         </DialogContent>

--- a/components/nft/MintButton.tsx
+++ b/components/nft/MintButton.tsx
@@ -244,7 +244,8 @@ export function MintButton({
           />
         </div>
         <p className="text-xs text-muted-foreground">
-          ${(threshold - totalTips).toFixed(2)} more to mint NFT
+          ${(threshold - totalTips).toFixed(2)} more in support to become
+          eligible
         </p>
       </div>
     )
@@ -287,8 +288,8 @@ export function MintButton({
 
           <div className="space-y-4">
             {!wallet.isConnected && (
-              <div className="bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3">
-                <p className="text-sm text-amber-900 dark:text-amber-100">
+              <div className="bg-warning text-warning-foreground border border-warning/30 rounded-lg p-3">
+                <p className="text-sm">
                   Connect your wallet to mint this article as an NFT.
                 </p>
               </div>
@@ -302,26 +303,22 @@ export function MintButton({
                 </div>
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">Threshold Met:</span>
-                  <span className="font-medium text-green-800 dark:text-green-300">
+                  <span className="font-medium text-success-foreground">
                     ✓ Yes
                   </span>
                 </div>
                 {wallet.isConnected && wallet.publicKey ? (
-                  <div className="bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800 rounded p-2">
+                  <div className="bg-success/10 text-success-foreground border border-success/30 rounded p-2">
                     <div className="flex items-center justify-between text-xs">
-                      <span className="text-green-900 dark:text-green-200 font-medium">
-                        ✓ Wallet Connected
-                      </span>
-                      <span className="font-mono text-green-700 dark:text-green-300">
+                      <span className="font-medium">✓ Wallet Connected</span>
+                      <span className="font-mono">
                         {`${wallet.publicKey.slice(0, 4)}...${wallet.publicKey.slice(-4)}`}
                       </span>
                     </div>
                   </div>
                 ) : (
-                  <div className="bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded p-2">
-                    <span className="text-xs text-amber-900 dark:text-amber-100">
-                      Wallet not connected
-                    </span>
+                  <div className="bg-warning text-warning-foreground border border-warning/30 rounded p-2">
+                    <span className="text-xs">Wallet not connected</span>
                   </div>
                 )}
               </div>
@@ -329,7 +326,7 @@ export function MintButton({
 
             {isLoading && (
               <div
-                className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-900/50 dark:bg-blue-950/30"
+                className="rounded-lg border border-info/30 bg-info/10 p-4 text-info-foreground"
                 aria-busy="true"
                 aria-live="polite"
               >
@@ -351,7 +348,7 @@ export function MintButton({
                           className={cn(
                             'flex h-8 w-8 shrink-0 items-center justify-center rounded-full border-2 text-xs font-semibold transition-colors',
                             isComplete &&
-                              'border-green-600 bg-green-100 text-green-800 dark:border-green-500 dark:bg-green-950/50 dark:text-green-300',
+                              'border-success bg-success/20 text-success-foreground',
                             isCurrent &&
                               !isComplete &&
                               'border-primary bg-primary/10 text-primary',

--- a/components/nft/NFTBadge.tsx
+++ b/components/nft/NFTBadge.tsx
@@ -36,58 +36,20 @@ export function NFTBadge({
   const getRarity = (tips?: number) => {
     if (rarityProp) {
       const rarityMap = {
-        legendary: {
-          label: 'Legendary',
-          color: 'bg-gradient-to-r from-purple-500 to-pink-500',
-        },
-        epic: {
-          label: 'Epic',
-          color: 'bg-gradient-to-r from-blue-500 to-purple-500',
-        },
-        rare: {
-          label: 'Rare',
-          color: 'bg-gradient-to-r from-green-500 to-blue-500',
-        },
-        uncommon: {
-          label: 'Uncommon',
-          color: 'bg-gradient-to-r from-yellow-500 to-green-500',
-        },
-        common: {
-          label: 'Common',
-          color: 'bg-gradient-to-r from-gray-500 to-gray-600',
-        },
+        legendary: { label: 'Legendary' },
+        epic: { label: 'Epic' },
+        rare: { label: 'Rare' },
+        uncommon: { label: 'Uncommon' },
+        common: { label: 'Common' },
       }
       return rarityMap[rarityProp]
     }
-    if (tips === undefined)
-      return {
-        label: 'NFT',
-        color: 'bg-gradient-to-r from-gray-500 to-gray-600',
-      }
-    if (tips >= 100)
-      return {
-        label: 'Legendary',
-        color: 'bg-gradient-to-r from-purple-500 to-pink-500',
-      }
-    if (tips >= 50)
-      return {
-        label: 'Epic',
-        color: 'bg-gradient-to-r from-blue-500 to-purple-500',
-      }
-    if (tips >= 25)
-      return {
-        label: 'Rare',
-        color: 'bg-gradient-to-r from-green-500 to-blue-500',
-      }
-    if (tips >= 10)
-      return {
-        label: 'Uncommon',
-        color: 'bg-gradient-to-r from-yellow-500 to-green-500',
-      }
-    return {
-      label: 'Common',
-      color: 'bg-gradient-to-r from-gray-500 to-gray-600',
-    }
+    if (tips === undefined) return { label: 'NFT' }
+    if (tips >= 100) return { label: 'Legendary' }
+    if (tips >= 50) return { label: 'Epic' }
+    if (tips >= 25) return { label: 'Rare' }
+    if (tips >= 10) return { label: 'Uncommon' }
+    return { label: 'Common' }
   }
 
   const rarity = getRarity(totalTips)
@@ -119,9 +81,7 @@ export function NFTBadge({
   // Simple badge without tooltip if showLabel is true
   if (showLabel) {
     return (
-      <Badge
-        className={`${sizeClasses[size]} ${rarity.color} text-white border-0`}
-      >
+      <Badge variant="secondary" className={sizeClasses[size]}>
         <Sparkles className={`mr-1 ${iconSize[size]}`} />
         {rarity.label}
       </Badge>
@@ -133,7 +93,8 @@ export function NFTBadge({
       <Tooltip>
         <TooltipTrigger asChild>
           <Badge
-            className={`${sizeClasses[size]} ${rarity.color} text-white border-0 cursor-default`}
+            variant="secondary"
+            className={`${sizeClasses[size]} cursor-default`}
           >
             <Sparkles className={`mr-1 ${iconSize[size]}`} />
             NFT {rarity.label !== 'NFT' ? `• ${rarity.label}` : ''}

--- a/components/nft/NFTIntegration.tsx
+++ b/components/nft/NFTIntegration.tsx
@@ -135,7 +135,7 @@ export function NFTIntegration({
                     </div>
                     <div className="w-full bg-muted rounded-full h-2">
                       <div
-                        className="bg-gradient-to-r from-blue-500 to-purple-500 h-2 rounded-full transition-all duration-500"
+                        className="bg-primary/50 h-2 rounded-full transition-all duration-500"
                         style={{
                           width: `${Math.min(progressPercentage, 100)}%`,
                         }}
@@ -144,7 +144,7 @@ export function NFTIntegration({
                     <p className="text-xs text-muted-foreground mt-2">
                       {progressPercentage >= 100
                         ? 'Eligible for minting!'
-                        : `${(100 - progressPercentage).toFixed(0)}% more tips needed to unlock NFT minting`}
+                        : `$${((nftStatus.tipThreshold - nftStatus.totalTips) / 100).toFixed(2)} more in reader support to become eligible`}
                     </p>
                   </div>
 

--- a/components/nft/TransferModal.tsx
+++ b/components/nft/TransferModal.tsx
@@ -196,20 +196,20 @@ export function TransferModal({
 
   const messageBannerClass =
     transferMessage.kind === 'success'
-      ? 'bg-green-50 text-green-700 dark:bg-green-950/50 dark:text-green-200'
+      ? 'bg-success text-success-foreground'
       : transferMessage.kind === 'error'
-        ? 'bg-red-50 text-red-700 dark:bg-red-950/50 dark:text-red-200'
+        ? 'bg-destructive/10 text-destructive'
         : transferMessage.kind === 'progress'
-          ? 'bg-blue-50 text-blue-700 dark:bg-blue-950/50 dark:text-blue-200'
+          ? 'bg-info text-info-foreground'
           : ''
 
   const messageIcon =
     transferMessage.kind === 'progress' ? (
       <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
     ) : transferMessage.kind === 'success' ? (
-      <CheckCircle className="h-4 w-4 shrink-0 text-green-500" />
+      <CheckCircle className="h-4 w-4 shrink-0" />
     ) : transferMessage.kind === 'error' ? (
-      <AlertCircle className="h-4 w-4 shrink-0 text-red-500" />
+      <AlertCircle className="h-4 w-4 shrink-0" />
     ) : null
 
   const irreversibleWarning = `You are transferring ownership of the NFT for "${articleTitle}" to @${recipientUsername}. This cannot be undone.`
@@ -381,7 +381,6 @@ export function TransferModal({
                   transferMessage.kind === 'success' ||
                   !recipientUsername.trim()
                 }
-                className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600"
               >
                 <Send className="mr-2 h-4 w-4" aria-hidden />
                 Review transfer
@@ -392,7 +391,6 @@ export function TransferModal({
                 onClick={() => void handleTransfer()}
                 disabled={isBusy || transferMessage.kind === 'success'}
                 aria-busy={isBusy}
-                className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600"
               >
                 {isBusy ? (
                   <>

--- a/components/tipping/TipAppreciationStep.tsx
+++ b/components/tipping/TipAppreciationStep.tsx
@@ -66,7 +66,7 @@ export function TipAppreciationStep({
   return (
     <>
       {variant === 'highlight' && displayHighlightText ? (
-        <div className="p-3 bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800 rounded-lg">
+        <div className="p-3 bg-muted border border-border rounded-lg">
           <p className="text-sm text-foreground italic">
             &ldquo;{displayHighlightText}&rdquo;
           </p>
@@ -75,8 +75,8 @@ export function TipAppreciationStep({
 
       <p className="text-muted-foreground text-sm">
         {variant === 'article'
-          ? `Show your appreciation for ${authorName}'s work with a micro-tip.`
-          : `Tip ${authorName} for this insight that stood out to you.`}
+          ? `Choose an amount to support ${authorName}.`
+          : `Support ${authorName} for this passage.`}
       </p>
 
       <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
@@ -89,14 +89,14 @@ export function TipAppreciationStep({
               onCustomAmountChange('')
             }}
             disabled={isLoading}
-            className={`focus-ring relative flex min-h-12 items-center justify-center px-4 py-3 rounded-lg border-2 transition-all disabled:opacity-50 ${
+            className={`focus-ring relative flex min-h-12 items-center justify-center px-4 py-3 rounded-lg border transition-colors disabled:opacity-50 ${
               selectedAmount === amount.cents
-                ? 'border-orange-500 bg-orange-50 dark:bg-orange-950/30'
-                : 'border-border hover:border-orange-300'
+                ? 'border-primary bg-muted ring-1 ring-primary'
+                : 'border-input hover:bg-accent'
             }`}
           >
             {amount.popular && (
-              <span className="absolute -top-2 left-1/2 transform -translate-x-1/2 px-2 py-0.5 bg-orange-500 text-white text-xs rounded-full">
+              <span className="absolute -top-2 left-1/2 transform -translate-x-1/2 px-2 py-0.5 bg-primary text-primary-foreground text-xs rounded-full">
                 Popular
               </span>
             )}

--- a/components/tipping/TipCheckoutStep.tsx
+++ b/components/tipping/TipCheckoutStep.tsx
@@ -30,7 +30,6 @@ interface TipCheckoutStepProps {
   onSignIn: () => void
   onConnectWallet: () => void
   onSendTip: () => void
-  useGradientButtons?: boolean
 }
 
 export function TipCheckoutStep({
@@ -50,13 +49,7 @@ export function TipCheckoutStep({
   onSignIn,
   onConnectWallet,
   onSendTip,
-  useGradientButtons = false,
 }: TipCheckoutStepProps) {
-  const primaryGradientClass =
-    'bg-gradient-to-r from-yellow-400 to-orange-500 text-white hover:from-yellow-500 hover:to-orange-600'
-  const connectGradientClass =
-    'bg-gradient-to-r from-blue-500 to-blue-600 text-white hover:from-blue-600 hover:to-blue-700'
-
   const renderPrimaryButton = () => {
     if (!isAuthenticated) {
       return (
@@ -64,7 +57,7 @@ export function TipCheckoutStep({
           type="button"
           onClick={onSignIn}
           disabled={isLoading}
-          className={`flex-1 gap-2 ${useGradientButtons ? primaryGradientClass : ''}`}
+          className="flex-1 gap-2"
         >
           <Heart className="w-4 h-4" />
           Sign in to tip
@@ -78,7 +71,7 @@ export function TipCheckoutStep({
           type="button"
           onClick={onConnectWallet}
           disabled={isLoading || isWalletLoading}
-          className={`flex-1 gap-2 ${useGradientButtons ? connectGradientClass : ''}`}
+          className="flex-1 gap-2"
         >
           {isWalletLoading ? (
             <>
@@ -100,7 +93,7 @@ export function TipCheckoutStep({
         type="button"
         onClick={onSendTip}
         disabled={isLoading || !!tipSuccess}
-        className={`flex-1 gap-2 ${useGradientButtons ? primaryGradientClass : ''}`}
+        className="flex-1 gap-2"
       >
         {isLoading ? (
           <>
@@ -130,7 +123,7 @@ export function TipCheckoutStep({
           </p>
         </div>
       ) : !isConnected ? (
-        <div className="p-3 bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-lg text-sm text-amber-900 dark:text-amber-100">
+        <div className="p-3 bg-warning text-warning-foreground border border-warning/30 rounded-lg text-sm">
           <p>
             Connect your Stellar wallet to send your {formatTipLabel(variant)}{' '}
             to {authorName}.
@@ -139,7 +132,7 @@ export function TipCheckoutStep({
             New to crypto?{' '}
             <Link
               href="/guide"
-              className="focus-ring rounded text-amber-700 dark:text-amber-300 underline font-medium hover:text-amber-900 dark:hover:text-amber-100"
+              className="focus-ring rounded underline font-medium hover:opacity-80"
             >
               Follow our setup guide
             </Link>
@@ -165,7 +158,7 @@ export function TipCheckoutStep({
       </div>
 
       {isConnected && publicKey ? (
-        <div className="text-xs text-green-800 dark:text-green-300 text-center">
+        <div className="text-xs text-success-foreground text-center">
           <p className="flex items-center justify-center gap-1">
             <Wallet className="w-3 h-3" />
             Connected: {publicKey.slice(0, 6)}...{publicKey.slice(-6)}

--- a/components/tipping/TipStats.tsx
+++ b/components/tipping/TipStats.tsx
@@ -38,14 +38,14 @@ export function TipStats({ articleId, className = '' }: TipStatsProps) {
       className={`flex items-center gap-4 text-sm text-muted-foreground ${className}`}
     >
       <div className="flex items-center gap-1">
-        <Coins className="w-4 h-4 text-yellow-500" />
+        <Coins className="w-4 h-4 text-muted-foreground" />
         <span className="font-medium">
           ${(stats?.totalAmountUsd ?? 0).toFixed(2)}
         </span>
         <span>earned</span>
       </div>
       <div className="flex items-center gap-1">
-        <Users className="w-4 h-4 text-blue-500" />
+        <Users className="w-4 h-4 text-muted-foreground" />
         <span className="font-medium">{stats?.uniqueTippers ?? 0}</span>
         <span>
           {(stats?.uniqueTippers ?? 0) === 1 ? 'supporter' : 'supporters'}

--- a/docs/design-system/monetization-status-colors.md
+++ b/docs/design-system/monetization-status-colors.md
@@ -4,15 +4,15 @@ Reader-facing tip, highlight-tip, and NFT surfaces use semantic status tokens fr
 
 ## Token mapping
 
-| State | Tailwind utilities |
-|-------|-------------------|
-| Wallet not connected | `bg-warning text-warning-foreground border-warning/30` |
-| Tip sent / upload verified | `bg-success text-success-foreground` |
-| Pending upload / informational | `bg-info text-info-foreground` |
-| Section icons / quiet stats | `text-muted-foreground` |
-| Heat intensity bars / legend | `--heatmap-gradient` (cream → sky blue → navy → primary) |
-| NFT progress fill | `bg-primary/50` on `bg-muted` track |
-| Error / failed upload | `destructive` button or `bg-destructive/10 text-destructive` |
+| State                          | Tailwind utilities                                           |
+| ------------------------------ | ------------------------------------------------------------ |
+| Wallet not connected           | `bg-warning text-warning-foreground border-warning/30`       |
+| Tip sent / upload verified     | `bg-success text-success-foreground`                         |
+| Pending upload / informational | `bg-info text-info-foreground`                               |
+| Section icons / quiet stats    | `text-muted-foreground`                                      |
+| Heat intensity bars / legend   | `--heatmap-gradient` (cream → sky blue → navy → primary)     |
+| NFT progress fill              | `bg-primary/50` on `bg-muted` track                          |
+| Error / failed upload          | `destructive` button or `bg-destructive/10 text-destructive` |
 
 ## Accent
 

--- a/docs/design-system/monetization-status-colors.md
+++ b/docs/design-system/monetization-status-colors.md
@@ -1,0 +1,22 @@
+# Monetization Status Colors
+
+Reader-facing tip, highlight-tip, and NFT surfaces use semantic status tokens from `app/globals.css` instead of ad-hoc Tailwind palette classes.
+
+## Token mapping
+
+| State | Tailwind utilities |
+|-------|-------------------|
+| Wallet not connected | `bg-warning text-warning-foreground border-warning/30` |
+| Tip sent / upload verified | `bg-success text-success-foreground` |
+| Pending upload / informational | `bg-info text-info-foreground` |
+| Section icons / quiet stats | `text-muted-foreground` |
+| Heat intensity / NFT progress fill | `bg-primary/50` on `bg-muted` track |
+| Error / failed upload | `destructive` button or `bg-destructive/10 text-destructive` |
+
+## Accent
+
+Wallet and NFT actions use `--primary` as the single subdued accent. No separate `--monetization` token.
+
+## CTAs
+
+Monetization buttons use `Button` variants from `components/ui/button.tsx` (`outline`, `default`, `secondary`). Avoid custom gradients, `hover:scale-*`, and heavy shadows on tip/NFT controls.

--- a/docs/design-system/monetization-status-colors.md
+++ b/docs/design-system/monetization-status-colors.md
@@ -10,7 +10,8 @@ Reader-facing tip, highlight-tip, and NFT surfaces use semantic status tokens fr
 | Tip sent / upload verified | `bg-success text-success-foreground` |
 | Pending upload / informational | `bg-info text-info-foreground` |
 | Section icons / quiet stats | `text-muted-foreground` |
-| Heat intensity / NFT progress fill | `bg-primary/50` on `bg-muted` track |
+| Heat intensity bars / legend | `--heatmap-gradient` (cream → sky blue → navy → primary) |
+| NFT progress fill | `bg-primary/50` on `bg-muted` track |
 | Error / failed upload | `destructive` button or `bg-destructive/10 text-destructive` |
 
 ## Accent

--- a/lib/stellar/highlight-utils.test.ts
+++ b/lib/stellar/highlight-utils.test.ts
@@ -42,9 +42,7 @@ function channelValue(hex: string, channel: 'r' | 'g' | 'b'): number {
 function relativeLuminance(hex: string): number {
   const channels = (['r', 'g', 'b'] as const).map((channel) => {
     const value = channelValue(hex, channel) / 255
-    return value <= 0.03928
-      ? value / 12.92
-      : ((value + 0.055) / 1.055) ** 2.4
+    return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
   })
   const [r, g, b] = channels
   return 0.2126 * (r ?? 0) + 0.7152 * (g ?? 0) + 0.0722 * (b ?? 0)

--- a/lib/stellar/highlight-utils.test.ts
+++ b/lib/stellar/highlight-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   calculateTipBreakdown,
   formatTipAmount,
+  getHeatmapColor,
 } from '@/lib/stellar/highlight-utils'
 import { STELLAR_CONFIG } from '@/lib/stellar/config'
 
@@ -28,6 +29,26 @@ describe('calculateTipBreakdown', () => {
     expect(b.authorShare).toBe(249)
     expect(b.platformFeeFormatted).toBe('$0.06')
     expect(b.authorShareFormatted).toBe('$2.49')
+  })
+})
+
+describe('getHeatmapColor', () => {
+  it('returns low opacity for zero amount when max is zero', () => {
+    expect(getHeatmapColor(0, 0)).toBe(0.15)
+  })
+
+  it('returns monotonically increasing opacity with amount', () => {
+    const low = getHeatmapColor(10, 100)
+    const mid = getHeatmapColor(50, 100)
+    const high = getHeatmapColor(100, 100)
+    expect(low).toBeLessThan(mid)
+    expect(mid).toBeLessThan(high)
+    expect(high).toBeLessThanOrEqual(1)
+    expect(low).toBeGreaterThanOrEqual(0.2)
+  })
+
+  it('caps intensity at max amount', () => {
+    expect(getHeatmapColor(200, 100)).toBe(getHeatmapColor(100, 100))
   })
 })
 

--- a/lib/stellar/highlight-utils.test.ts
+++ b/lib/stellar/highlight-utils.test.ts
@@ -1,11 +1,16 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { describe, it, expect } from 'vitest'
 import {
   calculateTipBreakdown,
   formatTipAmount,
   getHeatmapColor,
+  HEATMAP_GRADIENT_CSS,
   HEATMAP_PALETTE,
 } from '@/lib/stellar/highlight-utils'
 import { STELLAR_CONFIG } from '@/lib/stellar/config'
+
+const GLOBALS_CSS = readFileSync(join(process.cwd(), 'app/globals.css'), 'utf8')
 
 describe('calculateTipBreakdown', () => {
   it('splits cents with floor on platform fee and preserves total', () => {
@@ -48,22 +53,75 @@ function relativeLuminance(hex: string): number {
   return 0.2126 * (r ?? 0) + 0.7152 * (g ?? 0) + 0.0722 * (b ?? 0)
 }
 
+function contrastRatio(a: string, b: string): number {
+  const [lighter, darker] = [relativeLuminance(a), relativeLuminance(b)].sort(
+    (left, right) => right - left
+  )
+  return ((lighter ?? 0) + 0.05) / ((darker ?? 0) + 0.05)
+}
+
+function cssBlock(css: string, selector: string): string {
+  const selectorStart = css.indexOf(`${selector} {`)
+  if (selectorStart === -1) return ''
+
+  const blockStart = css.indexOf('{', selectorStart) + 1
+  const blockEnd = css.indexOf('\n}', blockStart)
+
+  return css.slice(blockStart, blockEnd)
+}
+
+function cssVariableValue(block: string, variable: string): string | undefined {
+  const match = new RegExp(`${variable}:\\s*([^;]+);`).exec(block)
+  return match?.[1]?.trim()
+}
+
+describe('heatmap theme tokens', () => {
+  it('uses CSS variables as the single palette source for inline heatmap styles', () => {
+    expect(HEATMAP_PALETTE).toEqual([
+      'var(--heatmap-0)',
+      'var(--heatmap-1)',
+      'var(--heatmap-2)',
+      'var(--heatmap-3)',
+    ])
+    expect(HEATMAP_GRADIENT_CSS).toBe('var(--heatmap-gradient)')
+  })
+
+  it('defines dark-mode high-intensity stops that contrast with muted tracks', () => {
+    const darkBlock = cssBlock(GLOBALS_CSS, '.dark')
+    const darkMuted = cssVariableValue(darkBlock, '--muted')
+    const highStop = cssVariableValue(darkBlock, '--heatmap-2')
+    const maxStop = cssVariableValue(darkBlock, '--heatmap-3')
+
+    expect(darkMuted).toBeDefined()
+    expect(highStop).toBeDefined()
+    expect(maxStop).toBeDefined()
+
+    expect(contrastRatio(highStop!, darkMuted!)).toBeGreaterThan(3)
+    expect(contrastRatio(maxStop!, darkMuted!)).toBeGreaterThan(3)
+  })
+})
+
 describe('getHeatmapColor', () => {
   it('returns the lightest palette color when max is zero', () => {
     expect(getHeatmapColor(0, 0)).toBe(HEATMAP_PALETTE[0])
   })
 
-  it('returns darker colors as amount increases', () => {
+  it('interpolates between theme tokens as amount increases', () => {
     const low = getHeatmapColor(10, 100)
     const mid = getHeatmapColor(50, 100)
     const high = getHeatmapColor(100, 100)
-    expect(relativeLuminance(low)).toBeGreaterThan(relativeLuminance(mid))
-    expect(relativeLuminance(mid)).toBeGreaterThan(relativeLuminance(high))
+
+    expect(low).toBe(
+      'color-mix(in srgb, var(--heatmap-0) 70%, var(--heatmap-1))'
+    )
+    expect(mid).toBe(
+      'color-mix(in srgb, var(--heatmap-1) 50%, var(--heatmap-2))'
+    )
     expect(high).toBe(HEATMAP_PALETTE[3])
   })
 
   it('caps intensity at max amount', () => {
-    expect(getHeatmapColor(200, 100)).toBe(getHeatmapColor(100, 100))
+    expect(getHeatmapColor(200, 100)).toBe(HEATMAP_PALETTE[3])
   })
 })
 

--- a/lib/stellar/highlight-utils.test.ts
+++ b/lib/stellar/highlight-utils.test.ts
@@ -3,6 +3,7 @@ import {
   calculateTipBreakdown,
   formatTipAmount,
   getHeatmapColor,
+  HEATMAP_PALETTE,
 } from '@/lib/stellar/highlight-utils'
 import { STELLAR_CONFIG } from '@/lib/stellar/config'
 
@@ -32,19 +33,34 @@ describe('calculateTipBreakdown', () => {
   })
 })
 
+function channelValue(hex: string, channel: 'r' | 'g' | 'b'): number {
+  const normalized = hex.replace('#', '')
+  const offset = channel === 'r' ? 0 : channel === 'g' ? 2 : 4
+  return parseInt(normalized.slice(offset, offset + 2), 16)
+}
+
+function relativeLuminance(hex: string): number {
+  const channels = (['r', 'g', 'b'] as const).map((channel) => {
+    const value = channelValue(hex, channel) / 255
+    return value <= 0.03928
+      ? value / 12.92
+      : ((value + 0.055) / 1.055) ** 2.4
+  })
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2]
+}
+
 describe('getHeatmapColor', () => {
-  it('returns low opacity for zero amount when max is zero', () => {
-    expect(getHeatmapColor(0, 0)).toBe(0.15)
+  it('returns the lightest palette color when max is zero', () => {
+    expect(getHeatmapColor(0, 0)).toBe(HEATMAP_PALETTE[0])
   })
 
-  it('returns monotonically increasing opacity with amount', () => {
+  it('returns darker colors as amount increases', () => {
     const low = getHeatmapColor(10, 100)
     const mid = getHeatmapColor(50, 100)
     const high = getHeatmapColor(100, 100)
-    expect(low).toBeLessThan(mid)
-    expect(mid).toBeLessThan(high)
-    expect(high).toBeLessThanOrEqual(1)
-    expect(low).toBeGreaterThanOrEqual(0.2)
+    expect(relativeLuminance(low)).toBeGreaterThan(relativeLuminance(mid))
+    expect(relativeLuminance(mid)).toBeGreaterThan(relativeLuminance(high))
+    expect(high).toBe(HEATMAP_PALETTE[3])
   })
 
   it('caps intensity at max amount', () => {

--- a/lib/stellar/highlight-utils.test.ts
+++ b/lib/stellar/highlight-utils.test.ts
@@ -46,7 +46,8 @@ function relativeLuminance(hex: string): number {
       ? value / 12.92
       : ((value + 0.055) / 1.055) ** 2.4
   })
-  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2]
+  const [r, g, b] = channels
+  return 0.2126 * (r ?? 0) + 0.7152 * (g ?? 0) + 0.0722 * (b ?? 0)
 }
 
 describe('getHeatmapColor', () => {

--- a/lib/stellar/highlight-utils.ts
+++ b/lib/stellar/highlight-utils.ts
@@ -104,36 +104,18 @@ export function truncateText(text: string, maxLength: number = 100): string {
   return text.slice(0, maxLength) + '...'
 }
 
-/** Heat intensity palette: light cream → sky blue → navy → Quilltip primary. */
+/** Heat intensity palette tokens defined in app/globals.css. */
 export const HEATMAP_PALETTE = [
-  '#E6E6C3',
-  '#7FB3D5',
-  '#003366',
-  '#1a365d',
+  'var(--heatmap-0)',
+  'var(--heatmap-1)',
+  'var(--heatmap-2)',
+  'var(--heatmap-3)',
 ] as const
 
 const HEATMAP_FALLBACK_COLOR = HEATMAP_PALETTE[0]!
 
-export const HEATMAP_GRADIENT_CSS = `linear-gradient(to right, ${HEATMAP_PALETTE.join(', ')})`
-
-function hexToRgb(hex: string): [number, number, number] {
-  const normalized = hex.replace('#', '')
-  return [
-    parseInt(normalized.slice(0, 2), 16),
-    parseInt(normalized.slice(2, 4), 16),
-    parseInt(normalized.slice(4, 6), 16),
-  ]
-}
-
-function rgbToHex(r: number, g: number, b: number): string {
-  return `#${[r, g, b]
-    .map((channel) =>
-      Math.round(Math.max(0, Math.min(255, channel)))
-        .toString(16)
-        .padStart(2, '0')
-    )
-    .join('')}`
-}
+/** Use `var(--heatmap-gradient)` in inline styles, defined in app/globals.css. */
+export const HEATMAP_GRADIENT_CSS = 'var(--heatmap-gradient)'
 
 function interpolateHeatmapPalette(intensity: number): string {
   const clamped = Math.max(0, Math.min(intensity, 1))
@@ -145,10 +127,13 @@ function interpolateHeatmapPalette(intensity: number): string {
   const lowerColor = HEATMAP_PALETTE[lowerIndex] ?? HEATMAP_FALLBACK_COLOR
   const upperColor = HEATMAP_PALETTE[upperIndex] ?? HEATMAP_FALLBACK_COLOR
 
-  const [r1, g1, b1] = hexToRgb(lowerColor)
-  const [r2, g2, b2] = hexToRgb(upperColor)
+  if (t === 0 || lowerColor === upperColor) {
+    return lowerColor
+  }
 
-  return rgbToHex(r1 + (r2 - r1) * t, g1 + (g2 - g1) * t, b1 + (b2 - b1) * t)
+  return `color-mix(in srgb, ${lowerColor} ${Math.round(
+    (1 - t) * 100
+  )}%, ${upperColor})`
 }
 
 /**
@@ -156,10 +141,10 @@ function interpolateHeatmapPalette(intensity: number): string {
  *
  * @param amount - Current tip amount in cents
  * @param maxAmount - Maximum tip amount in dataset
- * @returns Hex color for bars and heat indicators
+ * @returns CSS color value for bars and heat indicators
  */
 export function getHeatmapColor(amount: number, maxAmount: number): string {
-  if (maxAmount === 0) return HEATMAP_PALETTE[0]
+  if (maxAmount <= 0) return HEATMAP_PALETTE[0]
 
   const intensity = Math.min(amount / maxAmount, 1)
   return interpolateHeatmapPalette(intensity)

--- a/lib/stellar/highlight-utils.ts
+++ b/lib/stellar/highlight-utils.ts
@@ -112,6 +112,8 @@ export const HEATMAP_PALETTE = [
   '#1a365d',
 ] as const
 
+const HEATMAP_FALLBACK_COLOR = HEATMAP_PALETTE[0]!
+
 export const HEATMAP_GRADIENT_CSS = `linear-gradient(to right, ${HEATMAP_PALETTE.join(', ')})`
 
 function hexToRgb(hex: string): [number, number, number] {
@@ -140,8 +142,11 @@ function interpolateHeatmapPalette(intensity: number): string {
   const upperIndex = Math.min(lowerIndex + 1, HEATMAP_PALETTE.length - 1)
   const t = scaled - lowerIndex
 
-  const [r1, g1, b1] = hexToRgb(HEATMAP_PALETTE[lowerIndex])
-  const [r2, g2, b2] = hexToRgb(HEATMAP_PALETTE[upperIndex])
+  const lowerColor = HEATMAP_PALETTE[lowerIndex] ?? HEATMAP_FALLBACK_COLOR
+  const upperColor = HEATMAP_PALETTE[upperIndex] ?? HEATMAP_FALLBACK_COLOR
+
+  const [r1, g1, b1] = hexToRgb(lowerColor)
+  const [r2, g2, b2] = hexToRgb(upperColor)
 
   return rgbToHex(
     r1 + (r2 - r1) * t,

--- a/lib/stellar/highlight-utils.ts
+++ b/lib/stellar/highlight-utils.ts
@@ -105,39 +105,16 @@ export function truncateText(text: string, maxLength: number = 100): string {
 }
 
 /**
- * Get color intensity for heatmap visualization
- * Based on tip amount relative to max amount
+ * Get opacity intensity for heatmap visualization (0.2–1.0).
+ * Based on tip amount relative to max amount. Uses primary color at this opacity in UI.
  *
- * @param amount - Current tip amount
+ * @param amount - Current tip amount in cents
  * @param maxAmount - Maximum tip amount in dataset
- * @returns RGB color string
+ * @returns Opacity fraction for color-mix with var(--primary)
  */
-export function getHeatmapColor(amount: number, maxAmount: number): string {
-  if (maxAmount === 0) return 'rgb(255, 255, 200)' // Light yellow for zero
+export function getHeatmapColor(amount: number, maxAmount: number): number {
+  if (maxAmount === 0) return 0.15
 
   const intensity = Math.min(amount / maxAmount, 1)
-
-  // Helper to clamp RGB values between 0-255
-  const clamp = (value: number) => Math.max(0, Math.min(255, Math.floor(value)))
-
-  // Color gradient: Yellow (low) → Orange → Red (high)
-  if (intensity < 0.33) {
-    // Yellow to light orange
-    const r = 255
-    const g = clamp(255 - intensity * 3 * 100)
-    const b = 150
-    return `rgb(${r}, ${g}, ${b})`
-  } else if (intensity < 0.66) {
-    // Orange
-    const r = 255
-    const g = clamp(200 - (intensity - 0.33) * 3 * 100)
-    const b = 100
-    return `rgb(${r}, ${g}, ${b})`
-  } else {
-    // Red
-    const r = 255
-    const g = clamp(100 - (intensity - 0.66) * 3 * 100)
-    const b = 50
-    return `rgb(${r}, ${g}, ${b})`
-  }
+  return 0.2 + intensity * 0.8
 }

--- a/lib/stellar/highlight-utils.ts
+++ b/lib/stellar/highlight-utils.ts
@@ -104,17 +104,62 @@ export function truncateText(text: string, maxLength: number = 100): string {
   return text.slice(0, maxLength) + '...'
 }
 
+/** Heat intensity palette: light cream → sky blue → navy → Quilltip primary. */
+export const HEATMAP_PALETTE = [
+  '#E6E6C3',
+  '#7FB3D5',
+  '#003366',
+  '#1a365d',
+] as const
+
+export const HEATMAP_GRADIENT_CSS = `linear-gradient(to right, ${HEATMAP_PALETTE.join(', ')})`
+
+function hexToRgb(hex: string): [number, number, number] {
+  const normalized = hex.replace('#', '')
+  return [
+    parseInt(normalized.slice(0, 2), 16),
+    parseInt(normalized.slice(2, 4), 16),
+    parseInt(normalized.slice(4, 6), 16),
+  ]
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return `#${[r, g, b]
+    .map((channel) =>
+      Math.round(Math.max(0, Math.min(255, channel)))
+        .toString(16)
+        .padStart(2, '0')
+    )
+    .join('')}`
+}
+
+function interpolateHeatmapPalette(intensity: number): string {
+  const clamped = Math.max(0, Math.min(intensity, 1))
+  const scaled = clamped * (HEATMAP_PALETTE.length - 1)
+  const lowerIndex = Math.floor(scaled)
+  const upperIndex = Math.min(lowerIndex + 1, HEATMAP_PALETTE.length - 1)
+  const t = scaled - lowerIndex
+
+  const [r1, g1, b1] = hexToRgb(HEATMAP_PALETTE[lowerIndex])
+  const [r2, g2, b2] = hexToRgb(HEATMAP_PALETTE[upperIndex])
+
+  return rgbToHex(
+    r1 + (r2 - r1) * t,
+    g1 + (g2 - g1) * t,
+    b1 + (b2 - b1) * t
+  )
+}
+
 /**
- * Get opacity intensity for heatmap visualization (0.2–1.0).
- * Based on tip amount relative to max amount. Uses primary color at this opacity in UI.
+ * Map tip amount to a heat color from the Quilltip heat palette.
  *
  * @param amount - Current tip amount in cents
  * @param maxAmount - Maximum tip amount in dataset
- * @returns Opacity fraction for color-mix with var(--primary)
+ * @returns Hex color for bars and heat indicators
  */
-export function getHeatmapColor(amount: number, maxAmount: number): number {
-  if (maxAmount === 0) return 0.15
+export function getHeatmapColor(amount: number, maxAmount: number): string {
+  if (maxAmount === 0) return HEATMAP_PALETTE[0]
 
   const intensity = Math.min(amount / maxAmount, 1)
-  return 0.2 + intensity * 0.8
+  return interpolateHeatmapPalette(intensity)
 }

--- a/lib/stellar/highlight-utils.ts
+++ b/lib/stellar/highlight-utils.ts
@@ -148,11 +148,7 @@ function interpolateHeatmapPalette(intensity: number): string {
   const [r1, g1, b1] = hexToRgb(lowerColor)
   const [r2, g2, b2] = hexToRgb(upperColor)
 
-  return rgbToHex(
-    r1 + (r2 - r1) * t,
-    g1 + (g2 - g1) * t,
-    b1 + (b2 - b1) * t
-  )
+  return rgbToHex(r1 + (r2 - r1) * t, g1 + (g2 - g1) * t, b1 + (b2 - b1) * t)
 }
 
 /**


### PR DESCRIPTION
## Summary

Calms reader-facing monetization UI on the article page so tipping, highlight tips, and NFT surfaces feel editorial rather than crypto-demo loud. Replaces custom gradients and saturated one-off colors with design-system buttons and semantic status tokens, softens transactional copy, and removes hover-scale effects. 

## Changes

- Document monetization status color mapping in `app/globals.css` and `docs/design-system/monetization-status-colors.md`
- Replace custom gradient / saturated CTAs with `Button` variants on tip, highlight-tip, NFT transfer, and highlight save actions
- Apply semantic tokens (`warning`, `success`, `info`, `muted-foreground`, `primary`) across wallet prompts, Arweave status, tip stats, NFT badges, and progress bars
- Rewrite `getHeatmapColor()` to a muted single-hue ramp; neutralize heatmap phrase cards and legend
- Soften reader copy: remove "micro-tip" and "97.5%" from dialog headlines; use supportive "support" / "eligible" language
- Remove `hover:scale-105`, heavy shadows, and orange/yellow/purple one-off styling from monetization controls

**Touched surfaces:** article support bar, tip dialog, highlight tip popover/dialog, article details accordion, NFT module, highlight heatmap, Arweave status, NFT transfer/mint dialogs.

**Out of scope:** landing page, dashboard, profile NFT tab, user-chosen highlight colors in article body.

## Testing



- [x] `bun run test:once -- components/tipping/TipButton.test.tsx components/highlights/HighlightTipButton.test.tsx lib/stellar/highlight-utils.test.ts components/nft/`
- [x] `bun run typecheck`
- [x] `bun run lint`


## Notes

UI polish only — no tipping, NFT, or wallet business logic changes. Fee breakdown remains in fine print via `TipBreakdownSummaryLine`.

<img width="1440" height="859" alt="art_5" src="https://github.com/user-attachments/assets/fd98c590-3453-47ad-9560-301fc1c36bf9" />
<img width="1440" height="856" alt="art_1" src="https://github.com/user-attachments/assets/ce83e4f4-f2b2-4406-80d1-0cca125fe9fd" />
<img width="1437" height="861" alt="fin" src="https://github.com/user-attachments/assets/d2ac01ae-d708-42e4-9d3c-a803fcf6834a" />
