### PR TITLE
refactor(articles): improve article card and feed listing editorial quality (ENG-260)

### DIFF
--- a/components/articles/ArticleCard.tsx
+++ b/components/articles/ArticleCard.tsx
@@ -1,9 +1,15 @@
 import Link from 'next/link'
-import Image from 'next/image'
-import { formatDistanceToNow } from 'date-fns'
 import { ArticleForDisplay } from '@/types/index'
 import { ArticleAuthorByline } from '@/components/articles/ArticleAuthorByline'
+import { ArticleListingThumbnail } from '@/components/articles/ArticleListingThumbnail'
 import { TagFilterLink } from '@/components/articles/TagFilterLink'
+import {
+  formatListingPublishedDate,
+  formatListingReadTime,
+  formatListingTipCount,
+  getListingPublishedDateTime,
+  LISTING_CARD_TAG_LIMIT,
+} from '@/lib/articles/articleListingMeta'
 import type { BrowseView } from '@/lib/articles/browseDiscovery'
 
 interface ArticleCardProps {
@@ -14,62 +20,37 @@ interface ArticleCardProps {
   view?: BrowseView
 }
 
-function formatReadTime(minutes?: number): string | null {
-  if (!minutes || minutes < 1) return null
-  return `${minutes} min read`
-}
-
 export default function ArticleCard({
   article,
   priority,
   onArticleNavigate,
   tagLinkAuthor,
-  view = 'latest',
 }: ArticleCardProps) {
-  const publishedDate = article.publishedAt
-    ? formatDistanceToNow(new Date(article.publishedAt), { addSuffix: true })
-    : null
-  const readTimeLabel = formatReadTime(article.readTime)
-  const tipCount = article.tipCount ?? 0
-
-  const metaParts = [
-    readTimeLabel,
-    publishedDate,
-    view === 'featured' && tipCount > 0
-      ? `${tipCount} tip${tipCount === 1 ? '' : 's'}`
-      : null,
-  ].filter((part): part is string => Boolean(part))
+  const articleHref = `/${article.author.username}/${article.slug}`
+  const readTimeLabel = formatListingReadTime(article.readTime)
+  const publishedLabel = formatListingPublishedDate(article.publishedAt)
+  const tipLabel = formatListingTipCount(article.tipCount)
+  const publishedDateTime = getListingPublishedDateTime(article.publishedAt)
+  const navigate = () => onArticleNavigate?.()
 
   return (
     <article className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border ring-1 ring-border/60 hover:shadow-md transition-shadow duration-200 flex flex-col h-full">
-      {article.coverImage && (
-        <Link
-          href={`/${article.author.username}/${article.slug}`}
-          scroll={false}
-          className="focus-ring block rounded-t-[var(--card-radius)]"
-          onPointerDown={() => onArticleNavigate?.()}
-          onClick={() => onArticleNavigate?.()}
-        >
-          <div className="relative h-48 w-full overflow-hidden rounded-t-[var(--card-radius)]">
-            <Image
-              src={article.coverImage}
-              alt={article.title}
-              fill
-              sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
-              priority={priority}
-              className="object-cover hover:scale-105 transition-transform duration-200"
-            />
-          </div>
-        </Link>
-      )}
+      <ArticleListingThumbnail
+        title={article.title}
+        coverImage={article.coverImage}
+        href={articleHref}
+        variant="card"
+        priority={priority}
+        onNavigate={navigate}
+      />
 
       <div className="p-[var(--card-padding)] flex flex-col flex-1">
         <Link
-          href={`/${article.author.username}/${article.slug}`}
+          href={articleHref}
           scroll={false}
           className="focus-ring rounded-md"
-          onPointerDown={() => onArticleNavigate?.()}
-          onClick={() => onArticleNavigate?.()}
+          onPointerDown={navigate}
+          onClick={navigate}
         >
           <h2 className="text-xl font-bold text-foreground mb-2 hover:text-brand-blue transition-colors line-clamp-2">
             {article.title}
@@ -77,21 +58,26 @@ export default function ArticleCard({
         </Link>
 
         {article.excerpt && (
-          <p className="text-muted-foreground mb-4 line-clamp-3 flex-1">
+          <p className="text-muted-foreground mb-4 line-clamp-2 flex-1">
             {article.excerpt}
           </p>
         )}
 
         {article.tags.length > 0 && (
           <div className="flex flex-wrap gap-2 mb-4 min-h-[28px]">
-            {article.tags.slice(0, 3).map((tag) => (
-              <TagFilterLink key={tag.id} tag={tag.name} author={tagLinkAuthor}>
+            {article.tags.slice(0, LISTING_CARD_TAG_LIMIT).map((tag) => (
+              <TagFilterLink
+                key={tag.id}
+                tag={tag.name}
+                author={tagLinkAuthor}
+                className="px-3 py-1.5 text-[13px] bg-muted/80"
+              >
                 {tag.name}
               </TagFilterLink>
             ))}
-            {article.tags.length > 3 && (
+            {article.tags.length > LISTING_CARD_TAG_LIMIT && (
               <span className="text-xs px-2 py-1 text-muted-foreground">
-                +{article.tags.length - 3} more
+                +{article.tags.length - LISTING_CARD_TAG_LIMIT} more
               </span>
             )}
           </div>
@@ -100,9 +86,15 @@ export default function ArticleCard({
         <div className="flex items-end justify-between gap-3 pt-4 border-t border-border mt-auto">
           <ArticleAuthorByline author={article.author} size="sm" showHandle />
 
-          {metaParts.length > 0 && (
+          {(readTimeLabel || publishedLabel || tipLabel) && (
             <p className="text-xs text-muted-foreground text-right shrink-0">
-              {metaParts.join(' · ')}
+              {readTimeLabel}
+              {readTimeLabel && publishedLabel && ' · '}
+              {publishedLabel && (
+                <time dateTime={publishedDateTime}>{publishedLabel}</time>
+              )}
+              {(readTimeLabel || publishedLabel) && tipLabel && ' · '}
+              {tipLabel}
             </p>
           )}
         </div>

--- a/components/articles/ArticleCard.tsx
+++ b/components/articles/ArticleCard.tsx
@@ -10,14 +10,12 @@ import {
   getListingPublishedDateTime,
   LISTING_CARD_TAG_LIMIT,
 } from '@/lib/articles/articleListingMeta'
-import type { BrowseView } from '@/lib/articles/browseDiscovery'
 
 interface ArticleCardProps {
   article: ArticleForDisplay
   priority?: boolean
   onArticleNavigate?: () => void
   tagLinkAuthor?: string
-  view?: BrowseView
 }
 
 export default function ArticleCard({

--- a/components/articles/ArticleCardSkeleton.tsx
+++ b/components/articles/ArticleCardSkeleton.tsx
@@ -24,13 +24,16 @@ export function ArticleCardSkeleton() {
           <Skeleton className="h-6 w-20 rounded-full" />
         </div>
 
-        {/* Author */}
-        <div className="flex items-center gap-3 pt-4 border-t border-border">
-          <Skeleton className="h-9 w-9 rounded-full" />
-          <div>
-            <Skeleton className="h-4 w-24 mb-1" />
-            <Skeleton className="h-3 w-16" />
+        {/* Author + meta */}
+        <div className="flex items-end justify-between gap-3 pt-4 border-t border-border">
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-9 w-9 rounded-full" />
+            <div>
+              <Skeleton className="h-4 w-24 mb-1" />
+              <Skeleton className="h-3 w-16" />
+            </div>
           </div>
+          <Skeleton className="h-3 w-32" />
         </div>
       </div>
     </div>

--- a/components/articles/ArticleFeedRow.tsx
+++ b/components/articles/ArticleFeedRow.tsx
@@ -1,16 +1,17 @@
 import Link from 'next/link'
-import Image from 'next/image'
-import { format } from 'date-fns'
-import { Bookmark, MoreHorizontal } from 'lucide-react'
 import { ArticleForDisplay } from '@/types/index'
 import { canLinkAuthorProfile } from '@/components/articles/ArticleAuthorByline'
+import { ArticleListingThumbnail } from '@/components/articles/ArticleListingThumbnail'
 import { TagFilterLink } from '@/components/articles/TagFilterLink'
 import { UserAvatar } from '@/components/ui/user-avatar'
-import { Button } from '@/components/ui/button'
 import {
-  formatReadTime,
-  getFeedRowContextLabel,
-} from '@/lib/articles/feedRowStatus'
+  formatListingPublishedDate,
+  formatListingReadTime,
+  formatListingTipCount,
+  getListingPublishedDateTime,
+  LISTING_FEED_TAG_LIMIT,
+} from '@/lib/articles/articleListingMeta'
+import { getFeedRowContextLabel } from '@/lib/articles/feedRowStatus'
 import type { BrowseView } from '@/lib/articles/browseDiscovery'
 import { cn } from '@/lib/utils'
 
@@ -20,13 +21,7 @@ interface ArticleFeedRowProps {
   onArticleNavigate?: () => void
   tagLinkAuthor?: string
   view?: BrowseView
-}
-
-function formatPublishedDate(publishedAt: Date | string | null): string | null {
-  if (!publishedAt) return null
-  const date = publishedAt instanceof Date ? publishedAt : new Date(publishedAt)
-  if (Number.isNaN(date.getTime())) return null
-  return format(date, 'MMM d')
+  isHero?: boolean
 }
 
 function MetadataSeparator() {
@@ -43,25 +38,28 @@ export default function ArticleFeedRow({
   onArticleNavigate,
   tagLinkAuthor,
   view = 'latest',
+  isHero = false,
 }: ArticleFeedRowProps) {
   const articleHref = `/${article.author.username}/${article.slug}`
-  const publishedLabel = formatPublishedDate(article.publishedAt)
-  const readTimeLabel = formatReadTime(article.readTime)
   const contextLabel = getFeedRowContextLabel(view, article)
   const displayName = article.author.name || article.author.username
   const linkableAuthor = canLinkAuthorProfile(article.author)
-  const primaryTag = article.tags[0]
+  const visibleTags = article.tags.slice(0, LISTING_FEED_TAG_LIMIT)
   const handle = article.author.username
+  const readTimeLabel = formatListingReadTime(article.readTime)
+  const publishedLabel = formatListingPublishedDate(article.publishedAt)
+  const tipLabel = formatListingTipCount(article.tipCount)
+  const publishedDateTime = getListingPublishedDateTime(article.publishedAt)
 
   const navigate = () => onArticleNavigate?.()
 
-  const publishedDateTime =
-    article.publishedAt instanceof Date
-      ? article.publishedAt.toISOString()
-      : (article.publishedAt ?? undefined)
-
   return (
-    <article className="py-8 first:pt-6 last:pb-6">
+    <article
+      className={cn(
+        'py-6 first:pt-6 last:pb-6',
+        isHero && 'border-l-2 border-brand-blue pl-4'
+      )}
+    >
       <div className="mb-3 flex min-w-0 items-center gap-2 text-[13px] leading-none text-muted-foreground">
         <UserAvatar
           src={article.author.avatar}
@@ -88,10 +86,22 @@ export default function ArticleFeedRow({
               <span className="truncate">@{handle}</span>
             </>
           )}
+          {readTimeLabel && (
+            <>
+              <MetadataSeparator />
+              <span>{readTimeLabel}</span>
+            </>
+          )}
           {publishedLabel && (
             <>
               <MetadataSeparator />
               <time dateTime={publishedDateTime}>{publishedLabel}</time>
+            </>
+          )}
+          {tipLabel && (
+            <>
+              <MetadataSeparator />
+              <span>{tipLabel}</span>
             </>
           )}
         </div>
@@ -106,77 +116,50 @@ export default function ArticleFeedRow({
             onPointerDown={navigate}
             onClick={navigate}
           >
-            <h2 className="text-xl font-bold leading-snug text-foreground line-clamp-3 sm:text-2xl sm:leading-tight hover:text-brand-blue transition-colors">
+            <h2
+              className={cn(
+                'font-bold leading-snug text-foreground line-clamp-3 hover:text-brand-blue transition-colors',
+                isHero
+                  ? 'text-2xl sm:text-3xl sm:leading-tight'
+                  : 'text-xl sm:text-2xl sm:leading-tight'
+              )}
+            >
               {article.title}
             </h2>
           </Link>
 
           {article.excerpt && (
-            <p className="mt-2 text-sm leading-relaxed text-muted-foreground line-clamp-2 sm:text-base">
+            <p className="mt-2 line-clamp-2 text-sm leading-relaxed text-muted-foreground sm:text-base">
               {article.excerpt}
             </p>
           )}
         </div>
 
-        {article.coverImage && (
-          <Link
-            href={articleHref}
-            scroll={false}
-            className={cn(
-              'focus-ring relative shrink-0 overflow-hidden bg-muted',
-              'h-[72px] w-[72px] rounded-sm sm:h-[112px] sm:w-[112px]'
-            )}
-            onPointerDown={navigate}
-            onClick={navigate}
-          >
-            <Image
-              src={article.coverImage}
-              alt={article.title}
-              fill
-              sizes="(max-width: 640px) 72px, 112px"
-              priority={priority}
-              className="object-cover"
-            />
-          </Link>
-        )}
+        <ArticleListingThumbnail
+          title={article.title}
+          coverImage={article.coverImage}
+          href={articleHref}
+          variant="feed"
+          priority={priority}
+          onNavigate={navigate}
+        />
       </div>
 
-      <div className="mt-4 flex items-center justify-between gap-4">
-        <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2 text-[13px] text-muted-foreground">
-          {primaryTag && (
+      {(visibleTags.length > 0 || contextLabel) && (
+        <div className="mt-4 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2 text-[13px] text-muted-foreground">
+          {visibleTags.map((tag) => (
             <TagFilterLink
-              tag={primaryTag.name}
+              key={tag.id}
+              tag={tag.name}
               author={tagLinkAuthor}
               className="px-3 py-1.5 text-[13px] bg-muted/80"
             >
-              {primaryTag.name}
+              {tag.name}
             </TagFilterLink>
-          )}
-          {readTimeLabel && <span>{readTimeLabel}</span>}
+          ))}
           {contextLabel && <span>{contextLabel}</span>}
         </div>
-
-        <div className="flex shrink-0 items-center gap-0.5 text-muted-foreground">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="h-9 w-9 rounded-full text-muted-foreground hover:text-foreground"
-            aria-label={`Save ${article.title}`}
-          >
-            <Bookmark className="h-5 w-5" aria-hidden />
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="h-9 w-9 rounded-full text-muted-foreground hover:text-foreground"
-            aria-label={`More options for ${article.title}`}
-          >
-            <MoreHorizontal className="h-5 w-5" aria-hidden />
-          </Button>
-        </div>
-      </div>
+      )}
     </article>
   )
 }

--- a/components/articles/ArticleFeedSkeleton.tsx
+++ b/components/articles/ArticleFeedSkeleton.tsx
@@ -2,10 +2,12 @@ import { Skeleton } from '@/components/ui/skeleton'
 
 export function ArticleFeedRowSkeleton() {
   return (
-    <div className="py-8 first:pt-6 last:pb-6" aria-hidden>
+    <div className="py-6 first:pt-6 last:pb-6" aria-hidden>
       <div className="mb-3 flex items-center gap-2">
         <Skeleton className="h-5 w-5 rounded-full" />
         <Skeleton className="h-3.5 w-32" />
+        <Skeleton className="h-3.5 w-16" />
+        <Skeleton className="h-3.5 w-20" />
         <Skeleton className="h-3.5 w-16" />
         <Skeleton className="h-3.5 w-12" />
       </div>
@@ -20,15 +22,9 @@ export function ArticleFeedRowSkeleton() {
         <Skeleton className="h-[72px] w-[72px] shrink-0 rounded-sm sm:h-[112px] sm:w-[112px]" />
       </div>
 
-      <div className="mt-4 flex items-center justify-between gap-4">
-        <div className="flex items-center gap-3">
-          <Skeleton className="h-7 w-24 rounded-full" />
-          <Skeleton className="h-3.5 w-16" />
-        </div>
-        <div className="flex items-center gap-0.5">
-          <Skeleton className="h-9 w-9 rounded-full" />
-          <Skeleton className="h-9 w-9 rounded-full" />
-        </div>
+      <div className="mt-4 flex items-center gap-3">
+        <Skeleton className="h-7 w-24 rounded-full" />
+        <Skeleton className="h-7 w-20 rounded-full" />
       </div>
     </div>
   )

--- a/components/articles/ArticleGrid.tsx
+++ b/components/articles/ArticleGrid.tsx
@@ -117,7 +117,6 @@ export default function ArticleGrid({
           priority={index === 0}
           onArticleNavigate={onArticleNavigate}
           tagLinkAuthor={tagLinkAuthor}
-          view={view}
         />
       ))}
     </div>

--- a/components/articles/ArticleGrid.tsx
+++ b/components/articles/ArticleGrid.tsx
@@ -101,6 +101,7 @@ export default function ArticleGrid({
             onArticleNavigate={onArticleNavigate}
             tagLinkAuthor={tagLinkAuthor}
             view={view}
+            isHero={view === 'featured' && index === 0}
           />
         ))}
       </div>

--- a/components/articles/ArticleListingThumbnail.test.tsx
+++ b/components/articles/ArticleListingThumbnail.test.tsx
@@ -39,9 +39,13 @@ describe('ArticleListingThumbnail', () => {
 
     expect(screen.queryByRole('img')).not.toBeInTheDocument()
     expect(screen.getByText('He')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Hello World' })).toHaveAttribute(
+      'href',
+      '/author/slug'
+    )
   })
 
-  it('links to article href', () => {
+  it('labels card monogram links with the article title', () => {
     render(
       <ArticleListingThumbnail
         title="Hello World"
@@ -50,6 +54,9 @@ describe('ArticleListingThumbnail', () => {
       />
     )
 
-    expect(screen.getByRole('link')).toHaveAttribute('href', '/author/my-slug')
+    expect(screen.getByRole('link', { name: 'Hello World' })).toHaveAttribute(
+      'href',
+      '/author/my-slug'
+    )
   })
 })

--- a/components/articles/ArticleListingThumbnail.test.tsx
+++ b/components/articles/ArticleListingThumbnail.test.tsx
@@ -3,13 +3,7 @@ import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('next/image', () => ({
-  default: function MockImage({
-    alt,
-    src,
-  }: {
-    alt: string
-    src: string
-  }) {
+  default: function MockImage({ alt, src }: { alt: string; src: string }) {
     // eslint-disable-next-line @next/next/no-img-element -- test mock for next/image
     return <img alt={alt} src={src} />
   },

--- a/components/articles/ArticleListingThumbnail.test.tsx
+++ b/components/articles/ArticleListingThumbnail.test.tsx
@@ -1,0 +1,61 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/image', () => ({
+  default: function MockImage({
+    alt,
+    src,
+  }: {
+    alt: string
+    src: string
+  }) {
+    // eslint-disable-next-line @next/next/no-img-element -- test mock for next/image
+    return <img alt={alt} src={src} />
+  },
+}))
+
+import { ArticleListingThumbnail } from '@/components/articles/ArticleListingThumbnail'
+
+describe('ArticleListingThumbnail', () => {
+  it('renders cover image when coverImage is provided', () => {
+    render(
+      <ArticleListingThumbnail
+        title="Test Article"
+        coverImage="https://example.com/cover.jpg"
+        href="/author/slug"
+        variant="feed"
+      />
+    )
+
+    expect(screen.getByRole('img', { name: 'Test Article' })).toHaveAttribute(
+      'src',
+      'https://example.com/cover.jpg'
+    )
+  })
+
+  it('renders monogram placeholder when coverImage is missing', () => {
+    render(
+      <ArticleListingThumbnail
+        title="Hello World"
+        href="/author/slug"
+        variant="feed"
+      />
+    )
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(screen.getByText('He')).toBeInTheDocument()
+  })
+
+  it('links to article href', () => {
+    render(
+      <ArticleListingThumbnail
+        title="Hello World"
+        href="/author/my-slug"
+        variant="card"
+      />
+    )
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/author/my-slug')
+  })
+})

--- a/components/articles/ArticleListingThumbnail.tsx
+++ b/components/articles/ArticleListingThumbnail.tsx
@@ -1,0 +1,81 @@
+import Link from 'next/link'
+import Image from 'next/image'
+import { getTitleMonogram } from '@/lib/articles/articleListingMeta'
+import { cn } from '@/lib/utils'
+
+type ArticleListingThumbnailProps = {
+  title: string
+  coverImage?: string | null
+  href: string
+  variant: 'feed' | 'card'
+  priority?: boolean
+  onNavigate?: () => void
+}
+
+export function ArticleListingThumbnail({
+  title,
+  coverImage,
+  href,
+  variant,
+  priority,
+  onNavigate,
+}: ArticleListingThumbnailProps) {
+  const monogram = getTitleMonogram(title)
+
+  if (variant === 'feed') {
+    return (
+      <Link
+        href={href}
+        scroll={false}
+        className={cn(
+          'focus-ring relative shrink-0 overflow-hidden bg-muted',
+          'h-[72px] w-[72px] rounded-sm sm:h-[112px] sm:w-[112px]'
+        )}
+        onPointerDown={() => onNavigate?.()}
+        onClick={() => onNavigate?.()}
+      >
+        {coverImage ? (
+          <Image
+            src={coverImage}
+            alt={title}
+            fill
+            sizes="(max-width: 640px) 72px, 112px"
+            priority={priority}
+            className="object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-[13px] font-semibold uppercase tracking-wide text-muted-foreground sm:text-base">
+            {monogram}
+          </div>
+        )}
+      </Link>
+    )
+  }
+
+  return (
+    <Link
+      href={href}
+      scroll={false}
+      className="focus-ring block rounded-t-[var(--card-radius)]"
+      onPointerDown={() => onNavigate?.()}
+      onClick={() => onNavigate?.()}
+    >
+      <div className="relative h-48 w-full overflow-hidden rounded-t-[var(--card-radius)] bg-muted">
+        {coverImage ? (
+          <Image
+            src={coverImage}
+            alt={title}
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+            priority={priority}
+            className="object-cover hover:scale-105 transition-transform duration-200"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-2xl font-semibold uppercase tracking-wide text-muted-foreground">
+            {monogram}
+          </div>
+        )}
+      </div>
+    </Link>
+  )
+}

--- a/components/articles/ArticleListingThumbnail.tsx
+++ b/components/articles/ArticleListingThumbnail.tsx
@@ -27,6 +27,7 @@ export function ArticleListingThumbnail({
       <Link
         href={href}
         scroll={false}
+        aria-label={coverImage ? undefined : title}
         className={cn(
           'focus-ring relative shrink-0 overflow-hidden bg-muted',
           'h-[72px] w-[72px] rounded-sm sm:h-[112px] sm:w-[112px]'
@@ -56,6 +57,7 @@ export function ArticleListingThumbnail({
     <Link
       href={href}
       scroll={false}
+      aria-label={coverImage ? undefined : title}
       className="focus-ring block rounded-t-[var(--card-radius)]"
       onPointerDown={() => onNavigate?.()}
       onClick={() => onNavigate?.()}

--- a/components/articles/ArticlesBrowseContent.tsx
+++ b/components/articles/ArticlesBrowseContent.tsx
@@ -107,7 +107,9 @@ export function ArticlesBrowseContent({
   return (
     <>
       {contextMessage && (
-        <p className="mb-4 text-sm text-muted-foreground">{contextMessage}</p>
+        <p className="mb-6 rounded-md border border-border bg-muted/40 px-4 py-3 text-sm text-muted-foreground">
+          {contextMessage}
+        </p>
       )}
 
       <ArticleGrid

--- a/components/profile/ProfileArticlesTabContent.tsx
+++ b/components/profile/ProfileArticlesTabContent.tsx
@@ -5,7 +5,7 @@ import { usePaginationTransition } from '@/hooks/usePaginationTransition'
 import { mapListArticlesToDisplay } from '@/lib/articles/mapListArticleToDisplay'
 import ArticleGrid from '@/components/articles/ArticleGrid'
 import Pagination from '@/components/articles/Pagination'
-import { ArticleGridSkeleton } from '@/components/articles/ArticleCardSkeleton'
+import { ArticleFeedSkeleton } from '@/components/articles/ArticleFeedSkeleton'
 import { PaginationTransition } from '@/components/profile/PaginationTransition'
 import { BookOpen } from 'lucide-react'
 import Link from 'next/link'
@@ -32,7 +32,7 @@ export function ProfileArticlesTabContent({
   const { data, isPaginating } = usePaginationTransition(articlesData)
 
   if (data === undefined) {
-    return <ArticleGridSkeleton count={9} />
+    return <ArticleFeedSkeleton count={9} />
   }
 
   const articles = mapListArticlesToDisplay(data.articles)

--- a/components/profile/ProfilePageLoadingSkeleton.tsx
+++ b/components/profile/ProfilePageLoadingSkeleton.tsx
@@ -1,5 +1,5 @@
 import { Skeleton } from '@/components/ui/skeleton'
-import { ArticleGridSkeleton } from '@/components/articles/ArticleCardSkeleton'
+import { ArticleFeedSkeleton } from '@/components/articles/ArticleFeedSkeleton'
 
 export function ProfilePageLoadingSkeleton() {
   return (
@@ -48,7 +48,7 @@ export function ProfilePageLoadingSkeleton() {
         </nav>
       </div>
 
-      <ArticleGridSkeleton count={9} />
+      <ArticleFeedSkeleton count={9} />
     </main>
   )
 }

--- a/lib/articles/articleListingMeta.test.ts
+++ b/lib/articles/articleListingMeta.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildListingMetaParts,
+  formatListingPublishedDate,
+  formatListingReadTime,
+  formatListingTipCount,
+  getTitleMonogram,
+} from './articleListingMeta'
+
+describe('getTitleMonogram', () => {
+  it('returns first two characters of title', () => {
+    expect(getTitleMonogram('Hello World')).toBe('He')
+  })
+
+  it('returns fallback for empty title', () => {
+    expect(getTitleMonogram('   ')).toBe('QT')
+  })
+})
+
+describe('formatListingPublishedDate', () => {
+  it('returns null for missing or invalid dates', () => {
+    expect(formatListingPublishedDate(null)).toBeNull()
+    expect(formatListingPublishedDate('not-a-date')).toBeNull()
+  })
+
+  it('returns relative date string', () => {
+    const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+    const result = formatListingPublishedDate(weekAgo)
+    expect(result).toMatch(/ago/)
+  })
+})
+
+describe('formatListingReadTime', () => {
+  it('formats minutes', () => {
+    expect(formatListingReadTime(7)).toBe('7 min read')
+  })
+
+  it('returns null for missing or zero values', () => {
+    expect(formatListingReadTime(0)).toBeNull()
+    expect(formatListingReadTime(undefined)).toBeNull()
+  })
+})
+
+describe('formatListingTipCount', () => {
+  it('formats singular and plural tips', () => {
+    expect(formatListingTipCount(1)).toBe('1 tip')
+    expect(formatListingTipCount(3)).toBe('3 tips')
+  })
+
+  it('returns null when no tips', () => {
+    expect(formatListingTipCount(0)).toBeNull()
+    expect(formatListingTipCount(undefined)).toBeNull()
+  })
+})
+
+describe('buildListingMetaParts', () => {
+  it('orders parts as read time, date, tips', () => {
+    const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+    const parts = buildListingMetaParts({
+      readTime: 5,
+      publishedAt: weekAgo,
+      tipCount: 2,
+    })
+
+    expect(parts).toHaveLength(3)
+    expect(parts[0]).toBe('5 min read')
+    expect(parts[1]).toMatch(/ago/)
+    expect(parts[2]).toBe('2 tips')
+  })
+
+  it('omits null parts', () => {
+    expect(
+      buildListingMetaParts({
+        readTime: undefined,
+        publishedAt: null,
+        tipCount: 0,
+      })
+    ).toEqual([])
+  })
+})

--- a/lib/articles/articleListingMeta.ts
+++ b/lib/articles/articleListingMeta.ts
@@ -1,0 +1,57 @@
+import { formatDistanceToNow } from 'date-fns'
+
+export const LISTING_EXCERPT_CLAMP = 2
+export const LISTING_FEED_TAG_LIMIT = 2
+export const LISTING_CARD_TAG_LIMIT = 3
+
+export function getTitleMonogram(title: string): string {
+  const trimmed = title.trim()
+  if (!trimmed) return 'QT'
+  return trimmed.slice(0, 2)
+}
+
+export function formatListingPublishedDate(
+  publishedAt: Date | string | null
+): string | null {
+  if (!publishedAt) return null
+  const date = publishedAt instanceof Date ? publishedAt : new Date(publishedAt)
+  if (Number.isNaN(date.getTime())) return null
+  return formatDistanceToNow(date, { addSuffix: true })
+}
+
+export function formatListingReadTime(minutes?: number): string | null {
+  if (!minutes || minutes < 1) return null
+  return `${minutes} min read`
+}
+
+export function formatListingTipCount(tipCount?: number): string | null {
+  const count = tipCount ?? 0
+  if (count < 1) return null
+  return `${count} tip${count === 1 ? '' : 's'}`
+}
+
+export function buildListingMetaParts({
+  readTime,
+  publishedAt,
+  tipCount,
+}: {
+  readTime?: number
+  publishedAt: Date | string | null
+  tipCount?: number
+}): string[] {
+  return [
+    formatListingReadTime(readTime),
+    formatListingPublishedDate(publishedAt),
+    formatListingTipCount(tipCount),
+  ].filter((part): part is string => Boolean(part))
+}
+
+export function getListingPublishedDateTime(
+  publishedAt: Date | string | null
+): string | undefined {
+  if (!publishedAt) return undefined
+  if (publishedAt instanceof Date) return publishedAt.toISOString()
+  const date = new Date(publishedAt)
+  if (Number.isNaN(date.getTime())) return undefined
+  return date.toISOString()
+}

--- a/lib/articles/articleListingMeta.ts
+++ b/lib/articles/articleListingMeta.ts
@@ -1,6 +1,5 @@
 import { formatDistanceToNow } from 'date-fns'
 
-export const LISTING_EXCERPT_CLAMP = 2
 export const LISTING_FEED_TAG_LIMIT = 2
 export const LISTING_CARD_TAG_LIMIT = 3
 

--- a/lib/articles/feedRowStatus.ts
+++ b/lib/articles/feedRowStatus.ts
@@ -34,7 +34,4 @@ export function getFeedRowStatusLabel(
   return getFeedRowContextLabel(view, article)
 }
 
-export function formatReadTime(minutes?: number): string | null {
-  if (!minutes || minutes < 1) return null
-  return `${minutes} min read`
-}
+export { formatListingReadTime as formatReadTime } from './articleListingMeta'


### PR DESCRIPTION
## Summary

Improves article listing presentation across browse, profile, and home surfaces by extracting shared thumbnail and metadata formatting into reusable building blocks. Cards and feed rows now use consistent cover-image handling, title monogram fallbacks, and metadata display.

Closes ENG-260.

## Changes

- Add `ArticleListingThumbnail` for shared feed and card thumbnails with cover image or title monogram fallback
- Add `articleListingMeta` helpers for read time, published date, tip count, tag limits, and monogram generation
- Refactor `ArticleCard` and `ArticleFeedRow` to use the shared thumbnail and metadata utilities
- Align `ArticleCardSkeleton`, `ArticleFeedSkeleton`, and profile loading skeletons with updated listing layout
- Add unit tests for `ArticleListingThumbnail` and `articleListingMeta`

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run format`
- [x] `bun run test:once` (740 passed)
- [x] `bun run build`

## Notes

No backend or schema changes. UI-only refactor focused on listing consistency and editorial polish. Rebased onto latest `development`.
<img width="1440" height="859" alt="at_3" src="https://github.com/user-attachments/assets/a5dd02bf-8707-4dcb-ab04-4119ed343746" />

<img width="1440" height="859" alt="h_1" src="https://github.com/user-attachments/assets/12881464-baca-4bb8-a29e-184e31eda46f" />

<img width="1440" height="859" alt="h_2" src="https://github.com/user-attachments/assets/35427fe2-d894-48d8-93a9-3cbc1fcd9ae8" />
