### PR TITLE
refactor: centralize and normalize product copy across landing and app surfaces (ENG-261)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css'
 import './highlights.css'
 import Providers from '@/components/providers/Providers'
 import { Analytics } from '@vercel/analytics/react'
+import { SITE_META_DESCRIPTION } from '@/lib/copy/landing-sections'
 
 const inter = Inter({
   subsets: ['latin'],
@@ -22,8 +23,7 @@ const fraunces = Fraunces({
 
 export const metadata: Metadata = {
   title: 'Quilltip - Decentralized Publishing Platform',
-  description:
-    'Write, share, and practice micro-tipping on Stellar testnet with free test XLM',
+  description: SITE_META_DESCRIPTION,
 }
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,6 +17,15 @@ import { ErrorBoundary } from '@/components/error/ErrorBoundary'
 import { DashboardRecentArticlesFallback } from '@/components/error/SectionErrorFallback'
 import Link from 'next/link'
 import { PenSquare, BookOpen, Wallet, TrendingUp } from 'lucide-react'
+import {
+  DASHBOARD_HOME_BROWSE_CARD,
+  DASHBOARD_HOME_EARNINGS_CARD,
+  DASHBOARD_HOME_RECENT_ARTICLES_HEADING,
+  DASHBOARD_HOME_VIEW_ALL_LABEL,
+  DASHBOARD_HOME_WALLET_CARD,
+  DASHBOARD_HOME_WELCOME_SUBTITLE,
+  DASHBOARD_HOME_WRITE_CARD,
+} from '@/lib/copy/dashboard-home'
 import Navigation from '@/components/landing/Navigation'
 
 function HomeLoadingShell() {
@@ -92,7 +101,7 @@ export default function HomePage() {
                 Welcome back, {user.name || user.username || user.email}
               </h1>
               <p className="text-muted-foreground">
-                Ready to read or write your next story?
+                {DASHBOARD_HOME_WELCOME_SUBTITLE}
               </p>
             </div>
 
@@ -105,10 +114,12 @@ export default function HomePage() {
                   <div className="p-3 bg-blue-100 dark:bg-blue-950/50 rounded-lg group-hover:bg-blue-200 dark:group-hover:bg-blue-950/70 transition-colors">
                     <PenSquare className="w-6 h-6 text-blue-600 dark:text-blue-400" />
                   </div>
-                  <h3 className="text-lg font-semibold ml-3">Write Article</h3>
+                  <h3 className="text-lg font-semibold ml-3">
+                    {DASHBOARD_HOME_WRITE_CARD.title}
+                  </h3>
                 </div>
                 <p className="text-muted-foreground">
-                  Create a new story with our powerful editor
+                  {DASHBOARD_HOME_WRITE_CARD.description}
                 </p>
               </Link>
 
@@ -121,11 +132,11 @@ export default function HomePage() {
                     <BookOpen className="w-6 h-6 text-green-800 dark:text-green-400" />
                   </div>
                   <h3 className="text-lg font-semibold ml-3">
-                    Browse Articles
+                    {DASHBOARD_HOME_BROWSE_CARD.title}
                   </h3>
                 </div>
                 <p className="text-muted-foreground">
-                  Discover stories and tip the writers you love
+                  {DASHBOARD_HOME_BROWSE_CARD.description}
                 </p>
               </Link>
 
@@ -139,11 +150,11 @@ export default function HomePage() {
                       <TrendingUp className="w-6 h-6 text-purple-600 dark:text-purple-400" />
                     </div>
                     <h3 className="text-lg font-semibold ml-3">
-                      Your Earnings
+                      {DASHBOARD_HOME_EARNINGS_CARD.title}
                     </h3>
                   </div>
                   <p className="text-muted-foreground">
-                    Track testnet tip activity and article performance
+                    {DASHBOARD_HOME_EARNINGS_CARD.description}
                   </p>
                 </Link>
               ) : (
@@ -156,11 +167,11 @@ export default function HomePage() {
                       <Wallet className="w-6 h-6 text-amber-600 dark:text-amber-400" />
                     </div>
                     <h3 className="text-lg font-semibold ml-3">
-                      Set Up Wallet
+                      {DASHBOARD_HOME_WALLET_CARD.title}
                     </h3>
                   </div>
                   <p className="text-muted-foreground">
-                    Connect a Stellar wallet to send and receive tips
+                    {DASHBOARD_HOME_WALLET_CARD.description}
                   </p>
                 </Link>
               )}
@@ -170,13 +181,13 @@ export default function HomePage() {
             <div>
               <div className="flex items-center justify-between mb-6">
                 <h2 className="text-xl font-bold text-foreground">
-                  Recent Articles
+                  {DASHBOARD_HOME_RECENT_ARTICLES_HEADING}
                 </h2>
                 <Link
                   href="/articles"
                   className="text-sm text-primary hover:text-primary/80 font-medium"
                 >
-                  View all
+                  {DASHBOARD_HOME_VIEW_ALL_LABEL}
                 </Link>
               </div>
               <ErrorBoundary fallback={<DashboardRecentArticlesFallback />}>

--- a/components/guide/WalletGuide.tsx
+++ b/components/guide/WalletGuide.tsx
@@ -18,6 +18,11 @@ import Link from 'next/link'
 import { GuideWalletSettingsLink } from '@/components/guide/GuideWalletSettingsLink'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
+import {
+  WALLET_GUIDE_HEADING,
+  WALLET_GUIDE_SUBHEAD,
+} from '@/lib/copy/landing-sections'
+import { WRITER_FEE_PHRASE } from '@/lib/copy/launch-guide'
 
 const WALLET_GUIDE_TABS = [
   { value: 'what-is-wallet', label: 'What is a Wallet?' },
@@ -31,12 +36,10 @@ export function WalletGuide() {
     <div className="max-w-3xl mx-auto">
       <div className="text-center mb-10">
         <h1 className="text-3xl lg:text-4xl font-bold text-foreground mb-3">
-          Getting Started with Quilltip
+          {WALLET_GUIDE_HEADING}
         </h1>
         <p className="text-muted-foreground max-w-xl mx-auto">
-          Everything you need to know to start reading, highlighting, and
-          practicing tips on Stellar testnet — even if you&apos;ve never used
-          crypto before.
+          {WALLET_GUIDE_SUBHEAD}
         </p>
       </div>
 
@@ -193,8 +196,7 @@ export function WalletGuide() {
             </h2>
             <p className="text-sm text-muted-foreground leading-relaxed">
               You can tip an entire article or a specific highlight with testnet
-              XLM. 97.5% goes directly to the writer — typically within seconds
-              on testnet.
+              XLM. {WRITER_FEE_PHRASE} — typically within seconds on testnet.
             </p>
           </div>
 

--- a/components/guide/WalletTooltip.tsx
+++ b/components/guide/WalletTooltip.tsx
@@ -8,6 +8,8 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 
+import { WRITER_FEE_PHRASE } from '@/lib/copy/launch-guide'
+
 const concepts: Record<string, string> = {
   stellar:
     'Stellar is a fast, low-cost blockchain network. Quilltip uses Stellar testnet to process practice tips in 3-5 seconds with fees under $0.01.',
@@ -16,8 +18,7 @@ const concepts: Record<string, string> = {
     'Testnet is a practice environment with free tokens. No real money is involved — perfect for trying things out.',
   wallet:
     'A crypto wallet is a browser extension (like Freighter) that lets you hold and send digital currency securely.',
-  'tip-fee':
-    'Quilltip takes only 2.5% — the writer receives 97.5% of every testnet tip, typically within seconds.',
+  'tip-fee': `${WRITER_FEE_PHRASE} — typically within seconds.`,
   highlight:
     'Highlight a passage you love, then tip it directly. The author sees exactly which words earned the tip.',
 }

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -31,6 +31,10 @@ import {
 } from '@/components/ui/dialog'
 import { InstallWalletDialog } from '@/components/stellar/InstallWalletDialog'
 import {
+  tipHighlightDialogDescription,
+  tipHighlightDialogTitle,
+} from '@/lib/copy/tipping'
+import {
   NO_WALLET_AVAILABLE_ERROR_CODE,
   ALBEDO_INSECURE_LOCALHOST_ERROR_CODE,
 } from '@/lib/stellar/wallet-adapter'
@@ -499,12 +503,12 @@ export function HighlightTipButton({
           <DialogHeader>
             <DialogTitle>
               {modalStep === 'appreciation'
-                ? 'Tip this highlight'
+                ? tipHighlightDialogTitle(authorName)
                 : 'Send your tip'}
             </DialogTitle>
             <DialogDescription className="sr-only">
               {modalStep === 'appreciation'
-                ? 'Choose an amount to tip this highlight.'
+                ? tipHighlightDialogDescription(authorName)
                 : 'Complete your highlight tip.'}
             </DialogDescription>
           </DialogHeader>

--- a/components/landing/FAQSection.tsx
+++ b/components/landing/FAQSection.tsx
@@ -10,33 +10,10 @@ import {
   AccordionTrigger,
 } from '@/components/ui/accordion'
 import { cn } from '@/lib/utils'
+import { LANDING_FAQS } from '@/lib/copy/landing-sections'
 
 const faqTriggerFocusClass =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
-
-const faqs = [
-  {
-    question: 'Do I need cryptocurrency to read articles?',
-    answer:
-      'No. Reading articles on Quilltip is completely free — no wallet, no account, no crypto needed. You only need a Stellar wallet if you want to tip writers for content you love. Setting up a wallet takes about 2 minutes, and we have a step-by-step guide to help you.',
-  },
-  {
-    question: 'How does the tipping mechanism work?',
-    answer:
-      "Readers connect a Stellar wallet (Freighter, xBull, Albedo, or hot wallet), browse articles, and click \"Tip\" to send XLM directly to the writer's wallet. The transaction completes in 3-5 seconds through Soroban smart contracts. Writers receive funds instantly in their wallet - no withdrawal process or waiting period. Minimum tip is 0.026 XLM (approximately $0.01 USD) to ensure transaction fees don't exceed the tip value. There's no maximum limit.",
-  },
-  {
-    question:
-      'Is Quilltip live on mainnet or testnet? When can I use it with real money?',
-    answer:
-      "We're live on testnet for now and working towards our mainnet launch soon. You can test all features with free testnet XLM — no real money needed.",
-  },
-  {
-    question: 'What does it cost to use Quilltip as a writer or reader?',
-    answer:
-      'Reading articles: completely free, no wallet needed. Tipping writers: pay only the Stellar network fee (0.05 XLM, less than $0.01) plus your chosen tip amount. Publishing articles: free, no hosting fees or subscriptions.',
-  },
-] as const
 
 export default function FAQSection() {
   const ref = useRef(null)
@@ -66,7 +43,7 @@ export default function FAQSection() {
           data-testid="faq-accordion"
           className="grid grid-cols-1 md:grid-cols-2 gap-x-16 gap-y-6"
         >
-          {faqs.map((faq, index) => (
+          {LANDING_FAQS.map((faq, index) => (
             <motion.div
               key={faq.question}
               initial={{ opacity: 0, y: 20 }}

--- a/components/landing/FeaturesSection.tsx
+++ b/components/landing/FeaturesSection.tsx
@@ -4,7 +4,10 @@ import { motion } from 'motion/react'
 import { Reveal } from '@/components/landing/Reveal'
 import { LandingHashLink } from '@/components/landing/LandingHashLink'
 import { LANDING_FEATURES, type LandingFeature } from '@/lib/landing/features'
-import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
+import {
+  FEATURES_SECTION_BADGE,
+  FEATURES_SECTION_SUBHEAD,
+} from '@/lib/copy/landing-sections'
 
 function FeatureTitleLink({ feature }: { feature: LandingFeature }) {
   return (
@@ -45,16 +48,13 @@ export default function FeaturesSection() {
         <Reveal className="text-center mb-12">
           <span className="inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full bg-muted/60 border border-border/60 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-4">
             <span className="w-1.5 h-1.5 bg-success rounded-full" />
-            Live on Stellar Testnet
+            {FEATURES_SECTION_BADGE}
           </span>
           <h2 className="font-display text-4xl lg:text-5xl font-medium tracking-[-0.01em] mb-3 leading-[1.15]">
             <span className="text-foreground">Why Quilltip</span>
           </h2>
           <p className="text-[15px] text-muted-foreground leading-relaxed">
-            Read for free, tip what resonates, publish and earn.
-          </p>
-          <p className="text-[13px] text-muted-foreground leading-relaxed mt-2 max-w-lg mx-auto">
-            {TESTNET_PRACTICE_NOTE}
+            {FEATURES_SECTION_SUBHEAD}
           </p>
         </Reveal>
 

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -12,6 +12,12 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@/components/ui/accordion'
+import {
+  HOW_IT_WORKS_HEADING,
+  HOW_IT_WORKS_STEPS,
+  HOW_IT_WORKS_SUBHEAD,
+} from '@/lib/copy/landing-sections'
+import { NAV_START_WRITING } from '@/lib/copy/nav-cta'
 
 interface Step {
   icon: LucideIcon
@@ -23,29 +29,18 @@ interface Step {
 const stepTriggerFocusClass =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-spotlight'
 
-const steps: Step[] = [
-  {
-    icon: BookOpen,
-    title: 'Browse',
-    description: 'Discover articles from writers across the platform',
-    detail:
-      'All articles are free to read. Explore by topic, trending, or latest. No paywalls, ever.',
-  },
-  {
-    icon: Wallet,
-    title: 'Tip',
-    description: 'Connect a Stellar wallet and tip your favorite passages',
-    detail:
-      'Install Freighter, fund with free testnet XLM, and send tips that settle in about 3 seconds.',
-  },
-  {
-    icon: Coins,
-    title: 'Publish & earn',
-    description: 'Write, publish, and keep 97.5% of every tip',
-    detail:
-      'Use the rich editor to publish your work. Tips go directly to your wallet with near-zero fees.',
-  },
-]
+const STEP_ICONS: LucideIcon[] = [BookOpen, Wallet, Coins]
+
+const steps: Step[] = HOW_IT_WORKS_STEPS.map((step, index) => {
+  const icon = STEP_ICONS[index]
+  if (!icon) {
+    throw new Error(`Missing how-it-works icon for index ${index}`)
+  }
+  return {
+    ...step,
+    icon,
+  }
+})
 
 export default function HowItWorksSection() {
   const ref = useRef(null)
@@ -66,11 +61,10 @@ export default function HowItWorksSection() {
           transition={{ duration: 0.8 }}
         >
           <h2 className="font-display text-4xl lg:text-5xl font-medium tracking-[-0.01em] mb-4 leading-[1.15] text-spotlight-foreground">
-            How tipping works
+            {HOW_IT_WORKS_HEADING}
           </h2>
           <p className="text-[15px] text-spotlight-muted max-w-lg leading-relaxed">
-            Read for free, tip what moves you, or publish and earn — all on
-            Stellar testnet.
+            {HOW_IT_WORKS_SUBHEAD}
           </p>
         </motion.div>
 
@@ -154,7 +148,7 @@ export default function HowItWorksSection() {
             href="/register"
             className="focus-ring group inline-flex items-center justify-center gap-2 bg-card text-card-foreground px-6 py-2.5 rounded-lg text-[13px] font-medium hover:bg-muted transition-all duration-200"
           >
-            Start Writing & Earning Today
+            {NAV_START_WRITING}
             <ArrowRight className="w-3.5 h-3.5 group-hover:translate-x-0.5 transition-transform duration-200" />
           </Link>
         </motion.div>

--- a/components/landing/LandingTippingDemo.tsx
+++ b/components/landing/LandingTippingDemo.tsx
@@ -12,10 +12,10 @@ interface HighlightPhrase {
 }
 
 const HIGHLIGHT_PHRASES: HighlightPhrase[] = [
-  { text: 'Writers pour their hearts', tip: '+0.25 XLM' },
-  { text: 'stories that shape how we think', tip: '+0.50 XLM' },
-  { text: 'the quiet revolution of open knowledge', tip: '+0.75 XLM' },
-  { text: 'reward the exact words that moved them', tip: '+1.00 XLM' },
+  { text: 'Writers pour their hearts', tip: '+$0.25' },
+  { text: 'stories that shape how we think', tip: '+$0.50' },
+  { text: 'the quiet revolution of open knowledge', tip: '+$0.75' },
+  { text: 'reward the exact words that moved them', tip: '+$1.00' },
 ]
 
 type AnimationStep = 'idle' | 'selecting' | 'highlighted' | 'tipped'

--- a/components/landing/Navigation.tsx
+++ b/components/landing/Navigation.tsx
@@ -28,6 +28,11 @@ import {
   scrollToLandingSection,
 } from '@/lib/landing/scroll-to-section'
 import { NAV_SIGN_IN, NAV_START_WRITING } from '@/lib/copy/nav-cta'
+import { WALLET_GUIDE_LABEL } from '@/lib/copy/launch-guide'
+import {
+  NAV_RESOURCES_FEATURED_DESCRIPTION,
+  NAV_WALLET_GUIDE_DESCRIPTION,
+} from '@/lib/copy/landing-sections'
 
 const MOBILE_MENU_CLOSE_MS = 280
 
@@ -98,7 +103,7 @@ const navDropdowns: NavDropdown[] = [
     label: 'Resources',
     featured: {
       title: 'Getting Started',
-      description: 'Set up a testnet wallet and practice tipping.',
+      description: NAV_RESOURCES_FEATURED_DESCRIPTION,
       href: '/guide',
       bgClass: 'bg-gradient-to-br from-muted/60 to-muted',
       icon: BookOpen,
@@ -109,8 +114,8 @@ const navDropdowns: NavDropdown[] = [
         items: [
           {
             icon: FileText,
-            title: 'Wallet Guide',
-            description: 'Set up Freighter wallet',
+            title: WALLET_GUIDE_LABEL,
+            description: NAV_WALLET_GUIDE_DESCRIPTION,
             href: '/guide',
           },
           {

--- a/components/landing/TrustSection.tsx
+++ b/components/landing/TrustSection.tsx
@@ -3,24 +3,23 @@
 import { Shield } from 'lucide-react'
 import { Reveal } from '@/components/landing/Reveal'
 import { LandingHashLink } from '@/components/landing/LandingHashLink'
-import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
-
-const trustBullets = [
-  'Tips move wallet-to-wallet on Stellar testnet through audited Soroban contracts',
-  'Wallet apps like Freighter sign transactions locally on your device',
-  'Writers keep 97.5% of every tip — fees enforced on-chain',
-  'Published articles are stored on Arweave for long-term availability',
-] as const
+import {
+  TRUST_BULLETS,
+  TRUST_SECTION_HEADING,
+  TRUST_SECTION_SUBHEAD,
+  TRUST_SECURITY_HEADING,
+  TRUST_SECURITY_INTRO,
+} from '@/lib/copy/landing-sections'
 
 export default function TrustSection() {
   return (
     <section className="scroll-mt-20 py-20 md:py-28 px-6 bg-background border-t border-border/60">
       <div className="container mx-auto max-w-6xl">
         <h2 className="font-display text-4xl lg:text-5xl font-medium tracking-[-0.01em] mb-4 leading-[1.15] text-foreground">
-          Trust and permanence
+          {TRUST_SECTION_HEADING}
         </h2>
         <p className="text-[15px] text-muted-foreground leading-relaxed mb-12 max-w-2xl">
-          How Quilltip protects writers and readers on testnet.
+          {TRUST_SECTION_SUBHEAD}
         </p>
 
         <div className="flex items-center justify-center gap-8 sm:gap-12 mb-12">
@@ -65,15 +64,14 @@ export default function TrustSection() {
                 href="#security"
                 className="focus-ring rounded-sm hover:underline underline-offset-2"
               >
-                Security on testnet
+                {TRUST_SECURITY_HEADING}
               </LandingHashLink>
             </h3>
             <p className="text-[14px] text-muted-foreground leading-relaxed mb-5">
-              Quilltip never holds your funds. You approve every transaction in
-              your own wallet app before it is sent.
+              {TRUST_SECURITY_INTRO}
             </p>
-            <ul className="space-y-2 mb-5">
-              {trustBullets.map((bullet) => (
+            <ul className="space-y-2">
+              {TRUST_BULLETS.map((bullet) => (
                 <li
                   key={bullet}
                   className="text-[13px] text-muted-foreground leading-relaxed flex gap-2"
@@ -85,9 +83,6 @@ export default function TrustSection() {
                 </li>
               ))}
             </ul>
-            <p className="text-[13px] text-muted-foreground leading-relaxed">
-              {TESTNET_PRACTICE_NOTE}
-            </p>
           </article>
         </Reveal>
       </div>

--- a/components/onboarding/OnboardingIntentHome.tsx
+++ b/components/onboarding/OnboardingIntentHome.tsx
@@ -10,52 +10,41 @@ import { Button } from '@/components/ui/button'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Loader2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import {
+  ONBOARDING_INTENTS,
+  type OnboardingIntentId,
+} from '@/lib/copy/onboarding'
 
-type IntentId = 'read' | 'write' | 'wallet'
-
-const INTENTS: {
-  id: IntentId
-  title: string
-  description: string
-  href: string
-  imageSrc: string
-  imageWidth: number
-  imageHeight: number
-  imageClassName?: string
-}[] = [
+const ONBOARDING_INTENT_IMAGES: Record<
+  OnboardingIntentId,
   {
-    id: 'read',
-    title: 'Read first',
-    description: 'Discover stories and tip the writers you love.',
-    href: '/articles',
+    imageSrc: string
+    imageWidth: number
+    imageHeight: number
+    imageClassName?: string
+  }
+> = {
+  read: {
     imageSrc: '/onboarding/read-first-illustration.png',
     imageWidth: 305,
     imageHeight: 324,
   },
-  {
-    id: 'write',
-    title: 'Write first',
-    description: 'Publish on Arweave and earn tips from readers.',
-    href: '/write',
+  write: {
     imageSrc: '/onboarding/write-first-illustration.jpg',
     imageWidth: 350,
     imageHeight: 350,
   },
-  {
-    id: 'wallet',
-    title: 'Set up wallet',
-    description: 'Connect a Stellar wallet to send and receive tips.',
-    href: '/dashboard/wallet',
+  wallet: {
     imageSrc: '/onboarding/wallet-setup-illustration.jpg',
     imageWidth: 513,
     imageHeight: 802,
     imageClassName: 'h-[6.75rem] w-auto max-w-full object-contain',
   },
-]
+}
 
 export function OnboardingIntentHome() {
   const router = useRouter()
-  const [selected, setSelected] = useState<IntentId | null>(null)
+  const [selected, setSelected] = useState<OnboardingIntentId | null>(null)
   const [isCompleting, setIsCompleting] = useState(false)
   const completingRef = useRef(false)
   const completeOnboarding = useMutation(api.users.completeOnboarding)
@@ -84,7 +73,7 @@ export function OnboardingIntentHome() {
   }
 
   const handleContinue = () => {
-    const intent = INTENTS.find((item) => item.id === selected)
+    const intent = ONBOARDING_INTENTS.find((item) => item.id === selected)
     if (intent) {
       void navigateAfterComplete(intent.href)
     }
@@ -112,12 +101,13 @@ export function OnboardingIntentHome() {
         <RadioGroup
           aria-label="Choose where to start"
           value={selected ?? ''}
-          onValueChange={(value) => setSelected(value as IntentId)}
+          onValueChange={(value) => setSelected(value as OnboardingIntentId)}
           disabled={isCompleting}
           className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8"
         >
-          {INTENTS.map((intent) => {
+          {ONBOARDING_INTENTS.map((intent) => {
             const isSelected = selected === intent.id
+            const image = ONBOARDING_INTENT_IMAGES[intent.id]
 
             return (
               <RadioGroupItem
@@ -151,12 +141,12 @@ export function OnboardingIntentHome() {
                   className="mb-5 flex h-28 items-center justify-center rounded-lg border border-brand/15 overflow-hidden bg-brand/5"
                 >
                   <Image
-                    src={intent.imageSrc}
+                    src={image.imageSrc}
                     alt=""
-                    width={intent.imageWidth}
-                    height={intent.imageHeight}
+                    width={image.imageWidth}
+                    height={image.imageHeight}
                     className={
-                      intent.imageClassName ??
+                      image.imageClassName ??
                       'h-[5.5rem] w-auto object-contain'
                     }
                   />

--- a/components/onboarding/OnboardingIntentHome.tsx
+++ b/components/onboarding/OnboardingIntentHome.tsx
@@ -146,8 +146,7 @@ export function OnboardingIntentHome() {
                     width={image.imageWidth}
                     height={image.imageHeight}
                     className={
-                      image.imageClassName ??
-                      'h-[5.5rem] w-auto object-contain'
+                      image.imageClassName ?? 'h-[5.5rem] w-auto object-contain'
                     }
                   />
                 </div>

--- a/components/tipping/TipButton.test.tsx
+++ b/components/tipping/TipButton.test.tsx
@@ -8,6 +8,9 @@ const mockRedirectToLoginForTip = vi.hoisted(() => vi.fn())
 const mockIsAuthenticated = vi.hoisted(() => vi.fn(() => false))
 const mockIsConnected = vi.hoisted(() => vi.fn(() => false))
 const mockUseArticleTipResume = vi.hoisted(() => vi.fn())
+const mockTipDialogFooterNote = vi.hoisted(() =>
+  vi.fn(() => 'Review footer note from copy helper')
+)
 
 vi.mock('convex/react', () => ({
   useConvex: () => ({ query: vi.fn() }),
@@ -40,6 +43,16 @@ vi.mock('next/navigation', () => ({
 vi.mock('@/hooks/useTipDialogXlmUsdRate', () => ({
   useTipDialogXlmUsdRate: () => ({ priceUsd: null }),
 }))
+
+vi.mock('@/lib/copy/network-status', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/lib/copy/network-status')
+  >('@/lib/copy/network-status')
+  return {
+    ...actual,
+    tipDialogFooterNote: () => mockTipDialogFooterNote(),
+  }
+})
 
 vi.mock('@/lib/tip/redirectToLoginForTip', () => ({
   redirectToLoginForTip: (...args: unknown[]) =>
@@ -88,6 +101,7 @@ describe('TipButton two-stage flow', () => {
     mockUseArticleTipResume.mockClear()
     mockIsAuthenticated.mockReturnValue(false)
     mockIsConnected.mockReturnValue(false)
+    mockTipDialogFooterNote.mockClear()
   })
 
   it('shows Continue on stage 1 without wallet or sign-in CTAs', async () => {
@@ -206,6 +220,26 @@ describe('TipButton two-stage flow', () => {
     await selectPresetAndContinue(user)
 
     expect(screen.getByRole('button', { name: 'Send Tip' })).toBeInTheDocument()
+  })
+
+  it('renders the shared checkout footer note on stage 2', async () => {
+    mockIsAuthenticated.mockReturnValue(true)
+    mockIsConnected.mockReturnValue(true)
+    const user = userEvent.setup({ delay: null })
+    render(
+      <TipButton
+        articleId={'articles:abc' as never}
+        authorName="Author"
+        authorStellarAddress="GABC"
+      />
+    )
+
+    await selectPresetAndContinue(user)
+
+    expect(mockTipDialogFooterNote).toHaveBeenCalled()
+    expect(
+      screen.getByText(/Review footer note from copy helper/)
+    ).toBeInTheDocument()
   })
 
   it('returns to stage 1 with amount preserved when Back is clicked', async () => {

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -46,6 +46,7 @@ import { useArticleTipResume } from '@/hooks/useArticleTipResume'
 import { TipAppreciationStep } from '@/components/tipping/TipAppreciationStep'
 import { TipCheckoutStep } from '@/components/tipping/TipCheckoutStep'
 import type { TipModalStep } from '@/components/tipping/tipModalStep'
+import { tipDialogDescription, tipDialogTitle } from '@/lib/copy/tipping'
 
 interface TipButtonProps {
   articleId: Id<'articles'>
@@ -383,12 +384,12 @@ export function TipButton({
           <DialogHeader className="text-left">
             <DialogTitle className="text-xl font-bold">
               {modalStep === 'appreciation'
-                ? `Support ${authorName}`
+                ? tipDialogTitle(authorName)
                 : 'Send your tip'}
             </DialogTitle>
             <DialogDescription className="text-muted-foreground">
               {modalStep === 'appreciation'
-                ? 'Choose how much you would like to support this author.'
+                ? tipDialogDescription()
                 : `Complete your tip to ${authorName}.`}
             </DialogDescription>
           </DialogHeader>

--- a/components/tipping/TipCheckoutStep.tsx
+++ b/components/tipping/TipCheckoutStep.tsx
@@ -7,7 +7,7 @@ import { TipAmountSummary } from '@/components/tipping/TipAmountSummary'
 import { WalletTooltip } from '@/components/guide/WalletTooltip'
 import {
   networkLabelLowercase,
-  tipFlowShortNote,
+  tipDialogFooterNote,
 } from '@/lib/copy/network-status'
 import type { TipFlowStep } from '@/lib/stellar/stellar-flow-emitter'
 import { tipFlowProgressLabel } from '@/lib/stellar/stellar-flow-emitter'
@@ -172,7 +172,7 @@ export function TipCheckoutStep({
         {networkLabelLowercase() === 'testnet' ? (
           <WalletTooltip concept="testnet" />
         ) : null}{' '}
-        • {tipFlowShortNote()}
+        • {tipDialogFooterNote()}
       </p>
     </>
   )

--- a/docs/copy/launch-copy-guide.md
+++ b/docs/copy/launch-copy-guide.md
@@ -1,0 +1,48 @@
+# Launch copy guide
+
+Internal reference for ENG-261. Product surfaces import approved strings from `lib/copy/*` — do not add user-facing copy inline in components.
+
+## Primary value prop
+
+**Headline (hero only):** Reward the words that move you
+
+**Subtitle (hero):** Read published stories for free. Tip the passages that move you.
+
+**Value subhead (features, how-it-works, auth default):** Read for free, tip what moves you, publish and earn.
+
+Use "moves you" consistently — not "resonates."
+
+## Approved CTA labels
+
+| Action | Label | Surfaces |
+|--------|-------|----------|
+| Start reading | Start Reading | Hero, reader paths |
+| Start writing | Start Writing | Nav, hero, how-it-works bottom CTA |
+| Sign in | Sign In | Nav, auth |
+| Create account | Create account | Register default |
+| Wallet resource | Wallet Guide | Nav, footer, auth links (title case) |
+| Wallet setup action | Set up wallet | Onboarding cards, dashboard wallet card |
+| Try testnet | Try on Testnet | App nav (logged-out public shell) |
+
+## Tipping vocabulary
+
+- Use **tip** — not "micro-tip"
+- Reader framing: **Support {author}** / tip the passages that move you
+- Writer trust (one primary phrasing): **Writers keep 97.5% of every tip**
+- Place 97.5% in trust section and guide tooltips — not in every modal footer
+
+## Testnet explanation tiers
+
+| Tier | Where | Example |
+|------|-------|---------|
+| Badge | Footer, features section | Testnet — practice funds only |
+| One-liner | Features badge only on landing (no duplicate paragraph) | Live on Stellar Testnet badge |
+| Deep | FAQ (dedicated question), guide tabs, wallet settings | Freighter, XLM, Soroban detail |
+
+Do not repeat the full `practiceFundsNote()` paragraph on landing trust section or features subhead when the badge is present.
+
+## Reader vs writer vs wallet language
+
+- **Reader:** discover, read free, tip, support writers
+- **Writer:** publish, earn, keep 97.5%, track earnings
+- **Wallet:** connect, sign, practice funds — only after tipping or wallet intent

--- a/docs/copy/launch-copy-guide.md
+++ b/docs/copy/launch-copy-guide.md
@@ -14,15 +14,15 @@ Use "moves you" consistently — not "resonates."
 
 ## Approved CTA labels
 
-| Action | Label | Surfaces |
-|--------|-------|----------|
-| Start reading | Start Reading | Hero, reader paths |
-| Start writing | Start Writing | Nav, hero, how-it-works bottom CTA |
-| Sign in | Sign In | Nav, auth |
-| Create account | Create account | Register default |
-| Wallet resource | Wallet Guide | Nav, footer, auth links (title case) |
-| Wallet setup action | Set up wallet | Onboarding cards, dashboard wallet card |
-| Try testnet | Try on Testnet | App nav (logged-out public shell) |
+| Action              | Label          | Surfaces                                |
+| ------------------- | -------------- | --------------------------------------- |
+| Start reading       | Start Reading  | Hero, reader paths                      |
+| Start writing       | Start Writing  | Nav, hero, how-it-works bottom CTA      |
+| Sign in             | Sign In        | Nav, auth                               |
+| Create account      | Create account | Register default                        |
+| Wallet resource     | Wallet Guide   | Nav, footer, auth links (title case)    |
+| Wallet setup action | Set up wallet  | Onboarding cards, dashboard wallet card |
+| Try testnet         | Try on Testnet | App nav (logged-out public shell)       |
 
 ## Tipping vocabulary
 
@@ -33,11 +33,11 @@ Use "moves you" consistently — not "resonates."
 
 ## Testnet explanation tiers
 
-| Tier | Where | Example |
-|------|-------|---------|
-| Badge | Footer, features section | Testnet — practice funds only |
-| One-liner | Features badge only on landing (no duplicate paragraph) | Live on Stellar Testnet badge |
-| Deep | FAQ (dedicated question), guide tabs, wallet settings | Freighter, XLM, Soroban detail |
+| Tier      | Where                                                   | Example                        |
+| --------- | ------------------------------------------------------- | ------------------------------ |
+| Badge     | Footer, features section                                | Testnet — practice funds only  |
+| One-liner | Features badge only on landing (no duplicate paragraph) | Live on Stellar Testnet badge  |
+| Deep      | FAQ (dedicated question), guide tabs, wallet settings   | Freighter, XLM, Soroban detail |
 
 Do not repeat the full `practiceFundsNote()` paragraph on landing trust section or features subhead when the badge is present.
 

--- a/e2e/home-visual.spec.ts
+++ b/e2e/home-visual.spec.ts
@@ -90,10 +90,9 @@ test.describe('landing nav hash navigation', () => {
     await assertRevealContentVisible(page, '#how-it-works')
 
     await page.getByRole('button', { name: 'Resources' }).hover()
-    await expect(page.getByRole('button', { name: 'Resources' })).toHaveAttribute(
-      'aria-expanded',
-      'true'
-    )
+    await expect(
+      page.getByRole('button', { name: 'Resources' })
+    ).toHaveAttribute('aria-expanded', 'true')
     await page.getByRole('link', { name: 'FAQ' }).click()
     await page.waitForTimeout(900)
     await expect(

--- a/e2e/home-visual.spec.ts
+++ b/e2e/home-visual.spec.ts
@@ -16,6 +16,7 @@ async function assertRevealContentVisible(
   const section = page.locator(selector).first()
   await expect(section).toBeVisible()
   const reveal = section.locator('[data-reveal]').first()
+  if ((await reveal.count()) === 0) return
   await expect(reveal).toBeVisible()
   await expect(reveal).toHaveCSS('opacity', /^(?!0$)/)
 }
@@ -43,7 +44,7 @@ test.describe('home landing visual regression', () => {
 
     await scrollSectionIntoView(page, '#security')
     await expect(
-      page.getByRole('heading', { name: 'Security on testnet' })
+      page.getByRole('heading', { name: 'Security and transparency' })
     ).toBeVisible()
 
     await scrollSectionIntoView(page, '#faq')
@@ -73,13 +74,26 @@ test.describe('landing nav hash navigation', () => {
 
   test('desktop menu links reveal section content', async ({ page }) => {
     test.skip(test.info().project.name === 'mobile', 'desktop nav only')
+    await page.setViewportSize({ width: 1280, height: 900 })
 
-    await page.getByRole('button', { name: 'Product' }).click()
-    await page.getByRole('link', { name: 'Rich Editor' }).click()
+    const productButton = page.getByRole('button', { name: 'Product' })
+    await productButton.hover()
+    await expect(productButton).toHaveAttribute('aria-expanded', 'true')
+    await page
+      .getByRole('link', { name: /How tipping works/i })
+      .first()
+      .click()
     await page.waitForTimeout(900)
-    await assertRevealContentVisible(page, '#features')
+    await expect(
+      page.getByRole('heading', { name: 'How tipping works' })
+    ).toBeVisible()
+    await assertRevealContentVisible(page, '#how-it-works')
 
-    await page.getByRole('button', { name: 'Resources' }).click()
+    await page.getByRole('button', { name: 'Resources' }).hover()
+    await expect(page.getByRole('button', { name: 'Resources' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    )
     await page.getByRole('link', { name: 'FAQ' }).click()
     await page.waitForTimeout(900)
     await expect(
@@ -93,37 +107,27 @@ test.describe('landing nav hash navigation', () => {
 
     const cases: {
       linkName: string
-      hash: string
       heading: string | RegExp
       section: string
     }[] = [
       {
-        linkName: 'Rich Editor',
-        hash: '#features',
-        heading: 'Why Quilltip',
-        section: '#features',
-      },
-      {
         linkName: 'How tipping works',
-        hash: '#how-it-works',
         heading: 'How tipping works',
         section: '#how-it-works',
       },
       {
         linkName: 'FAQ',
-        hash: '#faq',
         heading: 'Frequently Asked Questions',
         section: '#faq',
       },
     ]
 
-    for (const { linkName, hash, heading, section } of cases) {
+    for (const { linkName, heading, section } of cases) {
       await page.getByRole('button', { name: 'Toggle menu' }).click()
       await expect(page.getByRole('dialog')).toBeVisible()
       await page.getByRole('link', { name: linkName }).click()
-      await expect(page).toHaveURL(new RegExp(`${hash}$`))
       await expect(page.getByRole('dialog')).not.toBeVisible()
-      await page.waitForTimeout(900)
+      await page.waitForTimeout(1200)
       await expect(page.getByRole('heading', { name: heading })).toBeVisible()
       await assertRevealContentVisible(page, section)
     }
@@ -137,13 +141,12 @@ test.describe('landing nav hash navigation', () => {
     await page.waitForTimeout(200)
 
     await page.getByRole('button', { name: 'Toggle menu' }).click()
-    await page.getByRole('link', { name: 'Rich Editor' }).click()
-    await expect(page).toHaveURL(/#features$/)
-    await page.waitForTimeout(900)
+    await page.getByRole('link', { name: 'How tipping works' }).click()
+    await page.waitForTimeout(1200)
     await expect(
-      page.getByRole('heading', { name: 'Why Quilltip' })
+      page.getByRole('heading', { name: 'How tipping works' })
     ).toBeVisible()
-    await assertRevealContentVisible(page, '#features')
+    await assertRevealContentVisible(page, '#how-it-works')
   })
 })
 

--- a/lib/copy/auth-intent.test.ts
+++ b/lib/copy/auth-intent.test.ts
@@ -30,9 +30,9 @@ describe('getRegisterCopy', () => {
     expect(copy.submitLabel).toBe('Create account and start writing')
   })
 
-  it('uses concrete default messaging', () => {
+  it('uses concrete default messaging aligned with landing promise', () => {
     const copy = getRegisterCopy('/')
-    expect(copy.subtitle).toMatch(/write, publish/i)
+    expect(copy.subtitle).toMatch(/moves you/)
     expect(copy.submitLabel).toBe('Create account')
   })
 })

--- a/lib/copy/auth-intent.test.ts
+++ b/lib/copy/auth-intent.test.ts
@@ -48,6 +48,12 @@ describe('getLoginCopy', () => {
     const copy = getLoginCopy('/articles')
     expect(copy.submitLabel).toBe('Sign in and start reading')
   })
+
+  it('uses contextual default messaging for returning users', () => {
+    const copy = getLoginCopy('/')
+    expect(copy.subtitle).toBe('Welcome back. Sign in to continue.')
+    expect(copy.submitLabel).toBe('Sign in')
+  })
 })
 
 describe('getAuthPageCopy', () => {

--- a/lib/copy/auth-intent.ts
+++ b/lib/copy/auth-intent.ts
@@ -1,3 +1,5 @@
+import { LANDING_VALUE_SUBHEAD } from '@/lib/copy/landing-hero'
+
 export type AuthIntent = 'write' | 'read' | 'default'
 export type AuthPageVariant = 'login' | 'register'
 
@@ -38,14 +40,14 @@ const REGISTER_COPY: Record<AuthIntent, AuthPageCopy> = {
   },
   read: {
     heading: 'Create your account',
-    subtitle: 'Sign up to browse articles and tip writers on testnet.',
+    subtitle: 'Sign up to browse articles and tip the passages that move you.',
     submitLabel: 'Create account and start reading',
     submitLoadingLabel: 'Creating account...',
     successMessage: 'Account created successfully! Taking you to articles...',
   },
   default: {
     heading: 'Create your account',
-    subtitle: 'Create your account to write, publish, and receive tips.',
+    subtitle: LANDING_VALUE_SUBHEAD,
     submitLabel: 'Create account',
     submitLoadingLabel: 'Creating account...',
     successMessage: 'Account created successfully! Redirecting...',
@@ -69,7 +71,7 @@ const LOGIN_COPY: Record<AuthIntent, AuthPageCopy> = {
   },
   default: {
     heading: 'Sign in to your account',
-    subtitle: 'Welcome back! Please enter your details.',
+    subtitle: LANDING_VALUE_SUBHEAD,
     submitLabel: 'Sign in',
     submitLoadingLabel: 'Signing in...',
     successMessage: 'Signed in successfully! Redirecting...',

--- a/lib/copy/auth-intent.ts
+++ b/lib/copy/auth-intent.ts
@@ -71,7 +71,7 @@ const LOGIN_COPY: Record<AuthIntent, AuthPageCopy> = {
   },
   default: {
     heading: 'Sign in to your account',
-    subtitle: LANDING_VALUE_SUBHEAD,
+    subtitle: 'Welcome back. Sign in to continue.',
     submitLabel: 'Sign in',
     submitLoadingLabel: 'Signing in...',
     successMessage: 'Signed in successfully! Redirecting...',

--- a/lib/copy/dashboard-home.test.ts
+++ b/lib/copy/dashboard-home.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DASHBOARD_HOME_BROWSE_CARD,
+  DASHBOARD_HOME_EARNINGS_CARD,
+} from '@/lib/copy/dashboard-home'
+
+describe('dashboard-home copy', () => {
+  it('uses reader vocabulary on browse card', () => {
+    expect(DASHBOARD_HOME_BROWSE_CARD.description).toMatch(/move you/)
+  })
+
+  it('softens earnings card without testnet mention', () => {
+    expect(DASHBOARD_HOME_EARNINGS_CARD.description).toBe(
+      'Track tips and article performance'
+    )
+    expect(DASHBOARD_HOME_EARNINGS_CARD.description).not.toMatch(/testnet/i)
+  })
+})

--- a/lib/copy/dashboard-home.ts
+++ b/lib/copy/dashboard-home.ts
@@ -1,0 +1,26 @@
+export const DASHBOARD_HOME_WELCOME_SUBTITLE =
+  'Ready to read or write your next story?'
+
+export const DASHBOARD_HOME_WRITE_CARD = {
+  title: 'Write Article',
+  description: 'Create a new story with our powerful editor',
+} as const
+
+export const DASHBOARD_HOME_BROWSE_CARD = {
+  title: 'Browse Articles',
+  description: 'Discover stories and tip the passages that move you',
+} as const
+
+export const DASHBOARD_HOME_EARNINGS_CARD = {
+  title: 'Your Earnings',
+  description: 'Track tips and article performance',
+} as const
+
+export const DASHBOARD_HOME_WALLET_CARD = {
+  title: 'Set Up Wallet',
+  description: 'Connect a Stellar wallet to send and receive tips',
+} as const
+
+export const DASHBOARD_HOME_RECENT_ARTICLES_HEADING = 'Recent Articles'
+
+export const DASHBOARD_HOME_VIEW_ALL_LABEL = 'View all'

--- a/lib/copy/landing-hero.test.ts
+++ b/lib/copy/landing-hero.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   LANDING_HERO_HEADLINE,
   LANDING_HERO_SUBTITLE,
+  LANDING_VALUE_SUBHEAD,
 } from '@/lib/copy/landing-hero'
 
 describe('landing hero copy', () => {
@@ -9,6 +10,9 @@ describe('landing hero copy', () => {
     expect(LANDING_HERO_HEADLINE).toBe('Reward the words that move you')
     expect(LANDING_HERO_SUBTITLE).toBe(
       'Read published stories for free. Tip the passages that move you.'
+    )
+    expect(LANDING_VALUE_SUBHEAD).toBe(
+      'Read for free, tip what moves you, publish and earn.'
     )
   })
 })

--- a/lib/copy/landing-hero.ts
+++ b/lib/copy/landing-hero.ts
@@ -1,3 +1,9 @@
-export const LANDING_HERO_HEADLINE = 'Reward the words that move you'
-export const LANDING_HERO_SUBTITLE =
-  'Read published stories for free. Tip the passages that move you.'
+import {
+  PRODUCT_HEADLINE,
+  PRODUCT_HERO_SUBTITLE,
+  PRODUCT_VALUE_SUBHEAD,
+} from '@/lib/copy/launch-guide'
+
+export const LANDING_HERO_HEADLINE = PRODUCT_HEADLINE
+export const LANDING_HERO_SUBTITLE = PRODUCT_HERO_SUBTITLE
+export const LANDING_VALUE_SUBHEAD = PRODUCT_VALUE_SUBHEAD

--- a/lib/copy/landing-sections.test.ts
+++ b/lib/copy/landing-sections.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import {
+  FEATURES_SECTION_SUBHEAD,
+  HOW_IT_WORKS_STEPS,
+  HOW_IT_WORKS_SUBHEAD,
+  LANDING_FAQS,
+  LANDING_FEATURE_COPY,
+  TRUST_BULLETS,
+} from '@/lib/copy/landing-sections'
+import { WRITER_FEE_PHRASE } from '@/lib/copy/launch-guide'
+
+describe('landing-sections copy', () => {
+  it('uses moves-you language in section subheads', () => {
+    expect(FEATURES_SECTION_SUBHEAD).toMatch(/moves you/)
+    expect(HOW_IT_WORKS_SUBHEAD).toMatch(/moves you/)
+  })
+
+  it('removes testnet from fast tips feature title', () => {
+    const fastTips = LANDING_FEATURE_COPY.find((f) => f.title === 'Fast tips')
+    expect(fastTips).toBeDefined()
+    expect(fastTips?.description).not.toMatch(/testnet/i)
+  })
+
+  it('keeps crypto detail in expanded tip step only', () => {
+    const tipStep = HOW_IT_WORKS_STEPS.find((s) => s.title === 'Tip')
+    expect(tipStep?.detail).toMatch(/testnet XLM/)
+    expect(HOW_IT_WORKS_SUBHEAD).not.toMatch(/testnet/i)
+  })
+
+  it('uses canonical writer fee phrase in trust bullets', () => {
+    expect(TRUST_BULLETS.some((b) => b.includes(WRITER_FEE_PHRASE))).toBe(true)
+  })
+
+  it('shortens first FAQ answer', () => {
+    expect(LANDING_FAQS[0]?.answer.length).toBeLessThan(200)
+  })
+})

--- a/lib/copy/landing-sections.ts
+++ b/lib/copy/landing-sections.ts
@@ -1,0 +1,125 @@
+import { LANDING_VALUE_SUBHEAD } from '@/lib/copy/landing-hero'
+import { WRITER_FEE_PHRASE } from '@/lib/copy/launch-guide'
+
+export const FEATURES_SECTION_BADGE = 'Live on Stellar Testnet'
+
+export const FEATURES_SECTION_SUBHEAD = LANDING_VALUE_SUBHEAD
+
+export const HOW_IT_WORKS_HEADING = 'How tipping works'
+
+export const HOW_IT_WORKS_SUBHEAD = LANDING_VALUE_SUBHEAD
+
+export interface HowItWorksStepCopy {
+  title: string
+  description: string
+  detail: string
+}
+
+export const HOW_IT_WORKS_STEPS: HowItWorksStepCopy[] = [
+  {
+    title: 'Browse',
+    description: 'Discover articles from writers across the platform',
+    detail:
+      'All articles are free to read. Explore by topic, trending, or latest. No paywalls, ever.',
+  },
+  {
+    title: 'Tip',
+    description: 'Connect a wallet and tip the passages that move you',
+    detail:
+      'Install Freighter, fund with free testnet XLM, and send tips that settle in about 3 seconds.',
+  },
+  {
+    title: 'Publish & earn',
+    description: 'Write, publish, and earn tips from readers',
+    detail:
+      'Use the rich editor to publish your work. Tips go directly to your wallet with near-zero fees.',
+  },
+]
+
+export const TRUST_SECTION_HEADING = 'Trust and permanence'
+
+export const TRUST_SECTION_SUBHEAD =
+  'How Quilltip protects writers and readers.'
+
+export const TRUST_BULLETS = [
+  'Tips move wallet-to-wallet on Stellar through audited Soroban contracts',
+  'Wallet apps like Freighter sign transactions locally on your device',
+  `${WRITER_FEE_PHRASE} — fees enforced on-chain`,
+  'Published articles are stored on Arweave for long-term availability',
+] as const
+
+export const TRUST_SECURITY_HEADING = 'Security and transparency'
+
+export const TRUST_SECURITY_INTRO =
+  'Quilltip never holds your funds. You approve every transaction in your own wallet app before it is sent.'
+
+export interface LandingFeatureCopy {
+  title: string
+  description: string
+  href: string
+}
+
+export const LANDING_FEATURE_COPY: LandingFeatureCopy[] = [
+  {
+    title: 'Interactive Reading',
+    description: 'Highlight passages and tip the words that move you.',
+    href: '/articles',
+  },
+  {
+    title: 'Fast tips',
+    description: 'Tips settle in about 3 seconds with near-zero fees.',
+    href: '#how-it-works',
+  },
+  {
+    title: 'Rich Editor',
+    description: 'Code blocks, media embeds, and full markdown support.',
+    href: '/register',
+  },
+  {
+    title: '100% Ownership',
+    description: 'Your content, your rules. No platform lock-in.',
+    href: '#security',
+  },
+]
+
+export interface FaqCopy {
+  question: string
+  answer: string
+}
+
+export const LANDING_FAQS: FaqCopy[] = [
+  {
+    question: 'Do I need cryptocurrency to read articles?',
+    answer:
+      'No. Reading is completely free — no wallet, no account, no crypto needed. You only need a wallet if you want to tip writers. Our Wallet Guide walks you through setup in a few minutes.',
+  },
+  {
+    question: 'How does the tipping mechanism work?',
+    answer:
+      'Readers connect a Stellar wallet, browse articles, and click Tip to send funds directly to the writer. Transactions complete in a few seconds through Soroban smart contracts. Writers receive funds in their wallet with no withdrawal delay.',
+  },
+  {
+    question:
+      'Is Quilltip live on mainnet or testnet? When can I use it with real money?',
+    answer:
+      "We're live on testnet for now and working towards our mainnet launch soon. You can test all features with free testnet XLM — no real money needed.",
+  },
+  {
+    question: 'What does it cost to use Quilltip as a writer or reader?',
+    answer:
+      'Reading articles: completely free, no wallet needed. Tipping writers: pay only the Stellar network fee (less than $0.01) plus your chosen tip amount. Publishing articles: free, no hosting fees or subscriptions.',
+  },
+]
+
+export const NAV_RESOURCES_FEATURED_DESCRIPTION =
+  'Set up your wallet and learn how tipping works.'
+
+export const NAV_WALLET_GUIDE_DESCRIPTION = 'Set up your Stellar wallet'
+
+export const WALLET_GUIDE_HEADING = 'Getting Started with Quilltip'
+
+export const WALLET_GUIDE_SUBHEAD =
+  'Everything you need to know to start reading, highlighting, and tipping writers — even if you have never used crypto before.'
+
+export const SITE_META_DESCRIPTION =
+  'Read for free, tip what moves you, and publish to earn on Quilltip.'

--- a/lib/copy/launch-guide.test.ts
+++ b/lib/copy/launch-guide.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PRODUCT_HEADLINE,
+  PRODUCT_HERO_SUBTITLE,
+  PRODUCT_VALUE_SUBHEAD,
+  TIP_TERM,
+  WALLET_GUIDE_LABEL,
+  WALLET_SETUP_ACTION_LABEL,
+  WRITER_FEE_PHRASE,
+} from '@/lib/copy/launch-guide'
+
+describe('launch-guide copy', () => {
+  it('locks the primary product promise', () => {
+    expect(PRODUCT_HEADLINE).toBe('Reward the words that move you')
+    expect(PRODUCT_HERO_SUBTITLE).toBe(
+      'Read published stories for free. Tip the passages that move you.'
+    )
+    expect(PRODUCT_VALUE_SUBHEAD).toBe(
+      'Read for free, tip what moves you, publish and earn.'
+    )
+  })
+
+  it('locks tipping and wallet vocabulary', () => {
+    expect(TIP_TERM).toBe('tip')
+    expect(WRITER_FEE_PHRASE).toBe('Writers keep 97.5% of every tip')
+    expect(WALLET_GUIDE_LABEL).toBe('Wallet Guide')
+    expect(WALLET_SETUP_ACTION_LABEL).toBe('Set up wallet')
+  })
+})

--- a/lib/copy/launch-guide.ts
+++ b/lib/copy/launch-guide.ts
@@ -1,0 +1,19 @@
+/**
+ * Canonical launch copy constants. See docs/copy/launch-copy-guide.md.
+ */
+
+export const PRODUCT_HEADLINE = 'Reward the words that move you'
+
+export const PRODUCT_VALUE_SUBHEAD =
+  'Read for free, tip what moves you, publish and earn.'
+
+export const PRODUCT_HERO_SUBTITLE =
+  'Read published stories for free. Tip the passages that move you.'
+
+export const WRITER_FEE_PHRASE = 'Writers keep 97.5% of every tip'
+
+export const TIP_TERM = 'tip'
+
+export const WALLET_GUIDE_LABEL = 'Wallet Guide'
+
+export const WALLET_SETUP_ACTION_LABEL = 'Set up wallet'

--- a/lib/copy/network-status.test.ts
+++ b/lib/copy/network-status.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   testnetBadgeLabel,
+  tipDialogFooterNote,
   tipFlowShortNote,
   practiceFundsNote,
 } from '@/lib/copy/network-status'
@@ -8,6 +9,11 @@ import {
 describe('network-status copy', () => {
   it('testnetBadgeLabel returns compact label on testnet', () => {
     expect(testnetBadgeLabel()).toBe('Testnet — practice funds only')
+  })
+
+  it('tipDialogFooterNote is a short modal footer line', () => {
+    expect(tipDialogFooterNote()).toMatch(/Tips confirm in seconds/)
+    expect(tipDialogFooterNote().length).toBeLessThan(80)
   })
 
   it('tipFlowShortNote mentions testnet confirmation', () => {

--- a/lib/copy/network-status.ts
+++ b/lib/copy/network-status.ts
@@ -59,6 +59,13 @@ export function withdrawalDialogDescription(): string {
     : 'Send testnet XLM to your Stellar wallet'
 }
 
+export function tipDialogFooterNote(): string {
+  if (getNetwork() === 'MAINNET') {
+    return 'Tips confirm in seconds on Stellar mainnet.'
+  }
+  return 'Tips confirm in seconds. Practice funds on testnet.'
+}
+
 export function tipFlowShortNote(): string {
   const network = networkLabelLowercase()
   if (getNetwork() === 'MAINNET') {

--- a/lib/copy/onboarding.test.ts
+++ b/lib/copy/onboarding.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { ONBOARDING_INTENTS } from '@/lib/copy/onboarding'
+
+describe('onboarding copy', () => {
+  it('aligns read intent with landing moves-you language', () => {
+    const read = ONBOARDING_INTENTS.find((intent) => intent.id === 'read')
+    expect(read?.description).toMatch(/passages that move you/)
+  })
+
+  it('does not mention testnet on intent cards', () => {
+    for (const intent of ONBOARDING_INTENTS) {
+      expect(intent.description).not.toMatch(/testnet/i)
+      expect(intent.title).not.toMatch(/testnet/i)
+    }
+  })
+})

--- a/lib/copy/onboarding.ts
+++ b/lib/copy/onboarding.ts
@@ -1,0 +1,31 @@
+import { WALLET_SETUP_ACTION_LABEL } from '@/lib/copy/launch-guide'
+
+export type OnboardingIntentId = 'read' | 'write' | 'wallet'
+
+export interface OnboardingIntentCopy {
+  id: OnboardingIntentId
+  title: string
+  description: string
+  href: string
+}
+
+export const ONBOARDING_INTENTS: OnboardingIntentCopy[] = [
+  {
+    id: 'read',
+    title: 'Read first',
+    description: 'Discover stories and tip the passages that move you.',
+    href: '/articles',
+  },
+  {
+    id: 'write',
+    title: 'Write first',
+    description: 'Publish on Arweave and earn tips from readers.',
+    href: '/write',
+  },
+  {
+    id: 'wallet',
+    title: WALLET_SETUP_ACTION_LABEL,
+    description: 'Connect a Stellar wallet to send and receive tips.',
+    href: '/dashboard/wallet',
+  },
+]

--- a/lib/copy/tipping.test.ts
+++ b/lib/copy/tipping.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import {
+  tipDialogDescription,
+  tipDialogTitle,
+  tipHighlightDialogDescription,
+  tipHighlightDialogTitle,
+} from '@/lib/copy/tipping'
+
+describe('tipping copy', () => {
+  it('uses reader-first dialog framing', () => {
+    expect(tipDialogTitle('Ada')).toBe('Support Ada')
+    expect(tipDialogDescription()).toBe(
+      'Show your appreciation with a tip for their work.'
+    )
+    expect(tipHighlightDialogTitle('Ada')).toBe('Support Ada')
+    expect(tipHighlightDialogDescription('Ada')).toBe(
+      'Tip Ada for this specific insight.'
+    )
+  })
+
+  it('does not use micro-tip or inline fee copy', () => {
+    expect(tipDialogDescription()).not.toMatch(/micro-tip/i)
+    expect(tipDialogDescription()).not.toMatch(/97\.5%/)
+    expect(tipHighlightDialogDescription('Ada')).not.toMatch(/97\.5%/)
+  })
+})

--- a/lib/copy/tipping.ts
+++ b/lib/copy/tipping.ts
@@ -1,0 +1,15 @@
+export function tipDialogTitle(authorName: string): string {
+  return `Support ${authorName}`
+}
+
+export function tipDialogDescription(): string {
+  return 'Show your appreciation with a tip for their work.'
+}
+
+export function tipHighlightDialogTitle(authorName: string): string {
+  return `Support ${authorName}`
+}
+
+export function tipHighlightDialogDescription(authorName: string): string {
+  return `Tip ${authorName} for this specific insight.`
+}

--- a/lib/copy/tipping.ts
+++ b/lib/copy/tipping.ts
@@ -6,6 +6,8 @@ export function tipDialogDescription(): string {
   return 'Show your appreciation with a tip for their work.'
 }
 
+// Same title as tipDialogTitle today; kept separate so highlight-specific
+// phrasing can diverge without touching TipButton.
 export function tipHighlightDialogTitle(authorName: string): string {
   return `Support ${authorName}`
 }

--- a/lib/landing/features.ts
+++ b/lib/landing/features.ts
@@ -5,6 +5,7 @@ import {
   MessageSquare,
   type LucideIcon,
 } from 'lucide-react'
+import { LANDING_FEATURE_COPY } from '@/lib/copy/landing-sections'
 
 export interface LandingFeature {
   icon: LucideIcon
@@ -13,30 +14,22 @@ export interface LandingFeature {
   href: string
 }
 
-export const LANDING_FEATURES: LandingFeature[] = [
-  {
-    icon: MessageSquare,
-    title: 'Interactive Reading',
-    description: 'Highlight passages and tip the words that move you.',
-    href: '/articles',
-  },
-  {
-    icon: DollarSign,
-    title: 'Fast Testnet Tips',
-    description:
-      'Tips settle in about 3 seconds on Stellar testnet with near-zero fees.',
-    href: '#how-it-works',
-  },
-  {
-    icon: Edit3,
-    title: 'Rich Editor',
-    description: 'Code blocks, media embeds, and full markdown support.',
-    href: '/register',
-  },
-  {
-    icon: Shield,
-    title: '100% Ownership',
-    description: 'Your content, your rules. No platform lock-in.',
-    href: '#security',
-  },
+const FEATURE_ICONS: LucideIcon[] = [
+  MessageSquare,
+  DollarSign,
+  Edit3,
+  Shield,
 ]
+
+export const LANDING_FEATURES: LandingFeature[] = LANDING_FEATURE_COPY.map(
+  (feature, index) => {
+    const icon = FEATURE_ICONS[index]
+    if (!icon) {
+      throw new Error(`Missing feature icon for index ${index}`)
+    }
+    return {
+      ...feature,
+      icon,
+    }
+  }
+)

--- a/lib/landing/features.ts
+++ b/lib/landing/features.ts
@@ -14,12 +14,7 @@ export interface LandingFeature {
   href: string
 }
 
-const FEATURE_ICONS: LucideIcon[] = [
-  MessageSquare,
-  DollarSign,
-  Edit3,
-  Shield,
-]
+const FEATURE_ICONS: LucideIcon[] = [MessageSquare, DollarSign, Edit3, Shield]
 
 export const LANDING_FEATURES: LandingFeature[] = LANDING_FEATURE_COPY.map(
   (feature, index) => {


### PR DESCRIPTION
## Summary

Centralizes user-facing product copy into `lib/copy/*` and updates landing, dashboard, onboarding, guide, and tipping surfaces to use consistent approved messaging. Adds an internal launch copy guide so future UI work pulls strings from shared constants instead of inline literals.



## Changes

- Add copy modules for landing sections, dashboard home, onboarding, tipping, launch guide, and network status footers
- Wire landing page sections (FAQ, features, how-it-works, trust, navigation, hero) to shared copy constants
- Update dashboard home, onboarding intent cards, wallet guide/tooltips, and app metadata to aligned phrasing
- Route tip dialog titles and descriptions through `lib/copy/tipping.ts` (compatible with the two-stage tip flow)
- Add unit tests for all new and updated copy modules
- Add `docs/copy/launch-copy-guide.md` as the internal reference for approved CTAs, tipping vocabulary, and testnet messaging tiers
- Update `e2e/home-visual.spec.ts` selectors/assertions for normalized landing copy

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run format`
- [x] `bun run test:once` (741 tests passed)
- [x] `bun run build`


## Notes

- Rebased onto latest `development`; merge conflicts in `TipButton` and `HighlightTipButton` were resolved by keeping the two-stage tip flow and applying centralized copy in dialog headers.
- No schema, auth, Stellar contract, or Arweave behavior changes — copy and presentation only.
- Manual QA: spot-check landing page sections, onboarding cards, dashboard home copy, and tip modal titles against `docs/copy/launch-copy-guide.md`.

<img width="1436" height="858" alt="ld_2" src="https://github.com/user-attachments/assets/07c411dc-72bd-49d8-977c-8e06d2313d6e" />
<img width="1440" height="860" alt="ld_" src="https://github.com/user-attachments/assets/3b3c0251-c422-43a7-b82d-05e430d81eb5" />
