### PR TITLE
refactor(ui): reduce color and gradient drift with semantic design tokens (ENG-262)

### DIFF
--- a/app/drafts/page.tsx
+++ b/app/drafts/page.tsx
@@ -22,7 +22,8 @@ import {
 } from '@/components/ui/alert-dialog'
 import { DraftsListSkeleton } from '@/components/drafts/DraftsListSkeleton'
 import { AUTO_SAVE_GUIDANCE } from '@/lib/autosave'
-import { Button } from '@/components/ui/button'
+import { Button, buttonVariants } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -189,7 +190,7 @@ export default function DraftsPage() {
                       {!draft.published && (
                         <>
                           <span>•</span>
-                          <span className="text-amber-600 dark:text-amber-400 font-medium">
+                          <span className="text-warning-foreground font-medium">
                             Draft
                           </span>
                         </>
@@ -252,7 +253,10 @@ export default function DraftsPage() {
             <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
             <AlertDialogAction
               disabled={isDeleting}
-              className="bg-red-600 hover:bg-red-700 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              className={cn(
+                buttonVariants({ variant: 'destructive' }),
+                'disabled:opacity-50 disabled:cursor-not-allowed'
+              )}
               onClick={(e) => {
                 e.preventDefault()
                 void handleConfirmDelete()

--- a/app/globals.css
+++ b/app/globals.css
@@ -81,7 +81,7 @@
 /* Highlight creation feedback */
 .highlight-creating {
   animation: highlight-fade-in 0.4s ease-out;
-  background-color: rgba(255, 235, 59, 0.3);
+  background-color: color-mix(in srgb, var(--warning) 30%, transparent);
 }
 
 /* Tooltip for highlights */
@@ -189,6 +189,19 @@
   --sidebar-ring: oklch(0.708 0 0);
 
   /*
+   * Approved semantic color variant matrix (ENG-262)
+   * -----------------------------------------------------------------------
+   * Primary CTA (tip, publish, connect)  -> Button default / bg-primary
+   * Success (connected, verified)        -> bg-success text-success-foreground
+   * Warning / pending                    -> bg-warning text-warning-foreground
+   * Info / support context               -> bg-info text-info-foreground
+   * Error                                -> bg-destructive text-destructive-foreground
+   * NFT / collectible                    -> bg-collectible* variants (tonal family)
+   * Decorative stat icon                 -> text-muted-foreground
+   * Do NOT use raw Tailwind palette classes (yellow-*, blue-500, etc.) for UI states.
+   */
+
+  /*
    * Semantic status tokens. Each pair: background (--*) + legible text (--*-foreground).
    * Use as Tailwind utilities: bg-success text-success-foreground, bg-warning text-warning-foreground, etc.
    * For error/danger states use --destructive / --destructive-foreground (already present above).
@@ -199,6 +212,31 @@
   --warning-foreground: oklch(0.45 0.14 85);
   --info: oklch(0.965 0.03 240);
   --info-foreground: oklch(0.48 0.17 240);
+
+  /* Aliased semantic tokens */
+  --support: var(--info);
+  --support-foreground: var(--info-foreground);
+  --wallet: var(--success);
+  --wallet-foreground: var(--success-foreground);
+
+  /* Collectible / NFT tonal family (restrained violet-navy, not rainbow) */
+  --collectible-muted: oklch(0.96 0.02 270);
+  --collectible-muted-foreground: oklch(0.5 0.08 270);
+  --collectible: oklch(0.93 0.04 265);
+  --collectible-foreground: oklch(0.42 0.14 265);
+  --collectible-emphasis: oklch(0.88 0.08 260);
+  --collectible-emphasis-foreground: oklch(0.35 0.16 260);
+
+  /* Documented gradient stops (use via bg-gradient-to-r from-* to-*) */
+  --gradient-brand-from: var(--brand);
+  --gradient-brand-to: var(--brand-hover);
+  --gradient-collectible-from: oklch(0.55 0.12 265);
+  --gradient-collectible-to: oklch(0.45 0.14 260);
+
+  /* Heatmap intensity scale (data encoding, not CTAs) */
+  --heatmap-low: oklch(0.95 0.04 85);
+  --heatmap-mid: oklch(0.75 0.14 55);
+  --heatmap-high: oklch(0.55 0.2 25);
 
   /*
    * Monetization status mapping (reader-facing tip, highlight, NFT surfaces):
@@ -571,6 +609,23 @@
   --color-warning-foreground: var(--warning-foreground);
   --color-info: var(--info);
   --color-info-foreground: var(--info-foreground);
+  --color-support: var(--support);
+  --color-support-foreground: var(--support-foreground);
+  --color-wallet: var(--wallet);
+  --color-wallet-foreground: var(--wallet-foreground);
+  --color-collectible-muted: var(--collectible-muted);
+  --color-collectible-muted-foreground: var(--collectible-muted-foreground);
+  --color-collectible: var(--collectible);
+  --color-collectible-foreground: var(--collectible-foreground);
+  --color-collectible-emphasis: var(--collectible-emphasis);
+  --color-collectible-emphasis-foreground: var(--collectible-emphasis-foreground);
+  --color-gradient-brand-from: var(--gradient-brand-from);
+  --color-gradient-brand-to: var(--gradient-brand-to);
+  --color-gradient-collectible-from: var(--gradient-collectible-from);
+  --color-gradient-collectible-to: var(--gradient-collectible-to);
+  --color-heatmap-low: var(--heatmap-low);
+  --color-heatmap-mid: var(--heatmap-mid);
+  --color-heatmap-high: var(--heatmap-high);
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
   --color-brand-hover: var(--brand-hover);
@@ -671,6 +726,27 @@
   --info: oklch(0.28 0.06 240);
   --info-foreground: oklch(0.9 0.07 240);
 
+  --support: var(--info);
+  --support-foreground: var(--info-foreground);
+  --wallet: var(--success);
+  --wallet-foreground: var(--success-foreground);
+
+  --collectible-muted: oklch(0.28 0.04 270);
+  --collectible-muted-foreground: oklch(0.82 0.05 270);
+  --collectible: oklch(0.32 0.06 265);
+  --collectible-foreground: oklch(0.88 0.06 265);
+  --collectible-emphasis: oklch(0.38 0.1 260);
+  --collectible-emphasis-foreground: oklch(0.92 0.05 260);
+
+  --gradient-brand-from: var(--brand);
+  --gradient-brand-to: var(--brand-hover);
+  --gradient-collectible-from: oklch(0.5 0.1 265);
+  --gradient-collectible-to: oklch(0.42 0.12 260);
+
+  --heatmap-low: oklch(0.35 0.06 85);
+  --heatmap-mid: oklch(0.45 0.12 55);
+  --heatmap-high: oklch(0.5 0.18 25);
+
   /* Landing semantic tokens */
   --brand: #1a365d;
   --brand-foreground: #fefefe;
@@ -694,6 +770,31 @@
 @layer utilities {
   .focus-ring {
     @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background;
+  }
+
+  .bg-gradient-brand {
+    background-image: linear-gradient(
+      to right,
+      var(--gradient-brand-from),
+      var(--gradient-brand-to)
+    );
+  }
+
+  .bg-gradient-collectible {
+    background-image: linear-gradient(
+      to right,
+      var(--gradient-collectible-from),
+      var(--gradient-collectible-to)
+    );
+  }
+
+  .bg-gradient-surface {
+    background-image: linear-gradient(
+      to bottom,
+      var(--background),
+      color-mix(in srgb, var(--muted) 30%, transparent),
+      var(--background)
+    );
   }
 
   .animate-accordion-down {

--- a/app/globals.css
+++ b/app/globals.css
@@ -618,7 +618,9 @@
   --color-collectible: var(--collectible);
   --color-collectible-foreground: var(--collectible-foreground);
   --color-collectible-emphasis: var(--collectible-emphasis);
-  --color-collectible-emphasis-foreground: var(--collectible-emphasis-foreground);
+  --color-collectible-emphasis-foreground: var(
+    --collectible-emphasis-foreground
+  );
   --color-gradient-brand-from: var(--gradient-brand-from);
   --color-gradient-brand-to: var(--gradient-brand-to);
   --color-gradient-collectible-from: var(--gradient-collectible-from);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -111,8 +111,8 @@ export default function HomePage() {
                 className="group p-6 bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] hover:shadow-md transition-shadow border border-border"
               >
                 <div className="flex items-center mb-4">
-                  <div className="p-3 bg-blue-100 dark:bg-blue-950/50 rounded-lg group-hover:bg-blue-200 dark:group-hover:bg-blue-950/70 transition-colors">
-                    <PenSquare className="w-6 h-6 text-blue-600 dark:text-blue-400" />
+                  <div className="p-3 bg-muted rounded-lg group-hover:bg-muted/80 transition-colors">
+                    <PenSquare className="w-6 h-6 text-brand" />
                   </div>
                   <h3 className="text-lg font-semibold ml-3">
                     {DASHBOARD_HOME_WRITE_CARD.title}
@@ -128,8 +128,8 @@ export default function HomePage() {
                 className="group p-6 bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] hover:shadow-md transition-shadow border border-border"
               >
                 <div className="flex items-center mb-4">
-                  <div className="p-3 bg-green-100 dark:bg-green-950/50 rounded-lg group-hover:bg-green-200 dark:group-hover:bg-green-950/70 transition-colors">
-                    <BookOpen className="w-6 h-6 text-green-800 dark:text-green-400" />
+                  <div className="p-3 bg-muted rounded-lg group-hover:bg-muted/80 transition-colors">
+                    <BookOpen className="w-6 h-6 text-foreground" />
                   </div>
                   <h3 className="text-lg font-semibold ml-3">
                     {DASHBOARD_HOME_BROWSE_CARD.title}
@@ -146,8 +146,8 @@ export default function HomePage() {
                   className="group p-6 bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] hover:shadow-md transition-shadow border border-border"
                 >
                   <div className="flex items-center mb-4">
-                    <div className="p-3 bg-purple-100 dark:bg-purple-950/50 rounded-lg group-hover:bg-purple-200 dark:group-hover:bg-purple-950/70 transition-colors">
-                      <TrendingUp className="w-6 h-6 text-purple-600 dark:text-purple-400" />
+                    <div className="p-3 bg-muted rounded-lg group-hover:bg-muted/80 transition-colors">
+                      <TrendingUp className="w-6 h-6 text-foreground" />
                     </div>
                     <h3 className="text-lg font-semibold ml-3">
                       {DASHBOARD_HOME_EARNINGS_CARD.title}
@@ -163,8 +163,8 @@ export default function HomePage() {
                   className="group p-6 bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] hover:shadow-md transition-shadow border border-border"
                 >
                   <div className="flex items-center mb-4">
-                    <div className="p-3 bg-amber-100 dark:bg-amber-950/50 rounded-lg group-hover:bg-amber-200 dark:group-hover:bg-amber-950/70 transition-colors">
-                      <Wallet className="w-6 h-6 text-amber-600 dark:text-amber-400" />
+                    <div className="p-3 bg-muted rounded-lg group-hover:bg-muted/80 transition-colors">
+                      <Wallet className="w-6 h-6 text-foreground" />
                     </div>
                     <h3 className="text-lg font-semibold ml-3">
                       {DASHBOARD_HOME_WALLET_CARD.title}

--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -19,7 +19,7 @@ export default function StatusPage() {
       <div className="space-y-10 text-foreground">
         <div
           role="status"
-          className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm leading-relaxed text-amber-950 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-100"
+          className="rounded-lg border border-warning/50 bg-warning/10 px-4 py-3 text-sm leading-relaxed text-warning-foreground"
         >
           {statusBanner}
         </div>
@@ -42,7 +42,7 @@ export default function StatusPage() {
                     {service.detail}
                   </p>
                 </div>
-                <span className="shrink-0 text-sm font-medium text-green-700 dark:text-green-400">
+                <span className="shrink-0 text-sm font-medium text-success-foreground">
                   {service.status}
                 </span>
               </li>

--- a/components/articles/ArweaveStatus.tsx
+++ b/components/articles/ArweaveStatus.tsx
@@ -11,6 +11,8 @@ import {
   Clock,
 } from 'lucide-react'
 import type { ArweaveStatus as ArweaveStatusType } from '@/lib/arweave/types'
+import { statusVariants } from '@/lib/ui/status-config'
+import { cn } from '@/lib/utils'
 
 interface ArweaveStatusProps {
   status?: string
@@ -21,25 +23,25 @@ interface ArweaveStatusProps {
 
 const statusConfig: Record<
   ArweaveStatusType,
-  { color: string; icon: React.ReactNode; label: string }
+  { className: string; icon: React.ReactNode; label: string }
 > = {
   pending: {
-    color: 'bg-warning text-warning-foreground',
+    className: statusVariants.pending,
     icon: <Clock className="w-4 h-4" />,
     label: 'Uploading to Arweave',
   },
   uploaded: {
-    color: 'bg-info text-info-foreground',
+    className: statusVariants.info,
     icon: <Loader2 className="w-4 h-4 animate-spin" />,
     label: 'Confirming on Arweave',
   },
   verified: {
-    color: 'bg-success text-success-foreground',
+    className: statusVariants.success,
     icon: <CheckCircle className="w-4 h-4" />,
     label: 'Permanently stored',
   },
   failed: {
-    color: 'bg-destructive/10 text-destructive',
+    className: statusVariants.error,
     icon: <XCircle className="w-4 h-4" />,
     label: 'Upload failed',
   },
@@ -59,7 +61,7 @@ export function ArweaveStatus({
     statusConfig[status as ArweaveStatusType] || statusConfig.pending
 
   return (
-    <div className={`rounded-lg p-3 ${config.color}`}>
+    <div className={cn('rounded-lg p-3', config.className)}>
       <button
         onClick={() => setExpanded(!expanded)}
         className="flex items-center justify-between w-full text-left"

--- a/components/articles/ShareButtons.tsx
+++ b/components/articles/ShareButtons.tsx
@@ -274,9 +274,7 @@ export default function ShareButtons({
               {copied ? (
                 <>
                   <Check className="h-4 w-4 text-success-foreground" />
-                  <span className="text-success-foreground">
-                    Copied!
-                  </span>
+                  <span className="text-success-foreground">Copied!</span>
                 </>
               ) : (
                 <>

--- a/components/articles/ShareButtons.tsx
+++ b/components/articles/ShareButtons.tsx
@@ -168,7 +168,7 @@ export default function ShareButtons({
         {/* Twitter */}
         <button
           onClick={() => openShareWindow(shareUrls.twitter)}
-          className="flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:text-blue-500 hover:bg-muted rounded-lg transition-colors"
+          className="flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:text-brand hover:bg-muted rounded-lg transition-colors"
           aria-label="Share on Twitter"
         >
           <Twitter className="h-4 w-4" />
@@ -178,7 +178,7 @@ export default function ShareButtons({
         {/* LinkedIn */}
         <button
           onClick={() => openShareWindow(shareUrls.linkedin)}
-          className="flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:text-blue-600 hover:bg-muted rounded-lg transition-colors"
+          className="flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:text-brand hover:bg-muted rounded-lg transition-colors"
           aria-label="Share on LinkedIn"
         >
           <Linkedin className="h-4 w-4" />
@@ -188,7 +188,7 @@ export default function ShareButtons({
         {/* Facebook */}
         <button
           onClick={() => openShareWindow(shareUrls.facebook)}
-          className="flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:text-blue-700 hover:bg-muted rounded-lg transition-colors"
+          className="flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:text-brand hover:bg-muted rounded-lg transition-colors"
           aria-label="Share on Facebook"
         >
           <Facebook className="h-4 w-4" />
@@ -203,8 +203,8 @@ export default function ShareButtons({
         >
           {copied ? (
             <>
-              <Check className="h-4 w-4 text-green-800 dark:text-green-300" />
-              <span className="hidden sm:inline text-green-800 dark:text-green-300">
+              <Check className="h-4 w-4 text-success-foreground" />
+              <span className="hidden sm:inline text-success-foreground">
                 Copied!
               </span>
             </>
@@ -239,7 +239,7 @@ export default function ShareButtons({
               href={shareUrls.twitter}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:text-blue-500 hover:bg-muted transition-colors"
+              className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:text-brand hover:bg-muted transition-colors"
               aria-label="Open Twitter share in new tab"
             >
               <Twitter className="h-4 w-4" />
@@ -249,7 +249,7 @@ export default function ShareButtons({
               href={shareUrls.linkedin}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:text-blue-600 hover:bg-muted transition-colors"
+              className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:text-brand hover:bg-muted transition-colors"
               aria-label="Open LinkedIn share in new tab"
             >
               <Linkedin className="h-4 w-4" />
@@ -259,7 +259,7 @@ export default function ShareButtons({
               href={shareUrls.facebook}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:text-blue-700 hover:bg-muted transition-colors"
+              className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:text-brand hover:bg-muted transition-colors"
               aria-label="Open Facebook share in new tab"
             >
               <Facebook className="h-4 w-4" />
@@ -273,8 +273,8 @@ export default function ShareButtons({
             >
               {copied ? (
                 <>
-                  <Check className="h-4 w-4 text-green-800 dark:text-green-300" />
-                  <span className="text-green-800 dark:text-green-300">
+                  <Check className="h-4 w-4 text-success-foreground" />
+                  <span className="text-success-foreground">
                     Copied!
                   </span>
                 </>

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -13,6 +13,7 @@ import { loginSchema, type LoginFormData } from '@/lib/validations/auth'
 import { CheckCircle, Eye, EyeOff, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Alert, AlertDescription } from '@/components/ui/alert'
 
 const authInputClassName =
   'rounded-lg bg-background text-foreground focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:border-transparent'
@@ -114,9 +115,9 @@ export default function LoginForm() {
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
       {/* Error Message */}
       {error && (
-        <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
-          <p className="text-sm text-red-700">{error}</p>
-        </div>
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
       )}
 
       {/* Email Field */}
@@ -136,7 +137,7 @@ export default function LoginForm() {
           placeholder="you@example.com"
         />
         {errors.email && (
-          <p className="mt-1 text-sm text-red-600">{errors.email.message}</p>
+          <p className="mt-1 text-sm text-destructive">{errors.email.message}</p>
         )}
       </div>
 
@@ -174,7 +175,7 @@ export default function LoginForm() {
           </Button>
         </div>
         {errors.password && (
-          <p className="mt-1 text-sm text-red-600">{errors.password.message}</p>
+          <p className="mt-1 text-sm text-destructive">{errors.password.message}</p>
         )}
       </div>
 

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -137,7 +137,9 @@ export default function LoginForm() {
           placeholder="you@example.com"
         />
         {errors.email && (
-          <p className="mt-1 text-sm text-destructive">{errors.email.message}</p>
+          <p className="mt-1 text-sm text-destructive">
+            {errors.email.message}
+          </p>
         )}
       </div>
 
@@ -175,7 +177,9 @@ export default function LoginForm() {
           </Button>
         </div>
         {errors.password && (
-          <p className="mt-1 text-sm text-destructive">{errors.password.message}</p>
+          <p className="mt-1 text-sm text-destructive">
+            {errors.password.message}
+          </p>
         )}
       </div>
 

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -14,6 +14,7 @@ import { CheckCircle, Eye, EyeOff, Loader2 } from 'lucide-react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Alert, AlertDescription } from '@/components/ui/alert'
 import {
   PasswordRequirements,
   PASSWORD_REQUIREMENTS_ID,
@@ -165,12 +166,9 @@ export default function RegisterForm() {
       ) : null}
 
       {formError ? (
-        <div
-          role="alert"
-          className="p-4 bg-red-50 border border-red-200 rounded-lg"
-        >
-          <p className="text-sm text-red-700">{formError}</p>
-        </div>
+        <Alert variant="destructive" role="alert">
+          <AlertDescription>{formError}</AlertDescription>
+        </Alert>
       ) : null}
 
       <RegisterFormField

--- a/components/dashboard/CreatorStatsPanel.tsx
+++ b/components/dashboard/CreatorStatsPanel.tsx
@@ -35,7 +35,10 @@ export function CreatorStatsPanel({
         <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
           <div className="flex items-center justify-between mb-2">
             <span className="text-muted-foreground">NFTs Owned</span>
-            <Image className="w-5 h-5 text-muted-foreground" aria-label="NFTs" />
+            <Image
+              className="w-5 h-5 text-muted-foreground"
+              aria-label="NFTs"
+            />
           </div>
           <p className="text-3xl font-bold text-foreground">{nftsOwned}</p>
         </div>

--- a/components/dashboard/CreatorStatsPanel.tsx
+++ b/components/dashboard/CreatorStatsPanel.tsx
@@ -19,14 +19,14 @@ export function CreatorStatsPanel({
         <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
           <div className="flex items-center justify-between mb-2">
             <span className="text-muted-foreground">Total Articles</span>
-            <BookOpen className="w-5 h-5 text-blue-500" />
+            <BookOpen className="w-5 h-5 text-muted-foreground" />
           </div>
           <p className="text-3xl font-bold text-foreground">{articleCount}</p>
         </div>
         <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
           <div className="flex items-center justify-between mb-2">
             <span className="text-muted-foreground">Tips Received</span>
-            <DollarSign className="w-5 h-5 text-green-500" />
+            <DollarSign className="w-5 h-5 text-muted-foreground" />
           </div>
           <p className="text-3xl font-bold text-foreground">
             {tipsReceivedCount}
@@ -35,7 +35,7 @@ export function CreatorStatsPanel({
         <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
           <div className="flex items-center justify-between mb-2">
             <span className="text-muted-foreground">NFTs Owned</span>
-            <Image className="w-5 h-5 text-purple-500" aria-label="NFTs" />
+            <Image className="w-5 h-5 text-muted-foreground" aria-label="NFTs" />
           </div>
           <p className="text-3xl font-bold text-foreground">{nftsOwned}</p>
         </div>

--- a/components/highlights/HighlightDetailsPanel.tsx
+++ b/components/highlights/HighlightDetailsPanel.tsx
@@ -31,8 +31,8 @@ import {
 import { HighlightTipButton } from './HighlightTipButton'
 import { formatTipAmount } from '@/lib/stellar/highlight-utils'
 import { UserAvatar } from '@/components/ui/user-avatar'
+import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
-import { cn } from '@/lib/utils'
 import { useClampedFixedPosition } from '@/hooks/useClampedFixedPosition'
 
 interface HighlightDetailsPanelProps {
@@ -278,12 +278,14 @@ export function HighlightDetailsPanel({
                   autoFocus
                 />
                 <div className="flex gap-2">
-                  <button
+                  <Button
+                    type="button"
+                    size="sm"
                     onClick={handleSaveNote}
-                    className="flex-1 px-3 py-1.5 bg-blue-500 text-white text-sm rounded-lg hover:bg-blue-600 transition-colors"
+                    className="flex-1"
                   >
                     Save
-                  </button>
+                  </Button>
                   <button
                     onClick={() => {
                       setEditedNote(highlight.note || '')
@@ -309,9 +311,9 @@ export function HighlightDetailsPanel({
 
         {/* Tip Statistics */}
         {tipStats.count > 0 && (
-          <div className="px-4 py-3 border-b border-border bg-muted">
+          <div className="px-4 py-3 border-b border-border bg-collectible/10">
             <div className="flex items-center gap-2 mb-2">
-              <TrendingUp className="w-4 h-4 text-muted-foreground" />
+              <TrendingUp className="w-4 h-4 text-collectible-foreground" />
               <span className="text-xs font-medium text-foreground">
                 Tip Statistics
               </span>
@@ -342,22 +344,21 @@ export function HighlightDetailsPanel({
             <div className="space-y-2">
               {!isEditing && (
                 <>
-                  <button
+                  <Button
+                    type="button"
+                    variant="secondary"
                     onClick={() => setIsEditing(true)}
-                    className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-300 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-950/50 transition-colors text-sm font-medium"
+                    className="w-full gap-2"
                   >
                     <Edit className="w-4 h-4" />
                     <span>Edit Note</span>
-                  </button>
-                  <button
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="destructive"
                     onClick={() => setDeleteConfirmOpen(true)}
                     disabled={isDeleting}
-                    className={cn(
-                      'w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg transition-colors text-sm font-medium',
-                      isDeleting
-                        ? 'bg-muted text-muted-foreground cursor-not-allowed'
-                        : 'bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-300 hover:bg-red-100 dark:hover:bg-red-950/50'
-                    )}
+                    className="w-full gap-2"
                   >
                     {isDeleting ? (
                       <>
@@ -370,7 +371,7 @@ export function HighlightDetailsPanel({
                         <span>Delete Highlight</span>
                       </>
                     )}
-                  </button>
+                  </Button>
                 </>
               )}
             </div>

--- a/components/highlights/HighlightNotes.tsx
+++ b/components/highlights/HighlightNotes.tsx
@@ -109,7 +109,7 @@ export function HighlightNotes({
             if (!tipData?.count) return null
             return (
               <div className="mb-2">
-                <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-muted text-muted-foreground text-xs rounded-full">
+                <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-warning text-warning-foreground text-xs rounded-full">
                   <Coins className="w-3 h-3" />
                   {tipData.count} tip{tipData.count > 1 ? 's' : ''}
                   {' · '}${tipData.totalUsd.toFixed(2)}

--- a/components/highlights/HighlightPopover.tsx
+++ b/components/highlights/HighlightPopover.tsx
@@ -187,7 +187,7 @@ export function HighlightPopover({
               >
                 {isPublic ? (
                   <>
-                    <Globe className="w-4 h-4 text-green-800 dark:text-green-300" />
+                    <Globe className="w-4 h-4 text-success-foreground" />
                     <span className="text-sm text-foreground">Public</span>
                   </>
                 ) : (
@@ -235,11 +235,12 @@ export function HighlightPopover({
             {isAuthenticated && (
               <Button
                 type="button"
+                size="sm"
                 onClick={handleSaveHighlight}
-                className="highlight-action-button flex-1"
+                className="min-w-0 flex-1 gap-2 shadow-md"
               >
-                <Highlighter className="w-4 h-4 mr-2" />
-                <span>Save</span>
+                <Highlighter className="w-4 h-4" />
+                <span className="font-medium">Save</span>
               </Button>
             )}
 
@@ -256,7 +257,7 @@ export function HighlightPopover({
                   highlightText={selectedText}
                   startOffset={startOffset}
                   endOffset={endOffset}
-                  className="flex-1"
+                  className="min-w-0 flex-1"
                   resumeOpen={Boolean(resumeHighlightTip)}
                   resumeAmountCents={resumeHighlightTip?.amountCents}
                   resumeCustomAmount={resumeHighlightTip?.customAmount}

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -481,12 +481,11 @@ export function HighlightTipButton({
         <DialogTrigger asChild>
           <Button
             type="button"
-            variant="outline"
             size="sm"
-            className={cn('gap-2', className)}
+            className={cn('w-full gap-2 shadow-md', className)}
             title="Tip this highlight"
           >
-            <Coins className="w-3.5 h-3.5" />
+            <Coins className="w-4 h-4" />
             <span className="font-medium">Tip Highlight</span>
           </Button>
         </DialogTrigger>

--- a/components/nft/MintButton.tsx
+++ b/components/nft/MintButton.tsx
@@ -288,8 +288,8 @@ export function MintButton({
 
           <div className="space-y-4">
             {!wallet.isConnected && (
-              <div className="bg-warning text-warning-foreground border border-warning/30 rounded-lg p-3">
-                <p className="text-sm">
+              <div className="bg-warning/10 border border-warning/50 rounded-lg p-3">
+                <p className="text-sm text-warning-foreground">
                   Connect your wallet to mint this article as an NFT.
                 </p>
               </div>
@@ -308,17 +308,21 @@ export function MintButton({
                   </span>
                 </div>
                 {wallet.isConnected && wallet.publicKey ? (
-                  <div className="bg-success/10 text-success-foreground border border-success/30 rounded p-2">
+                  <div className="bg-success/10 border border-success/50 rounded p-2">
                     <div className="flex items-center justify-between text-xs">
-                      <span className="font-medium">✓ Wallet Connected</span>
-                      <span className="font-mono">
+                      <span className="text-success-foreground font-medium">
+                        ✓ Wallet Connected
+                      </span>
+                      <span className="font-mono text-success-foreground">
                         {`${wallet.publicKey.slice(0, 4)}...${wallet.publicKey.slice(-4)}`}
                       </span>
                     </div>
                   </div>
                 ) : (
-                  <div className="bg-warning text-warning-foreground border border-warning/30 rounded p-2">
-                    <span className="text-xs">Wallet not connected</span>
+                  <div className="bg-warning/10 border border-warning/50 rounded p-2">
+                    <span className="text-xs text-warning-foreground">
+                      Wallet not connected
+                    </span>
                   </div>
                 )}
               </div>
@@ -326,7 +330,7 @@ export function MintButton({
 
             {isLoading && (
               <div
-                className="rounded-lg border border-info/30 bg-info/10 p-4 text-info-foreground"
+                className="rounded-lg border border-info/50 bg-info/10 p-4"
                 aria-busy="true"
                 aria-live="polite"
               >
@@ -348,7 +352,7 @@ export function MintButton({
                           className={cn(
                             'flex h-8 w-8 shrink-0 items-center justify-center rounded-full border-2 text-xs font-semibold transition-colors',
                             isComplete &&
-                              'border-success bg-success/20 text-success-foreground',
+                              'border-success bg-success text-success-foreground',
                             isCurrent &&
                               !isComplete &&
                               'border-primary bg-primary/10 text-primary',
@@ -377,7 +381,7 @@ export function MintButton({
                           className={cn(
                             'text-center text-[10px] font-medium leading-tight sm:text-xs',
                             isCurrent && 'text-foreground',
-                            isComplete && 'text-green-800 dark:text-green-300',
+                            isComplete && 'text-success-foreground',
                             !isCurrent && !isComplete && 'text-muted-foreground'
                           )}
                         >

--- a/components/nft/NFTBadge.tsx
+++ b/components/nft/NFTBadge.tsx
@@ -34,9 +34,6 @@ type CollectibleVariant =
 function rarityToVariant(tier: RarityTier): CollectibleVariant {
   if (tier === 'legendary') return 'collectible-emphasis'
   if (tier === 'rare' || tier === 'epic') return 'collectible'
-  if (tier === 'common' || tier === 'uncommon' || tier === 'nft') {
-    return 'collectible-muted'
-  }
   return 'collectible-muted'
 }
 

--- a/components/nft/NFTBadge.tsx
+++ b/components/nft/NFTBadge.tsx
@@ -23,6 +23,42 @@ export interface NFTBadgeProps {
   showLabel?: boolean
 }
 
+type RarityTier = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary' | 'nft'
+
+type CollectibleVariant =
+  | 'collectible-muted'
+  | 'collectible'
+  | 'collectible-emphasis'
+  | 'secondary'
+
+function rarityToVariant(tier: RarityTier): CollectibleVariant {
+  if (tier === 'legendary') return 'collectible-emphasis'
+  if (tier === 'rare' || tier === 'epic') return 'collectible'
+  if (tier === 'common' || tier === 'uncommon' || tier === 'nft') {
+    return 'collectible-muted'
+  }
+  return 'collectible-muted'
+}
+
+function getRarityFromTips(tips?: number, rarityProp?: NFTBadgeProps['rarity']) {
+  if (rarityProp) {
+    const labels: Record<Exclude<NFTBadgeProps['rarity'], undefined>, string> = {
+      legendary: 'Legendary',
+      epic: 'Epic',
+      rare: 'Rare',
+      uncommon: 'Uncommon',
+      common: 'Common',
+    }
+    return { label: labels[rarityProp], tier: rarityProp as RarityTier }
+  }
+  if (tips === undefined) return { label: 'NFT', tier: 'nft' as const }
+  if (tips >= 100) return { label: 'Legendary', tier: 'legendary' as const }
+  if (tips >= 50) return { label: 'Epic', tier: 'epic' as const }
+  if (tips >= 25) return { label: 'Rare', tier: 'rare' as const }
+  if (tips >= 10) return { label: 'Uncommon', tier: 'uncommon' as const }
+  return { label: 'Common', tier: 'common' as const }
+}
+
 export function NFTBadge({
   tokenId,
   totalTips,
@@ -32,27 +68,8 @@ export function NFTBadge({
   rarity: rarityProp,
   showLabel = false,
 }: NFTBadgeProps) {
-  // Determine rarity based on total tips or use provided rarity
-  const getRarity = (tips?: number) => {
-    if (rarityProp) {
-      const rarityMap = {
-        legendary: { label: 'Legendary' },
-        epic: { label: 'Epic' },
-        rare: { label: 'Rare' },
-        uncommon: { label: 'Uncommon' },
-        common: { label: 'Common' },
-      }
-      return rarityMap[rarityProp]
-    }
-    if (tips === undefined) return { label: 'NFT' }
-    if (tips >= 100) return { label: 'Legendary' }
-    if (tips >= 50) return { label: 'Epic' }
-    if (tips >= 25) return { label: 'Rare' }
-    if (tips >= 10) return { label: 'Uncommon' }
-    return { label: 'Common' }
-  }
-
-  const rarity = getRarity(totalTips)
+  const rarity = getRarityFromTips(totalTips, rarityProp)
+  const variant = rarityToVariant(rarity.tier)
 
   const sizeClasses = {
     sm: 'text-xs px-2 py-0.5',
@@ -67,7 +84,6 @@ export function NFTBadge({
   }
 
   if (!tokenId && totalTips !== undefined) {
-    // Show tip progress badge instead
     return (
       <Badge variant="outline" className={sizeClasses[size]}>
         <TrendingUp className={`mr-1 ${iconSize[size]}`} />$
@@ -78,10 +94,9 @@ export function NFTBadge({
 
   const mintDate = mintedAt ? new Date(mintedAt).toLocaleDateString() : ''
 
-  // Simple badge without tooltip if showLabel is true
   if (showLabel) {
     return (
-      <Badge variant="secondary" className={sizeClasses[size]}>
+      <Badge variant={variant} className={sizeClasses[size]}>
         <Sparkles className={`mr-1 ${iconSize[size]}`} />
         {rarity.label}
       </Badge>
@@ -93,7 +108,7 @@ export function NFTBadge({
       <Tooltip>
         <TooltipTrigger asChild>
           <Badge
-            variant="secondary"
+            variant={variant}
             className={`${sizeClasses[size]} cursor-default`}
           >
             <Sparkles className={`mr-1 ${iconSize[size]}`} />

--- a/components/nft/NFTBadge.tsx
+++ b/components/nft/NFTBadge.tsx
@@ -40,9 +40,15 @@ function rarityToVariant(tier: RarityTier): CollectibleVariant {
   return 'collectible-muted'
 }
 
-function getRarityFromTips(tips?: number, rarityProp?: NFTBadgeProps['rarity']) {
+function getRarityFromTips(
+  tips?: number,
+  rarityProp?: NFTBadgeProps['rarity']
+) {
   if (rarityProp) {
-    const labels: Record<Exclude<NFTBadgeProps['rarity'], undefined>, string> = {
+    const labels: Record<
+      Exclude<NFTBadgeProps['rarity'], undefined>,
+      string
+    > = {
       legendary: 'Legendary',
       epic: 'Epic',
       rare: 'Rare',

--- a/components/nft/NFTIntegration.tsx
+++ b/components/nft/NFTIntegration.tsx
@@ -135,7 +135,7 @@ export function NFTIntegration({
                     </div>
                     <div className="w-full bg-muted rounded-full h-2">
                       <div
-                        className="bg-primary/50 h-2 rounded-full transition-all duration-500"
+                        className="bg-collectible h-2 rounded-full transition-all duration-500"
                         style={{
                           width: `${Math.min(progressPercentage, 100)}%`,
                         }}

--- a/components/nft/TransferModal.tsx
+++ b/components/nft/TransferModal.tsx
@@ -19,6 +19,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { userFacingTransferNftError } from '@/lib/convex/userFacingTransferNftError'
+import { statusVariants } from '@/lib/ui/status-config'
 
 type TransferStep = 'details' | 'confirm'
 
@@ -196,20 +197,20 @@ export function TransferModal({
 
   const messageBannerClass =
     transferMessage.kind === 'success'
-      ? 'bg-success text-success-foreground'
+      ? statusVariants.success
       : transferMessage.kind === 'error'
-        ? 'bg-destructive/10 text-destructive'
+        ? statusVariants.error
         : transferMessage.kind === 'progress'
-          ? 'bg-info text-info-foreground'
+          ? statusVariants.info
           : ''
 
   const messageIcon =
     transferMessage.kind === 'progress' ? (
       <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
     ) : transferMessage.kind === 'success' ? (
-      <CheckCircle className="h-4 w-4 shrink-0" />
+      <CheckCircle className="h-4 w-4 shrink-0 text-success-foreground" />
     ) : transferMessage.kind === 'error' ? (
-      <AlertCircle className="h-4 w-4 shrink-0" />
+      <AlertCircle className="h-4 w-4 shrink-0 text-destructive" />
     ) : null
 
   const irreversibleWarning = `You are transferring ownership of the NFT for "${articleTitle}" to @${recipientUsername}. This cannot be undone.`

--- a/components/profile/ProfileNftsTabContent.tsx
+++ b/components/profile/ProfileNftsTabContent.tsx
@@ -98,7 +98,7 @@ export function ProfileNftsTabContent({
       {ownedData.total > 0 && (
         <div>
           <h3 className="text-xl font-semibold mb-4 flex items-center gap-2">
-            <Trophy className="w-5 h-5 text-yellow-500" />
+            <Trophy className="w-5 h-5 text-collectible-foreground" />
             Owned NFTs
           </h3>
           <PaginationTransition isPaginating={owned.isPaginating}>

--- a/components/stellar/WalletConnectButton.tsx
+++ b/components/stellar/WalletConnectButton.tsx
@@ -129,7 +129,7 @@ export function WalletConnectButton({
         size={size}
         variant="outline"
         className={cn(
-          'text-destructive border-destructive/50 dark:text-red-300 dark:border-red-800',
+          'text-destructive border-destructive/50',
           className
         )}
       >
@@ -150,7 +150,7 @@ export function WalletConnectButton({
             className={cn('gap-2', className)}
             aria-label="Open wallet menu"
           >
-            <CheckCircle className="w-4 h-4 text-green-800 dark:text-green-300" />
+            <CheckCircle className="w-4 h-4 text-success-foreground" />
             <div className="flex flex-col items-start">
               <span className="text-sm font-medium">
                 {formatAddress(publicKey)}

--- a/components/stellar/WalletConnectButton.tsx
+++ b/components/stellar/WalletConnectButton.tsx
@@ -128,10 +128,7 @@ export function WalletConnectButton({
         onClick={handleConnect}
         size={size}
         variant="outline"
-        className={cn(
-          'text-destructive border-destructive/50',
-          className
-        )}
+        className={cn('text-destructive border-destructive/50', className)}
       >
         <AlertCircle className="w-4 h-4 mr-2" />
         Wallet Error

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -246,7 +246,7 @@ export function WalletSettings({
                   <div className="p-4 bg-success border border-success/50 rounded-lg space-y-3">
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-2">
-                        <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
+                        <div className="w-2 h-2 bg-success rounded-full animate-pulse" />
                         <span className="text-sm font-medium text-success-foreground">
                           Wallet Connected
                         </span>

--- a/components/stellar/WalletStatus.tsx
+++ b/components/stellar/WalletStatus.tsx
@@ -94,14 +94,14 @@ export function WalletStatus({ className }: WalletStatusProps) {
       <Card className={className}>
         <CardContent className="pt-6">
           <div className="flex flex-col items-center space-y-4 text-center">
-            <div className="w-12 h-12 bg-red-100 dark:bg-red-950/50 rounded-full flex items-center justify-center">
-              <Wallet className="w-6 h-6 text-red-600 dark:text-red-300" />
+            <div className="w-12 h-12 bg-destructive/10 rounded-full flex items-center justify-center">
+              <Wallet className="w-6 h-6 text-destructive" />
             </div>
             <div>
-              <h3 className="font-semibold text-red-900 dark:text-red-200">
+              <h3 className="font-semibold text-destructive">
                 Wallet Connection Error
               </h3>
-              <p className="text-sm text-red-600 dark:text-red-300">{error}</p>
+              <p className="text-sm text-destructive">{error}</p>
             </div>
             <Button variant="outline" onClick={refreshConnection}>
               <RefreshCw className="w-4 h-4 mr-2" />
@@ -164,8 +164,8 @@ export function WalletStatus({ className }: WalletStatusProps) {
       <Card className={className}>
         <CardHeader className="pb-3">
           <CardTitle className="flex items-center gap-2">
-            <div className="w-8 h-8 bg-green-100 dark:bg-green-950/50 rounded-full flex items-center justify-center">
-              <Wallet className="w-4 h-4 text-green-800 dark:text-green-300" />
+            <div className="w-8 h-8 bg-success/20 rounded-full flex items-center justify-center">
+              <Wallet className="w-4 h-4 text-success-foreground" />
             </div>
             <div className="flex flex-col">
               <span>Wallet Connected</span>

--- a/components/tipping/TipAppreciationStep.tsx
+++ b/components/tipping/TipAppreciationStep.tsx
@@ -66,7 +66,7 @@ export function TipAppreciationStep({
   return (
     <>
       {variant === 'highlight' && displayHighlightText ? (
-        <div className="p-3 bg-muted border border-border rounded-lg">
+        <div className="p-3 bg-warning/10 border border-warning/50 rounded-lg">
           <p className="text-sm text-foreground italic">
             &ldquo;{displayHighlightText}&rdquo;
           </p>
@@ -91,8 +91,8 @@ export function TipAppreciationStep({
             disabled={isLoading}
             className={`focus-ring relative flex min-h-12 items-center justify-center px-4 py-3 rounded-lg border transition-colors disabled:opacity-50 ${
               selectedAmount === amount.cents
-                ? 'border-primary bg-muted ring-1 ring-primary'
-                : 'border-input hover:bg-accent'
+                ? 'border-primary bg-primary/5'
+                : 'border-border hover:border-primary/40'
             }`}
           >
             {amount.popular && (

--- a/components/tipping/TipCheckoutStep.tsx
+++ b/components/tipping/TipCheckoutStep.tsx
@@ -123,7 +123,7 @@ export function TipCheckoutStep({
           </p>
         </div>
       ) : !isConnected ? (
-        <div className="p-3 bg-warning text-warning-foreground border border-warning/30 rounded-lg text-sm">
+        <div className="p-3 bg-info/10 border border-info/50 rounded-lg text-sm text-info-foreground">
           <p>
             Connect your Stellar wallet to send your {formatTipLabel(variant)}{' '}
             to {authorName}.
@@ -132,7 +132,7 @@ export function TipCheckoutStep({
             New to crypto?{' '}
             <Link
               href="/guide"
-              className="focus-ring rounded underline font-medium hover:opacity-80"
+              className="focus-ring rounded text-info-foreground underline font-medium hover:opacity-80"
             >
               Follow our setup guide
             </Link>

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -11,6 +11,11 @@ const alertVariants = cva(
         default: 'bg-background text-foreground',
         destructive:
           'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
+        success:
+          'border-success/50 bg-success/10 text-success-foreground [&>svg]:text-success-foreground',
+        warning:
+          'border-warning/50 bg-warning/10 text-warning-foreground [&>svg]:text-warning-foreground',
+        info: 'border-info/50 bg-info/10 text-info-foreground [&>svg]:text-info-foreground',
       },
     },
     defaultVariants: {

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -14,6 +14,17 @@ const badgeVariants = cva(
           'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
         destructive:
           'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
+        success:
+          'border-transparent bg-success text-success-foreground hover:bg-success/80',
+        warning:
+          'border-transparent bg-warning text-warning-foreground hover:bg-warning/80',
+        info: 'border-transparent bg-info text-info-foreground hover:bg-info/80',
+        collectible:
+          'border-transparent bg-collectible text-collectible-foreground hover:bg-collectible/80',
+        'collectible-muted':
+          'border-transparent bg-collectible-muted text-collectible-muted-foreground hover:bg-collectible-muted/80',
+        'collectible-emphasis':
+          'border-transparent bg-collectible-emphasis text-collectible-emphasis-foreground hover:bg-collectible-emphasis/80',
         outline: 'text-foreground',
       },
     },

--- a/lib/ui/status-config.ts
+++ b/lib/ui/status-config.ts
@@ -6,7 +6,7 @@ export const statusVariants = {
   pending: 'bg-warning text-warning-foreground',
   info: 'bg-info text-info-foreground',
   success: 'bg-success text-success-foreground',
-  error: 'bg-destructive text-destructive-foreground',
+  error: 'bg-destructive/10 text-destructive',
 } as const
 
 export type StatusVariant = keyof typeof statusVariants

--- a/lib/ui/status-config.ts
+++ b/lib/ui/status-config.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared status chip/panel class maps (ENG-262).
+ * Use for Arweave, transfer, system status — not for primary CTAs.
+ */
+export const statusVariants = {
+  pending: 'bg-warning text-warning-foreground',
+  info: 'bg-info text-info-foreground',
+  success: 'bg-success text-success-foreground',
+  error: 'bg-destructive text-destructive-foreground',
+} as const
+
+export type StatusVariant = keyof typeof statusVariants


### PR DESCRIPTION
## Summary

Replaces hardcoded color classes across launch surfaces with semantic design tokens so status, tipping, wallet, and NFT UI stay consistent and theme-aware. 

## Changes

- Add semantic CSS tokens in `app/globals.css` for collectible/NFT surfaces, status tones, and heatmap helpers
- Add shared `statusVariants` map in `lib/ui/status-config.ts` for Arweave, transfer, and system status chips
- Extend `badge` and `alert` primitives with collectible and status variants
- Replace inline `bg-*` / gradient classes with tokens across articles, highlights, tipping, NFT, wallet, auth, and dashboard components
- Tone down NFT badge rarity styling to use collectible token variants instead of ad-hoc colors
- Rebase onto latest `development` (includes ENG-257, ENG-260, ENG-261)

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run format`
- [x] `bun run test:once` (756 tests passed)
- [x] `bun run build`


## Notes

- No schema, API, or env changes
- Heatmap color logic keeps development's theme-adaptive CSS variable palette (`--heatmap-*`); ENG-262 token work applies to surrounding UI surfaces
- Status panels use tonal backgrounds (`bg-warning/10`, `bg-info/10`, etc.) instead of full-saturation fills for calmer launch-ready density
<img width="1440" height="865" alt="hm_" src="https://github.com/user-attachments/assets/1b7db19a-861e-475e-a088-087277a9e26f" />

<img width="1440" height="860" alt="Screenshot 2026-06-24 at 8 22 20 PM" src="https://github.com/user-attachments/assets/df9ccd28-825a-43ee-ab33-b1b9d6fd41b7" />

