### PR TITLE
feat(ui): normalize loading, empty, and protected page shells (ENG-259)

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -93,7 +93,7 @@ export default function ProfilePage({ params }: ProfilePageProps) {
     return <AuthorNotFoundPage username={username} />
   }
 
-  if (user === undefined) {
+  if (authLoading || user === undefined) {
     return (
       <div className="min-h-screen bg-background">
         <AppNavigation />

--- a/app/drafts/page.test.tsx
+++ b/app/drafts/page.test.tsx
@@ -1,0 +1,69 @@
+/** @vitest-environment jsdom */
+import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import DraftsPage from './page'
+
+const mockUseAuth = vi.fn()
+const mockUseUserDrafts = vi.fn()
+
+vi.mock('next/link', () => ({
+  default: (props: { href: string; children: ReactNode }) => (
+    <a href={props.href}>{props.children}</a>
+  ),
+}))
+
+vi.mock('@/components/providers/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+vi.mock('@/hooks/convex', () => ({
+  useUserDrafts: () => mockUseUserDrafts(),
+}))
+
+vi.mock('@/hooks/useRedirectWhenUnauthenticated', () => ({
+  useRedirectWhenUnauthenticated: vi.fn(),
+}))
+
+vi.mock('@/components/layout/AppNavigation', () => ({
+  default: () => <nav data-testid="app-navigation" />,
+}))
+
+vi.mock('convex/react', () => ({
+  useMutation: () => vi.fn(),
+}))
+
+describe('DraftsPage', () => {
+  beforeEach(() => {
+    mockUseUserDrafts.mockReturnValue([])
+  })
+
+  it('shows loading skeleton while auth resolves', () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: true,
+    })
+
+    render(<DraftsPage />)
+
+    expect(screen.getByTestId('app-navigation')).toBeInTheDocument()
+    expect(screen.queryByText('Your Drafts')).not.toBeInTheDocument()
+  })
+
+  it('shows start draft action in empty state', () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+    })
+
+    render(<DraftsPage />)
+
+    expect(
+      screen.getByRole('heading', { name: 'No drafts yet' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Start a draft' })).toHaveAttribute(
+      'href',
+      '/write'
+    )
+  })
+})

--- a/app/drafts/page.tsx
+++ b/app/drafts/page.tsx
@@ -89,182 +89,184 @@ export default function DraftsPage() {
       }
     >
       <div className="min-h-screen bg-muted/30">
-      <AppNavigation />
-      <div className="max-w-5xl mx-auto pt-24 pb-8 px-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center mb-8">
-          <h1 className="text-3xl font-bold text-foreground">Your Drafts</h1>
-          <Link
-            href="/write"
-            className="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors shrink-0 self-start sm:self-auto"
-          >
-            New Article
-          </Link>
-        </div>
+        <AppNavigation />
+        <div className="max-w-5xl mx-auto pt-24 pb-8 px-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center mb-8">
+            <h1 className="text-3xl font-bold text-foreground">Your Drafts</h1>
+            <Link
+              href="/write"
+              className="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors shrink-0 self-start sm:self-auto"
+            >
+              New Article
+            </Link>
+          </div>
 
-        {loading ? (
-          <DraftsListSkeleton />
-        ) : drafts.length === 0 ? (
-          <RouteEmptyState
-            icon={FileText}
-            title="No drafts yet"
-            description="Saved drafts appear here while you work on an article."
-            action={{ label: 'Start a draft', href: '/write' }}
-          />
-        ) : (
-          <div className="space-y-4">
-            {drafts.map((draft) => (
-              <div
-                key={draft._id}
-                className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border ring-1 ring-border/60 p-[var(--card-padding)] hover:shadow-md transition-shadow"
-              >
-                <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-start">
-                  <div className="min-w-0 flex-1 w-full">
-                    <div className="flex items-start justify-between gap-2 mb-2">
-                      <h2 className="text-xl font-semibold text-foreground break-words min-w-0 flex-1">
-                        {draft.title || 'Untitled'}
-                      </h2>
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            className="sm:hidden shrink-0"
-                            aria-label="Draft actions"
-                          >
-                            <MoreHorizontal className="h-4 w-4" />
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent
-                          align="end"
-                          className="min-w-[10rem]"
-                        >
-                          <DropdownMenuItem asChild>
-                            <Link
-                              href={`/write?id=${draft._id}`}
-                              className="cursor-pointer gap-2"
+          {loading ? (
+            <DraftsListSkeleton />
+          ) : drafts.length === 0 ? (
+            <RouteEmptyState
+              icon={FileText}
+              title="No drafts yet"
+              description="Saved drafts appear here while you work on an article."
+              action={{ label: 'Start a draft', href: '/write' }}
+            />
+          ) : (
+            <div className="space-y-4">
+              {drafts.map((draft) => (
+                <div
+                  key={draft._id}
+                  className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border ring-1 ring-border/60 p-[var(--card-padding)] hover:shadow-md transition-shadow"
+                >
+                  <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-start">
+                    <div className="min-w-0 flex-1 w-full">
+                      <div className="flex items-start justify-between gap-2 mb-2">
+                        <h2 className="text-xl font-semibold text-foreground break-words min-w-0 flex-1">
+                          {draft.title || 'Untitled'}
+                        </h2>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="icon"
+                              className="sm:hidden shrink-0"
+                              aria-label="Draft actions"
                             >
-                              <Pencil className="h-4 w-4" />
-                              Edit
-                            </Link>
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            className="cursor-pointer gap-2 text-destructive focus:text-destructive disabled:opacity-50 disabled:pointer-events-none"
-                            disabled={isDeleting}
-                            onSelect={() => {
-                              if (isDeleting) return
-                              setDeleteTarget(draft._id)
-                            }}
+                              <MoreHorizontal className="h-4 w-4" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent
+                            align="end"
+                            className="min-w-[10rem]"
                           >
-                            <Trash2 className="h-4 w-4" />
-                            Delete
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    </div>
-                    {draft.excerpt && (
-                      <p className="text-muted-foreground mb-3 line-clamp-2">
-                        {draft.excerpt}
-                      </p>
-                    )}
-                    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
-                      <span>
-                        Created:{' '}
-                        {formatDate(
-                          new Date(draft._creationTime).toISOString()
-                        )}
-                      </span>
-                      <span>•</span>
-                      <span>
-                        Last saved:{' '}
-                        {formatDate(new Date(draft.updatedAt).toISOString())}
-                      </span>
-                      {!draft.published && (
-                        <>
-                          <span>•</span>
-                          <span className="text-warning-foreground font-medium">
-                            Draft
-                          </span>
-                        </>
+                            <DropdownMenuItem asChild>
+                              <Link
+                                href={`/write?id=${draft._id}`}
+                                className="cursor-pointer gap-2"
+                              >
+                                <Pencil className="h-4 w-4" />
+                                Edit
+                              </Link>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              className="cursor-pointer gap-2 text-destructive focus:text-destructive disabled:opacity-50 disabled:pointer-events-none"
+                              disabled={isDeleting}
+                              onSelect={() => {
+                                if (isDeleting) return
+                                setDeleteTarget(draft._id)
+                              }}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                              Delete
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
+                      {draft.excerpt && (
+                        <p className="text-muted-foreground mb-3 line-clamp-2">
+                          {draft.excerpt}
+                        </p>
                       )}
+                      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
+                        <span>
+                          Created:{' '}
+                          {formatDate(
+                            new Date(draft._creationTime).toISOString()
+                          )}
+                        </span>
+                        <span>•</span>
+                        <span>
+                          Last saved:{' '}
+                          {formatDate(new Date(draft.updatedAt).toISOString())}
+                        </span>
+                        {!draft.published && (
+                          <>
+                            <span>•</span>
+                            <span className="text-warning-foreground font-medium">
+                              Draft
+                            </span>
+                          </>
+                        )}
+                      </div>
                     </div>
-                  </div>
-                  <div className="hidden sm:flex gap-2 shrink-0">
-                    <Link
-                      href={`/write?id=${draft._id}`}
-                      className="px-4 py-2 rounded-lg border border-primary text-primary bg-primary/5 hover:bg-primary/10 transition-colors"
-                    >
-                      Edit
-                    </Link>
-                    <button
-                      type="button"
-                      disabled={isDeleting}
-                      onClick={() => setDeleteTarget(draft._id)}
-                      className="px-4 py-2 rounded-lg border border-destructive text-destructive bg-destructive/5 hover:bg-destructive/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      Delete
-                    </button>
+                    <div className="hidden sm:flex gap-2 shrink-0">
+                      <Link
+                        href={`/write?id=${draft._id}`}
+                        className="px-4 py-2 rounded-lg border border-primary text-primary bg-primary/5 hover:bg-primary/10 transition-colors"
+                      >
+                        Edit
+                      </Link>
+                      <button
+                        type="button"
+                        disabled={isDeleting}
+                        onClick={() => setDeleteTarget(draft._id)}
+                        className="px-4 py-2 rounded-lg border border-destructive text-destructive bg-destructive/5 hover:bg-destructive/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        Delete
+                      </button>
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
+              ))}
+            </div>
+          )}
+
+          <div className="mt-8 text-sm text-muted-foreground bg-muted border border-border p-4 rounded-lg">
+            <p className="font-semibold mb-2">About Drafts</p>
+            <ul className="space-y-1">
+              <li>
+                • All your unpublished articles are saved here automatically
+              </li>
+              <li>• Click &quot;Edit&quot; to continue working on any draft</li>
+              <li>• {AUTO_SAVE_GUIDANCE}</li>
+              <li>
+                • Delete drafts you no longer need to keep your workspace clean
+              </li>
+            </ul>
           </div>
-        )}
-
-        <div className="mt-8 text-sm text-muted-foreground bg-muted border border-border p-4 rounded-lg">
-          <p className="font-semibold mb-2">About Drafts</p>
-          <ul className="space-y-1">
-            <li>
-              • All your unpublished articles are saved here automatically
-            </li>
-            <li>• Click &quot;Edit&quot; to continue working on any draft</li>
-            <li>• {AUTO_SAVE_GUIDANCE}</li>
-            <li>
-              • Delete drafts you no longer need to keep your workspace clean
-            </li>
-          </ul>
         </div>
-      </div>
 
-      <AlertDialog
-        open={!!deleteTarget}
-        onOpenChange={(open) => {
-          if (isDeleting) return
-          if (!open) setDeleteTarget(null)
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete this draft?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This action cannot be undone. The draft will be permanently
-              deleted.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              disabled={isDeleting}
-              className={cn(
-                buttonVariants({ variant: 'destructive' }),
-                'disabled:opacity-50 disabled:cursor-not-allowed'
-              )}
-              onClick={(e) => {
-                e.preventDefault()
-                void handleConfirmDelete()
-              }}
-            >
-              {isDeleting ? (
-                <>
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  Deleting...
-                </>
-              ) : (
-                'Delete'
-              )}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        <AlertDialog
+          open={!!deleteTarget}
+          onOpenChange={(open) => {
+            if (isDeleting) return
+            if (!open) setDeleteTarget(null)
+          }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete this draft?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This action cannot be undone. The draft will be permanently
+                deleted.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isDeleting}>
+                Cancel
+              </AlertDialogCancel>
+              <AlertDialogAction
+                disabled={isDeleting}
+                className={cn(
+                  buttonVariants({ variant: 'destructive' }),
+                  'disabled:opacity-50 disabled:cursor-not-allowed'
+                )}
+                onClick={(e) => {
+                  e.preventDefault()
+                  void handleConfirmDelete()
+                }}
+              >
+                {isDeleting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Deleting...
+                  </>
+                ) : (
+                  'Delete'
+                )}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </div>
     </ProtectedPageShell>
   )

--- a/app/drafts/page.tsx
+++ b/app/drafts/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react'
 import { useAuth } from '@/components/providers/AuthContext'
-import { useRedirectWhenUnauthenticated } from '@/hooks/useRedirectWhenUnauthenticated'
 import Link from 'next/link'
 import AppNavigation from '@/components/layout/AppNavigation'
 import { useMutation } from 'convex/react'
@@ -31,13 +30,13 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Skeleton } from '@/components/ui/skeleton'
-import { Loader2, MoreHorizontal, Pencil, Trash2 } from 'lucide-react'
+import { Loader2, MoreHorizontal, Pencil, Trash2, FileText } from 'lucide-react'
 import { mutationWithTimeout } from '@/lib/convexMutationWithTimeout'
+import { ProtectedPageShell } from '@/components/layout/ProtectedPageShell'
+import { RouteEmptyState } from '@/components/ui/route-empty-state'
 
 export default function DraftsPage() {
   const { isAuthenticated, isLoading } = useAuth()
-
-  useRedirectWhenUnauthenticated(isLoading, isAuthenticated)
 
   const draftsQuery = useUserDrafts()
   const loading = draftsQuery === undefined
@@ -63,25 +62,6 @@ export default function DraftsPage() {
     }
   }
 
-  if (isLoading) {
-    return (
-      <div className="min-h-screen bg-muted/30">
-        <AppNavigation />
-        <div className="max-w-5xl mx-auto pt-24 pb-8 px-4">
-          <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center mb-8">
-            <Skeleton className="h-9 w-48" />
-            <Skeleton className="h-10 w-32" />
-          </div>
-          <DraftsListSkeleton />
-        </div>
-      </div>
-    )
-  }
-
-  if (!isAuthenticated) {
-    return null
-  }
-
   const formatDate = (dateString: string) => {
     const date = new Date(dateString)
     return date.toLocaleDateString('en-US', {
@@ -94,7 +74,21 @@ export default function DraftsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-muted/30">
+    <ProtectedPageShell
+      isLoading={isLoading}
+      isAuthenticated={isAuthenticated}
+      shellClassName="min-h-screen bg-muted/30"
+      loadingContent={
+        <div className="max-w-5xl mx-auto pt-24 pb-8 px-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center mb-8">
+            <Skeleton className="h-9 w-48" />
+            <Skeleton className="h-10 w-32" />
+          </div>
+          <DraftsListSkeleton />
+        </div>
+      }
+    >
+      <div className="min-h-screen bg-muted/30">
       <AppNavigation />
       <div className="max-w-5xl mx-auto pt-24 pb-8 px-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center mb-8">
@@ -110,15 +104,12 @@ export default function DraftsPage() {
         {loading ? (
           <DraftsListSkeleton />
         ) : drafts.length === 0 ? (
-          <div className="text-center py-12 bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)]">
-            <div className="text-muted-foreground mb-4">No drafts yet</div>
-            <Link
-              href="/write"
-              className="text-primary hover:text-primary/80 font-medium"
-            >
-              Start writing your first article →
-            </Link>
-          </div>
+          <RouteEmptyState
+            icon={FileText}
+            title="No drafts yet"
+            description="Saved drafts appear here while you work on an article."
+            action={{ label: 'Start a draft', href: '/write' }}
+          />
         ) : (
           <div className="space-y-4">
             {drafts.map((draft) => (
@@ -274,6 +265,7 @@ export default function DraftsPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </div>
+      </div>
+    </ProtectedPageShell>
   )
 }

--- a/app/write/page.tsx
+++ b/app/write/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useAuth } from '@/components/providers/AuthContext'
-import { useRedirectWhenUnauthenticated } from '@/hooks/useRedirectWhenUnauthenticated'
 import AppNavigation from '@/components/layout/AppNavigation'
+import { ProtectedPageShell } from '@/components/layout/ProtectedPageShell'
 import { EditorChromeSkeleton } from '@/components/editor/EditorChromeSkeleton'
 import { ErrorBoundary } from '@/components/error/ErrorBoundary'
 import { EditorWorkspaceErrorFallback } from '@/components/error/SectionErrorFallback'
@@ -16,12 +16,11 @@ export default function WritePage() {
   const router = useRouter()
   const { isStale, reset: resetStale } = useStaleLoading(isLoading)
 
-  useRedirectWhenUnauthenticated(isLoading, isAuthenticated)
-
-  if (isLoading) {
-    return (
-      <div className="min-h-screen bg-background">
-        <AppNavigation />
+  return (
+    <ProtectedPageShell
+      isLoading={isLoading}
+      isAuthenticated={isAuthenticated}
+      loadingContent={
         <LoadingRegion
           label="editor"
           isLoading
@@ -34,24 +33,18 @@ export default function WritePage() {
         >
           <div />
         </LoadingRegion>
+      }
+    >
+      <div className="min-h-screen bg-background">
+        <AppNavigation />
+        <ErrorBoundary
+          fallback={({ reset }) => (
+            <EditorWorkspaceErrorFallback onRetry={reset} />
+          )}
+        >
+          <WriteEditorWorkspace />
+        </ErrorBoundary>
       </div>
-    )
-  }
-
-  if (!isAuthenticated) {
-    return null
-  }
-
-  return (
-    <div className="min-h-screen bg-background">
-      <AppNavigation />
-      <ErrorBoundary
-        fallback={({ reset }) => (
-          <EditorWorkspaceErrorFallback onRetry={reset} />
-        )}
-      >
-        <WriteEditorWorkspace />
-      </ErrorBoundary>
-    </div>
+    </ProtectedPageShell>
   )
 }

--- a/components/articles/ArticleGrid.test.tsx
+++ b/components/articles/ArticleGrid.test.tsx
@@ -1,0 +1,88 @@
+/** @vitest-environment jsdom */
+import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import ArticleGrid from '@/components/articles/ArticleGrid'
+
+vi.mock('next/link', () => ({
+  default: (props: { href: string; children: ReactNode }) => (
+    <a href={props.href}>{props.children}</a>
+  ),
+}))
+
+describe('ArticleGrid empty states', () => {
+  it('shows quoted search term and clear search button', async () => {
+    const onClearSearch = vi.fn()
+    render(
+      <ArticleGrid
+        articles={[]}
+        emptyState={{
+          hasSearch: true,
+          hasFilters: true,
+          searchTerm: 'blockchain',
+          onClearSearch,
+        }}
+      />
+    )
+
+    expect(
+      screen.getByRole('heading', { name: 'No results for "blockchain"' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Try a different term or clear your search.')
+    ).toBeInTheDocument()
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'Clear search' }))
+    expect(onClearSearch).toHaveBeenCalledOnce()
+  })
+
+  it('shows clear filters for filter-only empty state', async () => {
+    const onClearAll = vi.fn()
+    render(
+      <ArticleGrid
+        articles={[]}
+        emptyState={{
+          hasSearch: false,
+          hasFilters: true,
+          activeTag: 'rust',
+          onClearAll,
+        }}
+      />
+    )
+
+    expect(
+      screen.getByRole('heading', { name: 'No articles match these filters' })
+    ).toBeInTheDocument()
+    expect(screen.getByText(/tag "rust"/)).toBeInTheDocument()
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'Clear filters' }))
+    expect(onClearAll).toHaveBeenCalledOnce()
+  })
+
+  it('shows browse latest for empty catalog', () => {
+    render(<ArticleGrid articles={[]} />)
+
+    expect(
+      screen.getByRole('heading', { name: 'No articles yet' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Browse latest' })).toHaveAttribute(
+      'href',
+      '/articles'
+    )
+  })
+
+  it('home variant uses one primary and one secondary action', () => {
+    render(<ArticleGrid articles={[]} variant="home" />)
+
+    expect(
+      screen.getByRole('link', { name: 'Write your first article' })
+    ).toHaveAttribute('href', '/write')
+    expect(screen.getByRole('link', { name: 'Browse articles' })).toHaveAttribute(
+      'href',
+      '/articles'
+    )
+  })
+})

--- a/components/articles/ArticleGrid.test.tsx
+++ b/components/articles/ArticleGrid.test.tsx
@@ -80,9 +80,8 @@ describe('ArticleGrid empty states', () => {
     expect(
       screen.getByRole('link', { name: 'Write your first article' })
     ).toHaveAttribute('href', '/write')
-    expect(screen.getByRole('link', { name: 'Browse articles' })).toHaveAttribute(
-      'href',
-      '/articles'
-    )
+    expect(
+      screen.getByRole('link', { name: 'Browse articles' })
+    ).toHaveAttribute('href', '/articles')
   })
 })

--- a/components/articles/ArticleGrid.tsx
+++ b/components/articles/ArticleGrid.tsx
@@ -116,9 +116,15 @@ export default function ArticleGrid({
           description={browseEmpty.description}
           action={
             browseEmpty.onPrimary
-              ? { label: browseEmpty.primaryLabel, onClick: browseEmpty.onPrimary }
+              ? {
+                  label: browseEmpty.primaryLabel,
+                  onClick: browseEmpty.onPrimary,
+                }
               : browseEmpty.primaryHref
-                ? { label: browseEmpty.primaryLabel, href: browseEmpty.primaryHref }
+                ? {
+                    label: browseEmpty.primaryLabel,
+                    href: browseEmpty.primaryHref,
+                  }
                 : undefined
           }
         />

--- a/components/articles/ArticleGrid.tsx
+++ b/components/articles/ArticleGrid.tsx
@@ -1,14 +1,16 @@
 import ArticleCard from './ArticleCard'
 import ArticleFeedRow from './ArticleFeedRow'
 import { ArticleForDisplay } from '@/types/index'
-import Link from 'next/link'
 import { BookOpen } from 'lucide-react'
-import { Button } from '@/components/ui/button'
+import { RouteEmptyState } from '@/components/ui/route-empty-state'
 import type { BrowseView } from '@/lib/articles/browseDiscovery'
 
 export type ArticleGridEmptyState = {
   hasSearch: boolean
   hasFilters: boolean
+  searchTerm?: string
+  activeTag?: string
+  activeAuthor?: string
   onClearSearch?: () => void
   onClearAll?: () => void
 }
@@ -20,6 +22,66 @@ interface ArticleGridProps {
   onArticleNavigate?: () => void
   tagLinkAuthor?: string
   emptyState?: ArticleGridEmptyState
+}
+
+function getBrowseEmptyContent(emptyState?: ArticleGridEmptyState): {
+  title: string
+  description: string
+  primaryLabel: string
+  onPrimary: (() => void) | undefined
+  primaryHref: string | undefined
+} {
+  const hasSearch = Boolean(emptyState?.hasSearch)
+  const hasTagOrAuthor = Boolean(
+    emptyState?.activeTag?.trim() || emptyState?.activeAuthor?.trim()
+  )
+  const searchTerm = emptyState?.searchTerm?.trim() ?? ''
+
+  if (hasSearch && hasTagOrAuthor) {
+    const filterParts = [
+      emptyState?.activeTag ? `tag "${emptyState.activeTag}"` : null,
+      emptyState?.activeAuthor ? `author "${emptyState.activeAuthor}"` : null,
+    ].filter(Boolean)
+    return {
+      title: `No results for "${searchTerm}"`,
+      description: `No articles match your search with ${filterParts.join(' and ')}. Try another term or clear everything.`,
+      primaryLabel: 'Clear all',
+      onPrimary: emptyState?.onClearAll,
+      primaryHref: undefined,
+    }
+  }
+
+  if (hasSearch) {
+    return {
+      title: `No results for "${searchTerm}"`,
+      description: 'Try a different term or clear your search.',
+      primaryLabel: 'Clear search',
+      onPrimary: emptyState?.onClearSearch,
+      primaryHref: undefined,
+    }
+  }
+
+  if (hasTagOrAuthor) {
+    const filterParts = [
+      emptyState?.activeTag ? `tag "${emptyState.activeTag}"` : null,
+      emptyState?.activeAuthor ? `author "${emptyState.activeAuthor}"` : null,
+    ].filter(Boolean)
+    return {
+      title: 'No articles match these filters',
+      description: `No articles found for ${filterParts.join(' and ')}. Try different filters or clear them.`,
+      primaryLabel: 'Clear filters',
+      onPrimary: emptyState?.onClearAll,
+      primaryHref: undefined,
+    }
+  }
+
+  return {
+    title: 'No articles yet',
+    description: 'Check back soon for new stories from writers on Quilltip.',
+    primaryLabel: 'Browse latest',
+    onPrimary: undefined,
+    primaryHref: '/articles',
+  }
 }
 
 export default function ArticleGrid({
@@ -34,58 +96,32 @@ export default function ArticleGrid({
     if (variant === 'home') {
       return (
         <div className="text-center py-12">
-          <div className="max-w-sm mx-auto">
-            <BookOpen className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
-            <h3 className="text-lg font-medium text-foreground mb-1">
-              No articles in your feed yet
-            </h3>
-            <p className="text-muted-foreground mb-6">
-              Browse articles or write your first story.
-            </p>
-            <div className="flex flex-col sm:flex-row gap-3 justify-center">
-              <Link
-                href="/articles"
-                className="inline-flex items-center justify-center rounded-md text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 h-9 px-4"
-              >
-                Browse articles
-              </Link>
-              <Link
-                href="/write"
-                className="inline-flex items-center justify-center rounded-md text-sm font-medium bg-muted text-foreground hover:bg-muted/80 h-9 px-4 border border-border"
-              >
-                Write your first article
-              </Link>
-            </div>
-          </div>
+          <RouteEmptyState
+            icon={BookOpen}
+            title="No articles in your feed yet"
+            description="Write your first story or browse what others have published."
+            action={{ label: 'Write your first article', href: '/write' }}
+            secondaryAction={{ label: 'Browse articles', href: '/articles' }}
+          />
         </div>
       )
     }
 
+    const browseEmpty = getBrowseEmptyContent(emptyState)
     return (
       <div className="text-center py-12">
-        <div className="max-w-sm mx-auto rounded-[var(--card-radius)] border border-border bg-card px-6 py-10 shadow-[var(--card-shadow)]">
-          <BookOpen className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
-          <h3 className="text-lg font-medium text-foreground mb-1">
-            No articles found
-          </h3>
-          <p className="text-muted-foreground mb-6">
-            {emptyState?.hasSearch
-              ? 'No articles match your search. Try a different term or clear your search.'
-              : "Try adjusting your search or filters to find what you're looking for."}
-          </p>
-          {emptyState?.hasSearch && emptyState.onClearSearch && (
-            <Button type="button" onClick={emptyState.onClearSearch}>
-              Clear search
-            </Button>
-          )}
-          {!emptyState?.hasSearch &&
-            emptyState?.hasFilters &&
-            emptyState.onClearAll && (
-              <Button type="button" onClick={emptyState.onClearAll}>
-                Clear filters
-              </Button>
-            )}
-        </div>
+        <RouteEmptyState
+          icon={BookOpen}
+          title={browseEmpty.title}
+          description={browseEmpty.description}
+          action={
+            browseEmpty.onPrimary
+              ? { label: browseEmpty.primaryLabel, onClick: browseEmpty.onPrimary }
+              : browseEmpty.primaryHref
+                ? { label: browseEmpty.primaryLabel, href: browseEmpty.primaryHref }
+                : undefined
+          }
+        />
       </div>
     )
   }

--- a/components/articles/ArticlesBrowseContent.tsx
+++ b/components/articles/ArticlesBrowseContent.tsx
@@ -119,6 +119,9 @@ export function ArticlesBrowseContent({
         emptyState={{
           hasSearch,
           hasFilters,
+          searchTerm: urlSearch?.trim() || undefined,
+          activeTag: tag,
+          activeAuthor: author,
           onClearSearch: handleClearSearch,
           onClearAll: handleClearAll,
         }}

--- a/components/dashboard/DashboardShell.test.tsx
+++ b/components/dashboard/DashboardShell.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { DashboardShell } from '@/components/dashboard/DashboardShell'
 
 const mockUseAuth = vi.fn()
+const mockUsePathname = vi.fn()
 const mockUseRedirectWhenUnauthenticated = vi.fn()
 
 vi.mock('@/components/providers/AuthContext', () => ({
@@ -16,7 +17,7 @@ vi.mock('@/hooks/useRedirectWhenUnauthenticated', () => ({
 }))
 
 vi.mock('next/navigation', () => ({
-  usePathname: () => '/dashboard/earnings',
+  usePathname: () => mockUsePathname(),
 }))
 
 vi.mock('@/components/layout/AppNavigation', () => ({
@@ -31,8 +32,15 @@ vi.mock('@/components/dashboard/DashboardTabBar', () => ({
   DashboardTabBar: () => <nav data-testid="dashboard-tab-bar" />,
 }))
 
+vi.mock('@/components/dashboard/DashboardShellSkeleton', () => ({
+  DashboardShellSkeleton: ({ activeTab }: { activeTab: string }) => (
+    <div data-testid="dashboard-shell-skeleton">{activeTab}</div>
+  ),
+}))
+
 describe('DashboardShell', () => {
   beforeEach(() => {
+    mockUsePathname.mockReturnValue('/dashboard/earnings')
     mockUseAuth.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
@@ -54,6 +62,24 @@ describe('DashboardShell', () => {
     expect(screen.getByTestId('app-navigation')).toBeInTheDocument()
     expect(screen.queryByText('Creator Dashboard')).not.toBeInTheDocument()
     expect(screen.queryByText('Dashboard content')).not.toBeInTheDocument()
+  })
+
+  it('passes the active dashboard tab into the loading skeleton', () => {
+    mockUsePathname.mockReturnValue('/dashboard/wallet')
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: true,
+    })
+
+    render(
+      <DashboardShell>
+        <div>Dashboard content</div>
+      </DashboardShell>
+    )
+
+    expect(screen.getByTestId('dashboard-shell-skeleton')).toHaveTextContent(
+      'wallet'
+    )
   })
 
   it('renders dashboard chrome when authenticated', () => {

--- a/components/dashboard/DashboardShell.test.tsx
+++ b/components/dashboard/DashboardShell.test.tsx
@@ -1,0 +1,84 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { DashboardShell } from '@/components/dashboard/DashboardShell'
+
+const mockUseAuth = vi.fn()
+const mockUseRedirectWhenUnauthenticated = vi.fn()
+
+vi.mock('@/components/providers/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+vi.mock('@/hooks/useRedirectWhenUnauthenticated', () => ({
+  useRedirectWhenUnauthenticated: (...args: unknown[]) =>
+    mockUseRedirectWhenUnauthenticated(...args),
+}))
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/dashboard/earnings',
+}))
+
+vi.mock('@/components/layout/AppNavigation', () => ({
+  default: () => <nav data-testid="app-navigation" />,
+}))
+
+vi.mock('@/components/layout/SiteFooter', () => ({
+  SiteFooter: () => <footer data-testid="site-footer" />,
+}))
+
+vi.mock('@/components/dashboard/DashboardTabBar', () => ({
+  DashboardTabBar: () => <nav data-testid="dashboard-tab-bar" />,
+}))
+
+describe('DashboardShell', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+    })
+  })
+
+  it('shows loading skeleton while auth resolves', () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: true,
+    })
+
+    render(
+      <DashboardShell>
+        <div>Dashboard content</div>
+      </DashboardShell>
+    )
+
+    expect(screen.getByTestId('app-navigation')).toBeInTheDocument()
+    expect(screen.queryByText('Creator Dashboard')).not.toBeInTheDocument()
+    expect(screen.queryByText('Dashboard content')).not.toBeInTheDocument()
+  })
+
+  it('renders dashboard chrome when authenticated', () => {
+    render(
+      <DashboardShell>
+        <div>Dashboard content</div>
+      </DashboardShell>
+    )
+
+    expect(screen.getByText('Creator Dashboard')).toBeInTheDocument()
+    expect(screen.getByText('Dashboard content')).toBeInTheDocument()
+  })
+
+  it('returns null when unauthenticated and auth resolved', () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    })
+
+    const { container } = render(
+      <DashboardShell>
+        <div>Dashboard content</div>
+      </DashboardShell>
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/components/dashboard/DashboardShell.tsx
+++ b/components/dashboard/DashboardShell.tsx
@@ -6,6 +6,7 @@ import { useRedirectWhenUnauthenticated } from '@/hooks/useRedirectWhenUnauthent
 import AppNavigation from '@/components/layout/AppNavigation'
 import { SiteFooter } from '@/components/layout/SiteFooter'
 import { DashboardTabBar } from '@/components/dashboard/DashboardTabBar'
+import { DashboardShellSkeleton } from '@/components/dashboard/DashboardShellSkeleton'
 import {
   DASHBOARD_TAB_IDS,
   type DashboardTabId,
@@ -36,6 +37,19 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
 
   if (!isAuthenticated && !isLoading) {
     return null
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen flex-col bg-background">
+        <AppNavigation />
+
+        <main className="flex-1 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12 w-full min-w-0">
+          <DashboardShellSkeleton />
+        </main>
+        <SiteFooter variant="default" />
+      </div>
+    )
   }
 
   return (

--- a/components/dashboard/DashboardShell.tsx
+++ b/components/dashboard/DashboardShell.tsx
@@ -45,7 +45,7 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
         <AppNavigation />
 
         <main className="flex-1 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-12 w-full min-w-0">
-          <DashboardShellSkeleton />
+          <DashboardShellSkeleton activeTab={activeTab} />
         </main>
         <SiteFooter variant="default" />
       </div>

--- a/components/dashboard/DashboardShellSkeleton.test.tsx
+++ b/components/dashboard/DashboardShellSkeleton.test.tsx
@@ -1,0 +1,48 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { DashboardShellSkeleton } from '@/components/dashboard/DashboardShellSkeleton'
+
+vi.mock('@/components/dashboard/EarningsDashboardSkeleton', () => ({
+  EarningsDashboardSkeleton: () => (
+    <div data-testid="earnings-dashboard-skeleton" />
+  ),
+}))
+
+vi.mock('@/components/dashboard/DashboardWalletSkeleton', () => ({
+  DashboardWalletSkeleton: () => (
+    <div data-testid="dashboard-wallet-skeleton" />
+  ),
+}))
+
+vi.mock('@/components/dashboard/DashboardStatsSkeleton', () => ({
+  DashboardStatsSkeleton: () => <div data-testid="dashboard-stats-skeleton" />,
+}))
+
+describe('DashboardShellSkeleton', () => {
+  it('renders the earnings skeleton when earnings is active', () => {
+    render(<DashboardShellSkeleton activeTab="earnings" />)
+
+    expect(
+      screen.getByTestId('earnings-dashboard-skeleton')
+    ).toBeInTheDocument()
+  })
+
+  it('renders the wallet skeleton when wallet is active', () => {
+    render(<DashboardShellSkeleton activeTab="wallet" />)
+
+    expect(screen.getByTestId('dashboard-wallet-skeleton')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('earnings-dashboard-skeleton')
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the stats skeleton when stats is active', () => {
+    render(<DashboardShellSkeleton activeTab="stats" />)
+
+    expect(screen.getByTestId('dashboard-stats-skeleton')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('earnings-dashboard-skeleton')
+    ).not.toBeInTheDocument()
+  })
+})

--- a/components/dashboard/DashboardShellSkeleton.tsx
+++ b/components/dashboard/DashboardShellSkeleton.tsx
@@ -1,0 +1,33 @@
+import { Skeleton } from '@/components/ui/skeleton'
+import { EarningsDashboardSkeleton } from '@/components/dashboard/EarningsDashboardSkeleton'
+
+function DashboardHeaderSkeleton() {
+  return (
+    <div className="mb-8 space-y-2">
+      <Skeleton className="h-9 w-64 max-w-full" />
+      <Skeleton className="h-5 w-96 max-w-full" />
+    </div>
+  )
+}
+
+function DashboardTabBarSkeleton() {
+  return (
+    <div className="min-w-0 w-full overflow-hidden border-b border-border mb-8">
+      <div className="-mb-px flex flex-nowrap gap-4 sm:gap-8 pb-0.5">
+        {[1, 2, 3].map((i) => (
+          <Skeleton key={i} className="h-10 w-24 shrink-0" />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function DashboardShellSkeleton() {
+  return (
+    <>
+      <DashboardHeaderSkeleton />
+      <DashboardTabBarSkeleton />
+      <EarningsDashboardSkeleton />
+    </>
+  )
+}

--- a/components/dashboard/DashboardShellSkeleton.tsx
+++ b/components/dashboard/DashboardShellSkeleton.tsx
@@ -1,5 +1,8 @@
 import { Skeleton } from '@/components/ui/skeleton'
 import { EarningsDashboardSkeleton } from '@/components/dashboard/EarningsDashboardSkeleton'
+import { DashboardStatsSkeleton } from '@/components/dashboard/DashboardStatsSkeleton'
+import { DashboardWalletSkeleton } from '@/components/dashboard/DashboardWalletSkeleton'
+import type { DashboardTabId } from '@/lib/dashboard/dashboardTab'
 
 function DashboardHeaderSkeleton() {
   return (
@@ -22,12 +25,32 @@ function DashboardTabBarSkeleton() {
   )
 }
 
-export function DashboardShellSkeleton() {
+type DashboardShellSkeletonProps = {
+  activeTab: DashboardTabId
+}
+
+function DashboardTabContentSkeleton({
+  activeTab,
+}: DashboardShellSkeletonProps) {
+  if (activeTab === 'wallet') {
+    return <DashboardWalletSkeleton />
+  }
+
+  if (activeTab === 'stats') {
+    return <DashboardStatsSkeleton />
+  }
+
+  return <EarningsDashboardSkeleton />
+}
+
+export function DashboardShellSkeleton({
+  activeTab,
+}: DashboardShellSkeletonProps) {
   return (
     <>
       <DashboardHeaderSkeleton />
       <DashboardTabBarSkeleton />
-      <EarningsDashboardSkeleton />
+      <DashboardTabContentSkeleton activeTab={activeTab} />
     </>
   )
 }

--- a/components/dashboard/DashboardStatsSkeleton.tsx
+++ b/components/dashboard/DashboardStatsSkeleton.tsx
@@ -1,0 +1,26 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+export function DashboardStatsSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="mb-6 space-y-2">
+        <Skeleton className="h-8 w-44" />
+        <Skeleton className="h-5 w-80 max-w-full" />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {[1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6"
+          >
+            <div className="flex items-center justify-between mb-3">
+              <Skeleton className="h-5 w-28" />
+              <Skeleton className="h-5 w-5 rounded-full" />
+            </div>
+            <Skeleton className="h-9 w-16" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/dashboard/DashboardWalletContent.tsx
+++ b/components/dashboard/DashboardWalletContent.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { useAuth } from '@/components/providers/AuthContext'
 import { useUserByUsername } from '@/hooks/convex'
 import { WalletSettings } from '@/components/stellar'
+import { DashboardWalletSkeleton } from '@/components/dashboard/DashboardWalletSkeleton'
 
 export function DashboardWalletContent() {
   const { user: currentUser } = useAuth()
@@ -19,7 +20,7 @@ export function DashboardWalletContent() {
   }, [user?.stellarAddress, localWalletAddress])
 
   if (!currentUser?.username || user === undefined) {
-    return null
+    return <DashboardWalletSkeleton />
   }
 
   const profileDisplayName = user?.name || currentUser.username

--- a/components/dashboard/DashboardWalletSkeleton.tsx
+++ b/components/dashboard/DashboardWalletSkeleton.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+export function DashboardWalletSkeleton() {
+  return (
+    <div className="space-y-8">
+      <div className="mb-6 space-y-2">
+        <Skeleton className="h-8 w-56" />
+        <Skeleton className="h-5 w-80 max-w-full" />
+      </div>
+      <div className="max-w-2xl bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-8 space-y-4">
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="h-4 w-full max-w-md" />
+        <Skeleton className="h-10 w-36" />
+      </div>
+    </div>
+  )
+}

--- a/components/dashboard/TipHistory.tsx
+++ b/components/dashboard/TipHistory.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import { useMemo, useState } from 'react'
+import Link from 'next/link'
 import { formatDistanceToNow } from 'date-fns'
+import { Button } from '@/components/ui/button'
 import type { Doc } from '@/types/convex'
 
 export type ReceivedTipRow = Doc<'tips'> & {
@@ -322,11 +324,14 @@ export function TipHistory({ tips }: TipHistoryProps) {
           </div>
         </>
       ) : (
-        <div className="flex min-h-[12rem] flex-col items-center justify-center gap-2 px-6 py-10 text-center">
+        <div className="flex min-h-[12rem] flex-col items-center justify-center gap-3 px-6 py-10 text-center">
           <p className="font-medium text-foreground">No tips yet</p>
           <p className="max-w-sm text-sm text-muted-foreground">
             When readers tip your work, they will show up here.
           </p>
+          <Button asChild className="mt-2">
+            <Link href="/write">Write an article</Link>
+          </Button>
         </div>
       )}
     </div>

--- a/components/layout/AppNavigation.test.tsx
+++ b/components/layout/AppNavigation.test.tsx
@@ -7,6 +7,7 @@ import AppNavigation from '@/components/layout/AppNavigation'
 import { NAV_SIGN_IN, NAV_TRY_ON_TESTNET } from '@/lib/copy/nav-cta'
 
 const mockUseAuth = vi.fn()
+const mockUsePathname = vi.fn(() => '/')
 
 vi.mock('next/link', () => ({
   default: (props: { href: string; children: ReactNode }) => (
@@ -15,7 +16,7 @@ vi.mock('next/link', () => ({
 }))
 
 vi.mock('next/navigation', () => ({
-  usePathname: () => '/',
+  usePathname: () => mockUsePathname(),
 }))
 
 vi.mock('@/components/providers/AuthContext', () => ({
@@ -124,6 +125,7 @@ describe('AppNavigation mobile menu', () => {
 describe('AppNavigation auth CTAs', () => {
   beforeEach(() => {
     document.body.style.pointerEvents = ''
+    mockUsePathname.mockReturnValue('/')
   })
 
   it('hides signed-out CTAs while auth is loading', () => {
@@ -169,5 +171,40 @@ describe('AppNavigation auth CTAs', () => {
     expect(screen.getByText('Dashboard')).toBeInTheDocument()
     expect(screen.queryByText(NAV_SIGN_IN)).not.toBeInTheDocument()
     expect(screen.queryByText(NAV_TRY_ON_TESTNET)).not.toBeInTheDocument()
+  })
+
+  it('shows auth skeleton on protected routes while guest auth resolves', () => {
+    mockUsePathname.mockReturnValue('/drafts')
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      signOut: vi.fn(),
+    })
+
+    const { container } = render(<AppNavigation />)
+
+    expect(screen.queryByText(NAV_SIGN_IN)).not.toBeInTheDocument()
+    expect(screen.queryByText(NAV_TRY_ON_TESTNET)).not.toBeInTheDocument()
+    expect(container.querySelector('[aria-hidden]')).toBeInTheDocument()
+  })
+
+  it('shows auth skeleton in mobile menu on protected routes for guests', async () => {
+    mockUsePathname.mockReturnValue('/drafts')
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      signOut: vi.fn(),
+    })
+
+    const user = userEvent.setup()
+    const { container } = render(<AppNavigation />)
+
+    await user.click(screen.getByRole('button', { name: 'Toggle menu' }))
+
+    expect(screen.queryByText(NAV_SIGN_IN)).not.toBeInTheDocument()
+    expect(screen.queryByText(NAV_TRY_ON_TESTNET)).not.toBeInTheDocument()
+    expect(container.querySelector('[aria-hidden]')).toBeInTheDocument()
   })
 })

--- a/components/layout/AppNavigation.tsx
+++ b/components/layout/AppNavigation.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/components/ui/sheet'
 import { Logo } from '@/components/ui/Logo'
 import { NAV_SIGN_IN, NAV_TRY_ON_TESTNET } from '@/lib/copy/nav-cta'
+import { isProtectedPath } from '@/lib/navigation/protectedRoutes'
 
 function AuthActionsSkeleton() {
   return (
@@ -112,6 +113,10 @@ export default function AppNavigation() {
       )
     }
 
+    if (isProtectedPath(pathname)) {
+      return <AuthActionsSkeleton />
+    }
+
     return (
       <>
         <Link
@@ -189,6 +194,14 @@ export default function AppNavigation() {
             <span>Sign Out</span>
           </button>
         </>
+      )
+    }
+
+    if (isProtectedPath(pathname)) {
+      return (
+        <div className="pt-2 mt-2 border-t border-border">
+          <AuthActionsSkeleton />
+        </div>
       )
     }
 

--- a/components/layout/ProtectedPageShell.test.tsx
+++ b/components/layout/ProtectedPageShell.test.tsx
@@ -1,0 +1,63 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ProtectedPageShell } from '@/components/layout/ProtectedPageShell'
+
+const mockUseRedirectWhenUnauthenticated = vi.fn()
+
+vi.mock('@/hooks/useRedirectWhenUnauthenticated', () => ({
+  useRedirectWhenUnauthenticated: (...args: unknown[]) =>
+    mockUseRedirectWhenUnauthenticated(...args),
+}))
+
+vi.mock('@/components/layout/AppNavigation', () => ({
+  default: () => <nav data-testid="app-navigation" />,
+}))
+
+describe('ProtectedPageShell', () => {
+  it('shows loading shell while auth resolves', () => {
+    render(
+      <ProtectedPageShell
+        isLoading
+        isAuthenticated={false}
+        loadingContent={<div data-testid="loading-skeleton" />}
+      >
+        <div data-testid="page-content">Content</div>
+      </ProtectedPageShell>
+    )
+
+    expect(screen.getByTestId('app-navigation')).toBeInTheDocument()
+    expect(screen.getByTestId('loading-skeleton')).toBeInTheDocument()
+    expect(screen.queryByTestId('page-content')).not.toBeInTheDocument()
+    expect(mockUseRedirectWhenUnauthenticated).toHaveBeenCalledWith(true, false)
+  })
+
+  it('renders children when authenticated', () => {
+    render(
+      <ProtectedPageShell
+        isLoading={false}
+        isAuthenticated
+        loadingContent={<div data-testid="loading-skeleton" />}
+      >
+        <div data-testid="page-content">Content</div>
+      </ProtectedPageShell>
+    )
+
+    expect(screen.getByTestId('page-content')).toBeInTheDocument()
+    expect(screen.queryByTestId('loading-skeleton')).not.toBeInTheDocument()
+  })
+
+  it('returns null when unauthenticated and auth resolved', () => {
+    const { container } = render(
+      <ProtectedPageShell
+        isLoading={false}
+        isAuthenticated={false}
+        loadingContent={<div data-testid="loading-skeleton" />}
+      >
+        <div data-testid="page-content">Content</div>
+      </ProtectedPageShell>
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/components/layout/ProtectedPageShell.tsx
+++ b/components/layout/ProtectedPageShell.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import AppNavigation from '@/components/layout/AppNavigation'
+import { useRedirectWhenUnauthenticated } from '@/hooks/useRedirectWhenUnauthenticated'
+
+type ProtectedPageShellProps = {
+  isLoading: boolean
+  isAuthenticated: boolean
+  loadingContent: ReactNode
+  children: ReactNode
+  shellClassName?: string
+}
+
+export function ProtectedPageShell({
+  isLoading,
+  isAuthenticated,
+  loadingContent,
+  children,
+  shellClassName = 'min-h-screen bg-background',
+}: ProtectedPageShellProps) {
+  useRedirectWhenUnauthenticated(isLoading, isAuthenticated)
+
+  if (isLoading) {
+    return (
+      <div className={shellClassName}>
+        <AppNavigation />
+        {loadingContent}
+      </div>
+    )
+  }
+
+  if (!isAuthenticated) {
+    return null
+  }
+
+  return <>{children}</>
+}

--- a/components/profile/ProfileNftsTabContent.tsx
+++ b/components/profile/ProfileNftsTabContent.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import Link from 'next/link'
 import { usePathname, useSearchParams } from 'next/navigation'
 import {
   useNFTsByOwnerPaginated,
@@ -14,6 +13,7 @@ import { PaginationTransition } from '@/components/profile/PaginationTransition'
 import Pagination from '@/components/articles/Pagination'
 import { buildProfileNftPaginationHref } from '@/lib/profile/buildProfileNftPaginationHref'
 import { NftCard } from '@/components/nft/NftCard'
+import { RouteEmptyState } from '@/components/ui/route-empty-state'
 import { ImageIcon, Trophy } from 'lucide-react'
 
 const NFT_PAGE_LIMIT = 9
@@ -181,28 +181,20 @@ export function ProfileNftsTabContent({
       )}
 
       {bothEmpty && (
-        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-8 sm:p-12 text-center">
-          <ImageIcon
-            className="w-12 h-12 text-muted-foreground/50 mx-auto mb-4"
-            aria-hidden
-          />
-          <h3 className="text-lg font-semibold text-foreground mb-2">
-            No NFTs yet
-          </h3>
-          <p className="text-muted-foreground max-w-md mx-auto">
-            {isOwnProfile
+        <RouteEmptyState
+          icon={ImageIcon}
+          title="No NFTs yet"
+          description={
+            isOwnProfile
               ? 'Articles earn NFTs when they reach the tip threshold. Mint or collect one to see it here.'
-              : `${displayName} doesn't have any NFTs yet.`}
-          </p>
-          {isOwnProfile && (
-            <Link
-              href="/articles"
-              className="focus-ring inline-block mt-6 text-sm font-medium text-brand-blue hover:underline"
-            >
-              Browse articles
-            </Link>
-          )}
-        </div>
+              : `${displayName} doesn't have any NFTs yet.`
+          }
+          action={
+            isOwnProfile
+              ? { label: 'Browse articles', href: '/articles' }
+              : undefined
+          }
+        />
       )}
     </div>
   )

--- a/components/ui/route-empty-state.tsx
+++ b/components/ui/route-empty-state.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link'
+import type { LucideIcon } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+type RouteEmptyStateAction = {
+  label: string
+  href?: string
+  onClick?: () => void
+}
+
+type RouteEmptyStateProps = {
+  icon: LucideIcon
+  title: string
+  description: string
+  action?: RouteEmptyStateAction
+  secondaryAction?: { label: string; href: string }
+  className?: string
+}
+
+export function RouteEmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+  secondaryAction,
+  className,
+}: RouteEmptyStateProps) {
+  return (
+    <div
+      className={
+        className ??
+        'bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-8 sm:p-12 text-center'
+      }
+    >
+      <Icon
+        className="w-12 h-12 text-muted-foreground mx-auto mb-4"
+        aria-hidden
+      />
+      <h3 className="text-lg font-semibold text-foreground mb-2">{title}</h3>
+      <p className="text-muted-foreground max-w-md mx-auto">{description}</p>
+      {(action || secondaryAction) && (
+        <div className="mt-6 flex flex-col sm:flex-row gap-3 justify-center">
+          {action?.onClick ? (
+            <Button type="button" onClick={action.onClick}>
+              {action.label}
+            </Button>
+          ) : action?.href ? (
+            <Button asChild>
+              <Link href={action.href}>{action.label}</Link>
+            </Button>
+          ) : null}
+          {secondaryAction && (
+            <Button variant="outline" asChild>
+              <Link href={secondaryAction.href}>{secondaryAction.label}</Link>
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/ui/route-empty-state.tsx
+++ b/components/ui/route-empty-state.tsx
@@ -2,11 +2,21 @@ import Link from 'next/link'
 import type { LucideIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
-type RouteEmptyStateAction = {
+type RouteEmptyStateLinkAction = {
   label: string
-  href?: string
-  onClick?: () => void
+  href: string
+  onClick?: never
 }
+
+type RouteEmptyStateButtonAction = {
+  label: string
+  onClick: () => void
+  href?: never
+}
+
+type RouteEmptyStateAction =
+  | RouteEmptyStateLinkAction
+  | RouteEmptyStateButtonAction
 
 type RouteEmptyStateProps = {
   icon: LucideIcon
@@ -15,6 +25,12 @@ type RouteEmptyStateProps = {
   action?: RouteEmptyStateAction
   secondaryAction?: { label: string; href: string }
   className?: string
+}
+
+function isLinkAction(
+  action: RouteEmptyStateAction
+): action is RouteEmptyStateLinkAction {
+  return typeof action.href === 'string'
 }
 
 export function RouteEmptyState({
@@ -40,13 +56,13 @@ export function RouteEmptyState({
       <p className="text-muted-foreground max-w-md mx-auto">{description}</p>
       {(action || secondaryAction) && (
         <div className="mt-6 flex flex-col sm:flex-row gap-3 justify-center">
-          {action?.onClick ? (
-            <Button type="button" onClick={action.onClick}>
-              {action.label}
-            </Button>
-          ) : action?.href ? (
+          {action && isLinkAction(action) ? (
             <Button asChild>
               <Link href={action.href}>{action.label}</Link>
+            </Button>
+          ) : action ? (
+            <Button type="button" onClick={action.onClick}>
+              {action.label}
             </Button>
           ) : null}
           {secondaryAction && (

--- a/components/ui/route-empty-state.type-test.tsx
+++ b/components/ui/route-empty-state.type-test.tsx
@@ -1,0 +1,45 @@
+import type { ComponentProps } from 'react'
+import { FileText } from 'lucide-react'
+import { RouteEmptyState } from '@/components/ui/route-empty-state'
+
+type RouteEmptyStateActionProp = ComponentProps<
+  typeof RouteEmptyState
+>['action']
+
+const hrefAction: RouteEmptyStateActionProp = {
+  label: 'Start a draft',
+  href: '/write',
+}
+
+const buttonAction: RouteEmptyStateActionProp = {
+  label: 'Clear filters',
+  onClick: () => undefined,
+}
+
+const ambiguousActionInput = {
+  label: 'Ambiguous action',
+  href: '/articles',
+  onClick: () => undefined,
+}
+
+// @ts-expect-error RouteEmptyState actions must not provide href and onClick together.
+export const ambiguousAction: RouteEmptyStateActionProp = ambiguousActionInput
+
+export function RouteEmptyStateTypeExamples() {
+  return (
+    <>
+      <RouteEmptyState
+        icon={FileText}
+        title="No drafts"
+        description="Saved drafts appear here."
+        action={hrefAction}
+      />
+      <RouteEmptyState
+        icon={FileText}
+        title="No results"
+        description="Try a different search."
+        action={buttonAction}
+      />
+    </>
+  )
+}

--- a/lib/navigation/protectedRoutes.test.ts
+++ b/lib/navigation/protectedRoutes.test.ts
@@ -4,7 +4,6 @@ import { isProtectedPath } from './protectedRoutes'
 describe('isProtectedPath', () => {
   it('returns true for protected route prefixes', () => {
     expect(isProtectedPath('/write')).toBe(true)
-    expect(isProtectedPath('/write?id=abc')).toBe(false)
     expect(isProtectedPath('/drafts')).toBe(true)
     expect(isProtectedPath('/dashboard')).toBe(true)
     expect(isProtectedPath('/dashboard/earnings')).toBe(true)
@@ -15,9 +14,14 @@ describe('isProtectedPath', () => {
   it('returns false for public routes', () => {
     expect(isProtectedPath('/')).toBe(false)
     expect(isProtectedPath('/articles')).toBe(false)
-    expect(isProtectedPath('/articles?search=foo')).toBe(false)
     expect(isProtectedPath('/guide')).toBe(false)
     expect(isProtectedPath('/login')).toBe(false)
     expect(isProtectedPath('/writer')).toBe(false)
+  })
+
+  it('returns false for query-string inputs outside the usePathname contract', () => {
+    // Next's usePathname returns pathnames without query strings.
+    expect(isProtectedPath('/write?id=abc')).toBe(false)
+    expect(isProtectedPath('/articles?search=foo')).toBe(false)
   })
 })

--- a/lib/navigation/protectedRoutes.test.ts
+++ b/lib/navigation/protectedRoutes.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { isProtectedPath } from './protectedRoutes'
+
+describe('isProtectedPath', () => {
+  it('returns true for protected route prefixes', () => {
+    expect(isProtectedPath('/write')).toBe(true)
+    expect(isProtectedPath('/write?id=abc')).toBe(false)
+    expect(isProtectedPath('/drafts')).toBe(true)
+    expect(isProtectedPath('/dashboard')).toBe(true)
+    expect(isProtectedPath('/dashboard/earnings')).toBe(true)
+    expect(isProtectedPath('/profile')).toBe(true)
+    expect(isProtectedPath('/settings/profile')).toBe(true)
+  })
+
+  it('returns false for public routes', () => {
+    expect(isProtectedPath('/')).toBe(false)
+    expect(isProtectedPath('/articles')).toBe(false)
+    expect(isProtectedPath('/articles?search=foo')).toBe(false)
+    expect(isProtectedPath('/guide')).toBe(false)
+    expect(isProtectedPath('/login')).toBe(false)
+    expect(isProtectedPath('/writer')).toBe(false)
+  })
+})

--- a/lib/navigation/protectedRoutes.ts
+++ b/lib/navigation/protectedRoutes.ts
@@ -1,0 +1,13 @@
+const PROTECTED_PREFIXES = [
+  '/write',
+  '/drafts',
+  '/dashboard',
+  '/profile',
+  '/settings/profile',
+] as const
+
+export function isProtectedPath(pathname: string): boolean {
+  return PROTECTED_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+  )
+}


### PR DESCRIPTION
## Summary

Normalizes loading, empty, and auth-gated page shells across protected routes so drafts, write, dashboard, browse, and profile feel consistent during load and when there is no content. 

## Changes

- Add `ProtectedPageShell` for shared auth gating, redirect handling, and route-level loading shells
- Add `RouteEmptyState` for consistent empty-state layout, copy, and primary/secondary actions
- Add `isProtectedPath` helper for protected route detection in navigation
- Refactor `/drafts` and `/write` to use `ProtectedPageShell` with dedicated loading content
- Add `DashboardShellSkeleton` and `DashboardWalletSkeleton` for dashboard loading states
- Update `ArticleGrid` with clearer empty states for search/filter/no-results cases
- Update profile NFT tab and articles browse to use the shared empty/loading patterns
- Add regression tests for protected shells, dashboard loading, article grid empty states, drafts page, and protected route helpers

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run format`
- [x] `bun run test:once` (772 tests passed)
- [x] `bun run build`


## Notes

- Rebased onto latest `development` before opening PR
- No schema, API, or env changes
- UI-only consistency work; no changes to business logic for drafts, publishing, or wallet flows
<img width="1440" height="860" alt="1" src="https://github.com/user-attachments/assets/f52cff0c-ab2d-42f5-939e-0b617b4568a4" />
<img width="1440" height="860" alt="2" src="https://github.com/user-attachments/assets/4a79fb9d-9016-4319-a9fa-7de4a0d68655" />
<img width="1440" height="860" alt="3" src="https://github.com/user-attachments/assets/1780a5f6-62c0-4578-8355-c3fb06fc0699" />
<img width="1440" height="859" alt="4" src="https://github.com/user-attachments/assets/64aa0ee0-20ec-47e5-898d-239ee96ceadb" />

<img width="1440" height="859" alt="5" src="https://github.com/user-attachments/assets/53a58d39-ec8e-43de-b75e-07af7964ed59" />


<img width="1440" height="859" alt="6" src="https://github.com/user-attachments/assets/9ea5f2d3-ace1-4b0d-977c-cda84fc99cf3" />
