### PR TITLE
feat(ui): establish launch-ready surface density and component consistency (ENG-263)

### DIFF
--- a/app/[username]/[slug]/page.tsx
+++ b/app/[username]/[slug]/page.tsx
@@ -22,6 +22,7 @@ import {
   ArticleSidebarSectionFallback,
 } from '@/components/error/SectionErrorFallback'
 import { ReadingProgressBar } from '@/components/articles/ReadingProgressBar'
+import { EditorialSurface } from '@/components/layout/EditorialSurface'
 import { extractH2HeadingsFromTiptapJson } from '@/lib/tiptap/headings'
 import { LoadingRegion } from '@/components/a11y/LoadingRegion'
 import { useStaleLoading } from '@/hooks/useStaleLoading'
@@ -113,7 +114,7 @@ export default function ArticlePage({ params }: ArticlePageProps) {
       <AppNavigation />
       <ReadingProgressBar />
       <main className="flex-1 pt-20 w-full">
-        <div className="max-w-4xl mx-auto px-4 py-8">
+        <EditorialSurface>
           <ErrorBoundary fallback={<ArticleDisplaySectionFallback />}>
             <ArticleDisplay
               article={articleForDisplay}
@@ -147,7 +148,7 @@ export default function ArticlePage({ params }: ArticlePageProps) {
               arweaveTimestamp={article.arweaveTimestamp}
             />
           </ErrorBoundary>
-        </div>
+        </EditorialSurface>
       </main>
       <SiteFooter variant="default" />
     </div>

--- a/app/drafts/page.tsx
+++ b/app/drafts/page.tsx
@@ -131,7 +131,10 @@ export default function DraftsPage() {
             className="divide-y divide-border overflow-hidden"
           >
             {drafts.map((draft) => (
-              <div key={draft._id} className="p-[var(--workspace-row-padding)] hover:bg-muted/40 transition-colors">
+              <div
+                key={draft._id}
+                className="p-[var(--workspace-row-padding)] hover:bg-muted/40 transition-colors"
+              >
                 <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-start">
                   <div className="min-w-0 flex-1 w-full">
                     <div className="flex items-start justify-between gap-2 mb-2">

--- a/app/drafts/page.tsx
+++ b/app/drafts/page.tsx
@@ -30,6 +30,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { Card } from '@/components/ui/card'
+import { WorkspaceSurface } from '@/components/layout/WorkspaceSurface'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Loader2, MoreHorizontal, Pencil, Trash2 } from 'lucide-react'
 import { mutationWithTimeout } from '@/lib/convexMutationWithTimeout'
@@ -67,13 +69,13 @@ export default function DraftsPage() {
     return (
       <div className="min-h-screen bg-muted/30">
         <AppNavigation />
-        <div className="max-w-5xl mx-auto pt-24 pb-8 px-4">
+        <WorkspaceSurface>
           <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center mb-8">
             <Skeleton className="h-9 w-48" />
             <Skeleton className="h-10 w-32" />
           </div>
           <DraftsListSkeleton />
-        </div>
+        </WorkspaceSurface>
       </div>
     )
   }
@@ -96,7 +98,7 @@ export default function DraftsPage() {
   return (
     <div className="min-h-screen bg-muted/30">
       <AppNavigation />
-      <div className="max-w-5xl mx-auto pt-24 pb-8 px-4">
+      <WorkspaceSurface>
         <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center mb-8">
           <h1 className="text-3xl font-bold text-foreground">Your Drafts</h1>
           <Link
@@ -110,7 +112,7 @@ export default function DraftsPage() {
         {loading ? (
           <DraftsListSkeleton />
         ) : drafts.length === 0 ? (
-          <div className="text-center py-12 bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)]">
+          <div className="text-center py-12">
             <div className="text-muted-foreground mb-4">No drafts yet</div>
             <Link
               href="/write"
@@ -118,14 +120,18 @@ export default function DraftsPage() {
             >
               Start writing your first article →
             </Link>
+            <p className="mt-6 text-sm text-muted-foreground max-w-md mx-auto">
+              {AUTO_SAVE_GUIDANCE} Delete drafts you no longer need to keep your
+              workspace clean.
+            </p>
           </div>
         ) : (
-          <div className="space-y-4">
+          <Card
+            variant="quiet"
+            className="divide-y divide-border overflow-hidden"
+          >
             {drafts.map((draft) => (
-              <div
-                key={draft._id}
-                className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border ring-1 ring-border/60 p-[var(--card-padding)] hover:shadow-md transition-shadow"
-              >
+              <div key={draft._id} className="p-[var(--workspace-row-padding)] hover:bg-muted/40 transition-colors">
                 <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-start">
                   <div className="min-w-0 flex-1 w-full">
                     <div className="flex items-start justify-between gap-2 mb-2">
@@ -216,23 +222,9 @@ export default function DraftsPage() {
                 </div>
               </div>
             ))}
-          </div>
+          </Card>
         )}
-
-        <div className="mt-8 text-sm text-muted-foreground bg-muted border border-border p-4 rounded-lg">
-          <p className="font-semibold mb-2">About Drafts</p>
-          <ul className="space-y-1">
-            <li>
-              • All your unpublished articles are saved here automatically
-            </li>
-            <li>• Click &quot;Edit&quot; to continue working on any draft</li>
-            <li>• {AUTO_SAVE_GUIDANCE}</li>
-            <li>
-              • Delete drafts you no longer need to keep your workspace clean
-            </li>
-          </ul>
-        </div>
-      </div>
+      </WorkspaceSurface>
 
       <AlertDialog
         open={!!deleteTarget}

--- a/app/globals.css
+++ b/app/globals.css
@@ -147,6 +147,7 @@
   --surface-editorial-max: 56rem;
   --surface-workspace-max: 64rem;
   --surface-settings-max: 42rem;
+  --surface-guide-max: 48rem;
   --chrome-quiet: none;
   --chrome-raised: var(--card-shadow);
   --workspace-row-padding: 1rem;

--- a/app/globals.css
+++ b/app/globals.css
@@ -143,6 +143,14 @@
   --card-radius: 0.75rem;
   --card-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
 
+  /* Surface density tokens */
+  --surface-editorial-max: 56rem;
+  --surface-workspace-max: 64rem;
+  --surface-settings-max: 42rem;
+  --chrome-quiet: none;
+  --chrome-raised: var(--card-shadow);
+  --workspace-row-padding: 1rem;
+
   /* Shadcn semantic vars (quill palette) */
   --background: #fefefe;
   --foreground: #202124;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,6 +27,8 @@ import {
   DASHBOARD_HOME_WRITE_CARD,
 } from '@/lib/copy/dashboard-home'
 import Navigation from '@/components/landing/Navigation'
+import { cardVariants } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
 
 function HomeLoadingShell() {
   return (
@@ -71,6 +73,11 @@ function PublicLandingPage() {
   )
 }
 
+const actionTileClassName = cn(
+  cardVariants({ variant: 'action' }),
+  'group block'
+)
+
 export default function HomePage() {
   const { user, isAuthenticated, isLoading } = useAuth()
 
@@ -105,37 +112,34 @@ export default function HomePage() {
               </p>
             </div>
 
-            <div className="grid md:grid-cols-3 gap-6 mb-12">
-              <Link
-                href="/write"
-                className="group p-6 bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] hover:shadow-md transition-shadow border border-border"
-              >
-                <div className="flex items-center mb-4">
-                  <div className="p-3 bg-muted rounded-lg group-hover:bg-muted/80 transition-colors">
-                    <PenSquare className="w-6 h-6 text-brand" />
+            <p className="text-sm font-medium text-muted-foreground mb-3">
+              Quick actions
+            </p>
+            <div className="grid md:grid-cols-3 gap-4 mb-12">
+              <Link href="/write" className={actionTileClassName}>
+                <div className="flex items-center mb-3">
+                  <div className="p-2.5 bg-blue-100 dark:bg-blue-950/50 rounded-lg group-hover:bg-blue-200 dark:group-hover:bg-blue-950/70 transition-colors">
+                    <PenSquare className="w-5 h-5 text-blue-600 dark:text-blue-400" />
                   </div>
-                  <h3 className="text-lg font-semibold ml-3">
+                  <h3 className="text-base font-semibold ml-3">
                     {DASHBOARD_HOME_WRITE_CARD.title}
                   </h3>
                 </div>
-                <p className="text-muted-foreground">
+                <p className="text-sm text-muted-foreground">
                   {DASHBOARD_HOME_WRITE_CARD.description}
                 </p>
               </Link>
 
-              <Link
-                href="/articles"
-                className="group p-6 bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] hover:shadow-md transition-shadow border border-border"
-              >
-                <div className="flex items-center mb-4">
-                  <div className="p-3 bg-muted rounded-lg group-hover:bg-muted/80 transition-colors">
-                    <BookOpen className="w-6 h-6 text-foreground" />
+              <Link href="/articles" className={actionTileClassName}>
+                <div className="flex items-center mb-3">
+                  <div className="p-2.5 bg-green-100 dark:bg-green-950/50 rounded-lg group-hover:bg-green-200 dark:group-hover:bg-green-950/70 transition-colors">
+                    <BookOpen className="w-5 h-5 text-green-800 dark:text-green-400" />
                   </div>
-                  <h3 className="text-lg font-semibold ml-3">
+                  <h3 className="text-base font-semibold ml-3">
                     {DASHBOARD_HOME_BROWSE_CARD.title}
                   </h3>
                 </div>
-                <p className="text-muted-foreground">
+                <p className="text-sm text-muted-foreground">
                   {DASHBOARD_HOME_BROWSE_CARD.description}
                 </p>
               </Link>
@@ -143,34 +147,31 @@ export default function HomePage() {
               {hasWallet ? (
                 <Link
                   href="/dashboard/earnings"
-                  className="group p-6 bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] hover:shadow-md transition-shadow border border-border"
+                  className={actionTileClassName}
                 >
-                  <div className="flex items-center mb-4">
-                    <div className="p-3 bg-muted rounded-lg group-hover:bg-muted/80 transition-colors">
-                      <TrendingUp className="w-6 h-6 text-foreground" />
+                  <div className="flex items-center mb-3">
+                    <div className="p-2.5 bg-purple-100 dark:bg-purple-950/50 rounded-lg group-hover:bg-purple-200 dark:group-hover:bg-purple-950/70 transition-colors">
+                      <TrendingUp className="w-5 h-5 text-purple-600 dark:text-purple-400" />
                     </div>
-                    <h3 className="text-lg font-semibold ml-3">
+                    <h3 className="text-base font-semibold ml-3">
                       {DASHBOARD_HOME_EARNINGS_CARD.title}
                     </h3>
                   </div>
-                  <p className="text-muted-foreground">
+                  <p className="text-sm text-muted-foreground">
                     {DASHBOARD_HOME_EARNINGS_CARD.description}
                   </p>
                 </Link>
               ) : (
-                <Link
-                  href="/dashboard/wallet"
-                  className="group p-6 bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] hover:shadow-md transition-shadow border border-border"
-                >
-                  <div className="flex items-center mb-4">
-                    <div className="p-3 bg-muted rounded-lg group-hover:bg-muted/80 transition-colors">
-                      <Wallet className="w-6 h-6 text-foreground" />
+                <Link href="/dashboard/wallet" className={actionTileClassName}>
+                  <div className="flex items-center mb-3">
+                    <div className="p-2.5 bg-amber-100 dark:bg-amber-950/50 rounded-lg group-hover:bg-amber-200 dark:group-hover:bg-amber-950/70 transition-colors">
+                      <Wallet className="w-5 h-5 text-amber-600 dark:text-amber-400" />
                     </div>
-                    <h3 className="text-lg font-semibold ml-3">
+                    <h3 className="text-base font-semibold ml-3">
                       {DASHBOARD_HOME_WALLET_CARD.title}
                     </h3>
                   </div>
-                  <p className="text-muted-foreground">
+                  <p className="text-sm text-muted-foreground">
                     {DASHBOARD_HOME_WALLET_CARD.description}
                   </p>
                 </Link>

--- a/components/dashboard/CreatorStatsPanel.tsx
+++ b/components/dashboard/CreatorStatsPanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { BookOpen, DollarSign, Image } from 'lucide-react'
+import { Card, CardContent } from '@/components/ui/card'
 
 type CreatorStatsPanelProps = {
   articleCount: number
@@ -14,35 +15,37 @@ export function CreatorStatsPanel({
   nftsOwned,
 }: CreatorStatsPanelProps) {
   return (
-    <div className="space-y-6">
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-muted-foreground">Total Articles</span>
-            <BookOpen className="w-5 h-5 text-muted-foreground" />
+    <Card variant="quiet">
+      <CardContent className="pt-6">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-muted-foreground">Total Articles</span>
+              <BookOpen className="w-5 h-5 text-muted-foreground" />
+            </div>
+            <p className="text-3xl font-bold text-foreground">{articleCount}</p>
           </div>
-          <p className="text-3xl font-bold text-foreground">{articleCount}</p>
-        </div>
-        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-muted-foreground">Tips Received</span>
-            <DollarSign className="w-5 h-5 text-muted-foreground" />
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-muted-foreground">Tips Received</span>
+              <DollarSign className="w-5 h-5 text-muted-foreground" />
+            </div>
+            <p className="text-3xl font-bold text-foreground">
+              {tipsReceivedCount}
+            </p>
           </div>
-          <p className="text-3xl font-bold text-foreground">
-            {tipsReceivedCount}
-          </p>
-        </div>
-        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-muted-foreground">NFTs Owned</span>
-            <Image
-              className="w-5 h-5 text-muted-foreground"
-              aria-label="NFTs"
-            />
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-muted-foreground">NFTs Owned</span>
+              <Image
+                className="w-5 h-5 text-muted-foreground"
+                aria-label="NFTs"
+              />
+            </div>
+            <p className="text-3xl font-bold text-foreground">{nftsOwned}</p>
           </div>
-          <p className="text-3xl font-bold text-foreground">{nftsOwned}</p>
         </div>
-      </div>
-    </div>
+      </CardContent>
+    </Card>
   )
 }

--- a/components/dashboard/EarningsStats.tsx
+++ b/components/dashboard/EarningsStats.tsx
@@ -8,6 +8,7 @@ import { MonthlyEarningsChart } from '@/components/dashboard/monthly-earnings-ch
 import { TopEarningArticles } from '@/components/dashboard/top-earning-articles'
 import { useDashboardNavigation } from '@/hooks/useDashboardNavigation'
 import { networkLabelLowercase } from '@/lib/copy/network-status'
+import { Card, CardContent } from '@/components/ui/card'
 
 export type EarningsStatsProps = {
   earnings: Doc<'authorEarnings'>
@@ -36,68 +37,72 @@ export function EarningsStats({
         <ContextualWalletSetup mode="receive" />
       )}
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-muted-foreground">Total Earned</span>
-            <DollarSign className="w-5 h-5 text-success-foreground" />
-          </div>
-          <p className="text-2xl font-bold text-foreground">
-            ${earnings.totalEarnedUsd.toFixed(2)}
-          </p>
-          <p className="text-sm text-muted-foreground mt-1">
-            {earnings.tipCount} {networkLabelLowercase()} tips received
-          </p>
-        </div>
+      <Card variant="quiet">
+        <CardContent className="pt-6">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-muted-foreground">Total Earned</span>
+                <DollarSign className="w-5 h-5 text-success-foreground" />
+              </div>
+              <p className="text-2xl font-bold text-foreground">
+                ${earnings.totalEarnedUsd.toFixed(2)}
+              </p>
+              <p className="text-sm text-muted-foreground mt-1">
+                {earnings.tipCount} {networkLabelLowercase()} tips received
+              </p>
+            </div>
 
-        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-muted-foreground">Available Balance</span>
-            <Coins className="w-5 h-5 text-warning-foreground" />
-          </div>
-          <p className="text-2xl font-bold text-foreground">
-            ${earnings.availableBalanceUsd.toFixed(2)}
-          </p>
-          <button
-            ref={withdrawTriggerRef}
-            type="button"
-            onClick={() => {
-              if (!userProfile?.stellarAddress) {
-                navigateToDashboard('wallet')
-              } else {
-                onOpenWithdrawModal()
-              }
-            }}
-            disabled={earnings.availableBalanceUsd < minWithdrawalUsd}
-            className="mt-3 w-full px-3 py-1.5 bg-brand text-brand-foreground text-sm rounded-lg hover:bg-brand-hover disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-          >
-            <Wallet className="w-4 h-4" />
-            {!userProfile?.stellarAddress ? 'Set Up Wallet' : 'Withdraw'}
-          </button>
-          {showMinimumWithdrawalHelper && (
-            <p className="mt-2 text-sm text-muted-foreground">
-              Withdrawals require a minimum available balance of $
-              {minWithdrawalUsd.toFixed(2)}. Add more tips until your balance
-              reaches this amount.
-            </p>
-          )}
-        </div>
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-muted-foreground">Available Balance</span>
+                <Coins className="w-5 h-5 text-warning-foreground" />
+              </div>
+              <p className="text-2xl font-bold text-foreground">
+                ${earnings.availableBalanceUsd.toFixed(2)}
+              </p>
+              <button
+                ref={withdrawTriggerRef}
+                type="button"
+                onClick={() => {
+                  if (!userProfile?.stellarAddress) {
+                    navigateToDashboard('wallet')
+                  } else {
+                    onOpenWithdrawModal()
+                  }
+                }}
+                disabled={earnings.availableBalanceUsd < minWithdrawalUsd}
+                className="mt-3 w-full px-3 py-1.5 bg-brand text-brand-foreground text-sm rounded-lg hover:bg-brand-hover disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              >
+                <Wallet className="w-4 h-4" />
+                {!userProfile?.stellarAddress ? 'Set Up Wallet' : 'Withdraw'}
+              </button>
+              {showMinimumWithdrawalHelper && (
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Withdrawals require a minimum available balance of $
+                  {minWithdrawalUsd.toFixed(2)}. Add more tips until your balance
+                  reaches this amount.
+                </p>
+              )}
+            </div>
 
-        <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-muted-foreground">Total Withdrawn</span>
-            <Clock className="w-5 h-5 text-info-foreground" />
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-muted-foreground">Total Withdrawn</span>
+                <Clock className="w-5 h-5 text-info-foreground" />
+              </div>
+              <p className="text-2xl font-bold text-foreground">
+                ${earnings.withdrawnUsd.toFixed(2)}
+              </p>
+              {lastWithdrawal && (
+                <p className="text-sm text-muted-foreground mt-1">
+                  Last: {new Date(lastWithdrawal).toLocaleDateString()}
+                </p>
+              )}
+            </div>
           </div>
-          <p className="text-2xl font-bold text-foreground">
-            ${earnings.withdrawnUsd.toFixed(2)}
-          </p>
-          {lastWithdrawal && (
-            <p className="text-sm text-muted-foreground mt-1">
-              Last: {new Date(lastWithdrawal).toLocaleDateString()}
-            </p>
-          )}
-        </div>
-      </div>
+        </CardContent>
+      </Card>
 
       <MonthlyEarningsChart monthlyEarnings={earnings.monthlyEarnings ?? {}} />
 

--- a/components/dashboard/EarningsStats.tsx
+++ b/components/dashboard/EarningsStats.tsx
@@ -80,8 +80,8 @@ export function EarningsStats({
               {showMinimumWithdrawalHelper && (
                 <p className="mt-2 text-sm text-muted-foreground">
                   Withdrawals require a minimum available balance of $
-                  {minWithdrawalUsd.toFixed(2)}. Add more tips until your balance
-                  reaches this amount.
+                  {minWithdrawalUsd.toFixed(2)}. Add more tips until your
+                  balance reaches this amount.
                 </p>
               )}
             </div>

--- a/components/dashboard/TipHistory.tsx
+++ b/components/dashboard/TipHistory.tsx
@@ -157,180 +157,182 @@ export function TipHistory({ tips }: TipHistoryProps) {
   return (
     <Card variant="quiet" className="overflow-hidden">
       <CardContent className="p-0">
-      <div className="p-6 border-b border-border">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <h3 className="text-lg font-semibold">Recent Tips</h3>
-          {list ? (
-            <div className="flex flex-wrap items-center gap-3">
-              <div className="flex flex-wrap items-center gap-2 md:hidden">
-                <label className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <span>Sort by</span>
-                  <select
-                    className="h-8 rounded-md border border-border bg-background px-2 text-foreground"
-                    value={sortKey}
-                    onChange={(e) => setSort(e.target.value as SortKey)}
-                    aria-label="Sort tips by"
+        <div className="p-6 border-b border-border">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <h3 className="text-lg font-semibold">Recent Tips</h3>
+            {list ? (
+              <div className="flex flex-wrap items-center gap-3">
+                <div className="flex flex-wrap items-center gap-2 md:hidden">
+                  <label className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <span>Sort by</span>
+                    <select
+                      className="h-8 rounded-md border border-border bg-background px-2 text-foreground"
+                      value={sortKey}
+                      onChange={(e) => setSort(e.target.value as SortKey)}
+                      aria-label="Sort tips by"
+                    >
+                      {SORT_OPTIONS.map((opt) => (
+                        <option key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => setSort(sortKey)}
+                    className="h-8 rounded-md border border-border bg-background px-3 text-sm text-foreground hover:bg-muted"
+                    aria-label={`Sort direction: ${sortDir === 'asc' ? 'ascending' : 'descending'}`}
                   >
-                    {SORT_OPTIONS.map((opt) => (
-                      <option key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </option>
-                    ))}
-                  </select>
-                </label>
+                    {sortDir === 'asc' ? 'Ascending' : 'Descending'}
+                  </button>
+                </div>
                 <button
                   type="button"
-                  onClick={() => setSort(sortKey)}
+                  onClick={onDownloadCsv}
                   className="h-8 rounded-md border border-border bg-background px-3 text-sm text-foreground hover:bg-muted"
-                  aria-label={`Sort direction: ${sortDir === 'asc' ? 'ascending' : 'descending'}`}
                 >
-                  {sortDir === 'asc' ? 'Ascending' : 'Descending'}
+                  Download CSV
                 </button>
+                <label className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <span>Rows</span>
+                  <select
+                    className="h-8 rounded-md border border-border bg-background px-2 text-foreground"
+                    value={pageSize}
+                    onChange={(e) => {
+                      const value = e.target.value
+                      setPageSize(
+                        value === 'all'
+                          ? 'all'
+                          : (Number(value) as 10 | 25 | 50)
+                      )
+                    }}
+                    aria-label="Rows per page"
+                  >
+                    <option value="10">10</option>
+                    <option value="25">25</option>
+                    <option value="50">50</option>
+                    <option value="all">All</option>
+                  </select>
+                </label>
               </div>
-              <button
-                type="button"
-                onClick={onDownloadCsv}
-                className="h-8 rounded-md border border-border bg-background px-3 text-sm text-foreground hover:bg-muted"
-              >
-                Download CSV
-              </button>
-              <label className="flex items-center gap-2 text-sm text-muted-foreground">
-                <span>Rows</span>
-                <select
-                  className="h-8 rounded-md border border-border bg-background px-2 text-foreground"
-                  value={pageSize}
-                  onChange={(e) => {
-                    const value = e.target.value
-                    setPageSize(
-                      value === 'all' ? 'all' : (Number(value) as 10 | 25 | 50)
-                    )
-                  }}
-                  aria-label="Rows per page"
-                >
-                  <option value="10">10</option>
-                  <option value="25">25</option>
-                  <option value="50">50</option>
-                  <option value="all">All</option>
-                </select>
-              </label>
-            </div>
-          ) : null}
+            ) : null}
+          </div>
         </div>
-      </div>
-      {visibleTips ? (
-        <>
-          <div
-            data-testid="tip-history-mobile-list"
-            className="md:hidden divide-y divide-border"
-          >
-            {visibleTips.map((tip) => (
-              <div key={tip._id} className="p-4 hover:bg-muted/40">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0 flex-1">
-                    <p className="font-medium text-foreground line-clamp-2">
-                      {tip.articleTitle}
-                    </p>
-                    <p className="mt-1 text-sm text-muted-foreground truncate">
-                      {getTipperName(tip)}
+        {visibleTips ? (
+          <>
+            <div
+              data-testid="tip-history-mobile-list"
+              className="md:hidden divide-y divide-border"
+            >
+              {visibleTips.map((tip) => (
+                <div key={tip._id} className="p-4 hover:bg-muted/40">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <p className="font-medium text-foreground line-clamp-2">
+                        {tip.articleTitle}
+                      </p>
+                      <p className="mt-1 text-sm text-muted-foreground truncate">
+                        {getTipperName(tip)}
+                      </p>
+                    </div>
+                    <p className="shrink-0 font-semibold text-success-foreground">
+                      +${tip.amountUsd.toFixed(2)}
                     </p>
                   </div>
-                  <p className="shrink-0 font-semibold text-success-foreground">
-                    +${tip.amountUsd.toFixed(2)}
-                  </p>
+                  <div className="mt-2">
+                    <TipDateTime createdAt={tip.createdAt} />
+                  </div>
                 </div>
-                <div className="mt-2">
-                  <TipDateTime createdAt={tip.createdAt} />
-                </div>
-              </div>
-            ))}
-          </div>
-          <div className="hidden md:block overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead className="border-b border-border bg-muted/30">
-                <tr>
-                  <th
-                    scope="col"
-                    aria-sort={ariaSort('tipper')}
-                    className="px-4 py-3 text-left font-medium text-foreground"
-                  >
-                    <button
-                      type="button"
-                      onClick={() => setSort('tipper')}
-                      className="inline-flex items-center hover:underline"
+              ))}
+            </div>
+            <div className="hidden md:block overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="border-b border-border bg-muted/30">
+                  <tr>
+                    <th
+                      scope="col"
+                      aria-sort={ariaSort('tipper')}
+                      className="px-4 py-3 text-left font-medium text-foreground"
                     >
-                      Tipper{sortIndicator('tipper')}
-                    </button>
-                  </th>
-                  <th
-                    scope="col"
-                    aria-sort={ariaSort('articleTitle')}
-                    className="px-4 py-3 text-left font-medium text-foreground"
-                  >
-                    <button
-                      type="button"
-                      onClick={() => setSort('articleTitle')}
-                      className="inline-flex items-center hover:underline"
+                      <button
+                        type="button"
+                        onClick={() => setSort('tipper')}
+                        className="inline-flex items-center hover:underline"
+                      >
+                        Tipper{sortIndicator('tipper')}
+                      </button>
+                    </th>
+                    <th
+                      scope="col"
+                      aria-sort={ariaSort('articleTitle')}
+                      className="px-4 py-3 text-left font-medium text-foreground"
                     >
-                      Article{sortIndicator('articleTitle')}
-                    </button>
-                  </th>
-                  <th
-                    scope="col"
-                    aria-sort={ariaSort('amountUsd')}
-                    className="px-4 py-3 text-right font-medium text-foreground"
-                  >
-                    <button
-                      type="button"
-                      onClick={() => setSort('amountUsd')}
-                      className="inline-flex items-center hover:underline"
+                      <button
+                        type="button"
+                        onClick={() => setSort('articleTitle')}
+                        className="inline-flex items-center hover:underline"
+                      >
+                        Article{sortIndicator('articleTitle')}
+                      </button>
+                    </th>
+                    <th
+                      scope="col"
+                      aria-sort={ariaSort('amountUsd')}
+                      className="px-4 py-3 text-right font-medium text-foreground"
                     >
-                      Amount{sortIndicator('amountUsd')}
-                    </button>
-                  </th>
-                  <th
-                    scope="col"
-                    aria-sort={ariaSort('createdAt')}
-                    className="px-4 py-3 text-right font-medium text-foreground"
-                  >
-                    <button
-                      type="button"
-                      onClick={() => setSort('createdAt')}
-                      className="inline-flex items-center hover:underline"
+                      <button
+                        type="button"
+                        onClick={() => setSort('amountUsd')}
+                        className="inline-flex items-center hover:underline"
+                      >
+                        Amount{sortIndicator('amountUsd')}
+                      </button>
+                    </th>
+                    <th
+                      scope="col"
+                      aria-sort={ariaSort('createdAt')}
+                      className="px-4 py-3 text-right font-medium text-foreground"
                     >
-                      Date{sortIndicator('createdAt')}
-                    </button>
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {visibleTips.map((tip) => (
-                  <tr key={tip._id} className="hover:bg-muted/40">
-                    <td className="px-4 py-3 font-medium text-foreground">
-                      {getTipperName(tip)}
-                    </td>
-                    <td className="px-4 py-3 text-muted-foreground">
-                      {tip.articleTitle}
-                    </td>
-                    <td className="px-4 py-3 text-right font-semibold text-success-foreground">
-                      +${tip.amountUsd.toFixed(2)}
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      <TipDateTime createdAt={tip.createdAt} />
-                    </td>
+                      <button
+                        type="button"
+                        onClick={() => setSort('createdAt')}
+                        className="inline-flex items-center hover:underline"
+                      >
+                        Date{sortIndicator('createdAt')}
+                      </button>
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {visibleTips.map((tip) => (
+                    <tr key={tip._id} className="hover:bg-muted/40">
+                      <td className="px-4 py-3 font-medium text-foreground">
+                        {getTipperName(tip)}
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {tip.articleTitle}
+                      </td>
+                      <td className="px-4 py-3 text-right font-semibold text-success-foreground">
+                        +${tip.amountUsd.toFixed(2)}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <TipDateTime createdAt={tip.createdAt} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
+        ) : (
+          <div className="flex min-h-[12rem] flex-col items-center justify-center gap-2 px-6 py-10 text-center">
+            <p className="font-medium text-foreground">No tips yet</p>
+            <p className="max-w-sm text-sm text-muted-foreground">
+              When readers tip your work, they will show up here.
+            </p>
           </div>
-        </>
-      ) : (
-        <div className="flex min-h-[12rem] flex-col items-center justify-center gap-2 px-6 py-10 text-center">
-          <p className="font-medium text-foreground">No tips yet</p>
-          <p className="max-w-sm text-sm text-muted-foreground">
-            When readers tip your work, they will show up here.
-          </p>
-        </div>
-      )}
+        )}
       </CardContent>
     </Card>
   )

--- a/components/dashboard/TipHistory.tsx
+++ b/components/dashboard/TipHistory.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import type { Doc } from '@/types/convex'
+import { Card, CardContent } from '@/components/ui/card'
 
 export type ReceivedTipRow = Doc<'tips'> & {
   tipper: { name?: string; username?: string } | null
@@ -154,7 +155,8 @@ export function TipHistory({ tips }: TipHistoryProps) {
   }
 
   return (
-    <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border">
+    <Card variant="quiet" className="overflow-hidden">
+      <CardContent className="p-0">
       <div className="p-6 border-b border-border">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <h3 className="text-lg font-semibold">Recent Tips</h3>
@@ -329,6 +331,7 @@ export function TipHistory({ tips }: TipHistoryProps) {
           </p>
         </div>
       )}
-    </div>
+      </CardContent>
+    </Card>
   )
 }

--- a/components/dashboard/monthly-earnings-chart.tsx
+++ b/components/dashboard/monthly-earnings-chart.tsx
@@ -5,6 +5,7 @@ import {
   formatMonthLabel,
   monthWindowSpansTwoYears,
 } from '@/lib/earnings/monthly-earnings'
+import { Card, CardContent } from '@/components/ui/card'
 
 type MonthlyEarningsChartProps = {
   monthlyEarnings: Record<string, number>
@@ -18,38 +19,40 @@ export function MonthlyEarningsChart({
   const allZero = slots.every((slot) => slot.amountUsd === 0)
 
   return (
-    <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border p-6">
-      <div className="mb-4">
-        <h3 className="text-lg font-semibold">Monthly Earnings</h3>
-        {allZero && (
-          <p className="text-sm text-muted-foreground mt-1">
-            No earnings in the last 6 months
-          </p>
-        )}
-      </div>
-      <div className="grid grid-cols-3 sm:grid-cols-6 gap-2">
-        {slots.map((slot) => {
-          const hasEarnings = slot.amountUsd > 0
-          return (
-            <div key={slot.monthKey} className="min-w-0 text-center">
-              <div className="text-xs text-muted-foreground mb-1 whitespace-nowrap">
-                {formatMonthLabel(slot.monthKey, { showYear })}
+    <Card variant="quiet" className="mt-6">
+      <CardContent className="pt-6">
+        <div className="mb-4">
+          <h3 className="text-lg font-semibold">Monthly Earnings</h3>
+          {allZero && (
+            <p className="text-sm text-muted-foreground mt-1">
+              No earnings in the last 6 months
+            </p>
+          )}
+        </div>
+        <div className="grid grid-cols-3 sm:grid-cols-6 gap-2">
+          {slots.map((slot) => {
+            const hasEarnings = slot.amountUsd > 0
+            return (
+              <div key={slot.monthKey} className="min-w-0 text-center">
+                <div className="text-xs text-muted-foreground mb-1 whitespace-nowrap">
+                  {formatMonthLabel(slot.monthKey, { showYear })}
+                </div>
+                <div
+                  className={
+                    hasEarnings
+                      ? 'bg-success text-success-foreground rounded-lg p-2'
+                      : 'bg-muted text-muted-foreground rounded-lg border border-border p-2'
+                  }
+                >
+                  <p className="text-sm font-semibold">
+                    ${slot.amountUsd.toFixed(0)}
+                  </p>
+                </div>
               </div>
-              <div
-                className={
-                  hasEarnings
-                    ? 'bg-success text-success-foreground rounded-lg p-2'
-                    : 'bg-muted text-muted-foreground rounded-lg border border-border p-2'
-                }
-              >
-                <p className="text-sm font-semibold">
-                  ${slot.amountUsd.toFixed(0)}
-                </p>
-              </div>
-            </div>
-          )
-        })}
-      </div>
-    </div>
+            )
+          })}
+        </div>
+      </CardContent>
+    </Card>
   )
 }

--- a/components/dashboard/top-earning-articles.tsx
+++ b/components/dashboard/top-earning-articles.tsx
@@ -22,38 +22,38 @@ export function TopEarningArticles({ articles }: TopEarningArticlesProps) {
   return (
     <Card variant="quiet" className="mt-6 overflow-hidden">
       <CardContent className="p-0">
-      <div className="p-6 border-b border-border">
-        <h3 className="text-lg font-semibold flex items-center gap-2">
-          <TrendingUp className="w-5 h-5 text-success-foreground" />
-          Top Earning Articles
-        </h3>
-      </div>
-      <div className="divide-y divide-border">
-        {articles.slice(0, 5).map((article, index) => (
-          <div key={article.articleId} className="p-4 hover:bg-muted/50">
-            <div className="flex items-center justify-between">
-              <div className="flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium text-muted-foreground">
-                    #{index + 1}
-                  </span>
-                  <h4 className="font-medium text-foreground">
-                    {article.title}
-                  </h4>
+        <div className="p-6 border-b border-border">
+          <h3 className="text-lg font-semibold flex items-center gap-2">
+            <TrendingUp className="w-5 h-5 text-success-foreground" />
+            Top Earning Articles
+          </h3>
+        </div>
+        <div className="divide-y divide-border">
+          {articles.slice(0, 5).map((article, index) => (
+            <div key={article.articleId} className="p-4 hover:bg-muted/50">
+              <div className="flex items-center justify-between">
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-muted-foreground">
+                      #{index + 1}
+                    </span>
+                    <h4 className="font-medium text-foreground">
+                      {article.title}
+                    </h4>
+                  </div>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    {article.tipCount} tips
+                  </p>
                 </div>
-                <p className="text-sm text-muted-foreground mt-1">
-                  {article.tipCount} tips
-                </p>
-              </div>
-              <div className="text-right">
-                <p className="font-semibold text-foreground">
-                  ${article.earnings.toFixed(2)}
-                </p>
+                <div className="text-right">
+                  <p className="font-semibold text-foreground">
+                    ${article.earnings.toFixed(2)}
+                  </p>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
       </CardContent>
     </Card>
   )

--- a/components/dashboard/top-earning-articles.tsx
+++ b/components/dashboard/top-earning-articles.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { TrendingUp } from 'lucide-react'
+import { Card, CardContent } from '@/components/ui/card'
 
 export type TopArticleRow = {
   articleId: string
@@ -19,7 +20,8 @@ export function TopEarningArticles({ articles }: TopEarningArticlesProps) {
   }
 
   return (
-    <div className="bg-card rounded-lg shadow-[var(--card-shadow)] border border-border">
+    <Card variant="quiet" className="mt-6 overflow-hidden">
+      <CardContent className="p-0">
       <div className="p-6 border-b border-border">
         <h3 className="text-lg font-semibold flex items-center gap-2">
           <TrendingUp className="w-5 h-5 text-success-foreground" />
@@ -52,6 +54,7 @@ export function TopEarningArticles({ articles }: TopEarningArticlesProps) {
           </div>
         ))}
       </div>
-    </div>
+      </CardContent>
+    </Card>
   )
 }

--- a/components/drafts/DraftsListSkeleton.tsx
+++ b/components/drafts/DraftsListSkeleton.tsx
@@ -1,12 +1,13 @@
 import { Skeleton } from '@/components/ui/skeleton'
+import { Card } from '@/components/ui/card'
 
 export function DraftsListSkeleton() {
   return (
-    <div className="space-y-4">
+    <Card variant="quiet" className="divide-y divide-border overflow-hidden">
       {Array.from({ length: 4 }).map((_, i) => (
         <div
           key={i}
-          className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border ring-1 ring-border/60 p-[var(--card-padding)]"
+          className="p-[var(--workspace-row-padding)]"
         >
           <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-start">
             <div className="min-w-0 flex-1 w-full space-y-3">
@@ -28,6 +29,6 @@ export function DraftsListSkeleton() {
           </div>
         </div>
       ))}
-    </div>
+    </Card>
   )
 }

--- a/components/drafts/DraftsListSkeleton.tsx
+++ b/components/drafts/DraftsListSkeleton.tsx
@@ -5,10 +5,7 @@ export function DraftsListSkeleton() {
   return (
     <Card variant="quiet" className="divide-y divide-border overflow-hidden">
       {Array.from({ length: 4 }).map((_, i) => (
-        <div
-          key={i}
-          className="p-[var(--workspace-row-padding)]"
-        >
+        <div key={i} className="p-[var(--workspace-row-padding)]">
           <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-start">
             <div className="min-w-0 flex-1 w-full space-y-3">
               <div className="flex items-start justify-between gap-2">

--- a/components/guide/WalletGuide.test.tsx
+++ b/components/guide/WalletGuide.test.tsx
@@ -22,7 +22,9 @@ vi.mock('@/components/stellar/WalletConnectButton', () => {
 describe('WalletGuide tabs', () => {
   it('labels the tab list for screen readers', () => {
     render(<WalletGuide />)
-    expect(screen.getByLabelText('Wallet setup steps')).toBeInTheDocument()
+    expect(
+      screen.getByRole('tablist', { name: 'Wallet setup steps' })
+    ).toBeInTheDocument()
   })
 
   it('renders all tab labels in full', () => {
@@ -41,8 +43,8 @@ describe('WalletGuide tabs', () => {
 
   it('uses underline tab navigation', () => {
     render(<WalletGuide />)
-    const list = screen.getByLabelText('Wallet setup steps')
-    expect(list.className).toContain('border-b')
+    const list = screen.getByRole('tablist', { name: 'Wallet setup steps' })
+    expect(list.parentElement?.className).toContain('border-b')
     const trigger = screen.getByRole('tab', { name: 'What is a Wallet?' })
     expect(trigger.className).toContain('border-b-2')
     expect(trigger.className).toContain('whitespace-normal')

--- a/components/guide/WalletGuide.test.tsx
+++ b/components/guide/WalletGuide.test.tsx
@@ -39,16 +39,12 @@ describe('WalletGuide tabs', () => {
     ).toBeInTheDocument()
   })
 
-  it('uses a 2×2 grid on mobile and a single row on larger screens', () => {
+  it('uses underline tab navigation', () => {
     render(<WalletGuide />)
     const list = screen.getByLabelText('Wallet setup steps')
-    expect(list.className).toContain('grid-cols-2')
-    expect(list.className).toContain('sm:grid-cols-4')
-  })
-
-  it('allows tab labels to wrap', () => {
-    render(<WalletGuide />)
+    expect(list.className).toContain('border-b')
     const trigger = screen.getByRole('tab', { name: 'What is a Wallet?' })
+    expect(trigger.className).toContain('border-b-2')
     expect(trigger.className).toContain('whitespace-normal')
   })
 

--- a/components/guide/WalletGuide.tsx
+++ b/components/guide/WalletGuide.tsx
@@ -16,13 +16,15 @@ import {
 } from 'lucide-react'
 import Link from 'next/link'
 import { GuideWalletSettingsLink } from '@/components/guide/GuideWalletSettingsLink'
-import { Alert, AlertDescription } from '@/components/ui/alert'
+import { ActionableNotice } from '@/components/ui/ActionableNotice'
+import { GuideSurface } from '@/components/layout/GuideSurface'
 import { TESTNET_PRACTICE_NOTE } from '@/lib/copy/network-status'
 import {
   WALLET_GUIDE_HEADING,
   WALLET_GUIDE_SUBHEAD,
 } from '@/lib/copy/landing-sections'
 import { WRITER_FEE_PHRASE } from '@/lib/copy/launch-guide'
+import { cn } from '@/lib/utils'
 
 const WALLET_GUIDE_TABS = [
   { value: 'what-is-wallet', label: 'What is a Wallet?' },
@@ -31,52 +33,65 @@ const WALLET_GUIDE_TABS = [
   { value: 'first-tip', label: 'Your First Tip' },
 ] as const
 
+function GuideTabIntro({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="mb-8">
+      <h2 className="text-lg font-semibold text-foreground mb-2">{title}</h2>
+      <p className="text-sm text-muted-foreground leading-relaxed">{children}</p>
+    </div>
+  )
+}
+
 export function WalletGuide() {
   return (
-    <div className="max-w-3xl mx-auto">
+    <GuideSurface>
       <div className="text-center mb-10">
         <h1 className="text-3xl lg:text-4xl font-bold text-foreground mb-3">
           {WALLET_GUIDE_HEADING}
         </h1>
-        <p className="text-muted-foreground max-w-xl mx-auto">
+        <p className="text-muted-foreground max-w-xl mx-auto mb-3">
           {WALLET_GUIDE_SUBHEAD}
         </p>
+        <ActionableNotice intent="informational" className="max-w-xl mx-auto">
+          {TESTNET_PRACTICE_NOTE}
+        </ActionableNotice>
       </div>
 
-      <Alert className="mb-8 border-border bg-muted/60">
-        <AlertDescription className="text-sm text-muted-foreground">
-          {TESTNET_PRACTICE_NOTE}
-        </AlertDescription>
-      </Alert>
-
       <Tabs defaultValue="what-is-wallet" className="w-full">
-        <TabsList
-          className="grid w-full grid-cols-2 gap-2 h-auto p-1 mb-8 sm:grid-cols-4 sm:gap-1"
+        <div
+          className="min-w-0 w-full overflow-hidden border-b border-border mb-8"
           aria-label="Wallet setup steps"
         >
-          {WALLET_GUIDE_TABS.map((tab) => (
-            <TabsTrigger
-              key={tab.value}
-              value={tab.value}
-              className="min-h-11 py-2.5 px-2 text-sm whitespace-normal text-center leading-snug sm:min-h-9 sm:py-1.5 sm:px-3 data-[state=active]:ring-2 data-[state=active]:ring-ring"
-            >
-              {tab.label}
-            </TabsTrigger>
-          ))}
-        </TabsList>
+          <TabsList className="h-auto w-full justify-start gap-4 sm:gap-8 rounded-none bg-transparent p-0">
+            {WALLET_GUIDE_TABS.map((tab) => (
+              <TabsTrigger
+                key={tab.value}
+                value={tab.value}
+                className={cn(
+                  'shrink-0 rounded-none border-0 border-b-2 bg-transparent px-3 py-3 min-h-[44px] text-sm font-medium shadow-none whitespace-normal text-center leading-snug',
+                  'text-muted-foreground data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none',
+                  'data-[state=active]:border-brand-blue dark:data-[state=active]:border-primary',
+                  'border-transparent hover:text-foreground hover:border-border'
+                )}
+              >
+                {tab.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </div>
 
-        {/* Tab 1: What is a Wallet? */}
         <TabsContent value="what-is-wallet">
-          <div className="rounded-xl border border-border bg-muted/60 p-6 mb-8">
-            <h2 className="text-lg font-semibold text-foreground mb-2">
-              No crypto experience? No problem.
-            </h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              Reading articles on Quilltip is completely free — no wallet
-              needed. You only need a wallet if you want to{' '}
-              <strong>tip writers</strong> for content you love.
-            </p>
-          </div>
+          <GuideTabIntro title="No crypto experience? No problem.">
+            Reading articles on Quilltip is completely free — no wallet needed.
+            You only need a wallet if you want to <strong>tip writers</strong>{' '}
+            for content you love.
+          </GuideTabIntro>
 
           <WalletStepCard
             step={1}
@@ -99,17 +114,11 @@ export function WalletGuide() {
           />
         </TabsContent>
 
-        {/* Tab 2: Set Up Freighter */}
         <TabsContent value="setup">
-          <div className="rounded-xl border border-border bg-muted/60 p-6 mb-8">
-            <h2 className="text-lg font-semibold text-foreground mb-2">
-              Freighter is the easiest Stellar wallet
-            </h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              It&apos;s a free browser extension that takes about 2 minutes to
-              set up. Works with Chrome, Firefox, and Brave.
-            </p>
-          </div>
+          <GuideTabIntro title="Freighter is the easiest Stellar wallet">
+            It&apos;s a free browser extension that takes about 2 minutes to set
+            up. Works with Chrome, Firefox, and Brave.
+          </GuideTabIntro>
 
           <WalletStepCard
             step={1}
@@ -154,17 +163,11 @@ export function WalletGuide() {
           </WalletStepCard>
         </TabsContent>
 
-        {/* Tab 3: Connect to Quilltip */}
         <TabsContent value="connect">
-          <div className="rounded-xl border border-border bg-muted/60 p-6 mb-8">
-            <h2 className="text-lg font-semibold text-foreground mb-2">
-              Connect your wallet to Quilltip
-            </h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              Once Freighter is installed, connecting takes one click. Try it
-              right here!
-            </p>
-          </div>
+          <GuideTabIntro title="Connect your wallet to Quilltip">
+            Once Freighter is installed, connecting takes one click. Try it right
+            here!
+          </GuideTabIntro>
 
           <WalletStepCard
             step={1}
@@ -188,17 +191,11 @@ export function WalletGuide() {
           </WalletStepCard>
         </TabsContent>
 
-        {/* Tab 4: Your First Tip */}
         <TabsContent value="first-tip">
-          <div className="rounded-xl border border-border bg-muted/60 p-6 mb-8">
-            <h2 className="text-lg font-semibold text-foreground mb-2">
-              Tipping on Quilltip is simple
-            </h2>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              You can tip an entire article or a specific highlight with testnet
-              XLM. {WRITER_FEE_PHRASE} — typically within seconds on testnet.
-            </p>
-          </div>
+          <GuideTabIntro title="Tipping on Quilltip is simple">
+            You can tip an entire article or a specific highlight with testnet
+            XLM. {WRITER_FEE_PHRASE} — typically within seconds on testnet.
+          </GuideTabIntro>
 
           <WalletStepCard
             step={1}
@@ -230,6 +227,6 @@ export function WalletGuide() {
           />
         </TabsContent>
       </Tabs>
-    </div>
+    </GuideSurface>
   )
 }

--- a/components/guide/WalletGuide.tsx
+++ b/components/guide/WalletGuide.tsx
@@ -43,7 +43,9 @@ function GuideTabIntro({
   return (
     <div className="mb-8">
       <h2 className="text-lg font-semibold text-foreground mb-2">{title}</h2>
-      <p className="text-sm text-muted-foreground leading-relaxed">{children}</p>
+      <p className="text-sm text-muted-foreground leading-relaxed">
+        {children}
+      </p>
     </div>
   )
 }
@@ -165,8 +167,8 @@ export function WalletGuide() {
 
         <TabsContent value="connect">
           <GuideTabIntro title="Connect your wallet to Quilltip">
-            Once Freighter is installed, connecting takes one click. Try it right
-            here!
+            Once Freighter is installed, connecting takes one click. Try it
+            right here!
           </GuideTabIntro>
 
           <WalletStepCard

--- a/components/guide/WalletGuide.tsx
+++ b/components/guide/WalletGuide.tsx
@@ -66,11 +66,11 @@ export function WalletGuide() {
       </div>
 
       <Tabs defaultValue="what-is-wallet" className="w-full">
-        <div
-          className="min-w-0 w-full overflow-hidden border-b border-border mb-8"
-          aria-label="Wallet setup steps"
-        >
-          <TabsList className="h-auto w-full justify-start gap-4 sm:gap-8 rounded-none bg-transparent p-0">
+        <div className="min-w-0 w-full overflow-hidden border-b border-border mb-8">
+          <TabsList
+            aria-label="Wallet setup steps"
+            className="h-auto w-full justify-start gap-4 sm:gap-8 rounded-none bg-transparent p-0"
+          >
             {WALLET_GUIDE_TABS.map((tab) => (
               <TabsTrigger
                 key={tab.value}

--- a/components/layout/EditorialSurface.tsx
+++ b/components/layout/EditorialSurface.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@/lib/utils'
+
+type EditorialSurfaceProps = {
+  children: React.ReactNode
+  className?: string
+}
+
+export function EditorialSurface({ children, className }: EditorialSurfaceProps) {
+  return (
+    <div
+      className={cn('mx-auto w-full max-w-4xl px-4 py-8', className)}
+      style={{ maxWidth: 'var(--surface-editorial-max)' }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/components/layout/EditorialSurface.tsx
+++ b/components/layout/EditorialSurface.tsx
@@ -11,8 +11,10 @@ export function EditorialSurface({
 }: EditorialSurfaceProps) {
   return (
     <div
-      className={cn('mx-auto w-full max-w-4xl px-4 py-8', className)}
-      style={{ maxWidth: 'var(--surface-editorial-max)' }}
+      className={cn(
+        'mx-auto w-full max-w-[var(--surface-editorial-max)] px-4 py-8',
+        className
+      )}
     >
       {children}
     </div>

--- a/components/layout/EditorialSurface.tsx
+++ b/components/layout/EditorialSurface.tsx
@@ -5,7 +5,10 @@ type EditorialSurfaceProps = {
   className?: string
 }
 
-export function EditorialSurface({ children, className }: EditorialSurfaceProps) {
+export function EditorialSurface({
+  children,
+  className,
+}: EditorialSurfaceProps) {
   return (
     <div
       className={cn('mx-auto w-full max-w-4xl px-4 py-8', className)}

--- a/components/layout/GuideSurface.tsx
+++ b/components/layout/GuideSurface.tsx
@@ -1,0 +1,12 @@
+import { cn } from '@/lib/utils'
+
+type GuideSurfaceProps = {
+  children: React.ReactNode
+  className?: string
+}
+
+export function GuideSurface({ children, className }: GuideSurfaceProps) {
+  return (
+    <div className={cn('mx-auto w-full max-w-3xl', className)}>{children}</div>
+  )
+}

--- a/components/layout/GuideSurface.tsx
+++ b/components/layout/GuideSurface.tsx
@@ -7,6 +7,13 @@ type GuideSurfaceProps = {
 
 export function GuideSurface({ children, className }: GuideSurfaceProps) {
   return (
-    <div className={cn('mx-auto w-full max-w-3xl', className)}>{children}</div>
+    <div
+      className={cn(
+        'mx-auto w-full max-w-[var(--surface-guide-max)]',
+        className
+      )}
+    >
+      {children}
+    </div>
   )
 }

--- a/components/layout/SettingsSurface.tsx
+++ b/components/layout/SettingsSurface.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@/lib/utils'
+
+type SettingsSurfaceProps = {
+  children: React.ReactNode
+  className?: string
+}
+
+export function SettingsSurface({ children, className }: SettingsSurfaceProps) {
+  return (
+    <div
+      className={cn('mx-auto w-full max-w-2xl', className)}
+      style={{ maxWidth: 'var(--surface-settings-max)' }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/components/layout/SettingsSurface.tsx
+++ b/components/layout/SettingsSurface.tsx
@@ -8,8 +8,10 @@ type SettingsSurfaceProps = {
 export function SettingsSurface({ children, className }: SettingsSurfaceProps) {
   return (
     <div
-      className={cn('mx-auto w-full max-w-2xl', className)}
-      style={{ maxWidth: 'var(--surface-settings-max)' }}
+      className={cn(
+        'mx-auto w-full max-w-[var(--surface-settings-max)]',
+        className
+      )}
     >
       {children}
     </div>

--- a/components/layout/WorkspaceSurface.tsx
+++ b/components/layout/WorkspaceSurface.tsx
@@ -11,8 +11,10 @@ export function WorkspaceSurface({
 }: WorkspaceSurfaceProps) {
   return (
     <div
-      className={cn('mx-auto w-full max-w-5xl px-4 pt-24 pb-8', className)}
-      style={{ maxWidth: 'var(--surface-workspace-max)' }}
+      className={cn(
+        'mx-auto w-full max-w-[var(--surface-workspace-max)] px-4 pt-24 pb-8',
+        className
+      )}
     >
       {children}
     </div>

--- a/components/layout/WorkspaceSurface.tsx
+++ b/components/layout/WorkspaceSurface.tsx
@@ -5,7 +5,10 @@ type WorkspaceSurfaceProps = {
   className?: string
 }
 
-export function WorkspaceSurface({ children, className }: WorkspaceSurfaceProps) {
+export function WorkspaceSurface({
+  children,
+  className,
+}: WorkspaceSurfaceProps) {
   return (
     <div
       className={cn('mx-auto w-full max-w-5xl px-4 pt-24 pb-8', className)}

--- a/components/layout/WorkspaceSurface.tsx
+++ b/components/layout/WorkspaceSurface.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@/lib/utils'
+
+type WorkspaceSurfaceProps = {
+  children: React.ReactNode
+  className?: string
+}
+
+export function WorkspaceSurface({ children, className }: WorkspaceSurfaceProps) {
+  return (
+    <div
+      className={cn('mx-auto w-full max-w-5xl px-4 pt-24 pb-8', className)}
+      style={{ maxWidth: 'var(--surface-workspace-max)' }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/components/profile/ProfileHeader.tsx
+++ b/components/profile/ProfileHeader.tsx
@@ -2,6 +2,7 @@ import { User, Calendar } from 'lucide-react'
 import { UserAvatar } from '@/components/ui/user-avatar'
 import { ProfileAvatarEditor } from '@/components/profile/ProfileAvatarEditor'
 import { formatDistanceToNow } from 'date-fns'
+import { Card, CardContent } from '@/components/ui/card'
 
 interface ProfileHeaderProps {
   user: {
@@ -24,68 +25,74 @@ export default function ProfileHeader({
     addSuffix: true,
   })
 
-  return (
-    <div className="bg-card rounded-[var(--card-radius)] shadow-[var(--card-shadow)] border border-border p-8">
-      <div className="flex flex-col sm:flex-row gap-6">
-        <div className="flex-shrink-0">
-          {isOwnProfile ? (
-            <ProfileAvatarEditor
-              avatar={user.avatar}
-              name={user.name || user.username}
-              username={user.username}
-            />
-          ) : (
-            <UserAvatar
-              src={user.avatar}
-              alt={user.name || user.username}
-              name={user.name || user.username}
-              className="h-[120px] w-[120px] border-4 border-border"
-              fallbackClassName="text-4xl font-bold"
-            />
-          )}
+  const content = (
+    <div className="flex flex-col sm:flex-row gap-6">
+      <div className="flex-shrink-0">
+        {isOwnProfile ? (
+          <ProfileAvatarEditor
+            avatar={user.avatar}
+            name={user.name || user.username}
+            username={user.username}
+          />
+        ) : (
+          <UserAvatar
+            src={user.avatar}
+            alt={user.name || user.username}
+            name={user.name || user.username}
+            className="h-[120px] w-[120px] border-4 border-border"
+            fallbackClassName="text-4xl font-bold"
+          />
+        )}
+      </div>
+
+      <div className="flex-grow">
+        <div className="mb-4">
+          <h1 className="text-3xl font-bold text-foreground">
+            {user.name || user.username}
+          </h1>
+          <p className="text-lg text-muted-foreground">@{user.username}</p>
         </div>
 
-        {/* User Info */}
-        <div className="flex-grow">
-          <div className="mb-4">
-            <h1 className="text-3xl font-bold text-foreground">
-              {user.name || user.username}
-            </h1>
-            <p className="text-lg text-muted-foreground">@{user.username}</p>
+        {user.bio && (
+          <p className="text-foreground mb-4 max-w-2xl">{user.bio}</p>
+        )}
+
+        <div className="flex flex-wrap gap-6 text-sm">
+          <div className="flex items-center gap-2">
+            <div className="p-2 bg-brand-blue/10 rounded-lg">
+              <User className="w-4 h-4 text-brand-blue" />
+            </div>
+            <div>
+              <p className="font-semibold text-foreground">
+                {user.articleCount}
+              </p>
+              <p className="text-muted-foreground">
+                {user.articleCount === 1 ? 'Article' : 'Articles'}
+              </p>
+            </div>
           </div>
 
-          {/* Bio */}
-          {user.bio && (
-            <p className="text-foreground mb-4 max-w-2xl">{user.bio}</p>
-          )}
-
-          {/* Stats */}
-          <div className="flex flex-wrap gap-6 text-sm">
-            <div className="flex items-center gap-2">
-              <div className="p-2 bg-brand-blue/10 rounded-lg">
-                <User className="w-4 h-4 text-brand-blue" />
-              </div>
-              <div>
-                <p className="font-semibold text-foreground">
-                  {user.articleCount}
-                </p>
-                <p className="text-muted-foreground">
-                  {user.articleCount === 1 ? 'Article' : 'Articles'}
-                </p>
-              </div>
+          <div className="flex items-center gap-2">
+            <div className="p-2 bg-brand-blue/10 rounded-lg">
+              <Calendar className="w-4 h-4 text-brand-blue" />
             </div>
-
-            <div className="flex items-center gap-2">
-              <div className="p-2 bg-brand-blue/10 rounded-lg">
-                <Calendar className="w-4 h-4 text-brand-blue" />
-              </div>
-              <div>
-                <p className="text-muted-foreground">Member {memberSince}</p>
-              </div>
+            <div>
+              <p className="font-semibold text-foreground">Member</p>
+              <p className="text-muted-foreground">Joined {memberSince}</p>
             </div>
           </div>
         </div>
       </div>
     </div>
+  )
+
+  if (isOwnProfile) {
+    return <div className="border-b border-border pb-8">{content}</div>
+  }
+
+  return (
+    <Card variant="default">
+      <CardContent className="pt-6">{content}</CardContent>
+    </Card>
   )
 }

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -15,13 +15,13 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { ActionableNotice } from '@/components/ui/ActionableNotice'
 import type { FlowFeedback } from '@/lib/feedback/flow-feedback'
 import {
   Wallet,
   Copy,
   Check,
   AlertCircle,
-  DollarSign,
   ArrowUpRight,
   Loader2,
   Power,
@@ -147,7 +147,7 @@ export function WalletSettings({
 
   if (!isOwnProfile && !walletAddress) {
     return (
-      <Card className={className}>
+      <Card variant="quiet" className={className}>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Wallet className="h-5 w-5" />
@@ -162,13 +162,10 @@ export function WalletSettings({
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <Alert>
-            <AlertCircle className="h-4 w-4" />
-            <AlertDescription>
-              You can still read their work. Once they connect a wallet, you can
-              tip from any article using &quot;Tip Author&quot;.
-            </AlertDescription>
-          </Alert>
+          <ActionableNotice intent="informational">
+            You can still read their work. Once they connect a wallet, you can
+            tip from any article using &quot;Tip Author&quot;.
+          </ActionableNotice>
 
           <div className="flex flex-col gap-2 sm:flex-row">
             {profileUsername ? (
@@ -189,7 +186,7 @@ export function WalletSettings({
 
   return (
     <>
-      <Card className={className}>
+      <Card variant="quiet" className={className}>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Wallet className="h-5 w-5" />
@@ -222,15 +219,12 @@ export function WalletSettings({
             </Alert>
           )}
           {isOwnProfile && walletAddress ? (
-            <Alert className="border-info/50 bg-info">
-              <AlertCircle className="h-4 w-4 text-info-foreground" />
-              <AlertDescription className="text-info-foreground">
-                <strong>This wallet is for receiving tips.</strong> When readers
-                tip your articles, payments come here. To send tips to other
-                authors, you&apos;ll connect your wallet extension directly on
-                their articles.
-              </AlertDescription>
-            </Alert>
+            <ActionableNotice intent="informational">
+              <strong>This wallet is for receiving tips.</strong> When readers tip
+              your articles, payments come here. To send tips to other authors,
+              you&apos;ll connect your wallet extension directly on their
+              articles.
+            </ActionableNotice>
           ) : null}
 
           {isOwnProfile ? (
@@ -278,14 +272,11 @@ export function WalletSettings({
                     </div>
                   </div>
 
-                  <Alert>
-                    <DollarSign className="h-4 w-4" />
-                    <AlertDescription>
-                      You can send and receive tips with this wallet. You can
-                      change it anytime by disconnecting and connecting a
-                      different account.
-                    </AlertDescription>
-                  </Alert>
+                  <ActionableNotice intent="informational">
+                    You can send and receive tips with this wallet. You can
+                    change it anytime by disconnecting and connecting a
+                    different account.
+                  </ActionableNotice>
 
                   <div className="flex gap-2">
                     <Button
@@ -369,13 +360,10 @@ export function WalletSettings({
                 View on Stellar Explorer
               </Button>
 
-              <Alert>
-                <DollarSign className="h-4 w-4" />
-                <AlertDescription>
-                  Want to tip in-app? Open any of their articles and click
-                  &quot;Tip Author&quot;.
-                </AlertDescription>
-              </Alert>
+              <ActionableNotice intent="informational">
+                Want to tip in-app? Open any of their articles and click
+                &quot;Tip Author&quot;.
+              </ActionableNotice>
             </div>
           )}
 

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -220,10 +220,10 @@ export function WalletSettings({
           )}
           {isOwnProfile && walletAddress ? (
             <ActionableNotice intent="informational">
-              <strong>This wallet is for receiving tips.</strong> When readers tip
-              your articles, payments come here. To send tips to other authors,
-              you&apos;ll connect your wallet extension directly on their
-              articles.
+              <strong>This wallet is for receiving tips.</strong> When readers
+              tip your articles, payments come here. To send tips to other
+              authors, you&apos;ll connect your wallet extension directly on
+              their articles.
             </ActionableNotice>
           ) : null}
 

--- a/components/ui/ActionableNotice.test.tsx
+++ b/components/ui/ActionableNotice.test.tsx
@@ -1,0 +1,31 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ActionableNotice } from '@/components/ui/ActionableNotice'
+
+describe('ActionableNotice', () => {
+  it('renders informational content as muted paragraph', () => {
+    render(
+      <ActionableNotice intent="informational">
+        Testnet uses practice funds only.
+      </ActionableNotice>
+    )
+    const note = screen.getByText('Testnet uses practice funds only.')
+    expect(note.tagName).toBe('P')
+    expect(note).toHaveClass('text-muted-foreground')
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('renders actionable content as alert', () => {
+    render(
+      <ActionableNotice intent="actionable" title="Connect wallet">
+        Connect your wallet to send tips.
+      </ActionableNotice>
+    )
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText('Connect wallet')).toBeInTheDocument()
+    expect(
+      screen.getByText('Connect your wallet to send tips.')
+    ).toBeInTheDocument()
+  })
+})

--- a/components/ui/ActionableNotice.tsx
+++ b/components/ui/ActionableNotice.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react'
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { cn } from '@/lib/utils'
+
+type ActionableNoticeProps = {
+  intent: 'actionable' | 'informational'
+  children: React.ReactNode
+  title?: string
+  className?: string
+  alertVariant?: 'default' | 'destructive'
+}
+
+export function ActionableNotice({
+  intent,
+  children,
+  title,
+  className,
+  alertVariant = 'default',
+}: ActionableNoticeProps) {
+  if (intent === 'informational') {
+    return (
+      <p className={cn('text-sm text-muted-foreground', className)}>
+        {children}
+      </p>
+    )
+  }
+
+  return (
+    <Alert variant={alertVariant} className={className}>
+      {title ? <AlertTitle>{title}</AlertTitle> : null}
+      <AlertDescription>{children}</AlertDescription>
+    </Alert>
+  )
+}

--- a/components/ui/card.test.tsx
+++ b/components/ui/card.test.tsx
@@ -1,0 +1,36 @@
+/** @vitest-environment jsdom */
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { Card, cardVariants } from '@/components/ui/card'
+
+describe('Card variants', () => {
+  it('default variant includes raised shadow', () => {
+    const { container } = render(<Card variant="default">Content</Card>)
+    expect(container.firstChild).toHaveClass('shadow-[var(--chrome-raised)]')
+  })
+
+  it('quiet variant has no shadow', () => {
+    const { container } = render(<Card variant="quiet">Content</Card>)
+    expect(container.firstChild).toHaveClass('shadow-[var(--chrome-quiet)]')
+    expect(container.firstChild).not.toHaveClass(
+      'shadow-[var(--chrome-raised)]'
+    )
+  })
+
+  it('action variant has no raised shadow and compact padding', () => {
+    const { container } = render(<Card variant="action">Content</Card>)
+    expect(container.firstChild).toHaveClass('p-4')
+    expect(container.firstChild).toHaveClass('shadow-[var(--chrome-quiet)]')
+  })
+
+  it('workspace-row variant has no shadow or full card radius', () => {
+    const { container } = render(<Card variant="workspace-row">Row</Card>)
+    expect(container.firstChild).toHaveClass('border-b')
+    expect(container.firstChild).toHaveClass('shadow-[var(--chrome-quiet)]')
+    expect(container.firstChild).toHaveClass('rounded-none')
+  })
+
+  it('cardVariants helper matches default when no variant passed', () => {
+    expect(cardVariants()).toContain('shadow-[var(--chrome-raised)]')
+  })
+})

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,17 +1,35 @@
 import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/lib/utils'
 
+const cardVariants = cva(
+  'rounded-[var(--card-radius)] bg-card text-card-foreground',
+  {
+    variants: {
+      variant: {
+        default: 'border shadow-[var(--chrome-raised)]',
+        quiet: 'border shadow-[var(--chrome-quiet)]',
+        action:
+          'border border-border p-4 shadow-[var(--chrome-quiet)] transition-colors hover:bg-muted/40',
+        'workspace-row':
+          'rounded-none border-0 border-b border-border shadow-[var(--chrome-quiet)] p-[var(--workspace-row-padding)] transition-colors hover:bg-muted/40 last:border-b-0',
+        inline: 'border-0 shadow-[var(--chrome-quiet)] bg-muted/30',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+)
+
 const Card = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof cardVariants>
+>(({ className, variant, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn(
-      'rounded-[var(--card-radius)] border bg-card text-card-foreground shadow-[var(--card-shadow)]',
-      className
-    )}
+    className={cn(cardVariants({ variant }), className)}
     {...props}
   />
 ))
@@ -80,4 +98,12 @@ const CardFooter = React.forwardRef<
 ))
 CardFooter.displayName = 'CardFooter'
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  cardVariants,
+}


### PR DESCRIPTION
## Summary

Introduces shared layout surfaces, card chrome variants, and an `ActionableNotice` primitive, then applies them across dashboard, drafts, profile, guide, and settings so spacing, elevation, and density feel consistent at launch. Rebased onto latest `development`; copy constants from ENG-261 are preserved.



## Changes

- Add layout surfaces: `EditorialSurface`, `GuideSurface`, `SettingsSurface`, `WorkspaceSurface` with CSS max-width tokens (`--surface-editorial-max`, `--surface-workspace-max`, `--surface-settings-max`)
- Extend `Card` with CVA variants: `quiet`, `action`, `workspace-row`, `inline`; add `--chrome-quiet` / `--chrome-raised` tokens in `globals.css`
- Add `ActionableNotice` for informational vs actionable alert patterns
- Apply quieter dashboard chrome on `CreatorStatsPanel`, `EarningsStats`, `TipHistory`, `monthly-earnings-chart`, and `top-earning-articles`
- Tighten authenticated home quick-action tiles (`action` card variant, denser grid)
- Update drafts list, profile header, wallet guide, wallet settings, and article reader layout to use the new surfaces
- Add unit tests for `card` variants and `ActionableNotice`; update `WalletGuide` tests

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run format`
- [x] `bun run test:once` (762 tests passed)
- [x] `bun run build`


## Notes

Visual-only refactor; no backend or payment logic changes. Spot-check light and dark mode on dashboard cards and the wallet guide tab bar.

<img width="1437" height="856" alt="1" src="https://github.com/user-attachments/assets/47be48aa-d9e7-4d26-a0ff-a1feb1ae30eb" />
<img width="1440" height="861" alt="dsh_wallet" src="https://github.com/user-attachments/assets/4157365e-7b8f-43ae-9b90-bac7860210e4" />
<img width="1440" height="855" alt="2" src="https://github.com/user-attachments/assets/7d2534c7-9145-42c7-9e71-4b64a3f07f9a" />
