### PR TITLE
feat(dashboard): add creator workspace with recent work and earnings overview (ENG-252)

### DIFF
--- a/app/drafts/page.test.tsx
+++ b/app/drafts/page.test.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import DraftsPage from './page'
+import { AUTO_SAVE_GUIDANCE } from '@/lib/autosave'
 
 const mockUseAuth = vi.fn()
 const mockUseUserDrafts = vi.fn()
@@ -35,6 +36,8 @@ vi.mock('convex/react', () => ({
 
 describe('DraftsPage', () => {
   beforeEach(() => {
+    mockUseAuth.mockReset()
+    mockUseUserDrafts.mockReset()
     mockUseUserDrafts.mockReturnValue([])
   })
 
@@ -47,10 +50,23 @@ describe('DraftsPage', () => {
     render(<DraftsPage />)
 
     expect(screen.getByTestId('app-navigation')).toBeInTheDocument()
-    expect(screen.queryByText('Your Drafts')).not.toBeInTheDocument()
+    expect(screen.queryByText('Your drafts')).not.toBeInTheDocument()
   })
 
-  it('shows start draft action in empty state', () => {
+  it('shows autosave guidance in the empty state only', () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+    })
+
+    render(<DraftsPage />)
+
+    expect(screen.getByText(/No drafts yet/i)).toBeInTheDocument()
+    expect(screen.getByText(new RegExp(AUTO_SAVE_GUIDANCE))).toBeInTheDocument()
+    expect(screen.queryByText(/About Drafts/i)).not.toBeInTheDocument()
+  })
+
+  it('shows start writing action in empty state', () => {
     mockUseAuth.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
@@ -59,11 +75,48 @@ describe('DraftsPage', () => {
     render(<DraftsPage />)
 
     expect(
-      screen.getByRole('heading', { name: 'No drafts yet' })
-    ).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Start a draft' })).toHaveAttribute(
+      screen.getByRole('link', { name: 'Start writing your first article' })
+    ).toHaveAttribute('href', '/write')
+  })
+
+  it('renders document rows without visible delete buttons', () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+    })
+    mockUseUserDrafts.mockReturnValue([
+      {
+        _id: 'draft1',
+        title: 'Test draft',
+        excerpt: 'A short excerpt',
+        updatedAt: Date.now(),
+        _creationTime: Date.now(),
+        published: false,
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'Hello world' }],
+            },
+          ],
+        },
+      },
+    ])
+
+    render(<DraftsPage />)
+
+    expect(screen.getByRole('link', { name: /Test draft/i })).toHaveAttribute(
       'href',
-      '/write'
+      '/write?id=draft1'
     )
+    expect(screen.getByText(/less than a minute ago/i)).toBeInTheDocument()
+    expect(screen.getByText(/2 words/i)).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /^Delete$/i })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Actions for Test draft/i })
+    ).toBeInTheDocument()
   })
 })

--- a/app/drafts/page.tsx
+++ b/app/drafts/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useAuth } from '@/components/providers/AuthContext'
 import Link from 'next/link'
 import AppNavigation from '@/components/layout/AppNavigation'
@@ -20,31 +20,37 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { DraftsListSkeleton } from '@/components/drafts/DraftsListSkeleton'
+import { DraftListRow } from '@/components/drafts/DraftListRow'
+import { DraftsSortControl } from '@/components/drafts/DraftsSortControl'
 import { AUTO_SAVE_GUIDANCE } from '@/lib/autosave'
+import { sortDraftsBy, type DraftSortKey } from '@/lib/drafts/draftMetadata'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
-import { Card } from '@/components/ui/card'
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { WorkspaceSurface } from '@/components/layout/WorkspaceSurface'
 import { Skeleton } from '@/components/ui/skeleton'
-import { Loader2, MoreHorizontal, Pencil, Trash2, FileText } from 'lucide-react'
+import { Loader2 } from 'lucide-react'
 import { mutationWithTimeout } from '@/lib/convexMutationWithTimeout'
 import { ProtectedPageShell } from '@/components/layout/ProtectedPageShell'
-import { RouteEmptyState } from '@/components/ui/route-empty-state'
 
 export default function DraftsPage() {
   const { isAuthenticated, isLoading } = useAuth()
 
   const draftsQuery = useUserDrafts()
   const loading = draftsQuery === undefined
-  const drafts = draftsQuery ?? []
 
-  // Convex mutation for deleting articles
+  const [sortKey, setSortKey] = useState<DraftSortKey>('updatedAt')
+
+  const sortedDrafts = useMemo(() => {
+    const drafts = draftsQuery ?? []
+    return sortDraftsBy(drafts, sortKey)
+  }, [draftsQuery, sortKey])
+
   const deleteArticleMutation = useMutation(api.articles.deleteArticle)
   const [deleteTarget, setDeleteTarget] = useState<Id<'articles'> | null>(null)
   const [isDeleting, setIsDeleting] = useState(false)
@@ -64,17 +70,6 @@ export default function DraftsPage() {
     }
   }
 
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString)
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    })
-  }
-
   return (
     <ProtectedPageShell
       isLoading={isLoading}
@@ -82,7 +77,7 @@ export default function DraftsPage() {
       shellClassName="min-h-screen bg-muted/30"
       loadingContent={
         <WorkspaceSurface>
-          <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center mb-8">
+          <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <Skeleton className="h-9 w-48" />
             <Skeleton className="h-10 w-32" />
           </div>
@@ -93,141 +88,57 @@ export default function DraftsPage() {
       <div className="min-h-screen bg-muted/30">
         <AppNavigation />
         <WorkspaceSurface>
-          <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center mb-8">
-            <h1 className="text-3xl font-bold text-foreground">Your Drafts</h1>
-            <Link
-              href="/write"
-              className="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors shrink-0 self-start sm:self-auto"
-            >
-              New Article
-            </Link>
+          <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <h1 className="text-3xl font-bold text-foreground">Your drafts</h1>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button asChild className="shrink-0 self-start sm:self-auto">
+                    <Link href="/write">New article</Link>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-xs">
+                  {AUTO_SAVE_GUIDANCE}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
 
           {loading ? (
             <DraftsListSkeleton />
-          ) : drafts.length === 0 ? (
-            <RouteEmptyState
-              icon={FileText}
-              title="No drafts yet"
-              description="Saved drafts appear here while you work on an article."
-              action={{ label: 'Start a draft', href: '/write' }}
-            />
+          ) : (draftsQuery ?? []).length === 0 ? (
+            <div className="rounded-[var(--card-radius)] border border-border bg-card px-6 py-12 text-center shadow-[var(--card-shadow)]">
+              <p className="mb-2 text-lg font-medium text-foreground">
+                No drafts yet
+              </p>
+              <p className="mb-6 text-sm text-muted-foreground">
+                Unpublished articles are saved here automatically.{' '}
+                {AUTO_SAVE_GUIDANCE}.
+              </p>
+              <Link
+                href="/write"
+                className="text-sm font-medium text-brand-blue hover:text-brand-accent"
+              >
+                Start writing your first article
+              </Link>
+            </div>
           ) : (
-            <Card
-              variant="quiet"
-              className="divide-y divide-border overflow-hidden"
-            >
-              {drafts.map((draft) => (
-                <div
-                  key={draft._id}
-                  className="p-[var(--workspace-row-padding)] hover:bg-muted/40 transition-colors"
-                >
-                  <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-start">
-                    <div className="min-w-0 flex-1 w-full">
-                      <div className="flex items-start justify-between gap-2 mb-2">
-                        <h2 className="text-xl font-semibold text-foreground break-words min-w-0 flex-1">
-                          {draft.title || 'Untitled'}
-                        </h2>
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              variant="outline"
-                              size="icon"
-                              className="sm:hidden shrink-0"
-                              aria-label="Draft actions"
-                            >
-                              <MoreHorizontal className="h-4 w-4" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent
-                            align="end"
-                            className="min-w-[10rem]"
-                          >
-                            <DropdownMenuItem asChild>
-                              <Link
-                                href={`/write?id=${draft._id}`}
-                                className="cursor-pointer gap-2"
-                              >
-                                <Pencil className="h-4 w-4" />
-                                Edit
-                              </Link>
-                            </DropdownMenuItem>
-                            <DropdownMenuItem
-                              className="cursor-pointer gap-2 text-destructive focus:text-destructive disabled:opacity-50 disabled:pointer-events-none"
-                              disabled={isDeleting}
-                              onSelect={() => {
-                                if (isDeleting) return
-                                setDeleteTarget(draft._id)
-                              }}
-                            >
-                              <Trash2 className="h-4 w-4" />
-                              Delete
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      </div>
-                      {draft.excerpt && (
-                        <p className="text-muted-foreground mb-3 line-clamp-2">
-                          {draft.excerpt}
-                        </p>
-                      )}
-                      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
-                        <span>
-                          Created:{' '}
-                          {formatDate(
-                            new Date(draft._creationTime).toISOString()
-                          )}
-                        </span>
-                        <span>•</span>
-                        <span>
-                          Last saved:{' '}
-                          {formatDate(new Date(draft.updatedAt).toISOString())}
-                        </span>
-                        {!draft.published && (
-                          <>
-                            <span>•</span>
-                            <span className="text-warning-foreground font-medium">
-                              Draft
-                            </span>
-                          </>
-                        )}
-                      </div>
-                    </div>
-                    <div className="hidden sm:flex gap-2 shrink-0">
-                      <Link
-                        href={`/write?id=${draft._id}`}
-                        className="px-4 py-2 rounded-lg border border-primary text-primary bg-primary/5 hover:bg-primary/10 transition-colors"
-                      >
-                        Edit
-                      </Link>
-                      <button
-                        type="button"
-                        disabled={isDeleting}
-                        onClick={() => setDeleteTarget(draft._id)}
-                        className="px-4 py-2 rounded-lg border border-destructive text-destructive bg-destructive/5 hover:bg-destructive/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                      >
-                        Delete
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </Card>
+            <>
+              <div className="mb-4">
+                <DraftsSortControl value={sortKey} onChange={setSortKey} />
+              </div>
+              <div className="space-y-3">
+                {sortedDrafts.map((draft) => (
+                  <DraftListRow
+                    key={draft._id}
+                    draft={draft}
+                    onDelete={setDeleteTarget}
+                    isDeleting={isDeleting}
+                  />
+                ))}
+              </div>
+            </>
           )}
-
-          <div className="mt-8 text-sm text-muted-foreground bg-muted border border-border p-4 rounded-lg">
-            <p className="font-semibold mb-2">About Drafts</p>
-            <ul className="space-y-1">
-              <li>
-                • All your unpublished articles are saved here automatically
-              </li>
-              <li>• Click &quot;Edit&quot; to continue working on any draft</li>
-              <li>• {AUTO_SAVE_GUIDANCE}</li>
-              <li>
-                • Delete drafts you no longer need to keep your workspace clean
-              </li>
-            </ul>
-          </div>
         </WorkspaceSurface>
 
         <AlertDialog
@@ -246,14 +157,12 @@ export default function DraftsPage() {
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel disabled={isDeleting}>
-                Cancel
-              </AlertDialogCancel>
+              <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
               <AlertDialogAction
                 disabled={isDeleting}
                 className={cn(
                   buttonVariants({ variant: 'destructive' }),
-                  'disabled:opacity-50 disabled:cursor-not-allowed'
+                  'disabled:cursor-not-allowed disabled:opacity-50'
                 )}
                 onClick={(e) => {
                   e.preventDefault()

--- a/app/drafts/page.tsx
+++ b/app/drafts/page.tsx
@@ -157,7 +157,9 @@ export default function DraftsPage() {
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+              <AlertDialogCancel disabled={isDeleting}>
+                Cancel
+              </AlertDialogCancel>
               <AlertDialogAction
                 disabled={isDeleting}
                 className={cn(

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -1,10 +1,12 @@
 /** @vitest-environment jsdom */
-import type { ReactNode } from 'react'
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import HomePage from './page'
 
 const useAuthMock = vi.fn()
+const useUserDraftsMock = vi.fn()
+const useCreatorRecentWorkMock = vi.fn()
+const useAuthorEarningsMock = vi.fn()
 
 vi.mock('@/components/providers/AuthContext', () => ({
   useAuth: () => useAuthMock(),
@@ -30,21 +32,24 @@ vi.mock('@/components/landing/useLandingHashScroll', () => ({
   useLandingHashScroll: () => {},
 }))
 
-vi.mock('@/components/onboarding/OnboardingDialog', () => ({
-  OnboardingDialog: () => null,
+vi.mock('@/components/onboarding/OnboardingIntentHome', () => ({
+  OnboardingIntentHome: () => null,
 }))
 
-vi.mock('@/components/articles/HomeRecentArticlesSection', () => ({
-  HomeRecentArticlesSection: () => null,
-}))
-
-vi.mock('@/components/error/ErrorBoundary', () => ({
-  ErrorBoundary: ({ children }: { children: ReactNode }) => children,
+vi.mock('@/hooks/convex', () => ({
+  useUserDrafts: () => useUserDraftsMock(),
+  useCreatorRecentWork: () => useCreatorRecentWorkMock(),
+  useAuthorEarnings: () => useAuthorEarningsMock(),
 }))
 
 describe('HomePage loading states', () => {
   beforeEach(() => {
     useAuthMock.mockReset()
+    useUserDraftsMock.mockReset()
+    useCreatorRecentWorkMock.mockReset()
+    useAuthorEarningsMock.mockReset()
+    useCreatorRecentWorkMock.mockReturnValue([])
+    useAuthorEarningsMock.mockReturnValue(null)
   })
 
   it('shows the public landing while auth is bootstrapping for guests', () => {
@@ -84,5 +89,78 @@ describe('HomePage loading states', () => {
 
     expect(screen.getByTestId('public-navigation')).toBeInTheDocument()
     expect(screen.queryByTestId('app-navigation')).not.toBeInTheDocument()
+  })
+})
+
+describe('HomePage creator workspace', () => {
+  const baseUser = {
+    _id: 'user1',
+    email: 'writer@example.com',
+    username: 'writer',
+    name: 'Writer',
+    onboardingCompleted: true,
+    stellarAddress: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX1',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  }
+
+  beforeEach(() => {
+    useAuthMock.mockReset()
+    useUserDraftsMock.mockReset()
+    useCreatorRecentWorkMock.mockReset()
+    useAuthorEarningsMock.mockReset()
+    useCreatorRecentWorkMock.mockReturnValue([])
+    useAuthorEarningsMock.mockReturnValue({
+      totalEarnedUsd: 0,
+      tipCount: 0,
+    })
+  })
+
+  it('shows Continue writing when the user has drafts', () => {
+    useAuthMock.mockReturnValue({
+      user: baseUser,
+      isAuthenticated: true,
+      isLoading: false,
+    })
+    useUserDraftsMock.mockReturnValue([
+      {
+        _id: 'draft1',
+        title: 'My draft',
+        updatedAt: 2000,
+        _creationTime: 1000,
+        published: false,
+      },
+      {
+        _id: 'draft2',
+        title: 'Older draft',
+        updatedAt: 1000,
+        _creationTime: 500,
+        published: false,
+      },
+    ])
+
+    render(<HomePage />)
+
+    expect(screen.getByRole('link', { name: /Continue writing/i })).toHaveAttribute(
+      'href',
+      '/write?id=draft1'
+    )
+    expect(screen.getByText('My draft')).toBeInTheDocument()
+  })
+
+  it('shows Start a new article when the user has no drafts', () => {
+    useAuthMock.mockReturnValue({
+      user: baseUser,
+      isAuthenticated: true,
+      isLoading: false,
+    })
+    useUserDraftsMock.mockReturnValue([])
+
+    render(<HomePage />)
+
+    expect(
+      screen.getByRole('link', { name: /Start a new article/i })
+    ).toHaveAttribute('href', '/write')
+    expect(screen.queryByText(/Continue writing/i)).not.toBeInTheDocument()
   })
 })

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -141,10 +141,9 @@ describe('HomePage creator workspace', () => {
 
     render(<HomePage />)
 
-    expect(screen.getByRole('link', { name: /Continue writing/i })).toHaveAttribute(
-      'href',
-      '/write?id=draft1'
-    )
+    expect(
+      screen.getByRole('link', { name: /Continue writing/i })
+    ).toHaveAttribute('href', '/write?id=draft1')
     expect(screen.getByText('My draft')).toBeInTheDocument()
   })
 

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -145,6 +145,10 @@ describe('HomePage creator workspace', () => {
       screen.getByRole('link', { name: /Continue writing/i })
     ).toHaveAttribute('href', '/write?id=draft1')
     expect(screen.getByText('My draft')).toBeInTheDocument()
+    expect(
+      screen.getByText('Your latest writing is ready when you are')
+    ).toBeInTheDocument()
+    expect(screen.getAllByText('Pick up where you left off')).toHaveLength(1)
   })
 
   it('shows Start a new article when the user has no drafts', () => {
@@ -161,5 +165,29 @@ describe('HomePage creator workspace', () => {
       screen.getByRole('link', { name: /Start a new article/i })
     ).toHaveAttribute('href', '/write')
     expect(screen.queryByText(/Continue writing/i)).not.toBeInTheDocument()
+    expect(
+      screen.getByText('Start your first article anytime')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText('Pick up where you left off')
+    ).not.toBeInTheDocument()
+  })
+
+  it('uses neutral creator workspace copy while drafts are loading', () => {
+    useAuthMock.mockReturnValue({
+      user: baseUser,
+      isAuthenticated: true,
+      isLoading: false,
+    })
+    useUserDraftsMock.mockReturnValue(undefined)
+
+    render(<HomePage />)
+
+    expect(
+      screen.getByText('Loading your writing workspace')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText('Pick up where you left off')
+    ).not.toBeInTheDocument()
   })
 })

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,50 +12,18 @@ const LandingBelowFold = dynamic(
 )
 import { useLandingHashScroll } from '@/components/landing/useLandingHashScroll'
 import { OnboardingIntentHome } from '@/components/onboarding/OnboardingIntentHome'
-import { HomeRecentArticlesSection } from '@/components/articles/HomeRecentArticlesSection'
-import { ErrorBoundary } from '@/components/error/ErrorBoundary'
-import { DashboardRecentArticlesFallback } from '@/components/error/SectionErrorFallback'
-import Link from 'next/link'
-import { PenSquare, BookOpen, Wallet, TrendingUp } from 'lucide-react'
 import {
-  DASHBOARD_HOME_BROWSE_CARD,
-  DASHBOARD_HOME_EARNINGS_CARD,
-  DASHBOARD_HOME_RECENT_ARTICLES_HEADING,
-  DASHBOARD_HOME_VIEW_ALL_LABEL,
-  DASHBOARD_HOME_WALLET_CARD,
-  DASHBOARD_HOME_WELCOME_SUBTITLE,
-  DASHBOARD_HOME_WRITE_CARD,
-} from '@/lib/copy/dashboard-home'
+  CreatorWorkspace,
+  CreatorWorkspaceLoadingShell,
+} from '@/components/dashboard/CreatorWorkspace'
 import Navigation from '@/components/landing/Navigation'
-import { cardVariants } from '@/components/ui/card'
-import { cn } from '@/lib/utils'
 
 function HomeLoadingShell() {
   return (
     <div className="min-h-screen bg-background">
       <AppNavigation />
-      <div className="pt-24 pb-8 max-w-6xl mx-auto px-4 animate-pulse">
-        <div className="mb-8 space-y-3">
-          <div className="h-9 w-64 rounded-lg bg-muted" />
-          <div className="h-5 w-80 rounded-lg bg-muted" />
-        </div>
-        <div className="grid md:grid-cols-3 gap-6 mb-12">
-          {[0, 1, 2].map((key) => (
-            <div
-              key={key}
-              className="h-40 rounded-[var(--card-radius)] bg-muted"
-            />
-          ))}
-        </div>
-        <div className="h-7 w-40 rounded-lg bg-muted mb-6" />
-        <div className="grid gap-4 md:grid-cols-2">
-          {[0, 1].map((key) => (
-            <div
-              key={key}
-              className="h-28 rounded-[var(--card-radius)] bg-muted"
-            />
-          ))}
-        </div>
+      <div className="mx-auto max-w-6xl px-4 pt-24 pb-8">
+        <CreatorWorkspaceLoadingShell />
       </div>
     </div>
   )
@@ -73,15 +41,9 @@ function PublicLandingPage() {
   )
 }
 
-const actionTileClassName = cn(
-  cardVariants({ variant: 'action' }),
-  'group block'
-)
-
 export default function HomePage() {
   const { user, isAuthenticated, isLoading } = useAuth()
 
-  const hasWallet = !!user?.stellarAddress
   const showOnboarding = isAuthenticated && user && !user.onboardingCompleted
 
   if (isAuthenticated && isLoading) {
@@ -101,101 +63,8 @@ export default function HomePage() {
     return (
       <div className="min-h-screen bg-background">
         <AppNavigation />
-        <div className="pt-24 pb-8">
-          <div className="max-w-6xl mx-auto px-4">
-            <div className="mb-8">
-              <h1 className="text-3xl font-bold text-foreground mb-2">
-                Welcome back, {user.name || user.username || user.email}
-              </h1>
-              <p className="text-muted-foreground">
-                {DASHBOARD_HOME_WELCOME_SUBTITLE}
-              </p>
-            </div>
-
-            <p className="text-sm font-medium text-muted-foreground mb-3">
-              Quick actions
-            </p>
-            <div className="grid md:grid-cols-3 gap-4 mb-12">
-              <Link href="/write" className={actionTileClassName}>
-                <div className="flex items-center mb-3">
-                  <div className="p-2.5 bg-blue-100 dark:bg-blue-950/50 rounded-lg group-hover:bg-blue-200 dark:group-hover:bg-blue-950/70 transition-colors">
-                    <PenSquare className="w-5 h-5 text-blue-600 dark:text-blue-400" />
-                  </div>
-                  <h3 className="text-base font-semibold ml-3">
-                    {DASHBOARD_HOME_WRITE_CARD.title}
-                  </h3>
-                </div>
-                <p className="text-sm text-muted-foreground">
-                  {DASHBOARD_HOME_WRITE_CARD.description}
-                </p>
-              </Link>
-
-              <Link href="/articles" className={actionTileClassName}>
-                <div className="flex items-center mb-3">
-                  <div className="p-2.5 bg-green-100 dark:bg-green-950/50 rounded-lg group-hover:bg-green-200 dark:group-hover:bg-green-950/70 transition-colors">
-                    <BookOpen className="w-5 h-5 text-green-800 dark:text-green-400" />
-                  </div>
-                  <h3 className="text-base font-semibold ml-3">
-                    {DASHBOARD_HOME_BROWSE_CARD.title}
-                  </h3>
-                </div>
-                <p className="text-sm text-muted-foreground">
-                  {DASHBOARD_HOME_BROWSE_CARD.description}
-                </p>
-              </Link>
-
-              {hasWallet ? (
-                <Link
-                  href="/dashboard/earnings"
-                  className={actionTileClassName}
-                >
-                  <div className="flex items-center mb-3">
-                    <div className="p-2.5 bg-purple-100 dark:bg-purple-950/50 rounded-lg group-hover:bg-purple-200 dark:group-hover:bg-purple-950/70 transition-colors">
-                      <TrendingUp className="w-5 h-5 text-purple-600 dark:text-purple-400" />
-                    </div>
-                    <h3 className="text-base font-semibold ml-3">
-                      {DASHBOARD_HOME_EARNINGS_CARD.title}
-                    </h3>
-                  </div>
-                  <p className="text-sm text-muted-foreground">
-                    {DASHBOARD_HOME_EARNINGS_CARD.description}
-                  </p>
-                </Link>
-              ) : (
-                <Link href="/dashboard/wallet" className={actionTileClassName}>
-                  <div className="flex items-center mb-3">
-                    <div className="p-2.5 bg-amber-100 dark:bg-amber-950/50 rounded-lg group-hover:bg-amber-200 dark:group-hover:bg-amber-950/70 transition-colors">
-                      <Wallet className="w-5 h-5 text-amber-600 dark:text-amber-400" />
-                    </div>
-                    <h3 className="text-base font-semibold ml-3">
-                      {DASHBOARD_HOME_WALLET_CARD.title}
-                    </h3>
-                  </div>
-                  <p className="text-sm text-muted-foreground">
-                    {DASHBOARD_HOME_WALLET_CARD.description}
-                  </p>
-                </Link>
-              )}
-            </div>
-
-            {/* Recent Articles */}
-            <div>
-              <div className="flex items-center justify-between mb-6">
-                <h2 className="text-xl font-bold text-foreground">
-                  {DASHBOARD_HOME_RECENT_ARTICLES_HEADING}
-                </h2>
-                <Link
-                  href="/articles"
-                  className="text-sm text-primary hover:text-primary/80 font-medium"
-                >
-                  {DASHBOARD_HOME_VIEW_ALL_LABEL}
-                </Link>
-              </div>
-              <ErrorBoundary fallback={<DashboardRecentArticlesFallback />}>
-                <HomeRecentArticlesSection />
-              </ErrorBoundary>
-            </div>
-          </div>
+        <div className="mx-auto max-w-6xl px-4 pt-24 pb-8">
+          <CreatorWorkspace user={user} />
         </div>
       </div>
     )

--- a/components/dashboard/CompactEarningsCard.tsx
+++ b/components/dashboard/CompactEarningsCard.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import Link from 'next/link'
+import { DollarSign, Wallet } from 'lucide-react'
+import { useAuthorEarnings } from '@/hooks/convex'
+import { networkLabelLowercase } from '@/lib/copy/network-status'
+import type { CurrentUserDoc } from '@/types/convex'
+import { Skeleton } from '@/components/ui/skeleton'
+
+type CompactEarningsCardProps = {
+  user: CurrentUserDoc
+}
+
+export function CompactEarningsCard({ user }: CompactEarningsCardProps) {
+  const earnings = useAuthorEarnings()
+  const hasWallet = Boolean(user.stellarAddress)
+  const username = user.username
+
+  if (earnings === undefined) {
+    return (
+      <div className="rounded-[var(--card-radius)] border border-border bg-card p-[var(--card-padding)] shadow-[var(--card-shadow)]">
+        <Skeleton className="mb-3 h-4 w-24" />
+        <Skeleton className="mb-2 h-8 w-20" />
+        <Skeleton className="h-4 w-32" />
+      </div>
+    )
+  }
+
+  if (!hasWallet) {
+    return (
+      <div className="rounded-[var(--card-radius)] border border-border bg-card p-[var(--card-padding)] shadow-[var(--card-shadow)]">
+        <div className="mb-3 flex items-center gap-2 text-sm font-medium text-foreground">
+          <Wallet className="h-4 w-4 text-muted-foreground" />
+          Wallet
+        </div>
+        <p className="mb-4 text-sm text-muted-foreground">
+          Set up a Stellar {networkLabelLowercase()} wallet to receive tips from
+          readers.
+        </p>
+        <Link
+          href="/guide"
+          className="text-sm font-medium text-brand-blue hover:text-brand-accent"
+        >
+          Set up wallet
+        </Link>
+      </div>
+    )
+  }
+
+  const totalEarned = earnings?.totalEarnedUsd ?? 0
+  const tipCount = earnings?.tipCount ?? 0
+  const earningsHref = `/${username}?tab=earnings`
+
+  return (
+    <div className="rounded-[var(--card-radius)] border border-border bg-card p-[var(--card-padding)] shadow-[var(--card-shadow)]">
+      <div className="mb-3 flex items-center justify-between">
+        <span className="text-sm font-medium text-muted-foreground">
+          Earnings
+        </span>
+        <DollarSign className="h-4 w-4 text-success-foreground" />
+      </div>
+      <p className="text-2xl font-bold text-foreground">
+        ${totalEarned.toFixed(2)}
+      </p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {tipCount} {networkLabelLowercase()} tip{tipCount === 1 ? '' : 's'}{' '}
+        received
+      </p>
+      <Link
+        href={earningsHref}
+        className="mt-4 inline-block text-sm font-medium text-brand-blue hover:text-brand-accent"
+      >
+        View earnings
+      </Link>
+    </div>
+  )
+}

--- a/components/dashboard/CreatorWorkspace.tsx
+++ b/components/dashboard/CreatorWorkspace.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import Link from 'next/link'
+import { BookOpen } from 'lucide-react'
+import { useUserDrafts } from '@/hooks/convex'
+import { getMostRecentDraft } from '@/lib/drafts/draftMetadata'
+import type { CurrentUserDoc } from '@/types/convex'
+import { PrimaryWritingAction } from '@/components/dashboard/PrimaryWritingAction'
+import { CompactEarningsCard } from '@/components/dashboard/CompactEarningsCard'
+import { RecentWorkList } from '@/components/dashboard/RecentWorkList'
+import { Skeleton } from '@/components/ui/skeleton'
+
+type CreatorWorkspaceProps = {
+  user: CurrentUserDoc
+}
+
+function CreatorWorkspaceSkeleton() {
+  return (
+    <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_280px]">
+      <div className="space-y-8">
+        <div className="rounded-[var(--card-radius)] border border-border bg-card p-[var(--card-padding)]">
+          <Skeleton className="mb-3 h-4 w-40" />
+          <Skeleton className="h-16 w-full" />
+        </div>
+        <div>
+          <Skeleton className="mb-4 h-6 w-36" />
+          <div className="space-y-2 rounded-[var(--card-radius)] border border-border bg-card p-2">
+            {[0, 1, 2].map((key) => (
+              <Skeleton key={key} className="h-14 w-full" />
+            ))}
+          </div>
+        </div>
+      </div>
+      <Skeleton className="h-36 rounded-[var(--card-radius)]" />
+    </div>
+  )
+}
+
+export function CreatorWorkspace({ user }: CreatorWorkspaceProps) {
+  const draftsQuery = useUserDrafts()
+  const displayName = user.name || user.username || user.email
+
+  if (draftsQuery === undefined) {
+    return (
+      <>
+        <div className="mb-8">
+          <h1 className="mb-2 text-3xl font-bold text-foreground">
+            Welcome back, {displayName}
+          </h1>
+          <p className="text-muted-foreground">Pick up where you left off</p>
+        </div>
+        <CreatorWorkspaceSkeleton />
+      </>
+    )
+  }
+
+  const mostRecentDraft = getMostRecentDraft(draftsQuery)
+  const hasDrafts = draftsQuery.length > 0
+
+  return (
+    <>
+      <div className="mb-8">
+        <h1 className="mb-2 text-3xl font-bold text-foreground">
+          Welcome back, {displayName}
+        </h1>
+        <p className="text-muted-foreground">Pick up where you left off</p>
+      </div>
+
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_280px]">
+        <div className="space-y-8">
+          <PrimaryWritingAction mostRecentDraft={mostRecentDraft} />
+          <RecentWorkList username={user.username} hasDrafts={hasDrafts} />
+        </div>
+
+        <aside className="space-y-4">
+          <CompactEarningsCard user={user} />
+          <Link
+            href="/articles"
+            className="flex items-center gap-2 rounded-[var(--card-radius)] border border-border bg-card px-4 py-3 text-sm text-muted-foreground shadow-[var(--card-shadow)] transition-colors hover:border-border hover:bg-muted/40 hover:text-foreground"
+          >
+            <BookOpen className="h-4 w-4 shrink-0" />
+            Browse articles
+          </Link>
+        </aside>
+      </div>
+    </>
+  )
+}
+
+export function CreatorWorkspaceLoadingShell() {
+  return (
+    <div className="animate-pulse">
+      <div className="mb-8 space-y-3">
+        <div className="h-9 w-64 rounded-lg bg-muted" />
+        <div className="h-5 w-48 rounded-lg bg-muted" />
+      </div>
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_280px]">
+        <div className="space-y-8">
+          <div className="h-36 rounded-[var(--card-radius)] bg-muted" />
+          <div>
+            <div className="mb-4 h-6 w-40 rounded-lg bg-muted" />
+            <div className="space-y-2">
+              {[0, 1, 2].map((key) => (
+                <div
+                  key={key}
+                  className="h-16 rounded-[var(--card-radius)] bg-muted"
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className="h-36 rounded-[var(--card-radius)] bg-muted" />
+      </div>
+    </div>
+  )
+}

--- a/components/dashboard/CreatorWorkspace.tsx
+++ b/components/dashboard/CreatorWorkspace.tsx
@@ -47,7 +47,9 @@ export function CreatorWorkspace({ user }: CreatorWorkspaceProps) {
           <h1 className="mb-2 text-3xl font-bold text-foreground">
             Welcome back, {displayName}
           </h1>
-          <p className="text-muted-foreground">Pick up where you left off</p>
+          <p className="text-muted-foreground">
+            Loading your writing workspace
+          </p>
         </div>
         <CreatorWorkspaceSkeleton />
       </>
@@ -56,6 +58,9 @@ export function CreatorWorkspace({ user }: CreatorWorkspaceProps) {
 
   const mostRecentDraft = getMostRecentDraft(draftsQuery)
   const hasDrafts = draftsQuery.length > 0
+  const workspaceSubtitle = hasDrafts
+    ? 'Your latest writing is ready when you are'
+    : 'Start your first article anytime'
 
   return (
     <>
@@ -63,7 +68,7 @@ export function CreatorWorkspace({ user }: CreatorWorkspaceProps) {
         <h1 className="mb-2 text-3xl font-bold text-foreground">
           Welcome back, {displayName}
         </h1>
-        <p className="text-muted-foreground">Pick up where you left off</p>
+        <p className="text-muted-foreground">{workspaceSubtitle}</p>
       </div>
 
       <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_280px]">

--- a/components/dashboard/PrimaryWritingAction.tsx
+++ b/components/dashboard/PrimaryWritingAction.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import Link from 'next/link'
+import { PenSquare } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { Doc } from '@/types/convex'
+
+type PrimaryWritingActionProps = {
+  mostRecentDraft: Doc<'articles'> | null
+}
+
+export function PrimaryWritingAction({
+  mostRecentDraft,
+}: PrimaryWritingActionProps) {
+  if (mostRecentDraft) {
+    const draftTitle = mostRecentDraft.title?.trim() || 'Untitled'
+    return (
+      <div className="rounded-[var(--card-radius)] border border-border bg-card p-[var(--card-padding)] shadow-[var(--card-shadow)]">
+        <p className="mb-3 text-sm text-muted-foreground">
+          Pick up where you left off
+        </p>
+        <Button
+          asChild
+          className="h-auto w-full flex-col items-start gap-1 bg-brand px-5 py-4 text-left text-brand-foreground hover:bg-brand-hover"
+        >
+          <Link href={`/write?id=${mostRecentDraft._id}`}>
+            <span className="flex items-center gap-2 text-base font-semibold">
+              <PenSquare className="h-5 w-5 shrink-0" />
+              Continue writing
+            </span>
+            <span className="line-clamp-1 text-sm font-normal opacity-90">
+              {draftTitle}
+            </span>
+          </Link>
+        </Button>
+        <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-sm">
+          <Link
+            href="/write"
+            className="text-brand-blue hover:text-brand-accent font-medium"
+          >
+            Start a new article
+          </Link>
+          <Link
+            href="/drafts"
+            className="text-muted-foreground hover:text-foreground"
+          >
+            View all drafts
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-[var(--card-radius)] border border-border bg-card p-[var(--card-padding)] shadow-[var(--card-shadow)]">
+      <p className="mb-3 text-sm text-muted-foreground">
+        Your writing workspace is ready
+      </p>
+      <Button
+        asChild
+        className="h-auto w-full gap-2 bg-brand px-5 py-4 text-base font-semibold text-brand-foreground hover:bg-brand-hover"
+      >
+        <Link href="/write">
+          <PenSquare className="h-5 w-5" />
+          Start a new article
+        </Link>
+      </Button>
+    </div>
+  )
+}

--- a/components/dashboard/RecentWorkList.tsx
+++ b/components/dashboard/RecentWorkList.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import Link from 'next/link'
+import { formatDistanceToNow } from 'date-fns'
+import { useCreatorRecentWork } from '@/hooks/convex'
+import type { Id } from '@/types/convex'
+import { Skeleton } from '@/components/ui/skeleton'
+import { cn } from '@/lib/utils'
+
+type CreatorWorkItem = {
+  _id: Id<'articles'>
+  title: string
+  excerpt?: string
+  published: boolean
+  updatedAt: number
+  slug: string
+  authorUsername: string
+}
+
+type RecentWorkListProps = {
+  username: string
+  hasDrafts: boolean
+}
+
+function WorkStatusBadge({ published }: { published: boolean }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex shrink-0 rounded-md px-2 py-0.5 text-xs font-medium',
+        published
+          ? 'bg-success/10 text-success-foreground'
+          : 'bg-warning/10 text-warning-foreground'
+      )}
+    >
+      {published ? 'Published' : 'Draft'}
+    </span>
+  )
+}
+
+function getWorkHref(item: CreatorWorkItem): string {
+  if (item.published) {
+    return `/${item.authorUsername}/${item.slug}`
+  }
+  return `/write?id=${item._id}`
+}
+
+function RecentWorkRow({ item }: { item: CreatorWorkItem }) {
+  const editedLabel = formatDistanceToNow(new Date(item.updatedAt), {
+    addSuffix: true,
+  })
+  const title = item.title?.trim() || 'Untitled'
+
+  return (
+    <Link
+      href={getWorkHref(item)}
+      className="group block rounded-lg border border-transparent px-3 py-3 transition-colors hover:border-border hover:bg-muted/40"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="min-w-0 flex-1 font-semibold text-foreground group-hover:text-brand-blue line-clamp-1">
+          {title}
+        </h3>
+        <WorkStatusBadge published={item.published} />
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">Edited {editedLabel}</p>
+      {item.excerpt && (
+        <p className="mt-2 line-clamp-1 text-sm text-muted-foreground">
+          {item.excerpt}
+        </p>
+      )}
+    </Link>
+  )
+}
+
+function RecentWorkListSkeleton() {
+  return (
+    <div className="space-y-1">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="px-3 py-3">
+          <Skeleton className="mb-2 h-5 w-2/3" />
+          <Skeleton className="h-3 w-24" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function RecentWorkList({ username, hasDrafts }: RecentWorkListProps) {
+  const recentWork = useCreatorRecentWork({ limit: 5 })
+
+  if (recentWork === undefined) {
+    return (
+      <section>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-foreground">
+            Your recent work
+          </h2>
+        </div>
+        <div className="rounded-[var(--card-radius)] border border-border bg-card shadow-[var(--card-shadow)]">
+          <RecentWorkListSkeleton />
+        </div>
+      </section>
+    )
+  }
+
+  const footerHref = hasDrafts ? '/drafts' : `/${username}?tab=articles`
+  const footerLabel = hasDrafts ? 'View all drafts' : 'View published articles'
+
+  return (
+    <section>
+      <div className="mb-4 flex items-center justify-between gap-4">
+        <h2 className="text-lg font-semibold text-foreground">
+          Your recent work
+        </h2>
+        {recentWork.length > 0 && (
+          <Link
+            href={footerHref}
+            className="shrink-0 text-sm font-medium text-brand-blue hover:text-brand-accent"
+          >
+            {footerLabel}
+          </Link>
+        )}
+      </div>
+
+      {recentWork.length === 0 ? (
+        <div className="rounded-[var(--card-radius)] border border-border bg-card p-8 text-center shadow-[var(--card-shadow)]">
+          <p className="mb-3 text-muted-foreground">
+            No articles yet. Start writing to see your work here.
+          </p>
+          <Link
+            href="/write"
+            className="text-sm font-medium text-brand-blue hover:text-brand-accent"
+          >
+            Start your first article
+          </Link>
+        </div>
+      ) : (
+        <div className="divide-y divide-border rounded-[var(--card-radius)] border border-border bg-card shadow-[var(--card-shadow)]">
+          {recentWork.map((item) => (
+            <RecentWorkRow key={item._id} item={item} />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/components/drafts/DraftListRow.tsx
+++ b/components/drafts/DraftListRow.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import Link from 'next/link'
+import { formatDistanceToNow } from 'date-fns'
+import { MoreHorizontal, Trash2 } from 'lucide-react'
+import type { Doc, Id } from '@/types/convex'
+import {
+  formatWordCount,
+  getWordCountFromContent,
+} from '@/lib/drafts/draftMetadata'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { cn } from '@/lib/utils'
+
+type DraftListRowProps = {
+  draft: Doc<'articles'>
+  onDelete: (id: Id<'articles'>) => void
+  isDeleting: boolean
+}
+
+export function DraftListRow({
+  draft,
+  onDelete,
+  isDeleting,
+}: DraftListRowProps) {
+  const title = draft.title?.trim() || 'Untitled'
+  const editedLabel = formatDistanceToNow(new Date(draft.updatedAt), {
+    addSuffix: true,
+  })
+  const wordCount = getWordCountFromContent(draft.content)
+
+  return (
+    <div className="group relative rounded-[var(--card-radius)] border border-border bg-card shadow-[var(--card-shadow)] transition-shadow hover:shadow-md">
+      <Link
+        href={`/write?id=${draft._id}`}
+        className="focus-ring block rounded-[var(--card-radius)] px-[var(--card-padding)] py-4 pr-14"
+      >
+        <h2 className="text-lg font-semibold text-foreground group-hover:text-brand-blue line-clamp-1 break-words">
+          {title}
+        </h2>
+        <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
+          <span
+            className={cn(
+              'inline-flex rounded-md px-2 py-0.5 text-xs font-medium',
+              'bg-warning/10 text-warning-foreground'
+            )}
+          >
+            Draft
+          </span>
+          <span aria-hidden="true">·</span>
+          <span>Edited {editedLabel}</span>
+          <span aria-hidden="true">·</span>
+          <span>{formatWordCount(wordCount)}</span>
+        </div>
+        {draft.excerpt && (
+          <p className="mt-2 line-clamp-2 text-sm text-muted-foreground">
+            {draft.excerpt}
+          </p>
+        )}
+      </Link>
+
+      <div className="absolute top-4 right-[var(--card-padding)]">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-muted-foreground hover:text-foreground"
+              aria-label={`Actions for ${title}`}
+              onClick={(event) => event.stopPropagation()}
+            >
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="min-w-[10rem]">
+            <DropdownMenuItem
+              className="cursor-pointer gap-2 text-destructive focus:text-destructive disabled:opacity-50 disabled:pointer-events-none"
+              disabled={isDeleting}
+              onSelect={() => {
+                if (isDeleting) return
+                onDelete(draft._id)
+              }}
+            >
+              <Trash2 className="h-4 w-4" />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  )
+}

--- a/components/drafts/DraftsListSkeleton.tsx
+++ b/components/drafts/DraftsListSkeleton.tsx
@@ -1,31 +1,23 @@
 import { Skeleton } from '@/components/ui/skeleton'
-import { Card } from '@/components/ui/card'
 
 export function DraftsListSkeleton() {
   return (
-    <Card variant="quiet" className="divide-y divide-border overflow-hidden">
+    <div className="space-y-3">
       {Array.from({ length: 4 }).map((_, i) => (
-        <div key={i} className="p-[var(--workspace-row-padding)]">
-          <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-start">
-            <div className="min-w-0 flex-1 w-full space-y-3">
-              <div className="flex items-start justify-between gap-2">
-                <Skeleton className="h-7 w-2/3" />
-                <Skeleton className="h-9 w-9 shrink-0 sm:hidden" />
-              </div>
+        <div
+          key={i}
+          className="rounded-[var(--card-radius)] border border-border bg-card p-[var(--card-padding)] shadow-[var(--card-shadow)]"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1 space-y-2">
+              <Skeleton className="h-6 w-2/3" />
+              <Skeleton className="h-4 w-48" />
               <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-4/5" />
-              <div className="flex flex-wrap gap-4 pt-2">
-                <Skeleton className="h-4 w-40" />
-                <Skeleton className="h-4 w-40" />
-              </div>
             </div>
-            <div className="hidden sm:flex gap-2 shrink-0">
-              <Skeleton className="h-9 w-20" />
-              <Skeleton className="h-9 w-20" />
-            </div>
+            <Skeleton className="h-8 w-8 shrink-0 rounded-md" />
           </div>
         </div>
       ))}
-    </Card>
+    </div>
   )
 }

--- a/components/drafts/DraftsSortControl.tsx
+++ b/components/drafts/DraftsSortControl.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import type { DraftSortKey } from '@/lib/drafts/draftMetadata'
+
+type DraftsSortControlProps = {
+  value: DraftSortKey
+  onChange: (value: DraftSortKey) => void
+}
+
+export function DraftsSortControl({ value, onChange }: DraftsSortControlProps) {
+  return (
+    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+      <span className="shrink-0">Sort by</span>
+      <Select
+        value={value}
+        onValueChange={(next) => onChange(next as DraftSortKey)}
+      >
+        <SelectTrigger className="h-8 w-[140px] bg-background">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="updatedAt">Last edited</SelectItem>
+          <SelectItem value="createdAt">Created</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/convex/articles.getCreatorRecentWork.test.ts
+++ b/convex/articles.getCreatorRecentWork.test.ts
@@ -1,0 +1,145 @@
+/// <reference types="vite/client" />
+import { readFileSync } from 'node:fs'
+import { convexTest } from 'convex-test'
+import { describe, expect, it } from 'vitest'
+import { api } from './_generated/api'
+import schema from './schema'
+
+const emptyDoc = { type: 'doc', content: [] }
+
+const modules = import.meta.glob(['./**/*.ts', '!./**/*.test.ts'])
+
+function recentWorkSource() {
+  const source = readFileSync(new URL('./articles.ts', import.meta.url), 'utf8')
+  const start = source.indexOf('export const getCreatorRecentWork')
+  const end = source.indexOf('// Create article', start)
+  if (start === -1 || end === -1) {
+    throw new Error('Could not locate getCreatorRecentWork source')
+  }
+  return source.slice(start, end)
+}
+
+describe('getCreatorRecentWork', () => {
+  it('declares an author updatedAt index for bounded recent-work reads', () => {
+    const articlesTable = (
+      schema as unknown as {
+        tables: {
+          articles: {
+            indexes: { indexDescriptor: string; fields: string[] }[]
+          }
+        }
+      }
+    ).tables.articles
+
+    expect(articlesTable.indexes).toContainEqual({
+      indexDescriptor: 'by_author_updated_at',
+      fields: ['authorId', 'updatedAt'],
+    })
+  })
+
+  it('uses the author updatedAt index without collecting every author article', () => {
+    const source = recentWorkSource()
+
+    expect(source).toContain(".withIndex('by_author_updated_at'")
+    expect(source).toContain('.take(limit)')
+    expect(source).not.toContain('.collect()')
+    expect(source).not.toContain('.sort(')
+  })
+
+  it('returns the newest work for the signed-in creator only', async () => {
+    const t = convexTest(schema, modules)
+    const { authorId } = await t.run(async (ctx) => {
+      const now = Date.now()
+      const authorId = await ctx.db.insert('users', {
+        email: 'writer@x.test',
+        username: 'writer',
+        createdAt: now,
+        updatedAt: now,
+      })
+      const otherAuthorId = await ctx.db.insert('users', {
+        email: 'other@x.test',
+        username: 'other',
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      await ctx.db.insert('articles', {
+        slug: 'old-draft',
+        title: 'Old Draft',
+        content: emptyDoc,
+        published: false,
+        authorId,
+        authorUsername: 'writer',
+        tags: [],
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      await ctx.db.insert('articles', {
+        slug: 'new-published',
+        title: 'New Published',
+        content: emptyDoc,
+        published: true,
+        publishedAt: now + 3_000,
+        authorId,
+        authorUsername: 'writer',
+        tags: [],
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now + 3_000,
+      })
+      await ctx.db.insert('articles', {
+        slug: 'middle-draft',
+        title: 'Middle Draft',
+        content: emptyDoc,
+        published: false,
+        authorId,
+        authorUsername: 'writer',
+        tags: [],
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now + 2_000,
+      })
+      await ctx.db.insert('articles', {
+        slug: 'other-newest',
+        title: 'Other Newest',
+        content: emptyDoc,
+        published: true,
+        publishedAt: now + 4_000,
+        authorId: otherAuthorId,
+        authorUsername: 'other',
+        tags: [],
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now + 4_000,
+      })
+
+      return { authorId }
+    })
+
+    const recent = await t
+      .withIdentity({ subject: authorId })
+      .query(api.articles.getCreatorRecentWork, { limit: 2 })
+
+    expect(recent.map((article) => article.title)).toEqual([
+      'New Published',
+      'Middle Draft',
+    ])
+    expect(recent).toHaveLength(2)
+    expect(recent.every((article) => article.authorUsername === 'writer')).toBe(
+      true
+    )
+  })
+})

--- a/convex/articles.ts
+++ b/convex/articles.ts
@@ -437,21 +437,19 @@ export const getCreatorRecentWork = query({
     const limit = args.limit ?? 8
     const articles = await ctx.db
       .query('articles')
-      .withIndex('by_author', (q) => q.eq('authorId', userId))
-      .collect()
+      .withIndex('by_author_updated_at', (q) => q.eq('authorId', userId))
+      .order('desc')
+      .take(limit)
 
-    return articles
-      .sort((a, b) => b.updatedAt - a.updatedAt)
-      .slice(0, limit)
-      .map((article) => ({
-        _id: article._id,
-        title: article.title,
-        excerpt: article.excerpt,
-        published: article.published,
-        updatedAt: article.updatedAt,
-        slug: article.slug,
-        authorUsername: article.authorUsername,
-      }))
+    return articles.map((article) => ({
+      _id: article._id,
+      title: article.title,
+      excerpt: article.excerpt,
+      published: article.published,
+      updatedAt: article.updatedAt,
+      slug: article.slug,
+      authorUsername: article.authorUsername,
+    }))
   },
 })
 

--- a/convex/articles.ts
+++ b/convex/articles.ts
@@ -428,6 +428,33 @@ export const getUserDrafts = query({
   },
 })
 
+export const getCreatorRecentWork = query({
+  args: { limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx)
+    if (!userId) return []
+
+    const limit = args.limit ?? 8
+    const articles = await ctx.db
+      .query('articles')
+      .withIndex('by_author', (q) => q.eq('authorId', userId))
+      .collect()
+
+    return articles
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+      .slice(0, limit)
+      .map((article) => ({
+        _id: article._id,
+        title: article.title,
+        excerpt: article.excerpt,
+        published: article.published,
+        updatedAt: article.updatedAt,
+        slug: article.slug,
+        authorUsername: article.authorUsername,
+      }))
+  },
+})
+
 // Create article
 export const createArticle = mutation({
   args: {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -100,6 +100,7 @@ export default defineSchema({
   })
     .index('by_slug', ['slug'])
     .index('by_author', ['authorId'])
+    .index('by_author_updated_at', ['authorId', 'updatedAt'])
     .index('by_published', ['published'])
     .index('by_author_published', ['authorId', 'published']) // Composite for author's published articles
     .index('by_published_date', ['published', 'publishedAt']) // For listing by date

--- a/hooks/convex/index.ts
+++ b/hooks/convex/index.ts
@@ -6,7 +6,9 @@ export {
   useArticleBySlug,
   useArticleById,
   useUserDrafts,
+  useCreatorRecentWork,
   type ListArticlesArgs,
+  type CreatorRecentWorkArgs,
 } from './useArticles'
 export {
   useArticleTipStats,

--- a/hooks/convex/useArticles.ts
+++ b/hooks/convex/useArticles.ts
@@ -46,3 +46,11 @@ export function useArticleById(articleId: Id<'articles'> | undefined) {
 export function useUserDrafts() {
   return useQuery(api.articles.getUserDrafts)
 }
+
+export type CreatorRecentWorkArgs = {
+  limit?: number
+}
+
+export function useCreatorRecentWork(args: CreatorRecentWorkArgs = {}) {
+  return useQuery(api.articles.getCreatorRecentWork, args)
+}

--- a/lib/drafts/draftMetadata.test.ts
+++ b/lib/drafts/draftMetadata.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatWordCount,
+  getMostRecentDraft,
+  getWordCountFromContent,
+  sortDraftsBy,
+} from '@/lib/drafts/draftMetadata'
+
+const drafts = [
+  { _id: 'a', _creationTime: 100, updatedAt: 300, content: null },
+  { _id: 'b', _creationTime: 200, updatedAt: 100, content: null },
+  { _id: 'c', _creationTime: 300, updatedAt: 200, content: null },
+]
+
+describe('draftMetadata', () => {
+  it('sorts drafts by updatedAt descending', () => {
+    expect(sortDraftsBy(drafts, 'updatedAt').map((d) => d._id)).toEqual([
+      'a',
+      'c',
+      'b',
+    ])
+  })
+
+  it('sorts drafts by createdAt descending', () => {
+    expect(sortDraftsBy(drafts, 'createdAt').map((d) => d._id)).toEqual([
+      'c',
+      'b',
+      'a',
+    ])
+  })
+
+  it('returns the most recently edited draft', () => {
+    expect(getMostRecentDraft(drafts)?._id).toBe('a')
+  })
+
+  it('counts words from TipTap content', () => {
+    const content = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'One two three' }],
+        },
+      ],
+    }
+    expect(getWordCountFromContent(content)).toBe(3)
+  })
+
+  it('formats word count labels', () => {
+    expect(formatWordCount(0)).toBe('No content yet')
+    expect(formatWordCount(1)).toBe('1 word')
+    expect(formatWordCount(42)).toBe('42 words')
+  })
+})

--- a/lib/drafts/draftMetadata.ts
+++ b/lib/drafts/draftMetadata.ts
@@ -1,0 +1,39 @@
+import { extractTextFromTiptapJson } from '@/lib/tiptap/extractTextFromTiptapJson'
+import { countWords } from '@/lib/reading-time'
+
+export type DraftSortKey = 'updatedAt' | 'createdAt'
+
+export type DraftLike = {
+  _id: string
+  _creationTime: number
+  updatedAt: number
+  content?: unknown
+}
+
+export function getWordCountFromContent(content: unknown): number {
+  const text = extractTextFromTiptapJson(content).trim()
+  if (!text) return 0
+  return countWords(text)
+}
+
+export function sortDraftsBy<T extends DraftLike>(
+  drafts: T[],
+  key: DraftSortKey
+): T[] {
+  return [...drafts].sort((a, b) => {
+    const aTime = key === 'updatedAt' ? a.updatedAt : a._creationTime
+    const bTime = key === 'updatedAt' ? b.updatedAt : b._creationTime
+    return bTime - aTime
+  })
+}
+
+export function getMostRecentDraft<T extends DraftLike>(drafts: T[]): T | null {
+  if (drafts.length === 0) return null
+  return sortDraftsBy(drafts, 'updatedAt')[0] ?? null
+}
+
+export function formatWordCount(count: number): string {
+  if (count === 0) return 'No content yet'
+  if (count === 1) return '1 word'
+  return `${count.toLocaleString()} words`
+}

--- a/lib/tiptap/extractTextFromTiptapJson.ts
+++ b/lib/tiptap/extractTextFromTiptapJson.ts
@@ -1,0 +1,10 @@
+/** Plain text extracted from TipTap/ProseMirror JSON (for word count). */
+export function extractTextFromTiptapJson(node: unknown): string {
+  if (!node || typeof node !== 'object') return ''
+  const n = node as Record<string, unknown>
+  if (n.type === 'text' && typeof n.text === 'string') return n.text
+  if (Array.isArray(n.content)) {
+    return n.content.map(extractTextFromTiptapJson).join(' ')
+  }
+  return ''
+}


### PR DESCRIPTION
## Summary

Replaces the signed-in home dashboard with a creator-focused workspace that surfaces the writer's most recent draft, published work, and earnings at a glance. Also refreshes the drafts page with sortable document rows and richer draft metadata.



## Changes

- Add `CreatorWorkspace` as the signed-in home view with welcome header, primary writing action, recent work list, and compact earnings card
- Add `PrimaryWritingAction` that shows "Continue writing" when drafts exist or "Start a new article" when none do
- Add `RecentWorkList` backed by a new `getCreatorRecentWork` Convex query and `useCreatorRecentWork` hook
- Add `CompactEarningsCard` with earnings summary and wallet setup guidance when no Stellar address is linked
- Refactor drafts page to use `DraftListRow`, `DraftsSortControl`, and sortable draft metadata (word count, relative edit time)
- Add `draftMetadata` utilities and `extractTextFromTiptapJson` for draft word counts
- Integrate with existing `ProtectedPageShell`, `WorkspaceSurface`, and `OnboardingIntentHome` patterns from development
- Add unit tests for home page creator workspace, drafts page behavior, and draft metadata helpers

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run format`
- [x] `bun run test:once` (792 tests passed)
- [x] `bun run build`


## Notes

Rebased onto latest `development`. Onboarding flow still uses `OnboardingIntentHome` as a full-page experience before the creator workspace is shown.
<img width="1440" height="859" alt="1" src="https://github.com/user-attachments/assets/5d976114-f62e-46c0-a9a6-e9674d2d4fb2" />
<img width="1440" height="859" alt="2" src="https://github.com/user-attachments/assets/1ebb943d-339f-42d5-bff6-c0490cd4ca72" />

<img width="1440" height="861" alt="3" src="https://github.com/user-attachments/assets/883fa10a-8976-4d21-ae11-70fc16079353" />

