### PR TITLE
feat(editor): collapse writer toolbar and move notes into more menu (ENG-253)

### DIFF
--- a/components/editor/EditorActionBar.test.tsx
+++ b/components/editor/EditorActionBar.test.tsx
@@ -254,6 +254,30 @@ describe('EditorActionBar excerpt menu', () => {
   })
 })
 
+describe('EditorActionBar notes menu', () => {
+  it('shows personal notes inside the more menu instead of the top bar', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <EditorActionBar
+        {...baseProps}
+        notes=""
+        onNotesChange={vi.fn()}
+        moreMenuOpen
+        onMoreMenuOpenChange={vi.fn()}
+      />
+    )
+
+    expect(
+      screen.queryByRole('button', { name: 'Notes' })
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByText('Personal notes'))
+
+    expect(screen.getByLabelText('Personal notes')).toBeInTheDocument()
+  })
+})
+
 describe('EditorActionBar cover image menu', () => {
   it('shows Add cover image when onAddCoverImage is provided and no cover is set', async () => {
     const user = userEvent.setup()

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -111,6 +111,8 @@ interface EditorActionBarProps {
   moreMenuOpen?: boolean
   onMoreMenuOpenChange?: (open: boolean) => void
   excerptMaxChars?: number
+  notesOpen?: boolean
+  onNotesOpenChange?: (open: boolean) => void
 }
 
 const RELATIVE_TIME_INTERVAL_MS = 30_000
@@ -118,6 +120,134 @@ const DEFAULT_EXCERPT_MAX_CHARS = 500
 
 const focusRing =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+
+function NotesMenuSection({
+  notes,
+  onNotesChange,
+  notesOpen,
+  onNotesOpenChange,
+  notesTextareaRef,
+  onRequestCloseMenu,
+}: {
+  notes: string
+  onNotesChange: (value: string) => void
+  notesOpen: boolean
+  onNotesOpenChange: (open: boolean) => void
+  notesTextareaRef: RefObject<HTMLTextAreaElement | null>
+  onRequestCloseMenu?: () => void
+}) {
+  const isMobile = useIsMobile()
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const notesTriggerRef = useRef<HTMLButtonElement>(null)
+
+  if (isMobile) {
+    return (
+      <>
+        <DropdownMenu.Item
+          className="px-4 py-2.5 text-sm text-foreground outline-none flex cursor-pointer flex-col items-start gap-0.5 hover:bg-muted focus:bg-muted"
+          onSelect={(event) => {
+            event.preventDefault()
+            onRequestCloseMenu?.()
+            setDrawerOpen(true)
+          }}
+        >
+          <span className="flex items-center gap-2">
+            <FileText className="h-4 w-4 shrink-0" />
+            <span>Personal notes</span>
+          </span>
+          <span className="pl-6 text-[11px] leading-snug text-muted-foreground">
+            Private, not published
+          </span>
+        </DropdownMenu.Item>
+        <Drawer open={drawerOpen} onOpenChange={setDrawerOpen}>
+          <DrawerContent
+            className="max-h-[min(70dvh,32rem)] gap-0 overflow-y-auto px-0 pb-6"
+            onOpenAutoFocus={(e) => {
+              e.preventDefault()
+              notesTextareaRef.current?.focus()
+            }}
+          >
+            <DrawerHeader className="space-y-0 px-4 pb-2 text-left">
+              <div className="flex items-start justify-between gap-3 pr-8">
+                <div className="min-w-0 space-y-1">
+                  <DrawerTitle className="text-base">Personal Notes</DrawerTitle>
+                  <DrawerDescription className="text-left text-xs leading-snug">
+                    {WRITER_NOTES_HELPER_TEXT}
+                  </DrawerDescription>
+                </div>
+                <DrawerClose asChild>
+                  <button
+                    ref={notesTriggerRef}
+                    type="button"
+                    className={cn(
+                      'shrink-0 rounded-md px-3 py-1.5 text-sm font-medium text-primary hover:bg-muted',
+                      focusRing
+                    )}
+                  >
+                    Done
+                  </button>
+                </DrawerClose>
+              </div>
+            </DrawerHeader>
+            <WriterNotesPanel
+              ref={notesTextareaRef}
+              notes={notes}
+              onNotesChange={onNotesChange}
+              showHeader={false}
+              textareaClassName="min-h-[8rem] rounded-none border-0 bg-background"
+            />
+          </DrawerContent>
+        </Drawer>
+      </>
+    )
+  }
+
+  return (
+    <Collapsible open={notesOpen} onOpenChange={onNotesOpenChange}>
+      <DropdownMenu.Item
+        className="px-4 py-2.5 text-sm text-foreground outline-none flex cursor-pointer items-center justify-between gap-2 hover:bg-muted focus:bg-muted data-[highlighted]:bg-muted"
+        onSelect={(event) => {
+          event.preventDefault()
+          const nextOpen = !notesOpen
+          onNotesOpenChange(nextOpen)
+          if (nextOpen) {
+            window.setTimeout(() => notesTextareaRef.current?.focus(), 0)
+          }
+        }}
+      >
+        <span className="flex min-w-0 flex-col items-start gap-0.5">
+          <span className="flex items-center gap-2">
+            <FileText className="h-4 w-4 shrink-0" />
+            <span>Personal notes</span>
+          </span>
+          <span className="pl-6 text-[11px] leading-snug text-muted-foreground">
+            Private, not published
+          </span>
+        </span>
+        <ChevronDown
+          className={cn(
+            'h-3.5 w-3.5 shrink-0 transition-transform',
+            notesOpen && 'rotate-180'
+          )}
+        />
+      </DropdownMenu.Item>
+      <CollapsibleContent>
+        <div
+          className="space-y-2 border-t border-border px-3 pb-3 pt-2"
+          onPointerDown={(event) => event.stopPropagation()}
+        >
+          <WriterNotesPanel
+            ref={notesTextareaRef}
+            notes={notes}
+            onNotesChange={onNotesChange}
+            showHeader={false}
+            textareaClassName="min-h-[6rem] resize-none text-sm"
+          />
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
 
 function MoreMenu({
   editor,
@@ -130,6 +260,11 @@ function MoreMenu({
   excerptOpen = false,
   onExcerptOpenChange,
   excerptTextareaRef,
+  notes = '',
+  onNotesChange,
+  notesOpen = false,
+  onNotesOpenChange,
+  notesTextareaRef,
   moreMenuOpen,
   onMoreMenuOpenChange,
   excerptMaxChars = DEFAULT_EXCERPT_MAX_CHARS,
@@ -145,6 +280,11 @@ function MoreMenu({
   excerptOpen?: boolean
   onExcerptOpenChange?: (open: boolean) => void
   excerptTextareaRef?: RefObject<HTMLTextAreaElement | null>
+  notes?: string
+  onNotesChange?: (value: string) => void
+  notesOpen?: boolean
+  onNotesOpenChange?: (open: boolean) => void
+  notesTextareaRef?: RefObject<HTMLTextAreaElement | null>
   moreMenuOpen?: boolean
   onMoreMenuOpenChange?: (open: boolean) => void
   excerptMaxChars?: number
@@ -164,7 +304,14 @@ function MoreMenu({
     } else {
       setInternalOpen(open)
     }
-    if (!open) onExcerptOpenChange?.(false)
+    if (!open) {
+      onExcerptOpenChange?.(false)
+      onNotesOpenChange?.(false)
+    }
+  }
+
+  const closeMenu = () => {
+    handleOpenChange(false)
   }
 
   return (
@@ -186,7 +333,7 @@ function MoreMenu({
         <DropdownMenu.Content
           className={cn(
             'bg-card rounded-lg shadow-lg border border-border py-1 z-50',
-            excerptOpen ? 'min-w-[280px]' : 'min-w-[180px]'
+            excerptOpen || notesOpen ? 'min-w-[280px]' : 'min-w-[180px]'
           )}
           sideOffset={4}
           align="end"
@@ -305,6 +452,19 @@ function MoreMenu({
               </Collapsible>
             </>
           ) : null}
+          {onNotesChange && onNotesOpenChange && notesTextareaRef ? (
+            <>
+              <DropdownMenu.Separator className="h-px bg-border my-1" />
+              <NotesMenuSection
+                notes={notes}
+                onNotesChange={onNotesChange}
+                notesOpen={notesOpen}
+                onNotesOpenChange={onNotesOpenChange}
+                notesTextareaRef={notesTextareaRef}
+                onRequestCloseMenu={closeMenu}
+              />
+            </>
+          ) : null}
           <DropdownMenu.Separator className="h-px bg-border my-1" />
           <DropdownMenu.Item
             className="px-4 py-2.5 text-sm text-muted-foreground outline-none flex items-center gap-2"
@@ -354,112 +514,6 @@ function MoreMenu({
   )
 }
 
-function NotesControl({
-  notes,
-  onNotesChange,
-}: {
-  notes: string
-  onNotesChange: (value: string) => void
-}) {
-  const isMobile = useIsMobile()
-  const [showNotes, setShowNotes] = useState(false)
-  const notesTriggerRef = useRef<HTMLButtonElement>(null)
-  const notesTextareaRef = useRef<HTMLTextAreaElement>(null)
-
-  const triggerButton = (
-    <button
-      ref={notesTriggerRef}
-      type="button"
-      aria-label="Notes"
-      aria-expanded={showNotes}
-      title="Notes"
-      onClick={() => {
-        if (isMobile) {
-          setShowNotes(true)
-        } else {
-          setShowNotes((open) => !open)
-        }
-      }}
-      className={cn(
-        'flex items-center gap-1.5 rounded px-2.5 py-1.5 text-sm font-medium transition-colors hover:bg-muted shrink-0',
-        focusRing,
-        showNotes ? 'bg-muted text-primary' : 'text-muted-foreground'
-      )}
-    >
-      <FileText className="h-4 w-4 shrink-0" />
-      <span className="hidden sm:inline">Notes</span>
-    </button>
-  )
-
-  if (isMobile) {
-    return (
-      <Drawer open={showNotes} onOpenChange={setShowNotes}>
-        {triggerButton}
-        <DrawerContent
-          className="max-h-[min(70dvh,32rem)] gap-0 overflow-y-auto px-0 pb-6"
-          onOpenAutoFocus={(e) => {
-            e.preventDefault()
-            notesTextareaRef.current?.focus()
-          }}
-          onCloseAutoFocus={(e) => {
-            e.preventDefault()
-            notesTriggerRef.current?.focus()
-          }}
-        >
-          <DrawerHeader className="space-y-0 px-4 pb-2 text-left">
-            <div className="flex items-start justify-between gap-3 pr-8">
-              <div className="min-w-0 space-y-1">
-                <DrawerTitle className="text-base">Personal Notes</DrawerTitle>
-                <DrawerDescription className="text-left text-xs leading-snug">
-                  {WRITER_NOTES_HELPER_TEXT}
-                </DrawerDescription>
-              </div>
-              <DrawerClose asChild>
-                <button
-                  type="button"
-                  className={cn(
-                    'shrink-0 rounded-md px-3 py-1.5 text-sm font-medium text-primary hover:bg-muted',
-                    focusRing
-                  )}
-                >
-                  Done
-                </button>
-              </DrawerClose>
-            </div>
-          </DrawerHeader>
-          <WriterNotesPanel
-            ref={notesTextareaRef}
-            notes={notes}
-            onNotesChange={onNotesChange}
-            showHeader={false}
-            textareaClassName="min-h-[8rem] rounded-none border-0 bg-background"
-          />
-        </DrawerContent>
-      </Drawer>
-    )
-  }
-
-  return (
-    <div className="relative">
-      {triggerButton}
-      {showNotes && (
-        <div
-          className="absolute top-full right-0 z-50 mt-1 w-72 max-w-[min(18rem,calc(100vw-2rem))] overflow-hidden rounded-lg border border-border bg-popover shadow-lg"
-          role="dialog"
-          aria-label="Personal notes"
-        >
-          <WriterNotesPanel
-            ref={notesTextareaRef}
-            notes={notes}
-            onNotesChange={onNotesChange}
-            textareaClassName="rounded-b-lg"
-          />
-        </div>
-      )}
-    </div>
-  )
-}
-
 export function EditorActionBar({
   editor,
   onBack,
@@ -489,10 +543,16 @@ export function EditorActionBar({
   moreMenuOpen,
   onMoreMenuOpenChange,
   excerptMaxChars,
+  notesOpen: notesOpenProp,
+  onNotesOpenChange: onNotesOpenChangeProp,
 }: EditorActionBarProps) {
   const publishBlockReasonId = useId()
   const [relativeTick, setRelativeTick] = useState(0)
   const isMobile = useIsMobile()
+  const [internalNotesOpen, setInternalNotesOpen] = useState(false)
+  const notesTextareaRef = useRef<HTMLTextAreaElement>(null)
+  const notesOpen = notesOpenProp ?? internalNotesOpen
+  const onNotesOpenChange = onNotesOpenChangeProp ?? setInternalNotesOpen
 
   const showRelativeSaved =
     !isSaving && !error && !hasUnsavedChanges && lastSavedAt != null
@@ -600,9 +660,6 @@ export function EditorActionBar({
             Back
           </button>
           <div className="flex min-w-0 items-center justify-end gap-1.5">
-            {onNotesChange && (
-              <NotesControl notes={notes} onNotesChange={onNotesChange} />
-            )}
             {publishControl}
             <MoreMenu
               editor={editor}
@@ -615,6 +672,11 @@ export function EditorActionBar({
               excerptOpen={excerptOpen}
               onExcerptOpenChange={onExcerptOpenChange}
               excerptTextareaRef={excerptTextareaRef}
+              notes={notes}
+              onNotesChange={onNotesChange}
+              notesOpen={notesOpen}
+              onNotesOpenChange={onNotesOpenChange}
+              notesTextareaRef={notesTextareaRef}
               moreMenuOpen={moreMenuOpen}
               onMoreMenuOpenChange={onMoreMenuOpenChange}
               excerptMaxChars={excerptMaxChars}
@@ -674,10 +736,6 @@ export function EditorActionBar({
             </>
           )}
 
-          {onNotesChange && (
-            <NotesControl notes={notes} onNotesChange={onNotesChange} />
-          )}
-
           {publishControl}
 
           <MoreMenu
@@ -691,6 +749,11 @@ export function EditorActionBar({
             excerptOpen={excerptOpen}
             onExcerptOpenChange={onExcerptOpenChange}
             excerptTextareaRef={excerptTextareaRef}
+            notes={notes}
+            onNotesChange={onNotesChange}
+            notesOpen={notesOpen}
+            onNotesOpenChange={onNotesOpenChange}
+            notesTextareaRef={notesTextareaRef}
             moreMenuOpen={moreMenuOpen}
             onMoreMenuOpenChange={onMoreMenuOpenChange}
             excerptMaxChars={excerptMaxChars}

--- a/components/editor/EditorActionBar.tsx
+++ b/components/editor/EditorActionBar.tsx
@@ -170,7 +170,9 @@ function NotesMenuSection({
             <DrawerHeader className="space-y-0 px-4 pb-2 text-left">
               <div className="flex items-start justify-between gap-3 pr-8">
                 <div className="min-w-0 space-y-1">
-                  <DrawerTitle className="text-base">Personal Notes</DrawerTitle>
+                  <DrawerTitle className="text-base">
+                    Personal Notes
+                  </DrawerTitle>
                   <DrawerDescription className="text-left text-xs leading-snug">
                     {WRITER_NOTES_HELPER_TEXT}
                   </DrawerDescription>

--- a/components/editor/EditorBubbleToolbar.test.tsx
+++ b/components/editor/EditorBubbleToolbar.test.tsx
@@ -69,14 +69,16 @@ describe('EditorBubbleToolbar', () => {
     const editor = makeStubEditor()
     render(<EditorBubbleToolbar editor={editor} />)
 
-    const handler = vi.mocked(editor.on).mock.calls.find(
-      ([event]) => event === 'selectionUpdate'
-    )?.[1]
+    const handler = vi
+      .mocked(editor.on)
+      .mock.calls.find(([event]) => event === 'selectionUpdate')?.[1]
     act(() => {
       handler?.()
     })
 
-    expect(await screen.findByRole('button', { name: 'Bold' })).toBeInTheDocument()
+    expect(
+      await screen.findByRole('button', { name: 'Bold' })
+    ).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Italic' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Add link' })).toBeInTheDocument()
     expect(
@@ -89,9 +91,9 @@ describe('EditorBubbleToolbar', () => {
     const editor = makeStubEditor()
     render(<EditorBubbleToolbar editor={editor} />)
 
-    const handler = vi.mocked(editor.on).mock.calls.find(
-      ([event]) => event === 'selectionUpdate'
-    )?.[1]
+    const handler = vi
+      .mocked(editor.on)
+      .mock.calls.find(([event]) => event === 'selectionUpdate')?.[1]
     act(() => {
       handler?.()
     })

--- a/components/editor/EditorBubbleToolbar.test.tsx
+++ b/components/editor/EditorBubbleToolbar.test.tsx
@@ -1,0 +1,109 @@
+/** @vitest-environment jsdom */
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import type { Editor } from '@tiptap/react'
+import { EditorBubbleToolbar } from '@/components/editor/EditorBubbleToolbar'
+
+function makeStubEditor(overrides: Partial<Editor> = {}): Editor {
+  const chain = {
+    focus: () => ({
+      toggleBold: () => ({ run: () => true }),
+      toggleItalic: () => ({ run: () => true }),
+      toggleUnderline: () => ({ run: () => true }),
+      toggleStrike: () => ({ run: () => true }),
+      toggleCode: () => ({ run: () => true }),
+      toggleBlockquote: () => ({ run: () => true }),
+      setTextAlign: () => ({ run: () => true }),
+      extendMarkRange: () => ({
+        setLink: () => ({ run: () => true }),
+        unsetLink: () => ({ run: () => true }),
+      }),
+      unsetLink: () => ({ run: () => true }),
+    }),
+  }
+
+  return {
+    state: { selection: { empty: false } },
+    isActive: () => false,
+    chain: () => chain,
+    can: () => ({
+      chain: () => ({
+        focus: () => ({
+          setTextAlign: () => ({ run: () => true }),
+        }),
+      }),
+    }),
+    on: vi.fn(),
+    off: vi.fn(),
+    commands: { focus: vi.fn() },
+    ...overrides,
+  } as unknown as Editor
+}
+
+function mockSelectionRect() {
+  const range = {
+    getBoundingClientRect: () => ({
+      top: 200,
+      left: 100,
+      width: 80,
+      height: 20,
+    }),
+  }
+  vi.spyOn(window, 'getSelection').mockReturnValue({
+    rangeCount: 1,
+    getRangeAt: () => range as unknown as Range,
+  } as unknown as Selection)
+}
+
+describe('EditorBubbleToolbar', () => {
+  beforeEach(() => {
+    mockSelectionRect()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders core formatting buttons when text is selected', async () => {
+    const editor = makeStubEditor()
+    render(<EditorBubbleToolbar editor={editor} />)
+
+    const handler = vi.mocked(editor.on).mock.calls.find(
+      ([event]) => event === 'selectionUpdate'
+    )?.[1]
+    act(() => {
+      handler?.()
+    })
+
+    expect(await screen.findByRole('button', { name: 'Bold' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Italic' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add link' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'More formatting' })
+    ).toBeInTheDocument()
+  })
+
+  it('shows overflow formatting options from the more menu', async () => {
+    const user = userEvent.setup()
+    const editor = makeStubEditor()
+    render(<EditorBubbleToolbar editor={editor} />)
+
+    const handler = vi.mocked(editor.on).mock.calls.find(
+      ([event]) => event === 'selectionUpdate'
+    )?.[1]
+    act(() => {
+      handler?.()
+    })
+
+    await user.click(
+      await screen.findByRole('button', { name: 'More formatting' })
+    )
+
+    expect(screen.getByText('Underline')).toBeInTheDocument()
+    expect(screen.getByText('Strikethrough')).toBeInTheDocument()
+    expect(screen.getByText('Inline code')).toBeInTheDocument()
+    expect(screen.getByText('Blockquote')).toBeInTheDocument()
+    expect(screen.getByText('Alignment')).toBeInTheDocument()
+  })
+})

--- a/components/editor/EditorBubbleToolbar.tsx
+++ b/components/editor/EditorBubbleToolbar.tsx
@@ -1,6 +1,12 @@
 'use client'
 
-import { useEffect, useRef, useState, useCallback, useLayoutEffect } from 'react'
+import {
+  useEffect,
+  useRef,
+  useState,
+  useCallback,
+  useLayoutEffect,
+} from 'react'
 import { createPortal } from 'react-dom'
 import { type Editor } from '@tiptap/react'
 import {
@@ -279,9 +285,7 @@ export function EditorBubbleToolbar({ editor }: Props) {
                     Underline
                   </DropdownMenu.Item>
                   <DropdownMenu.Item
-                    onSelect={() =>
-                      editor.chain().focus().toggleStrike().run()
-                    }
+                    onSelect={() => editor.chain().focus().toggleStrike().run()}
                     className={overflowItemClass(editor.isActive('strike'))}
                   >
                     <Strikethrough className="h-4 w-4 shrink-0" />
@@ -298,9 +302,7 @@ export function EditorBubbleToolbar({ editor }: Props) {
                     onSelect={() =>
                       editor.chain().focus().toggleBlockquote().run()
                     }
-                    className={overflowItemClass(
-                      editor.isActive('blockquote')
-                    )}
+                    className={overflowItemClass(editor.isActive('blockquote'))}
                   >
                     <Quote className="h-4 w-4 shrink-0" />
                     Blockquote

--- a/components/editor/EditorBubbleToolbar.tsx
+++ b/components/editor/EditorBubbleToolbar.tsx
@@ -1,27 +1,56 @@
 'use client'
 
-import { useEffect, useRef, useState, useCallback } from 'react'
+import { useEffect, useRef, useState, useCallback, useLayoutEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { type Editor } from '@tiptap/react'
 import {
+  AlignCenter,
+  AlignJustify,
+  AlignLeft,
+  AlignRight,
   Bold,
   Code,
   Italic,
   Link2,
+  MoreHorizontal,
   Quote,
   Strikethrough,
   Underline as UnderlineIcon,
   X,
 } from 'lucide-react'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { cn } from '@/lib/utils'
+import {
+  editorToolbarIconButtonClass,
+  editorToolbarIconButtonState,
+  editorToolbarPillClass,
+} from './editorToolbarUi'
 
 interface Props {
   editor: Editor | null
 }
 
+type TextAlignValue = 'left' | 'center' | 'right' | 'justify'
+
+function canSetTextAlign(editor: Editor, align: TextAlignValue): boolean {
+  const chain = editor.can().chain().focus() as {
+    setTextAlign?: (a: string) => { run: () => boolean }
+  }
+  if (typeof chain.setTextAlign !== 'function') return false
+  return chain.setTextAlign(align).run()
+}
+
+function setTextAlign(editor: Editor, align: TextAlignValue): void {
+  const chain = editor.chain().focus() as {
+    setTextAlign?: (a: string) => { run: () => boolean }
+  }
+  chain.setTextAlign?.(align).run()
+}
+
 export function EditorBubbleToolbar({ editor }: Props) {
   const [visible, setVisible] = useState(false)
   const [pos, setPos] = useState({ top: 0, left: 0 })
+  const [clampedLeft, setClampedLeft] = useState<number | null>(null)
   const [linkInput, setLinkInput] = useState<string | false>(false)
   const containerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -29,22 +58,26 @@ export function EditorBubbleToolbar({ editor }: Props) {
   const recalc = useCallback(() => {
     if (!editor || editor.state.selection.empty) {
       setVisible(false)
+      setClampedLeft(null)
       return
     }
     const sel = window.getSelection()
     if (!sel || sel.rangeCount === 0) {
       setVisible(false)
+      setClampedLeft(null)
       return
     }
     const rect = sel.getRangeAt(0).getBoundingClientRect()
     if (!rect.width && !rect.height) {
       setVisible(false)
+      setClampedLeft(null)
       return
     }
     setPos({
-      top: rect.top + window.scrollY - 52,
+      top: Math.max(8, rect.top + window.scrollY - 48),
       left: rect.left + window.scrollX + rect.width / 2,
     })
+    setClampedLeft(null)
     setVisible(true)
   }, [editor])
 
@@ -59,7 +92,21 @@ export function EditorBubbleToolbar({ editor }: Props) {
     }
   }, [editor, recalc])
 
-  // focus link input when it opens
+  useLayoutEffect(() => {
+    if (!visible || !containerRef.current) return
+    const rect = containerRef.current.getBoundingClientRect()
+    const margin = 8
+    const halfWidth = rect.width / 2
+    const centerX = pos.left
+    const minCenter = margin + halfWidth
+    const maxCenter = window.innerWidth - margin - halfWidth
+    if (centerX < minCenter) {
+      setClampedLeft(minCenter)
+    } else if (centerX > maxCenter) {
+      setClampedLeft(maxCenter)
+    }
+  }, [visible, pos, linkInput])
+
   useEffect(() => {
     if (linkInput !== false) {
       window.setTimeout(() => inputRef.current?.focus(), 0)
@@ -69,6 +116,11 @@ export function EditorBubbleToolbar({ editor }: Props) {
   if (!visible || !editor || typeof document === 'undefined') return null
 
   const stop = (e: React.MouseEvent) => e.preventDefault()
+
+  const runAlign = (align: TextAlignValue) => {
+    if (!canSetTextAlign(editor, align)) return
+    setTextAlign(editor, align)
+  }
 
   const btn = (
     title: string,
@@ -85,13 +137,21 @@ export function EditorBubbleToolbar({ editor }: Props) {
       onMouseDown={stop}
       onClick={action}
       className={cn(
-        'px-2.5 py-2 transition-colors hover:bg-muted',
-        active ? 'bg-muted text-primary' : 'text-foreground'
+        editorToolbarIconButtonClass,
+        editorToolbarIconButtonState(active)
       )}
     >
       {icon}
     </button>
   )
+
+  const overflowItemClass = (active = false) =>
+    cn(
+      'flex cursor-pointer items-center gap-2 px-3 py-2 text-sm outline-none hover:bg-muted focus:bg-muted',
+      active && 'bg-muted font-medium text-primary'
+    )
+
+  const displayLeft = clampedLeft ?? pos.left
 
   return createPortal(
     <div
@@ -99,12 +159,12 @@ export function EditorBubbleToolbar({ editor }: Props) {
       style={{
         position: 'absolute',
         top: pos.top,
-        left: pos.left,
+        left: displayLeft,
         transform: 'translateX(-50%)',
         zIndex: 60,
       }}
     >
-      <div className="flex items-stretch overflow-hidden rounded-lg border border-border bg-card shadow-lg">
+      <div className={editorToolbarPillClass}>
         {linkInput !== false ? (
           <div className="flex items-center gap-1 px-2 py-1">
             <input
@@ -132,7 +192,7 @@ export function EditorBubbleToolbar({ editor }: Props) {
                 }
               }}
               placeholder="Paste URL and press Enter"
-              className="w-52 bg-transparent py-1 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
+              className="w-48 bg-transparent py-1 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none sm:w-52"
             />
             <button
               type="button"
@@ -143,6 +203,7 @@ export function EditorBubbleToolbar({ editor }: Props) {
               }}
               className="rounded p-1 text-muted-foreground hover:text-foreground"
               title="Cancel"
+              aria-label="Cancel link"
             >
               <X className="h-3.5 w-3.5" />
             </button>
@@ -160,68 +221,6 @@ export function EditorBubbleToolbar({ editor }: Props) {
               <Italic className="h-3.5 w-3.5" />,
               () => editor.chain().focus().toggleItalic().run(),
               editor.isActive('italic')
-            )}
-            {btn(
-              'Underline',
-              <UnderlineIcon className="h-3.5 w-3.5" />,
-              () => editor.chain().focus().toggleUnderline().run(),
-              editor.isActive('underline')
-            )}
-            {btn(
-              'Strikethrough',
-              <Strikethrough className="h-3.5 w-3.5" />,
-              () => editor.chain().focus().toggleStrike().run(),
-              editor.isActive('strike')
-            )}
-            {btn(
-              'Inline code',
-              <Code className="h-3.5 w-3.5" />,
-              () => editor.chain().focus().toggleCode().run(),
-              editor.isActive('code')
-            )}
-            <div className="w-px self-stretch bg-border" />
-            <button
-              type="button"
-              title="Heading 2"
-              aria-label="Heading 2"
-              aria-pressed={editor.isActive('heading', { level: 2 })}
-              onMouseDown={stop}
-              onClick={() =>
-                editor.chain().focus().toggleHeading({ level: 2 }).run()
-              }
-              className={cn(
-                'px-2.5 py-2 text-xs font-semibold transition-colors hover:bg-muted',
-                editor.isActive('heading', { level: 2 })
-                  ? 'bg-muted text-primary'
-                  : 'text-foreground'
-              )}
-            >
-              H2
-            </button>
-            <button
-              type="button"
-              title="Heading 3"
-              aria-label="Heading 3"
-              aria-pressed={editor.isActive('heading', { level: 3 })}
-              onMouseDown={stop}
-              onClick={() =>
-                editor.chain().focus().toggleHeading({ level: 3 }).run()
-              }
-              className={cn(
-                'px-2.5 py-2 text-xs font-semibold transition-colors hover:bg-muted',
-                editor.isActive('heading', { level: 3 })
-                  ? 'bg-muted text-primary'
-                  : 'text-foreground'
-              )}
-            >
-              H3
-            </button>
-            <div className="w-px self-stretch bg-border" />
-            {btn(
-              'Blockquote',
-              <Quote className="h-3.5 w-3.5" />,
-              () => editor.chain().focus().toggleBlockquote().run(),
-              editor.isActive('blockquote')
             )}
             <button
               type="button"
@@ -242,14 +241,107 @@ export function EditorBubbleToolbar({ editor }: Props) {
                 }
               }}
               className={cn(
-                'px-2.5 py-2 transition-colors hover:bg-muted',
-                editor.isActive('link')
-                  ? 'bg-muted text-primary'
-                  : 'text-foreground'
+                editorToolbarIconButtonClass,
+                editorToolbarIconButtonState(editor.isActive('link'))
               )}
             >
               <Link2 className="h-3.5 w-3.5" />
             </button>
+            <div className="w-px self-stretch bg-border" />
+            <DropdownMenu.Root>
+              <DropdownMenu.Trigger asChild>
+                <button
+                  type="button"
+                  title="More formatting"
+                  aria-label="More formatting"
+                  onMouseDown={stop}
+                  className={cn(
+                    editorToolbarIconButtonClass,
+                    'text-foreground'
+                  )}
+                >
+                  <MoreHorizontal className="h-3.5 w-3.5" />
+                </button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                  className="z-[70] min-w-[180px] rounded-lg border border-border bg-popover py-1 shadow-lg"
+                  sideOffset={6}
+                  align="center"
+                >
+                  <DropdownMenu.Item
+                    onSelect={() =>
+                      editor.chain().focus().toggleUnderline().run()
+                    }
+                    className={overflowItemClass(editor.isActive('underline'))}
+                  >
+                    <UnderlineIcon className="h-4 w-4 shrink-0" />
+                    Underline
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    onSelect={() =>
+                      editor.chain().focus().toggleStrike().run()
+                    }
+                    className={overflowItemClass(editor.isActive('strike'))}
+                  >
+                    <Strikethrough className="h-4 w-4 shrink-0" />
+                    Strikethrough
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    onSelect={() => editor.chain().focus().toggleCode().run()}
+                    className={overflowItemClass(editor.isActive('code'))}
+                  >
+                    <Code className="h-4 w-4 shrink-0" />
+                    Inline code
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    onSelect={() =>
+                      editor.chain().focus().toggleBlockquote().run()
+                    }
+                    className={overflowItemClass(
+                      editor.isActive('blockquote')
+                    )}
+                  >
+                    <Quote className="h-4 w-4 shrink-0" />
+                    Blockquote
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Separator className="my-1 h-px bg-border" />
+                  <DropdownMenu.Sub>
+                    <DropdownMenu.SubTrigger className={overflowItemClass()}>
+                      <AlignLeft className="h-4 w-4 shrink-0" />
+                      Alignment
+                    </DropdownMenu.SubTrigger>
+                    <DropdownMenu.Portal>
+                      <DropdownMenu.SubContent
+                        className="z-[70] min-w-[160px] rounded-lg border border-border bg-popover py-1 shadow-lg"
+                        sideOffset={4}
+                      >
+                        {(
+                          [
+                            ['left', AlignLeft, 'Align left'],
+                            ['center', AlignCenter, 'Align center'],
+                            ['right', AlignRight, 'Align right'],
+                            ['justify', AlignJustify, 'Justify'],
+                          ] as const
+                        ).map(([align, Icon, label]) => (
+                          <DropdownMenu.Item
+                            key={align}
+                            disabled={!canSetTextAlign(editor, align)}
+                            onSelect={() => runAlign(align)}
+                            className={overflowItemClass(
+                              editor.isActive({ textAlign: align })
+                            )}
+                          >
+                            <Icon className="h-4 w-4 shrink-0" />
+                            {label}
+                          </DropdownMenu.Item>
+                        ))}
+                      </DropdownMenu.SubContent>
+                    </DropdownMenu.Portal>
+                  </DropdownMenu.Sub>
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Root>
           </>
         )}
       </div>

--- a/components/editor/EditorFloatingInsert.test.tsx
+++ b/components/editor/EditorFloatingInsert.test.tsx
@@ -55,23 +55,31 @@ describe('EditorFloatingInsert', () => {
       />
     )
 
-    const handler = vi.mocked(editor.on).mock.calls.find(
-      ([event]) => event === 'selectionUpdate'
-    )?.[1]
+    const handler = vi
+      .mocked(editor.on)
+      .mock.calls.find(([event]) => event === 'selectionUpdate')?.[1]
     act(() => {
       handler?.()
     })
 
-    await user.click(await screen.findByRole('button', { name: 'Insert block' }))
+    await user.click(
+      await screen.findByRole('button', { name: 'Insert block' })
+    )
 
     expect(screen.getByRole('group', { name: 'Format' })).toBeInTheDocument()
     expect(screen.getByRole('group', { name: 'Media' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Bullet list' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Bullet list' })
+    ).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: 'Numbered list' })
     ).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Insert image' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Embed YouTube' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Insert image' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Embed YouTube' })
+    ).toBeInTheDocument()
   })
 
   it('calls media callbacks from the insert menu', async () => {
@@ -88,14 +96,16 @@ describe('EditorFloatingInsert', () => {
       />
     )
 
-    const handler = vi.mocked(editor.on).mock.calls.find(
-      ([event]) => event === 'selectionUpdate'
-    )?.[1]
+    const handler = vi
+      .mocked(editor.on)
+      .mock.calls.find(([event]) => event === 'selectionUpdate')?.[1]
     act(() => {
       handler?.()
     })
 
-    await user.click(await screen.findByRole('button', { name: 'Insert block' }))
+    await user.click(
+      await screen.findByRole('button', { name: 'Insert block' })
+    )
     await user.click(screen.getByRole('button', { name: 'Insert image' }))
     await user.click(screen.getByRole('button', { name: 'Insert block' }))
     await user.click(screen.getByRole('button', { name: 'Embed YouTube' }))

--- a/components/editor/EditorFloatingInsert.test.tsx
+++ b/components/editor/EditorFloatingInsert.test.tsx
@@ -1,0 +1,106 @@
+/** @vitest-environment jsdom */
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import type { Editor } from '@tiptap/react'
+import { EditorFloatingInsert } from '@/components/editor/EditorFloatingInsert'
+
+function makeEmptyParagraphEditor(): Editor {
+  const parent = { type: { name: 'paragraph' }, content: { size: 0 } }
+  const chain = {
+    focus: () => ({
+      toggleHeading: () => ({ run: () => true }),
+      toggleBlockquote: () => ({ run: () => true }),
+      toggleCodeBlock: () => ({ run: () => true }),
+      toggleBulletList: () => ({ run: () => true }),
+      toggleOrderedList: () => ({ run: () => true }),
+    }),
+  }
+
+  return {
+    state: {
+      selection: {
+        $from: {
+          parent,
+          pos: 1,
+        },
+      },
+    },
+    isActive: () => false,
+    chain: () => chain,
+    view: {
+      coordsAtPos: () => ({ top: 240, left: 120 }),
+    },
+    on: vi.fn(),
+    off: vi.fn(),
+  } as unknown as Editor
+}
+
+describe('EditorFloatingInsert', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows format and media controls when the insert menu is opened', async () => {
+    const user = userEvent.setup()
+    const onInsertImage = vi.fn()
+    const onInsertYouTube = vi.fn()
+    const editor = makeEmptyParagraphEditor()
+
+    render(
+      <EditorFloatingInsert
+        editor={editor}
+        onInsertImage={onInsertImage}
+        onInsertYouTube={onInsertYouTube}
+      />
+    )
+
+    const handler = vi.mocked(editor.on).mock.calls.find(
+      ([event]) => event === 'selectionUpdate'
+    )?.[1]
+    act(() => {
+      handler?.()
+    })
+
+    await user.click(await screen.findByRole('button', { name: 'Insert block' }))
+
+    expect(screen.getByRole('group', { name: 'Format' })).toBeInTheDocument()
+    expect(screen.getByRole('group', { name: 'Media' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Bullet list' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Numbered list' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Insert image' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Embed YouTube' })).toBeInTheDocument()
+  })
+
+  it('calls media callbacks from the insert menu', async () => {
+    const user = userEvent.setup()
+    const onInsertImage = vi.fn()
+    const onInsertYouTube = vi.fn()
+    const editor = makeEmptyParagraphEditor()
+
+    render(
+      <EditorFloatingInsert
+        editor={editor}
+        onInsertImage={onInsertImage}
+        onInsertYouTube={onInsertYouTube}
+      />
+    )
+
+    const handler = vi.mocked(editor.on).mock.calls.find(
+      ([event]) => event === 'selectionUpdate'
+    )?.[1]
+    act(() => {
+      handler?.()
+    })
+
+    await user.click(await screen.findByRole('button', { name: 'Insert block' }))
+    await user.click(screen.getByRole('button', { name: 'Insert image' }))
+    await user.click(screen.getByRole('button', { name: 'Insert block' }))
+    await user.click(screen.getByRole('button', { name: 'Embed YouTube' }))
+
+    expect(onInsertImage).toHaveBeenCalledTimes(1)
+    expect(onInsertYouTube).toHaveBeenCalledTimes(1)
+  })
+})

--- a/components/editor/EditorFloatingInsert.tsx
+++ b/components/editor/EditorFloatingInsert.tsx
@@ -3,8 +3,21 @@
 import { useEffect, useState, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { type Editor } from '@tiptap/react'
-import { Code, Image as ImageIcon, Plus, Quote, Youtube } from 'lucide-react'
+import {
+  Code,
+  Image as ImageIcon,
+  List,
+  ListOrdered,
+  Plus,
+  Quote,
+  Youtube,
+} from 'lucide-react'
 import { cn } from '@/lib/utils'
+import {
+  editorInsertPlusButtonClass,
+  editorToolbarIconButtonClass,
+  editorToolbarPillClass,
+} from './editorToolbarUi'
 
 interface Props {
   editor: Editor | null
@@ -63,6 +76,57 @@ export function EditorFloatingInsert({
 
   const stop = (e: React.MouseEvent) => e.preventDefault()
 
+  const formatAction = (action: () => void) => () => {
+    action()
+    setOpen(false)
+  }
+
+  const iconBtn = (
+    title: string,
+    icon: React.ReactNode,
+    action: () => void,
+    active = false
+  ) => (
+    <button
+      key={title}
+      type="button"
+      title={title}
+      aria-label={title}
+      aria-pressed={active}
+      onMouseDown={stop}
+      onClick={formatAction(action)}
+      className={cn(
+        editorToolbarIconButtonClass,
+        active ? 'bg-muted text-primary' : 'text-foreground'
+      )}
+    >
+      {icon}
+    </button>
+  )
+
+  const headingBtn = (level: 2 | 3, label: string) => (
+    <button
+      key={label}
+      type="button"
+      title={`Heading ${level}`}
+      aria-label={`Heading ${level}`}
+      aria-pressed={editor.isActive('heading', { level })}
+      onMouseDown={stop}
+      onClick={formatAction(() =>
+        editor.chain().focus().toggleHeading({ level }).run()
+      )}
+      className={cn(
+        editorToolbarIconButtonClass,
+        'text-xs font-semibold',
+        editor.isActive('heading', { level })
+          ? 'bg-muted text-primary'
+          : 'text-foreground'
+      )}
+    >
+      {label}
+    </button>
+  )
+
   return createPortal(
     <div
       style={{
@@ -77,10 +141,11 @@ export function EditorFloatingInsert({
         type="button"
         title={open ? 'Close' : 'Insert block'}
         aria-label={open ? 'Close' : 'Insert block'}
+        aria-expanded={open}
         onMouseDown={stop}
         onClick={() => setOpen((v) => !v)}
         className={cn(
-          'flex h-7 w-7 items-center justify-center rounded-full border border-border bg-card text-muted-foreground transition-colors hover:border-primary hover:text-primary',
+          editorInsertPlusButtonClass,
           open && 'border-primary text-primary'
         )}
       >
@@ -90,93 +155,56 @@ export function EditorFloatingInsert({
       </button>
 
       {open && (
-        <div className="flex items-center overflow-hidden rounded-lg border border-border bg-card shadow-md">
-          {(
-            [
-              {
-                title: 'Heading 2',
-                label: 'H2',
-                action: () => {
-                  editor.chain().focus().toggleHeading({ level: 2 }).run()
-                  setOpen(false)
-                },
-              },
-              {
-                title: 'Heading 3',
-                label: 'H3',
-                action: () => {
-                  editor.chain().focus().toggleHeading({ level: 3 }).run()
-                  setOpen(false)
-                },
-              },
-            ] as const
-          ).map(({ title, label, action }) => (
-            <button
-              key={title}
-              type="button"
-              title={title}
-              aria-label={title}
-              onMouseDown={stop}
-              onClick={action}
-              className="px-2.5 py-2 text-xs font-semibold text-foreground transition-colors hover:bg-muted"
-            >
-              {label}
-            </button>
-          ))}
+        <div className={cn(editorToolbarPillClass, 'rounded-2xl')}>
+          <div
+            className="flex items-center px-1"
+            role="group"
+            aria-label="Format"
+          >
+            {headingBtn(2, 'H2')}
+            {headingBtn(3, 'H3')}
+            {iconBtn(
+              'Blockquote',
+              <Quote className="h-3.5 w-3.5" />,
+              () => editor.chain().focus().toggleBlockquote().run(),
+              editor.isActive('blockquote')
+            )}
+            {iconBtn(
+              'Code block',
+              <Code className="h-3.5 w-3.5" />,
+              () => editor.chain().focus().toggleCodeBlock().run(),
+              editor.isActive('codeBlock')
+            )}
+            {iconBtn(
+              'Bullet list',
+              <List className="h-3.5 w-3.5" />,
+              () => editor.chain().focus().toggleBulletList().run(),
+              editor.isActive('bulletList')
+            )}
+            {iconBtn(
+              'Numbered list',
+              <ListOrdered className="h-3.5 w-3.5" />,
+              () => editor.chain().focus().toggleOrderedList().run(),
+              editor.isActive('orderedList')
+            )}
+          </div>
           <div className="w-px self-stretch bg-border" />
-          <button
-            type="button"
-            title="Blockquote"
-            aria-label="Blockquote"
-            onMouseDown={stop}
-            onClick={() => {
-              editor.chain().focus().toggleBlockquote().run()
-              setOpen(false)
-            }}
-            className="px-2.5 py-2 text-foreground transition-colors hover:bg-muted"
+          <div
+            className="flex items-center px-1"
+            role="group"
+            aria-label="Media"
           >
-            <Quote className="h-3.5 w-3.5" />
-          </button>
-          <button
-            type="button"
-            title="Code block"
-            aria-label="Code block"
-            onMouseDown={stop}
-            onClick={() => {
-              editor.chain().focus().toggleCodeBlock().run()
-              setOpen(false)
-            }}
-            className="px-2.5 py-2 text-foreground transition-colors hover:bg-muted"
-          >
-            <Code className="h-3.5 w-3.5" />
-          </button>
-          <div className="w-px self-stretch bg-border" />
-          <button
-            type="button"
-            title="Insert image"
-            aria-label="Insert image"
-            onMouseDown={stop}
-            onClick={() => {
-              onInsertImage()
-              setOpen(false)
-            }}
-            className="px-2.5 py-2 text-foreground transition-colors hover:bg-muted"
-          >
-            <ImageIcon className="h-3.5 w-3.5" />
-          </button>
-          <button
-            type="button"
-            title="Embed YouTube"
-            aria-label="Embed YouTube"
-            onMouseDown={stop}
-            onClick={() => {
-              onInsertYouTube()
-              setOpen(false)
-            }}
-            className="px-2.5 py-2 text-foreground transition-colors hover:bg-muted"
-          >
-            <Youtube className="h-3.5 w-3.5" />
-          </button>
+            {iconBtn(
+              'Insert image',
+              <ImageIcon className="h-3.5 w-3.5" />,
+              onInsertImage
+            )}
+            {iconBtn(
+              'Embed YouTube',
+              <Youtube className="h-3.5 w-3.5" />,
+              onInsertYouTube
+            )}
+          </div>
         </div>
       )}
     </div>,

--- a/components/editor/editorToolbarUi.tsx
+++ b/components/editor/editorToolbarUi.tsx
@@ -1,0 +1,18 @@
+import { cn } from '@/lib/utils'
+
+export const editorToolbarPillClass =
+  'flex items-stretch overflow-hidden rounded-full border border-border bg-card shadow-md'
+
+export const editorToolbarIconButtonClass = cn(
+  'px-2 py-1.5 transition-colors hover:bg-muted',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset'
+)
+
+export function editorToolbarIconButtonState(active: boolean) {
+  return active ? 'bg-muted text-primary' : 'text-foreground'
+}
+
+export const editorInsertPlusButtonClass = cn(
+  'flex h-7 w-7 items-center justify-center rounded-full border border-border bg-card text-muted-foreground shadow-sm transition-colors',
+  'hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+)


### PR DESCRIPTION
## Summary

Collapses the writer editor chrome so the top action bar stays focused on drafting, publishing, and save status. Personal notes, excerpt editing, and secondary formatting controls move into overflow menus, with shared toolbar styling extracted for consistency.


## Changes

- Move personal notes from the top action bar into a collapsible section inside the EditorActionBar "More options" menu (desktop dropdown and mobile drawer)
- Keep excerpt editing as an expandable section inside the same more menu
- Refactor EditorBubbleToolbar to show core formatting inline and tuck secondary options behind a "More formatting" overflow menu
- Refactor EditorFloatingInsert to group format and media controls behind the insert menu
- Add shared toolbar UI helpers in `editorToolbarUi.tsx` for consistent pill/button styling across editor toolbars
- Add unit tests for notes menu placement, bubble toolbar overflow, and floating insert menu behavior

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run format`
- [x] `bun run test:once` (788 tests passed)
- [x] `bun run build`


## Notes

- Rebased onto latest `development` before opening this PR
- UI-only change in the write editor; no backend or schema changes
- Manual QA: open `/write`, confirm the top bar no longer shows a standalone Notes button, open More options to edit personal notes and excerpt, select text to verify bubble toolbar overflow, and use the floating insert menu on an empty line
<img width="1220" height="716" alt="1" src="https://github.com/user-attachments/assets/787e592d-4db6-40cf-84df-8a2f543fa9ac" />
<img width="1219" height="718" alt="2" src="https://github.com/user-attachments/assets/2f2ff333-e122-47fa-92b3-8e9d55d30234" />

<img width="1221" height="717" alt="3" src="https://github.com/user-attachments/assets/77d722de-0788-4feb-b130-9774d6df0599" />

<img width="1223" height="720" alt="4" src="https://github.com/user-attachments/assets/d6630413-fca5-402f-9c22-088f034d5349" />


