### PR TITLE
fix: harden wallet publishing and tipping flows

### DIFF
--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -12,6 +12,7 @@ import {
   parseBrowseSort,
   parseBrowseView,
 } from '@/lib/articles/browseDiscovery'
+import { parseArticlesPageParam } from '@/lib/articles/parseArticlesPageParam'
 import {
   buildArticlesBrowseScrollStorageKey,
   writeBrowseScrollY,
@@ -55,7 +56,7 @@ export default function ArticlesPage() {
     writeBrowseScrollY(scrollStorageKey, window.scrollY)
   }, [scrollStorageKey])
 
-  const currentPage = parseInt(searchParams?.get('page') || '1')
+  const currentPage = parseArticlesPageParam(searchParams?.get('page'))
   const tag = searchParams?.get('tag') || undefined
   const author = searchParams?.get('author') || undefined
   const urlSearch = searchParams?.get('search') || undefined

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import HomePage from './page'
 
 const useAuthMock = vi.fn()
-const useUserDraftsMock = vi.fn()
+const useCreatorWorkspaceSummaryMock = vi.fn()
 const useCreatorRecentWorkMock = vi.fn()
 const useAuthorEarningsMock = vi.fn()
 
@@ -37,7 +37,7 @@ vi.mock('@/components/onboarding/OnboardingIntentHome', () => ({
 }))
 
 vi.mock('@/hooks/convex', () => ({
-  useUserDrafts: () => useUserDraftsMock(),
+  useCreatorWorkspaceSummary: () => useCreatorWorkspaceSummaryMock(),
   useCreatorRecentWork: () => useCreatorRecentWorkMock(),
   useAuthorEarnings: () => useAuthorEarningsMock(),
 }))
@@ -45,9 +45,13 @@ vi.mock('@/hooks/convex', () => ({
 describe('HomePage loading states', () => {
   beforeEach(() => {
     useAuthMock.mockReset()
-    useUserDraftsMock.mockReset()
+    useCreatorWorkspaceSummaryMock.mockReset()
     useCreatorRecentWorkMock.mockReset()
     useAuthorEarningsMock.mockReset()
+    useCreatorWorkspaceSummaryMock.mockReturnValue({
+      hasDrafts: false,
+      mostRecentDraft: null,
+    })
     useCreatorRecentWorkMock.mockReturnValue([])
     useAuthorEarningsMock.mockReturnValue(null)
   })
@@ -106,9 +110,13 @@ describe('HomePage creator workspace', () => {
 
   beforeEach(() => {
     useAuthMock.mockReset()
-    useUserDraftsMock.mockReset()
+    useCreatorWorkspaceSummaryMock.mockReset()
     useCreatorRecentWorkMock.mockReset()
     useAuthorEarningsMock.mockReset()
+    useCreatorWorkspaceSummaryMock.mockReturnValue({
+      hasDrafts: false,
+      mostRecentDraft: null,
+    })
     useCreatorRecentWorkMock.mockReturnValue([])
     useAuthorEarningsMock.mockReturnValue({
       totalEarnedUsd: 0,
@@ -122,22 +130,16 @@ describe('HomePage creator workspace', () => {
       isAuthenticated: true,
       isLoading: false,
     })
-    useUserDraftsMock.mockReturnValue([
-      {
+    useCreatorWorkspaceSummaryMock.mockReturnValue({
+      hasDrafts: true,
+      mostRecentDraft: {
         _id: 'draft1',
         title: 'My draft',
         updatedAt: 2000,
         _creationTime: 1000,
         published: false,
       },
-      {
-        _id: 'draft2',
-        title: 'Older draft',
-        updatedAt: 1000,
-        _creationTime: 500,
-        published: false,
-      },
-    ])
+    })
 
     render(<HomePage />)
 
@@ -157,7 +159,10 @@ describe('HomePage creator workspace', () => {
       isAuthenticated: true,
       isLoading: false,
     })
-    useUserDraftsMock.mockReturnValue([])
+    useCreatorWorkspaceSummaryMock.mockReturnValue({
+      hasDrafts: false,
+      mostRecentDraft: null,
+    })
 
     render(<HomePage />)
 
@@ -179,7 +184,7 @@ describe('HomePage creator workspace', () => {
       isAuthenticated: true,
       isLoading: false,
     })
-    useUserDraftsMock.mockReturnValue(undefined)
+    useCreatorWorkspaceSummaryMock.mockReturnValue(undefined)
 
     render(<HomePage />)
 
@@ -189,5 +194,31 @@ describe('HomePage creator workspace', () => {
     expect(
       screen.queryByText('Pick up where you left off')
     ).not.toBeInTheDocument()
+  })
+
+  it('keeps the primary writing action when recent work fails', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    useAuthMock.mockReturnValue({
+      user: baseUser,
+      isAuthenticated: true,
+      isLoading: false,
+    })
+    useCreatorWorkspaceSummaryMock.mockReturnValue({
+      hasDrafts: false,
+      mostRecentDraft: null,
+    })
+    useCreatorRecentWorkMock.mockImplementation(() => {
+      throw new Error('Recent work failed')
+    })
+
+    render(<HomePage />)
+
+    expect(
+      screen.getByRole('link', { name: /Start a new article/i })
+    ).toHaveAttribute('href', '/write')
+    expect(screen.getByText('Workspace panel unavailable.')).toBeInTheDocument()
+    consoleError.mockRestore()
   })
 })

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { useAuthReturnPath } from '@/components/auth/useAuthReturnPath'
 import { getLoginCopy } from '@/lib/copy/auth-intent'
 import { readPendingTipIntent } from '@/lib/tip/pendingTipIntent'
+import { shouldUseFullPageAuthNavigation } from '@/lib/auth/postAuthNavigation'
 import { getSafeRedirectPath } from '@/lib/navigation/walletProfileDestination'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -79,10 +80,7 @@ export default function LoginForm() {
       // Full navigation for tip-resume flows so auth + URL params are stable
       // before the article page mounts (avoids inconsistent client-side resume).
       const pendingTipIntent = readPendingTipIntent()
-      if (
-        postLoginPath.includes('resumeArticleTip=1') ||
-        pendingTipIntent?.kind === 'highlight'
-      ) {
+      if (shouldUseFullPageAuthNavigation(postLoginPath, pendingTipIntent)) {
         window.location.assign(postLoginPath)
         return
       }

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -6,8 +6,10 @@ import { useForm, type FieldErrors } from 'react-hook-form'
 import { useAuthReturnPath } from '@/components/auth/useAuthReturnPath'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { parseRegisterSignInError } from '@/lib/auth/map-register-error'
+import { shouldUseFullPageAuthNavigation } from '@/lib/auth/postAuthNavigation'
 import { getFirstRegisterFieldError } from '@/lib/auth/register-form-a11y'
 import { getRegisterCopy } from '@/lib/copy/auth-intent'
+import { readPendingTipIntent } from '@/lib/tip/pendingTipIntent'
 import { registerSchema, type RegisterFormData } from '@/lib/validations/auth'
 import { allPasswordRulesMet } from '@/lib/validations/password-rules'
 import { CheckCircle, Eye, EyeOff, Loader2 } from 'lucide-react'
@@ -106,6 +108,12 @@ export default function RegisterForm() {
       })
 
       setSuccess(true)
+      const pendingTipIntent = readPendingTipIntent()
+      if (shouldUseFullPageAuthNavigation(returnPath, pendingTipIntent)) {
+        window.location.assign(returnPath)
+        return
+      }
+
       // Use replace to prevent back button returning to register
       router.replace(returnPath)
     } catch (error) {

--- a/components/dashboard/CompactEarningsCard.tsx
+++ b/components/dashboard/CompactEarningsCard.tsx
@@ -34,15 +34,23 @@ export function CompactEarningsCard({ user }: CompactEarningsCardProps) {
           Wallet
         </div>
         <p className="mb-4 text-sm text-muted-foreground">
-          Set up a Stellar {networkLabelLowercase()} wallet to receive tips from
-          readers.
+          Add a Stellar {networkLabelLowercase()} receiving wallet so published
+          articles are ready to earn tips.
         </p>
-        <Link
-          href="/guide"
-          className="text-sm font-medium text-brand-blue hover:text-brand-accent"
-        >
-          Set up wallet
-        </Link>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+          <Link
+            href="/dashboard/wallet"
+            className="text-sm font-medium text-brand-blue hover:text-brand-accent"
+          >
+            Set up wallet
+          </Link>
+          <Link
+            href="/guide"
+            className="text-sm text-muted-foreground hover:text-foreground"
+          >
+            Wallet guide
+          </Link>
+        </div>
       </div>
     )
   }

--- a/components/dashboard/CreatorWorkspace.tsx
+++ b/components/dashboard/CreatorWorkspace.tsx
@@ -2,12 +2,16 @@
 
 import Link from 'next/link'
 import { BookOpen } from 'lucide-react'
-import { useUserDrafts } from '@/hooks/convex'
-import { getMostRecentDraft } from '@/lib/drafts/draftMetadata'
+import { useCreatorWorkspaceSummary } from '@/hooks/convex'
 import type { CurrentUserDoc } from '@/types/convex'
 import { PrimaryWritingAction } from '@/components/dashboard/PrimaryWritingAction'
 import { CompactEarningsCard } from '@/components/dashboard/CompactEarningsCard'
 import { RecentWorkList } from '@/components/dashboard/RecentWorkList'
+import { ErrorBoundary } from '@/components/error/ErrorBoundary'
+import {
+  CreatorWorkspacePanelFallback,
+  CreatorWorkspaceWalletFallback,
+} from '@/components/error/SectionErrorFallback'
 import { Skeleton } from '@/components/ui/skeleton'
 
 type CreatorWorkspaceProps = {
@@ -36,11 +40,51 @@ function CreatorWorkspaceSkeleton() {
   )
 }
 
-export function CreatorWorkspace({ user }: CreatorWorkspaceProps) {
-  const draftsQuery = useUserDrafts()
+function CreatorWorkspacePrimaryFallback({ user }: CreatorWorkspaceProps) {
   const displayName = user.name || user.username || user.email
 
-  if (draftsQuery === undefined) {
+  return (
+    <>
+      <div className="mb-8">
+        <h1 className="mb-2 text-3xl font-bold text-foreground">
+          Welcome back, {displayName}
+        </h1>
+        <p className="text-muted-foreground">Your writing workspace is ready</p>
+      </div>
+
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_280px]">
+        <div className="space-y-8">
+          <PrimaryWritingAction mostRecentDraft={null} />
+          <CreatorWorkspacePanelFallback />
+        </div>
+
+        <aside className="space-y-4">
+          {!user.stellarAddress ? (
+            <Link
+              href="/dashboard/wallet"
+              className="block rounded-[var(--card-radius)] border border-border bg-card p-[var(--card-padding)] text-sm text-muted-foreground shadow-[var(--card-shadow)] transition-colors hover:bg-muted/40 hover:text-foreground"
+            >
+              Set up your receiving wallet to publish tip-ready articles.
+            </Link>
+          ) : null}
+          <Link
+            href="/articles"
+            className="flex items-center gap-2 rounded-[var(--card-radius)] border border-border bg-card px-4 py-3 text-sm text-muted-foreground shadow-[var(--card-shadow)] transition-colors hover:border-border hover:bg-muted/40 hover:text-foreground"
+          >
+            <BookOpen className="h-4 w-4 shrink-0" />
+            Browse articles
+          </Link>
+        </aside>
+      </div>
+    </>
+  )
+}
+
+function CreatorWorkspaceContent({ user }: CreatorWorkspaceProps) {
+  const workspaceSummary = useCreatorWorkspaceSummary()
+  const displayName = user.name || user.username || user.email
+
+  if (workspaceSummary === undefined) {
     return (
       <>
         <div className="mb-8">
@@ -56,8 +100,8 @@ export function CreatorWorkspace({ user }: CreatorWorkspaceProps) {
     )
   }
 
-  const mostRecentDraft = getMostRecentDraft(draftsQuery)
-  const hasDrafts = draftsQuery.length > 0
+  const mostRecentDraft = workspaceSummary.mostRecentDraft
+  const hasDrafts = workspaceSummary.hasDrafts
   const workspaceSubtitle = hasDrafts
     ? 'Your latest writing is ready when you are'
     : 'Start your first article anytime'
@@ -74,11 +118,15 @@ export function CreatorWorkspace({ user }: CreatorWorkspaceProps) {
       <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_280px]">
         <div className="space-y-8">
           <PrimaryWritingAction mostRecentDraft={mostRecentDraft} />
-          <RecentWorkList username={user.username} hasDrafts={hasDrafts} />
+          <ErrorBoundary fallback={<CreatorWorkspacePanelFallback />}>
+            <RecentWorkList username={user.username} hasDrafts={hasDrafts} />
+          </ErrorBoundary>
         </div>
 
         <aside className="space-y-4">
-          <CompactEarningsCard user={user} />
+          <ErrorBoundary fallback={<CreatorWorkspaceWalletFallback />}>
+            <CompactEarningsCard user={user} />
+          </ErrorBoundary>
           <Link
             href="/articles"
             className="flex items-center gap-2 rounded-[var(--card-radius)] border border-border bg-card px-4 py-3 text-sm text-muted-foreground shadow-[var(--card-shadow)] transition-colors hover:border-border hover:bg-muted/40 hover:text-foreground"
@@ -89,6 +137,14 @@ export function CreatorWorkspace({ user }: CreatorWorkspaceProps) {
         </aside>
       </div>
     </>
+  )
+}
+
+export function CreatorWorkspace({ user }: CreatorWorkspaceProps) {
+  return (
+    <ErrorBoundary fallback={<CreatorWorkspacePrimaryFallback user={user} />}>
+      <CreatorWorkspaceContent user={user} />
+    </ErrorBoundary>
   )
 }
 

--- a/components/dashboard/DashboardWalletContent.test.tsx
+++ b/components/dashboard/DashboardWalletContent.test.tsx
@@ -1,0 +1,67 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DashboardWalletContent } from '@/components/dashboard/DashboardWalletContent'
+
+const mockUseAuth = vi.hoisted(() => vi.fn())
+const mockUseUserByUsername = vi.hoisted(() => vi.fn())
+
+vi.mock('@/components/providers/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+vi.mock('@/hooks/convex', () => ({
+  useUserByUsername: (username: string | undefined) =>
+    mockUseUserByUsername(username),
+}))
+
+vi.mock('@/components/stellar', () => ({
+  WalletSettings: ({
+    walletAddress,
+    onAddressChange,
+  }: {
+    walletAddress?: string | null
+    onAddressChange?: (address: string | null) => void
+  }) => (
+    <div>
+      <p data-testid="wallet-address">{walletAddress ?? 'missing'}</p>
+      <button type="button" onClick={() => onAddressChange?.(null)}>
+        Disconnect wallet
+      </button>
+    </div>
+  ),
+}))
+
+vi.mock('@/components/dashboard/DashboardWalletSkeleton', () => ({
+  DashboardWalletSkeleton: () => <div data-testid="wallet-skeleton" />,
+}))
+
+describe('DashboardWalletContent', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset()
+    mockUseUserByUsername.mockReset()
+    mockUseAuth.mockReturnValue({
+      user: { username: 'writer' },
+    })
+    mockUseUserByUsername.mockReturnValue({
+      username: 'writer',
+      name: 'Writer',
+      stellarAddress: 'GOLDADDRESS',
+    })
+  })
+
+  it('does not fall back to a stale queried wallet after disconnect', async () => {
+    const user = userEvent.setup({ delay: null })
+
+    render(<DashboardWalletContent />)
+
+    expect(screen.getByTestId('wallet-address')).toHaveTextContent(
+      'GOLDADDRESS'
+    )
+
+    await user.click(screen.getByRole('button', { name: /Disconnect wallet/i }))
+
+    expect(screen.getByTestId('wallet-address')).toHaveTextContent('missing')
+  })
+})

--- a/components/dashboard/DashboardWalletContent.tsx
+++ b/components/dashboard/DashboardWalletContent.tsx
@@ -14,8 +14,11 @@ export function DashboardWalletContent() {
   >()
 
   useEffect(() => {
-    if (user?.stellarAddress !== localWalletAddress) {
-      setLocalWalletAddress(user?.stellarAddress)
+    if (
+      localWalletAddress !== undefined &&
+      user?.stellarAddress === localWalletAddress
+    ) {
+      setLocalWalletAddress(undefined)
     }
   }, [user?.stellarAddress, localWalletAddress])
 
@@ -24,6 +27,8 @@ export function DashboardWalletContent() {
   }
 
   const profileDisplayName = user?.name || currentUser.username
+  const walletAddress =
+    localWalletAddress === undefined ? user?.stellarAddress : localWalletAddress
 
   return (
     <div className="space-y-8">
@@ -38,13 +43,11 @@ export function DashboardWalletContent() {
 
       <div className="max-w-2xl">
         <WalletSettings
-          walletAddress={localWalletAddress ?? user?.stellarAddress}
+          walletAddress={walletAddress}
           profileUsername={currentUser.username}
           isOwnProfile
           profileDisplayName={profileDisplayName}
-          onAddressChange={(address) => {
-            setLocalWalletAddress(address || undefined)
-          }}
+          onAddressChange={setLocalWalletAddress}
         />
       </div>
     </div>

--- a/components/dashboard/EarningsStats.test.tsx
+++ b/components/dashboard/EarningsStats.test.tsx
@@ -105,7 +105,7 @@ describe('EarningsStats', () => {
       />
     )
 
-    expect(screen.getByText('Connect to receive tips')).toBeInTheDocument()
+    expect(screen.getByText('Set up your receiving wallet')).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: /Connect wallet/i })
     ).toBeInTheDocument()
@@ -129,5 +129,22 @@ describe('EarningsStats', () => {
       screen.getByText(/minimum available balance of \$10\.00/i)
     ).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /withdraw/i })).toBeDisabled()
+  })
+
+  it('keeps wallet setup enabled even when balance is below withdrawal minimum', () => {
+    const earnings = makeEarnings({
+      availableBalanceUsd: 0,
+      availableBalanceCents: 0,
+    })
+    render(
+      <EarningsStats
+        earnings={earnings}
+        userProfile={{ stellarAddress: null }}
+        minWithdrawalUsd={10}
+        onOpenWithdrawModal={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /Set Up Wallet/i })).toBeEnabled()
   })
 })

--- a/components/dashboard/EarningsStats.tsx
+++ b/components/dashboard/EarningsStats.tsx
@@ -28,6 +28,8 @@ export function EarningsStats({
   const navigateToDashboard = useDashboardNavigation()
   const lastWithdrawal = earnings.lastWithdrawalAt
   const belowWithdrawalMinimum = earnings.availableBalanceUsd < minWithdrawalUsd
+  const disableBalanceAction =
+    Boolean(userProfile?.stellarAddress) && belowWithdrawalMinimum
   const showMinimumWithdrawalHelper =
     belowWithdrawalMinimum && Boolean(userProfile?.stellarAddress)
 
@@ -71,7 +73,7 @@ export function EarningsStats({
                     onOpenWithdrawModal()
                   }
                 }}
-                disabled={earnings.availableBalanceUsd < minWithdrawalUsd}
+                disabled={disableBalanceAction}
                 className="mt-3 w-full px-3 py-1.5 bg-brand text-brand-foreground text-sm rounded-lg hover:bg-brand-hover disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
               >
                 <Wallet className="w-4 h-4" />

--- a/components/dashboard/PrimaryWritingAction.tsx
+++ b/components/dashboard/PrimaryWritingAction.tsx
@@ -5,8 +5,10 @@ import { PenSquare } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import type { Doc } from '@/types/convex'
 
+type PrimaryWritingDraft = Pick<Doc<'articles'>, '_id' | 'title'>
+
 type PrimaryWritingActionProps = {
-  mostRecentDraft: Doc<'articles'> | null
+  mostRecentDraft: PrimaryWritingDraft | null
 }
 
 export function PrimaryWritingAction({

--- a/components/editor/WriteEditorWorkspace.tsx
+++ b/components/editor/WriteEditorWorkspace.tsx
@@ -86,6 +86,12 @@ import { PublishSuccessPanel } from '@/components/editor/PublishSuccessPanel'
 const ARTICLE_TITLE_ERROR_ID = 'article-title-error'
 const TITLE_PUBLISH_ERROR = 'Add a title before publishing'
 const EXCERPT_MAX_CHARS = 500
+const PUBLISH_WALLET_REQUIRED_FEEDBACK: FlowFeedback = {
+  variant: 'default',
+  title: 'Set up a receiving wallet before publishing',
+  detail:
+    'This makes the article tip-ready as soon as it goes live. Readers can still read for free.',
+}
 
 function editorTitleFromStored(storedTitle: string): string {
   return isPlaceholderArticleTitle(storedTitle) ? '' : storedTitle
@@ -240,7 +246,6 @@ export function WriteEditorWorkspace() {
     hasUnsavedRef.current = hasUnsavedChanges
   }, [hasUnsavedChanges])
 
-  const createArticleMutation = useMutation(api.articles.createArticle)
   const publishArticleMutation = useMutation(api.articles.publishArticle)
   const deleteArticleMutation = useMutation(api.articles.deleteArticle)
 
@@ -643,34 +648,30 @@ export function WriteEditorWorkspace() {
       toast.warning(listingError)
       return
     }
+    if (!receivingWalletAddress) {
+      setPublishFeedback(PUBLISH_WALLET_REQUIRED_FEEDBACK)
+      toast.warning(PUBLISH_WALLET_REQUIRED_FEEDBACK.title)
+      return
+    }
 
     setPublishFeedback(null)
     setIsPublishing(true)
     try {
-      await saveNow()
-
-      let resultId: string
-      let publishedSlug: string | undefined
-
-      if (articleId) {
-        const published = await publishArticleMutation({
-          id: articleId as Id<'articles'>,
-        })
-        resultId = published.id
-        publishedSlug = published.slug
-      } else {
-        resultId = await createArticleMutation({
-          title: title.trim(),
-          content: editorContent,
-          excerpt: excerpt.trim(),
-          coverImage: coverImage || undefined,
-          tags: tags
-            .split(',')
-            .map((t) => t.trim())
-            .filter(Boolean),
-          published: true,
-        })
+      const savedDraft = await saveNow()
+      if (hasUnsavedChanges && !savedDraft) {
+        throw new Error('Save your latest changes before publishing')
       }
+
+      const targetArticleId = savedDraft?.id ?? articleId
+      if (!targetArticleId) {
+        throw new Error('Save your draft before publishing')
+      }
+
+      const published = await publishArticleMutation({
+        id: targetArticleId as Id<'articles'>,
+      })
+      const resultId = published.id
+      const publishedSlug = published.slug
 
       if (!articleId) {
         setArticleId(resultId)
@@ -707,16 +708,15 @@ export function WriteEditorWorkspace() {
     title,
     editorContent,
     excerpt,
-    coverImage,
-    tags,
     saveNow,
+    hasUnsavedChanges,
     articleId,
     publishArticleMutation,
-    createArticleMutation,
     editor,
     syncDraftIdInUrl,
     blockPublishForPlaceholderTitle,
     focusTitleField,
+    receivingWalletAddress,
   ])
 
   const handleRequestDelete = useCallback(() => {
@@ -912,6 +912,9 @@ export function WriteEditorWorkspace() {
     savedArticleForLink?.author?.username ??
     null
   const publishSlug = publishedSlugOverride ?? savedArticleForLink?.slug ?? null
+  const walletStatusLoading = receivingWalletAddress === undefined
+  const walletSetupRequired = receivingWalletAddress === null
+  const publishDialogBlocked = walletStatusLoading || walletSetupRequired
 
   return (
     <div className="flex flex-col pt-16">
@@ -1370,11 +1373,16 @@ export function WriteEditorWorkspace() {
                   }
                 />
                 <p className="text-sm text-muted-foreground">
-                  Readers cannot tip this article until a receiving wallet is
-                  connected.
+                  This is required before publishing so the article can receive
+                  Stellar TESTNET tips immediately.
                 </p>
               </div>
             )}
+            {walletStatusLoading ? (
+              <p className="text-sm text-muted-foreground">
+                Checking receiving wallet setup...
+              </p>
+            ) : null}
           </div>
 
           <DialogFooter>
@@ -1387,12 +1395,13 @@ export function WriteEditorWorkspace() {
             </Button>
             <Button
               type="button"
+              disabled={publishDialogBlocked || isPublishing}
               onClick={() => {
                 setPublishConfirmOpen(false)
                 void handlePublish()
               }}
             >
-              Publish
+              {walletSetupRequired ? 'Set up wallet to publish' : 'Publish'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/components/error/SectionErrorFallback.tsx
+++ b/components/error/SectionErrorFallback.tsx
@@ -39,6 +39,36 @@ export function DashboardRecentArticlesFallback() {
   )
 }
 
+export function CreatorWorkspacePanelFallback() {
+  return (
+    <div className="rounded-lg border border-border bg-muted p-6 text-center">
+      <p className="font-medium text-foreground">
+        Workspace panel unavailable.
+      </p>
+      <p className="mt-2 text-sm text-muted-foreground">
+        You can still write, publish, and manage your wallet.
+      </p>
+    </div>
+  )
+}
+
+export function CreatorWorkspaceWalletFallback() {
+  return (
+    <div className="rounded-lg border border-border bg-muted p-4">
+      <p className="font-medium text-foreground">Wallet panel unavailable.</p>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Open wallet settings to manage tip payouts.
+      </p>
+      <Link
+        href="/dashboard/wallet"
+        className="mt-4 inline-block text-sm font-medium text-primary underline-offset-4 hover:underline"
+      >
+        Wallet settings
+      </Link>
+    </div>
+  )
+}
+
 interface EditorWorkspaceErrorFallbackProps {
   onRetry: () => void
 }

--- a/components/highlights/HighlightTipButton.test.tsx
+++ b/components/highlights/HighlightTipButton.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { act, render, screen } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -24,6 +24,12 @@ const mockAuth = vi.hoisted(() => ({
   isAuthenticated: false,
 }))
 const mockIsConnected = vi.hoisted(() => vi.fn(() => false))
+const mockCanTipQuery = vi.hoisted(() => vi.fn())
+const mockCreateHighlightTip = vi.hoisted(() => vi.fn())
+const mockSignTransaction = vi.hoisted(() => vi.fn())
+const mockConnect = vi.hoisted(() => vi.fn())
+const mockBuildHighlightTipTransaction = vi.hoisted(() => vi.fn())
+const mockSubmitTipTransaction = vi.hoisted(() => vi.fn())
 
 vi.mock('@/components/providers/AuthContext', () => ({
   useAuth: () => ({ isAuthenticated: mockAuth.isAuthenticated }),
@@ -34,8 +40,8 @@ vi.mock('@/components/providers/WalletProvider', () => ({
     isConnected: mockIsConnected(),
     isLoading: false,
     publicKey: mockIsConnected() ? 'GABCDEF123456789' : null,
-    signTransaction: vi.fn(),
-    connect: vi.fn(),
+    signTransaction: mockSignTransaction,
+    connect: mockConnect,
   }),
 }))
 
@@ -49,8 +55,8 @@ vi.mock('next/navigation', () => ({
 }))
 
 vi.mock('convex/react', () => ({
-  useConvex: () => ({ query: vi.fn() }),
-  useMutation: () => vi.fn(),
+  useConvex: () => ({ query: mockCanTipQuery }),
+  useMutation: () => mockCreateHighlightTip,
 }))
 
 vi.mock('@/hooks/useTipDialogXlmUsdRate', () => ({
@@ -58,11 +64,16 @@ vi.mock('@/hooks/useTipDialogXlmUsdRate', () => ({
 }))
 
 vi.mock('@/lib/stellar/client', () => ({
-  stellarClient: {},
+  stellarClient: {
+    buildHighlightTipTransaction: (...args: unknown[]) =>
+      mockBuildHighlightTipTransaction(...args),
+    submitTipTransaction: (...args: unknown[]) =>
+      mockSubmitTipTransaction(...args),
+  },
 }))
 
 vi.mock('@/lib/stellar/stellar-flow-emitter', () => ({
-  stellarFlowEmitter: { subscribe: () => () => {} },
+  stellarFlowEmitter: { subscribe: () => () => {}, emit: vi.fn() },
   tipFlowProgressLabel: () => '',
 }))
 
@@ -104,6 +115,25 @@ describe('HighlightTipButton two-stage flow', () => {
     mockIsConnected.mockReturnValue(false)
     writePendingHighlightSelection.mockClear()
     signInToTip.mockClear()
+    mockCanTipQuery.mockReset()
+    mockCanTipQuery.mockResolvedValue({ allowed: true })
+    mockCreateHighlightTip.mockReset()
+    mockCreateHighlightTip.mockResolvedValue('highlight-tip-id')
+    mockSignTransaction.mockReset()
+    mockSignTransaction.mockResolvedValue('signed-xdr')
+    mockConnect.mockReset()
+    mockBuildHighlightTipTransaction.mockReset()
+    mockBuildHighlightTipTransaction.mockResolvedValue({
+      xdr: 'unsigned-xdr',
+      stroops: 10_000_000,
+      platformFee: 0.01,
+      authorReceived: 0.99,
+    })
+    mockSubmitTipTransaction.mockReset()
+    mockSubmitTipTransaction.mockResolvedValue({
+      transactionHash: 'tx-highlight-123456789',
+      tipId: 'contract-tip-highlight',
+    })
     clearPendingTipIntent.mockClear()
     readPendingTipIntent.mockReturnValue(null)
   })
@@ -247,5 +277,48 @@ describe('HighlightTipButton two-stage flow', () => {
     expect(
       screen.getByRole('button', { name: 'Connect Wallet' })
     ).toBeInTheDocument()
+  })
+
+  it('retries Convex sync for a submitted highlight tip without resubmitting Stellar tx', async () => {
+    mockAuth.isAuthenticated = true
+    mockIsConnected.mockReturnValue(true)
+    mockCreateHighlightTip
+      .mockRejectedValueOnce(new Error('Convex unavailable'))
+      .mockResolvedValueOnce('highlight-tip-id')
+    const user = userEvent.setup({ delay: null })
+    render(
+      <HighlightTipButton
+        articleId={'articles:123' as never}
+        articleSlug="my-article"
+        authorName="Author"
+        authorStellarAddress="GABC"
+        highlightText="Some highlighted text"
+        startOffset={10}
+        endOffset={20}
+      />
+    )
+
+    await openHighlightTipAndContinue(user)
+    await user.click(screen.getByRole('button', { name: 'Send Tip' }))
+
+    expect(
+      await screen.findByText('Tip sent, app sync failed')
+    ).toBeInTheDocument()
+    expect(mockSignTransaction).toHaveBeenCalledTimes(1)
+    expect(mockSubmitTipTransaction).toHaveBeenCalledTimes(1)
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => {
+      expect(mockCreateHighlightTip).toHaveBeenCalledTimes(2)
+    })
+    expect(mockCreateHighlightTip).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        stellarTxId: 'tx-highlight-123456789',
+      })
+    )
+    expect(mockSignTransaction).toHaveBeenCalledTimes(1)
+    expect(mockSubmitTipTransaction).toHaveBeenCalledTimes(1)
   })
 })

--- a/components/highlights/HighlightTipButton.tsx
+++ b/components/highlights/HighlightTipButton.tsx
@@ -77,6 +77,40 @@ interface HighlightTipButtonProps {
   onResumeDialogVisible?: () => void
 }
 
+type HighlightTipRecordArgs = {
+  highlightId: string
+  articleId: Id<'articles'>
+  highlightText: string
+  startOffset: number
+  endOffset: number
+  startContainerPath?: string
+  endContainerPath?: string
+  amountCents: number
+  stellarTxId: string
+  stellarMemo: string
+  stellarNetwork: 'TESTNET'
+  stellarLedger?: number
+  stellarFeeCharged?: string
+  stellarSourceAccount?: string
+  stellarDestinationAccount?: string
+  stellarAmountXlm?: string
+  contractTipId?: string
+  platformFee?: number
+  authorShare?: number
+}
+
+type PendingHighlightTipRecord = {
+  args: HighlightTipRecordArgs
+  amountCents: number
+  transactionHash?: string
+}
+
+const HIGHLIGHT_TIP_SYNC_FAILURE_MESSAGE: TipFailureMessage = {
+  title: 'Tip sent, app sync failed',
+  detail:
+    'Your Stellar transaction was submitted. Retry will record that same transaction without sending another payment.',
+}
+
 export function HighlightTipButton({
   articleId,
   articleSlug,
@@ -122,6 +156,8 @@ export function HighlightTipButton({
     null
   )
   const [tipSuccess, setTipSuccess] = useState<string | null>(null)
+  const [pendingTipRecord, setPendingTipRecord] =
+    useState<PendingHighlightTipRecord | null>(null)
 
   const convex = useConvex()
   const createHighlightTip = useMutation(api.highlightTips.create)
@@ -213,6 +249,61 @@ export function HighlightTipButton({
     setTipSuccess(null)
   }
 
+  const markTipRecordSynced = (
+    amountCents: number,
+    transactionHash?: string
+  ) => {
+    clearPendingTipIntent()
+    setPendingTipRecord(null)
+    setTipFailure(null)
+    setTipFormError(null)
+    const successMessage = `Successfully tipped ${authorName} ${formatTipAmount(amountCents)} for this highlight!`
+    setTipSuccess(successMessage)
+
+    toast.success(successMessage, {
+      description: transactionHash
+        ? `Transaction: ${transactionHash.slice(0, 8)}...`
+        : undefined,
+      action: transactionHash
+        ? {
+            label: 'View',
+            onClick: () =>
+              window.open(
+                `https://stellar.expert/explorer/testnet/tx/${transactionHash}`,
+                '_blank'
+              ),
+          }
+        : undefined,
+    })
+
+    window.setTimeout(() => {
+      setIsOpen(false)
+      resetModalState()
+      setSelectedAmount(null)
+      setCustomAmount('')
+      onSuccess?.()
+    }, 3000)
+  }
+
+  const retryPendingTipRecord = async (pending: PendingHighlightTipRecord) => {
+    setTipFailure(null)
+    setTipFormError(null)
+    setTipSuccess(null)
+    setIsLoading(true)
+    setTipFlowStep('confirming')
+
+    try {
+      await createHighlightTip(pending.args)
+      markTipRecordSynced(pending.amountCents, pending.transactionHash)
+    } catch (error) {
+      console.error('Highlight tip sync retry error:', error)
+      setTipFailure(HIGHLIGHT_TIP_SYNC_FAILURE_MESSAGE)
+    } finally {
+      setIsLoading(false)
+      setTipFlowStep(null)
+    }
+  }
+
   const suspendDialogForWalletRef = useRef(false)
 
   const handleOpenChange = (open: boolean) => {
@@ -282,6 +373,11 @@ export function HighlightTipButton({
   }
 
   const handleTip = async () => {
+    if (pendingTipRecord) {
+      await retryPendingTipRecord(pendingTipRecord)
+      return
+    }
+
     const validation = validateTipAmountForm({
       selectedAmount,
       customAmount,
@@ -324,6 +420,7 @@ export function HighlightTipButton({
     setTipSuccess(null)
     setIsLoading(true)
 
+    let submittedTipRecord: PendingHighlightTipRecord | null = null
     try {
       stellarFlowEmitter.emit({ flow: 'tip', step: 'awaiting_signature' })
       const highlightId = await generateHighlightId(
@@ -347,60 +444,45 @@ export function HighlightTipButton({
 
       const receipt = await stellarClient.submitTipTransaction(signedXDR)
 
-      await createHighlightTip({
-        highlightId,
-        articleId,
-        highlightText,
-        startOffset,
-        endOffset,
-        startContainerPath,
-        endContainerPath,
+      const tipRecord: PendingHighlightTipRecord = {
         amountCents,
-        stellarTxId: receipt.transactionHash ?? '',
-        stellarMemo: highlightId,
-        stellarNetwork: 'TESTNET',
-        stellarLedger: undefined,
-        stellarFeeCharged: undefined,
-        stellarSourceAccount: publicKey,
-        stellarDestinationAccount: authorStellarAddress,
-        stellarAmountXlm: (transactionData.stroops / 10_000_000).toString(),
-        contractTipId: receipt.tipId,
-        platformFee: transactionData.platformFee,
-        authorShare: transactionData.authorReceived,
-      })
+        transactionHash: receipt.transactionHash ?? undefined,
+        args: {
+          highlightId,
+          articleId,
+          highlightText,
+          startOffset,
+          endOffset,
+          startContainerPath,
+          endContainerPath,
+          amountCents,
+          stellarTxId: receipt.transactionHash ?? '',
+          stellarMemo: highlightId,
+          stellarNetwork: 'TESTNET',
+          stellarLedger: undefined,
+          stellarFeeCharged: undefined,
+          stellarSourceAccount: publicKey,
+          stellarDestinationAccount: authorStellarAddress,
+          stellarAmountXlm: (transactionData.stroops / 10_000_000).toString(),
+          contractTipId: receipt.tipId,
+          platformFee: transactionData.platformFee,
+          authorShare: transactionData.authorReceived,
+        },
+      }
+      submittedTipRecord = tipRecord
+      setPendingTipRecord(tipRecord)
+      setTipFlowStep('confirming')
 
-      clearPendingTipIntent()
-      setTipFailure(null)
-      setTipFormError(null)
-      const successMessage = `Successfully tipped ${authorName} ${formatTipAmount(amountCents)} for this highlight!`
-      setTipSuccess(successMessage)
+      await createHighlightTip(tipRecord.args)
 
-      toast.success(successMessage, {
-        description: receipt.transactionHash
-          ? `Transaction: ${receipt.transactionHash.slice(0, 8)}...`
-          : undefined,
-        action: receipt.transactionHash
-          ? {
-              label: 'View',
-              onClick: () =>
-                window.open(
-                  `https://stellar.expert/explorer/testnet/tx/${receipt.transactionHash}`,
-                  '_blank'
-                ),
-            }
-          : undefined,
-      })
-
-      window.setTimeout(() => {
-        setIsOpen(false)
-        resetModalState()
-        setSelectedAmount(null)
-        setCustomAmount('')
-        onSuccess?.()
-      }, 3000)
+      markTipRecordSynced(amountCents, receipt.transactionHash ?? undefined)
     } catch (error) {
       console.error('Highlight tip error:', error)
-      setTipFailure(formatTipFailureMessage(error))
+      if (submittedTipRecord || pendingTipRecord) {
+        setTipFailure(HIGHLIGHT_TIP_SYNC_FAILURE_MESSAGE)
+      } else {
+        setTipFailure(formatTipFailureMessage(error))
+      }
     } finally {
       setIsLoading(false)
       setTipFlowStep(null)
@@ -537,9 +619,11 @@ export function HighlightTipButton({
               authorName={authorName}
               amountCents={checkoutAmountCents}
               isAuthenticated={isAuthenticated}
-              isConnected={isConnected}
+              isConnected={isConnected || Boolean(pendingTipRecord)}
               isWalletLoading={isWalletLoading}
-              publicKey={publicKey}
+              publicKey={
+                publicKey ?? pendingTipRecord?.args.stellarSourceAccount ?? null
+              }
               isLoading={isLoading}
               tipSuccess={tipSuccess}
               tipFailure={tipFailure}

--- a/components/stellar/ContextualWalletSetup.test.tsx
+++ b/components/stellar/ContextualWalletSetup.test.tsx
@@ -63,10 +63,10 @@ describe('ContextualWalletSetup', () => {
   it('renders receive mode copy', () => {
     render(<ContextualWalletSetup mode="receive" />)
 
-    expect(screen.getByText('Connect to receive tips')).toBeInTheDocument()
+    expect(screen.getByText('Set up your receiving wallet')).toBeInTheDocument()
     expect(
       screen.getByText(
-        'When readers tip your articles, payments go to this wallet.'
+        'Published articles can receive tips after this Stellar testnet wallet is saved.'
       )
     ).toBeInTheDocument()
   })

--- a/components/stellar/ContextualWalletSetup.tsx
+++ b/components/stellar/ContextualWalletSetup.tsx
@@ -33,14 +33,14 @@ function getHeadline(mode: WalletSetupMode, recipientLabel?: string): string {
       ? `Connect to tip ${recipientLabel}`
       : 'Connect to send a tip'
   }
-  return 'Connect to receive tips'
+  return 'Set up your receiving wallet'
 }
 
 function getBody(mode: WalletSetupMode): string {
   if (mode === 'send') {
     return "You'll sign the tip in your Stellar wallet."
   }
-  return 'When readers tip your articles, payments go to this wallet.'
+  return 'Published articles can receive tips after this Stellar testnet wallet is saved.'
 }
 
 export function ContextualWalletSetup({

--- a/components/stellar/WalletSettings.test.tsx
+++ b/components/stellar/WalletSettings.test.tsx
@@ -46,7 +46,7 @@ vi.mock('@/components/stellar/ContextualWalletSetup', () => ({
     <div>
       {mode === 'send'
         ? `Connect to tip ${recipientLabel}`
-        : 'Connect to receive tips'}
+        : 'Set up your receiving wallet'}
       <button type="button">Connect wallet</button>
     </div>
   ),
@@ -102,7 +102,7 @@ describe('WalletSettings', () => {
   it('shows owner contextual wallet setup when wallet address is missing', () => {
     render(<WalletSettings isOwnProfile walletAddress={null} />)
 
-    expect(screen.getByText('Connect to receive tips')).toBeInTheDocument()
+    expect(screen.getByText('Set up your receiving wallet')).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: /Connect wallet/i })
     ).toBeInTheDocument()

--- a/components/stellar/WalletSettings.test.tsx
+++ b/components/stellar/WalletSettings.test.tsx
@@ -1,12 +1,17 @@
 /** @vitest-environment jsdom */
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { WalletSettings } from '@/components/stellar/WalletSettings'
 
 const mockDisconnect = vi.fn()
+const mockUpdateProfile = vi.fn()
+
+const savedAddress = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
+const nextAddress = 'GC2BKLYOOYPDEFJKLKY6FNNRQMGFLVHJKQRGNSSRRGSMPGF32LHCQVGF'
 
 vi.mock('convex/react', () => ({
-  useMutation: () => vi.fn(),
+  useMutation: () => mockUpdateProfile,
 }))
 
 vi.mock('@/components/providers/WalletProvider', () => ({
@@ -55,6 +60,8 @@ vi.mock('@/components/stellar/ContextualWalletSetup', () => ({
 describe('WalletSettings', () => {
   beforeEach(() => {
     mockDisconnect.mockReset()
+    mockUpdateProfile.mockReset()
+    mockUpdateProfile.mockResolvedValue(undefined)
   })
 
   it('shows visitor empty alert with profile display name', () => {
@@ -107,5 +114,37 @@ describe('WalletSettings', () => {
       screen.getByRole('button', { name: /Connect wallet/i })
     ).toBeInTheDocument()
     expect(screen.queryByText(/undefined/i)).not.toBeInTheDocument()
+  })
+
+  it('lets owners type and save a different receiving wallet address', async () => {
+    const onAddressChange = vi.fn()
+    const user = userEvent.setup({ delay: null })
+
+    render(
+      <WalletSettings
+        isOwnProfile
+        walletAddress={savedAddress}
+        onAddressChange={onAddressChange}
+      />
+    )
+
+    const addressInput = screen.getByLabelText(/Receiving wallet address/i)
+    expect(addressInput).not.toHaveAttribute('readonly')
+
+    await user.clear(addressInput)
+    await user.type(addressInput, nextAddress)
+
+    expect(addressInput).toHaveValue(nextAddress)
+
+    await user.click(
+      screen.getByRole('button', { name: /Save receiving wallet/i })
+    )
+
+    await waitFor(() => {
+      expect(mockUpdateProfile).toHaveBeenCalledWith({
+        stellarAddress: nextAddress,
+      })
+      expect(onAddressChange).toHaveBeenCalledWith(nextAddress)
+    })
   })
 })

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useMutation } from 'convex/react'
 import { api } from '@/convex/_generated/api'
 import Link from 'next/link'
@@ -32,6 +32,7 @@ import { useWallet } from '@/components/providers/WalletProvider'
 import { ContextualWalletSetup } from '@/components/stellar/ContextualWalletSetup'
 import { LegalLinks } from '@/components/legal/LegalLinks'
 import { networkLabelLowercase } from '@/lib/copy/network-status'
+import { isValidStellarAccountId } from '@/lib/stellar/is-valid-stellar-account-id'
 
 interface WalletSettingsProps {
   walletAddress?: string | null
@@ -56,15 +57,24 @@ export function WalletSettings({
   })
   const [isCopied, setIsCopied] = useState(false)
   const [isDisconnecting, setIsDisconnecting] = useState(false)
+  const [isSavingAddress, setIsSavingAddress] = useState(false)
+  const [walletAddressDraft, setWalletAddressDraft] = useState(
+    walletAddress ?? ''
+  )
   const [walletFeedback, setWalletFeedback] = useState<FlowFeedback | null>(
     null
   )
 
+  useEffect(() => {
+    setWalletAddressDraft(walletAddress ?? '')
+  }, [walletAddress])
+
   const handleCopy = async () => {
-    if (!walletAddress) return
+    const addressToCopy = walletAddressDraft.trim() || walletAddress
+    if (!addressToCopy) return
 
     try {
-      await navigator.clipboard.writeText(walletAddress)
+      await navigator.clipboard.writeText(addressToCopy)
       setIsCopied(true)
       setWalletFeedback(null)
       toast.success('Wallet address copied to clipboard')
@@ -76,6 +86,50 @@ export function WalletSettings({
         detail: 'Copy the address manually or try again.',
       })
       toast.error('Failed to copy address')
+    }
+  }
+
+  const handleSaveWalletAddress = async () => {
+    if (isSavingAddress) return
+
+    const nextAddress = walletAddressDraft.trim()
+    if (!isValidStellarAccountId(nextAddress)) {
+      setWalletFeedback({
+        variant: 'destructive',
+        title: 'Invalid wallet address',
+        detail:
+          'Enter a valid Stellar public key that starts with G and is 56 characters long.',
+      })
+      toast.error('Invalid Stellar wallet address')
+      return
+    }
+
+    if (nextAddress === walletAddress) return
+
+    setIsSavingAddress(true)
+    setWalletFeedback(null)
+
+    try {
+      await updateProfile({
+        stellarAddress: nextAddress,
+      })
+      onAddressChange?.(nextAddress)
+      toast.success('Receiving wallet saved')
+    } catch (error) {
+      console.error('[WalletSettings] Failed to save wallet address:', error)
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Please check the address and try again.'
+
+      setWalletFeedback({
+        variant: 'destructive',
+        title: 'Wallet save failed',
+        detail: message,
+      })
+      toast.error('Wallet save failed')
+    } finally {
+      setIsSavingAddress(false)
     }
   }
 
@@ -253,8 +307,14 @@ export function WalletSettings({
                       </Label>
                       <div className="flex gap-2">
                         <Input
-                          value={walletAddress || ''}
-                          readOnly
+                          aria-label="Receiving wallet address"
+                          value={walletAddressDraft}
+                          onChange={(event) =>
+                            setWalletAddressDraft(event.target.value)
+                          }
+                          autoCapitalize="characters"
+                          autoComplete="off"
+                          spellCheck={false}
                           className="font-mono text-xs"
                         />
                         <Button
@@ -269,13 +329,47 @@ export function WalletSettings({
                           )}
                         </Button>
                       </div>
+                      <div className="flex flex-col gap-2 sm:flex-row">
+                        <Button
+                          type="button"
+                          onClick={() => void handleSaveWalletAddress()}
+                          disabled={
+                            isSavingAddress ||
+                            walletAddressDraft.trim() === walletAddress
+                          }
+                          className="flex-1"
+                        >
+                          {isSavingAddress ? (
+                            <>
+                              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                              Saving...
+                            </>
+                          ) : (
+                            'Save receiving wallet'
+                          )}
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() =>
+                            setWalletAddressDraft(walletAddress ?? '')
+                          }
+                          disabled={
+                            isSavingAddress ||
+                            walletAddressDraft === (walletAddress ?? '')
+                          }
+                          className="flex-1"
+                        >
+                          Reset changes
+                        </Button>
+                      </div>
                     </div>
                   </div>
 
                   <ActionableNotice intent="informational">
-                    You can send and receive tips with this wallet. You can
-                    change it anytime by disconnecting and connecting a
-                    different account.
+                    This saved receiving wallet is editable. Paste or type a
+                    different Stellar testnet address, then save it before
+                    publishing or receiving tips.
                   </ActionableNotice>
 
                   <div className="flex gap-2">

--- a/components/stellar/WalletSettings.tsx
+++ b/components/stellar/WalletSettings.tsx
@@ -36,7 +36,7 @@ import { networkLabelLowercase } from '@/lib/copy/network-status'
 interface WalletSettingsProps {
   walletAddress?: string | null
   profileUsername?: string
-  onAddressChange?: (address: string) => void
+  onAddressChange?: (address: string | null) => void
   isOwnProfile: boolean
   profileDisplayName?: string
   className?: string
@@ -95,7 +95,7 @@ export function WalletSettings({
       disconnect()
 
       // Step 3: Notify parent component for immediate UI update
-      onAddressChange?.('')
+      onAddressChange?.(null)
       setWalletFeedback(null)
 
       toast.success('Wallet disconnected successfully')

--- a/components/tipping/TipButton.test.tsx
+++ b/components/tipping/TipButton.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { act, render, screen } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { TipButton } from '@/components/tipping/TipButton'
@@ -8,13 +8,19 @@ const mockRedirectToLoginForTip = vi.hoisted(() => vi.fn())
 const mockIsAuthenticated = vi.hoisted(() => vi.fn(() => false))
 const mockIsConnected = vi.hoisted(() => vi.fn(() => false))
 const mockUseArticleTipResume = vi.hoisted(() => vi.fn())
+const mockCanTipQuery = vi.hoisted(() => vi.fn())
+const mockSendTipMutation = vi.hoisted(() => vi.fn())
+const mockSignTransaction = vi.hoisted(() => vi.fn())
+const mockConnect = vi.hoisted(() => vi.fn())
+const mockBuildTipTransaction = vi.hoisted(() => vi.fn())
+const mockSubmitTipTransaction = vi.hoisted(() => vi.fn())
 const mockTipDialogFooterNote = vi.hoisted(() =>
   vi.fn(() => 'Review footer note from copy helper')
 )
 
 vi.mock('convex/react', () => ({
-  useConvex: () => ({ query: vi.fn() }),
-  useMutation: () => vi.fn(),
+  useConvex: () => ({ query: mockCanTipQuery }),
+  useMutation: () => mockSendTipMutation,
 }))
 
 vi.mock('@/components/providers/AuthContext', () => ({
@@ -26,8 +32,8 @@ vi.mock('@/components/providers/WalletProvider', () => ({
     isConnected: mockIsConnected(),
     isLoading: false,
     publicKey: mockIsConnected() ? 'GABCDEF123456789' : null,
-    signTransaction: vi.fn(),
-    connect: vi.fn(),
+    signTransaction: mockSignTransaction,
+    connect: mockConnect,
   }),
 }))
 
@@ -42,6 +48,15 @@ vi.mock('next/navigation', () => ({
 
 vi.mock('@/hooks/useTipDialogXlmUsdRate', () => ({
   useTipDialogXlmUsdRate: () => ({ priceUsd: null }),
+}))
+
+vi.mock('@/lib/stellar/client', () => ({
+  stellarClient: {
+    buildTipTransaction: (...args: unknown[]) =>
+      mockBuildTipTransaction(...args),
+    submitTipTransaction: (...args: unknown[]) =>
+      mockSubmitTipTransaction(...args),
+  },
 }))
 
 vi.mock('@/lib/copy/network-status', async () => {
@@ -70,7 +85,7 @@ vi.mock('@/hooks/useArticleTipResume', () => ({
 }))
 
 vi.mock('@/lib/stellar/stellar-flow-emitter', () => ({
-  stellarFlowEmitter: { subscribe: () => () => {} },
+  stellarFlowEmitter: { subscribe: () => () => {}, emit: vi.fn() },
   tipFlowProgressLabel: () => 'Processing',
 }))
 
@@ -101,6 +116,25 @@ describe('TipButton two-stage flow', () => {
     mockUseArticleTipResume.mockClear()
     mockIsAuthenticated.mockReturnValue(false)
     mockIsConnected.mockReturnValue(false)
+    mockCanTipQuery.mockReset()
+    mockCanTipQuery.mockResolvedValue({ allowed: true })
+    mockSendTipMutation.mockReset()
+    mockSendTipMutation.mockResolvedValue('tip-id')
+    mockSignTransaction.mockReset()
+    mockSignTransaction.mockResolvedValue('signed-xdr')
+    mockConnect.mockReset()
+    mockBuildTipTransaction.mockReset()
+    mockBuildTipTransaction.mockResolvedValue({
+      xdr: 'unsigned-xdr',
+      stroops: 10_000_000,
+      platformFee: 0.01,
+      authorReceived: 0.99,
+    })
+    mockSubmitTipTransaction.mockReset()
+    mockSubmitTipTransaction.mockResolvedValue({
+      transactionHash: 'tx-article-123456789',
+      tipId: 'contract-tip-article',
+    })
     mockTipDialogFooterNote.mockClear()
   })
 
@@ -307,5 +341,44 @@ describe('TipButton two-stage flow', () => {
     expect(
       screen.queryByRole('button', { name: 'Continue' })
     ).not.toBeInTheDocument()
+  })
+
+  it('retries Convex sync for a submitted tip without resubmitting Stellar tx', async () => {
+    mockIsAuthenticated.mockReturnValue(true)
+    mockIsConnected.mockReturnValue(true)
+    mockSendTipMutation
+      .mockRejectedValueOnce(new Error('Convex unavailable'))
+      .mockResolvedValueOnce('tip-id')
+    const user = userEvent.setup({ delay: null })
+    render(
+      <TipButton
+        articleId={'articles:abc' as never}
+        authorName="Author"
+        authorStellarAddress="GABC"
+      />
+    )
+
+    await selectPresetAndContinue(user)
+    await user.click(screen.getByRole('button', { name: 'Send Tip' }))
+
+    expect(
+      await screen.findByText('Tip sent, app sync failed')
+    ).toBeInTheDocument()
+    expect(mockSignTransaction).toHaveBeenCalledTimes(1)
+    expect(mockSubmitTipTransaction).toHaveBeenCalledTimes(1)
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => {
+      expect(mockSendTipMutation).toHaveBeenCalledTimes(2)
+    })
+    expect(mockSendTipMutation).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        stellarTxId: 'tx-article-123456789',
+      })
+    )
+    expect(mockSignTransaction).toHaveBeenCalledTimes(1)
+    expect(mockSubmitTipTransaction).toHaveBeenCalledTimes(1)
   })
 })

--- a/components/tipping/TipButton.tsx
+++ b/components/tipping/TipButton.tsx
@@ -55,6 +55,34 @@ interface TipButtonProps {
   className?: string
 }
 
+type ArticleTipRecordArgs = {
+  articleId: Id<'articles'>
+  amountUsd: number
+  message?: string
+  stellarTxId: string
+  stellarNetwork: 'TESTNET'
+  stellarLedger?: number
+  stellarFeeCharged?: string
+  stellarSourceAccount?: string
+  stellarDestinationAccount?: string
+  stellarAmountXlm?: string
+  contractTipId?: string
+  platformFee?: number
+  authorShare?: number
+}
+
+type PendingArticleTipRecord = {
+  args: ArticleTipRecordArgs
+  amountCents: number
+  transactionHash?: string
+}
+
+const TIP_SYNC_FAILURE_MESSAGE: TipFailureMessage = {
+  title: 'Tip sent, app sync failed',
+  detail:
+    'Your Stellar transaction was submitted. Retry will record that same transaction without sending another payment.',
+}
+
 export function TipButton({
   articleId,
   authorName,
@@ -85,6 +113,8 @@ export function TipButton({
   )
   const [tipSuccess, setTipSuccess] = useState<string | null>(null)
   const [tipMessage, setTipMessage] = useState('')
+  const [pendingTipRecord, setPendingTipRecord] =
+    useState<PendingArticleTipRecord | null>(null)
   const suspendDialogForWalletRef = useRef(false)
 
   const convex = useConvex()
@@ -121,6 +151,61 @@ export function TipButton({
     setTipFailure(null)
     setTipFormError(null)
     setTipSuccess(null)
+  }
+
+  const markTipRecordSynced = (
+    amountCents: number,
+    transactionHash?: string
+  ) => {
+    clearPendingTipIntent()
+    setPendingTipRecord(null)
+    setTipFailure(null)
+    setTipFormError(null)
+    const successMessage = `Successfully tipped ${authorName} $${(amountCents / 100).toFixed(2)} via Stellar!`
+    setTipSuccess(successMessage)
+
+    toast.success(successMessage, {
+      description: transactionHash
+        ? `Transaction: ${transactionHash.slice(0, 8)}...`
+        : undefined,
+      action: transactionHash
+        ? {
+            label: 'View',
+            onClick: () =>
+              window.open(
+                `https://stellar.expert/explorer/testnet/tx/${transactionHash}`,
+                '_blank'
+              ),
+          }
+        : undefined,
+    })
+
+    window.setTimeout(() => {
+      setIsOpen(false)
+      resetModalState()
+      setSelectedAmount(null)
+      setCustomAmount('')
+      setTipMessage('')
+    }, 3000)
+  }
+
+  const retryPendingTipRecord = async (pending: PendingArticleTipRecord) => {
+    setTipFailure(null)
+    setTipFormError(null)
+    setTipSuccess(null)
+    setIsLoading(true)
+    setTipFlowStep('confirming')
+
+    try {
+      await sendTip(pending.args)
+      markTipRecordSynced(pending.amountCents, pending.transactionHash)
+    } catch (error) {
+      console.error('Tip sync retry error:', error)
+      setTipFailure(TIP_SYNC_FAILURE_MESSAGE)
+    } finally {
+      setIsLoading(false)
+      setTipFlowStep(null)
+    }
   }
 
   const handleOpenChange = (open: boolean) => {
@@ -181,6 +266,11 @@ export function TipButton({
   }
 
   const handleTip = async () => {
+    if (pendingTipRecord) {
+      await retryPendingTipRecord(pendingTipRecord)
+      return
+    }
+
     const validation = validateTipAmountForm({
       selectedAmount,
       customAmount,
@@ -225,6 +315,7 @@ export function TipButton({
     setTipSuccess(null)
     setIsLoading(true)
 
+    let submittedTipRecord: PendingArticleTipRecord | null = null
     try {
       stellarFlowEmitter.emit({ flow: 'tip', step: 'awaiting_signature' })
       const transactionData = await stellarClient.buildTipTransaction(
@@ -240,54 +331,39 @@ export function TipButton({
       const signedXDR = await signTransaction(transactionData.xdr)
       const receipt = await stellarClient.submitTipTransaction(signedXDR)
 
-      await sendTip({
-        articleId,
-        amountUsd: amountCents / 100,
-        message: tipMessage.trim() ? tipMessage.trim() : undefined,
-        stellarTxId: receipt.transactionHash ?? '',
-        stellarNetwork: 'TESTNET',
-        stellarLedger: undefined,
-        stellarFeeCharged: undefined,
-        stellarSourceAccount: publicKey,
-        stellarDestinationAccount: authorStellarAddress,
-        stellarAmountXlm: (transactionData.stroops / 10_000_000).toString(),
-        contractTipId: receipt.tipId,
-        platformFee: transactionData.platformFee,
-        authorShare: transactionData.authorReceived,
-      })
+      const tipRecord: PendingArticleTipRecord = {
+        amountCents,
+        transactionHash: receipt.transactionHash ?? undefined,
+        args: {
+          articleId,
+          amountUsd: amountCents / 100,
+          message: tipMessage.trim() ? tipMessage.trim() : undefined,
+          stellarTxId: receipt.transactionHash ?? '',
+          stellarNetwork: 'TESTNET',
+          stellarLedger: undefined,
+          stellarFeeCharged: undefined,
+          stellarSourceAccount: publicKey,
+          stellarDestinationAccount: authorStellarAddress,
+          stellarAmountXlm: (transactionData.stroops / 10_000_000).toString(),
+          contractTipId: receipt.tipId,
+          platformFee: transactionData.platformFee,
+          authorShare: transactionData.authorReceived,
+        },
+      }
+      submittedTipRecord = tipRecord
+      setPendingTipRecord(tipRecord)
+      setTipFlowStep('confirming')
 
-      clearPendingTipIntent()
-      setTipFailure(null)
-      setTipFormError(null)
-      const successMessage = `Successfully tipped ${authorName} $${(amountCents / 100).toFixed(2)} via Stellar!`
-      setTipSuccess(successMessage)
+      await sendTip(tipRecord.args)
 
-      toast.success(successMessage, {
-        description: receipt.transactionHash
-          ? `Transaction: ${receipt.transactionHash.slice(0, 8)}...`
-          : undefined,
-        action: receipt.transactionHash
-          ? {
-              label: 'View',
-              onClick: () =>
-                window.open(
-                  `https://stellar.expert/explorer/testnet/tx/${receipt.transactionHash}`,
-                  '_blank'
-                ),
-            }
-          : undefined,
-      })
-
-      window.setTimeout(() => {
-        setIsOpen(false)
-        resetModalState()
-        setSelectedAmount(null)
-        setCustomAmount('')
-        setTipMessage('')
-      }, 3000)
+      markTipRecordSynced(amountCents, receipt.transactionHash ?? undefined)
     } catch (error) {
       console.error('Stellar tip error:', error)
-      setTipFailure(formatTipFailureMessage(error))
+      if (submittedTipRecord || pendingTipRecord) {
+        setTipFailure(TIP_SYNC_FAILURE_MESSAGE)
+      } else {
+        setTipFailure(formatTipFailureMessage(error))
+      }
     } finally {
       setIsLoading(false)
       setTipFlowStep(null)
@@ -421,9 +497,11 @@ export function TipButton({
               amountCents={checkoutAmountCents}
               message={tipMessage.trim() || undefined}
               isAuthenticated={isAuthenticated}
-              isConnected={isConnected}
+              isConnected={isConnected || Boolean(pendingTipRecord)}
               isWalletLoading={isWalletLoading}
-              publicKey={publicKey}
+              publicKey={
+                publicKey ?? pendingTipRecord?.args.stellarSourceAccount ?? null
+              }
               isLoading={isLoading}
               tipSuccess={tipSuccess}
               tipFailure={tipFailure}

--- a/convex/articles.getCreatorRecentWork.test.ts
+++ b/convex/articles.getCreatorRecentWork.test.ts
@@ -19,8 +19,18 @@ function recentWorkSource() {
   return source.slice(start, end)
 }
 
+function workspaceSummarySource() {
+  const source = readFileSync(new URL('./articles.ts', import.meta.url), 'utf8')
+  const start = source.indexOf('export const getCreatorWorkspaceSummary')
+  const end = source.indexOf('// Create article', start)
+  if (start === -1 || end === -1) {
+    throw new Error('Could not locate getCreatorWorkspaceSummary source')
+  }
+  return source.slice(start, end)
+}
+
 describe('getCreatorRecentWork', () => {
-  it('declares an author updatedAt index for bounded recent-work reads', () => {
+  it('declares author indexes for bounded creator workspace reads', () => {
     const articlesTable = (
       schema as unknown as {
         tables: {
@@ -35,6 +45,10 @@ describe('getCreatorRecentWork', () => {
       indexDescriptor: 'by_author_updated_at',
       fields: ['authorId', 'updatedAt'],
     })
+    expect(articlesTable.indexes).toContainEqual({
+      indexDescriptor: 'by_author_published_updated_at',
+      fields: ['authorId', 'published', 'updatedAt'],
+    })
   })
 
   it('uses the author updatedAt index without collecting every author article', () => {
@@ -44,6 +58,15 @@ describe('getCreatorRecentWork', () => {
     expect(source).toContain('.take(limit)')
     expect(source).not.toContain('.collect()')
     expect(source).not.toContain('.sort(')
+  })
+
+  it('uses the published updatedAt index for the workspace draft summary', () => {
+    const source = workspaceSummarySource()
+
+    expect(source).toContain(".withIndex('by_author_published_updated_at'")
+    expect(source).toContain(".eq('published', false)")
+    expect(source).toContain('.first()')
+    expect(source).not.toContain('.collect()')
   })
 
   it('returns the newest work for the signed-in creator only', async () => {
@@ -141,5 +164,76 @@ describe('getCreatorRecentWork', () => {
     expect(recent.every((article) => article.authorUsername === 'writer')).toBe(
       true
     )
+  })
+
+  it('returns the newest draft summary without loading every draft', async () => {
+    const t = convexTest(schema, modules)
+    const { authorId, olderDraft, newestDraft } = await t.run(async (ctx) => {
+      const now = Date.now()
+      const authorId = await ctx.db.insert('users', {
+        email: 'summary@x.test',
+        username: 'summary',
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      await ctx.db.insert('articles', {
+        slug: 'published-newer',
+        title: 'Published Newer',
+        content: emptyDoc,
+        published: true,
+        publishedAt: now + 3_000,
+        authorId,
+        authorUsername: 'summary',
+        tags: [],
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now + 3_000,
+      })
+      const olderDraft = await ctx.db.insert('articles', {
+        slug: 'older-draft',
+        title: 'Older Draft',
+        content: emptyDoc,
+        published: false,
+        authorId,
+        authorUsername: 'summary',
+        tags: [],
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now + 1_000,
+      })
+      const newestDraft = await ctx.db.insert('articles', {
+        slug: 'newest-draft',
+        title: 'Newest Draft',
+        content: emptyDoc,
+        published: false,
+        authorId,
+        authorUsername: 'summary',
+        tags: [],
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now + 2_000,
+      })
+
+      return { authorId, olderDraft, newestDraft }
+    })
+
+    const summary = await t
+      .withIdentity({ subject: authorId })
+      .query(api.articles.getCreatorWorkspaceSummary, {})
+
+    expect(summary.hasDrafts).toBe(true)
+    expect(summary.mostRecentDraft?._id).toBe(newestDraft)
+    expect(summary.mostRecentDraft?._id).not.toBe(olderDraft)
+    expect(summary.mostRecentDraft?.title).toBe('Newest Draft')
   })
 })

--- a/convex/articles.publishListingReady.test.ts
+++ b/convex/articles.publishListingReady.test.ts
@@ -19,13 +19,18 @@ const docWithBody = {
 const listingExcerpt = 'a'.repeat(MIN_LISTING_EXCERPT_CHARS)
 
 const modules = import.meta.glob(['./**/*.ts', '!./**/*.test.ts'])
+const authorWallet = 'GAUTHORRECEIVINGWALLET'
 
-async function seedAuthor(t: ReturnType<typeof convexTest>) {
+async function seedAuthor(
+  t: ReturnType<typeof convexTest>,
+  stellarAddress: string | null = authorWallet
+) {
   return await t.run(async (ctx) => {
     const now = Date.now()
     const userId = await ctx.db.insert('users', {
       email: 'pub@x.test',
       username: 'pubwriter',
+      ...(stellarAddress ? { stellarAddress } : {}),
       createdAt: now,
       updatedAt: now,
     })
@@ -132,6 +137,37 @@ describe('publish listing readiness', () => {
     expect(row?.published).toBe(true)
   })
 
+  it('rejects publishArticle when the author has no receiving wallet', async () => {
+    const t = convexTest(schema, modules)
+    const { userId, now } = await seedAuthor(t, null)
+    const asAuthor = t.withIdentity({ subject: userId })
+
+    const articleId = await t.run(async (ctx) => {
+      return await ctx.db.insert('articles', {
+        slug: 'ready-walletless-draft',
+        title: 'Real Title',
+        excerpt: listingExcerpt,
+        content: docWithBody,
+        published: false,
+        authorId: userId,
+        authorUsername: 'pubwriter',
+        tags: [],
+        viewCount: 0,
+        highlightCount: 0,
+        tipCount: 0,
+        totalTipsUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+    })
+
+    await expect(
+      asAuthor.mutation(api.articles.publishArticle, {
+        id: articleId as Id<'articles'>,
+      })
+    ).rejects.toThrow(/receiving wallet/)
+  })
+
   it('rejects createArticle with published when not listing-ready', async () => {
     const t = convexTest(schema, modules)
     const { userId } = await seedAuthor(t)
@@ -171,5 +207,20 @@ describe('publish listing readiness', () => {
 
     const row = await t.run(async (ctx) => ctx.db.get(id as Id<'articles'>))
     expect(row?.published).toBe(true)
+  })
+
+  it('rejects createArticle published when the author has no receiving wallet', async () => {
+    const t = convexTest(schema, modules)
+    const { userId } = await seedAuthor(t, null)
+    const asAuthor = t.withIdentity({ subject: userId })
+
+    await expect(
+      asAuthor.mutation(api.articles.createArticle, {
+        title: 'Good Title',
+        content: docWithBody,
+        excerpt: listingExcerpt,
+        published: true,
+      })
+    ).rejects.toThrow(/receiving wallet/)
   })
 })

--- a/convex/articles.publishTitle.test.ts
+++ b/convex/articles.publishTitle.test.ts
@@ -18,6 +18,7 @@ const docWithText = {
 
 const modules = import.meta.glob(['./**/*.ts', '!./**/*.test.ts'])
 const listingExcerpt = 'a'.repeat(MIN_LISTING_EXCERPT_CHARS)
+const authorWallet = 'GTITLEAUTHORRECEIVINGWALLET'
 
 async function drainScheduler(t: ReturnType<typeof convexTest>) {
   await new Promise((resolve) => setTimeout(resolve, 50))
@@ -32,6 +33,7 @@ async function seedAuthor(t: ReturnType<typeof convexTest>) {
     const userId = await ctx.db.insert('users', {
       email: 'writer@x.test',
       username: 'writer',
+      stellarAddress: authorWallet,
       createdAt: now,
       updatedAt: now,
     })

--- a/convex/articles.ts
+++ b/convex/articles.ts
@@ -33,6 +33,8 @@ import {
 } from './lib/tiptapContent'
 
 const WRITER_NOTES_MAX_LENGTH = 5000
+const PUBLISH_RECEIVING_WALLET_ERROR =
+  'Connect a receiving wallet before publishing so readers can tip this article'
 
 function stripWriterNotes<T extends { writerNotes?: string }>(
   article: T
@@ -71,6 +73,12 @@ function validateArticleInput(args: {
     throw new Error(
       `Writer notes must be ${WRITER_NOTES_MAX_LENGTH} characters or less`
     )
+  }
+}
+
+function assertAuthorCanReceiveTips(user: { stellarAddress?: string | null }) {
+  if (!user.stellarAddress) {
+    throw new Error(PUBLISH_RECEIVING_WALLET_ERROR)
   }
 }
 
@@ -434,7 +442,7 @@ export const getCreatorRecentWork = query({
     const userId = await getAuthUserId(ctx)
     if (!userId) return []
 
-    const limit = args.limit ?? 8
+    const limit = Math.min(Math.max(args.limit ?? 8, 1), 20)
     const articles = await ctx.db
       .query('articles')
       .withIndex('by_author_updated_at', (q) => q.eq('authorId', userId))
@@ -450,6 +458,39 @@ export const getCreatorRecentWork = query({
       slug: article.slug,
       authorUsername: article.authorUsername,
     }))
+  },
+})
+
+export const getCreatorWorkspaceSummary = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getAuthUserId(ctx)
+    if (!userId) {
+      return {
+        hasDrafts: false,
+        mostRecentDraft: null,
+      }
+    }
+
+    const mostRecentDraft = await ctx.db
+      .query('articles')
+      .withIndex('by_author_published_updated_at', (q) =>
+        q.eq('authorId', userId).eq('published', false)
+      )
+      .order('desc')
+      .first()
+
+    return {
+      hasDrafts: Boolean(mostRecentDraft),
+      mostRecentDraft: mostRecentDraft
+        ? {
+            _id: mostRecentDraft._id,
+            _creationTime: mostRecentDraft._creationTime,
+            title: mostRecentDraft.title,
+            updatedAt: mostRecentDraft.updatedAt,
+          }
+        : null,
+    }
   },
 })
 
@@ -481,6 +522,7 @@ export const createArticle = mutation({
     if (!user) throw new Error('User not found')
 
     if (args.published) {
+      assertAuthorCanReceiveTips(user)
       assertArticleListingReady({
         title: args.title,
         excerpt: args.excerpt,
@@ -647,6 +689,10 @@ export const publishArticle = mutation({
     if (article.authorId !== userId) throw new Error('Not authorized')
     if (article.published) throw new Error('Already published')
 
+    const user = await ctx.db.get(userId)
+    if (!user) throw new Error('User not found')
+    assertAuthorCanReceiveTips(user)
+
     // Validate article has required content before publishing
     assertPublishableArticleTitle(article.title)
     if (!article.content) {
@@ -703,13 +749,10 @@ export const publishArticle = mutation({
     }
 
     // Update user's article count
-    const user = await ctx.db.get(userId)
-    if (user) {
-      await ctx.db.patch(userId, {
-        articleCount: (user.articleCount || 0) + 1,
-        updatedAt: now,
-      })
-    }
+    await ctx.db.patch(userId, {
+      articleCount: (user.articleCount || 0) + 1,
+      updatedAt: now,
+    })
 
     return { id: args.id, slug }
   },

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -103,6 +103,11 @@ export default defineSchema({
     .index('by_author_updated_at', ['authorId', 'updatedAt'])
     .index('by_published', ['published'])
     .index('by_author_published', ['authorId', 'published']) // Composite for author's published articles
+    .index('by_author_published_updated_at', [
+      'authorId',
+      'published',
+      'updatedAt',
+    ])
     .index('by_published_date', ['published', 'publishedAt']) // For listing by date
     .searchIndex('search_listing', {
       searchField: 'searchContent',

--- a/hooks/convex/index.ts
+++ b/hooks/convex/index.ts
@@ -7,6 +7,7 @@ export {
   useArticleById,
   useUserDrafts,
   useCreatorRecentWork,
+  useCreatorWorkspaceSummary,
   type ListArticlesArgs,
   type CreatorRecentWorkArgs,
 } from './useArticles'

--- a/hooks/convex/useArticles.ts
+++ b/hooks/convex/useArticles.ts
@@ -54,3 +54,7 @@ export type CreatorRecentWorkArgs = {
 export function useCreatorRecentWork(args: CreatorRecentWorkArgs = {}) {
   return useQuery(api.articles.getCreatorRecentWork, args)
 }
+
+export function useCreatorWorkspaceSummary() {
+  return useQuery(api.articles.getCreatorWorkspaceSummary)
+}

--- a/hooks/useAutoSave.test.ts
+++ b/hooks/useAutoSave.test.ts
@@ -51,7 +51,7 @@ describe('useAutoSave', () => {
     expect(result.current.isSaving).toBe(false)
     expect(result.current.lastSavedAt).toBeNull()
 
-    let savePromise: Promise<void>
+    let savePromise: Promise<unknown>
     act(() => {
       savePromise = result.current.saveNow()
     })
@@ -113,7 +113,7 @@ describe('useAutoSave', () => {
       })
     )
 
-    let savePromise: Promise<void>
+    let savePromise: Promise<unknown>
     act(() => {
       savePromise = result.current.saveNow()
     })
@@ -128,6 +128,32 @@ describe('useAutoSave', () => {
       'Save timed out. Check your connection.'
     )
     expect(result.current.lastSavedAt).toBeNull()
+  })
+
+  it('returns the saved draft response from saveNow', async () => {
+    mockSaveDraft.mockResolvedValue('article-789')
+
+    const { result } = renderHook(() =>
+      useAutoSave({
+        content: sampleContent,
+        title: 'Returned draft',
+        enabled: false,
+      })
+    )
+
+    let response:
+      | Awaited<ReturnType<typeof result.current.saveNow>>
+      | undefined = undefined
+    await act(async () => {
+      response = await result.current.saveNow()
+    })
+
+    expect(response).toEqual(
+      expect.objectContaining({
+        id: 'article-789',
+        title: 'Returned draft',
+      })
+    )
   })
 
   it('calls onSaveSuccess only after a successful save', async () => {

--- a/hooks/useAutoSave.ts
+++ b/hooks/useAutoSave.ts
@@ -66,11 +66,13 @@ export function useAutoSave({
   // Convex mutation for saving drafts
   const saveDraftMutation = useMutation(api.articles.saveDraft)
 
-  const saveDraft = useCallback(async () => {
+  const saveDraft = useCallback(async (): Promise<
+    DraftResponse | undefined
+  > => {
     // Allow save when we have content OR (title or coverImage) for metadata-only drafts
     const hasContent = !!content
     const hasMetadata = !!(title?.trim() || coverImage || writerNotes?.trim())
-    if (!hasContent && !hasMetadata) return
+    if (!hasContent && !hasMetadata) return undefined
 
     setState((prev) => {
       if (prev.isSaving) return prev
@@ -117,6 +119,7 @@ export function useAutoSave({
       }
 
       onSaveSuccess?.(response)
+      return response
     } catch (error) {
       if (timeoutId !== undefined) clearTimeout(timeoutId)
       void mutationPromise.catch(() => {})
@@ -131,6 +134,7 @@ export function useAutoSave({
       }))
 
       onSaveError?.(err)
+      return undefined
     }
   }, [
     content,
@@ -214,7 +218,7 @@ export function useAutoSave({
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current)
     }
-    await saveDraft()
+    return await saveDraft()
   }, [saveDraft])
 
   return {

--- a/lib/articles/parseArticlesPageParam.test.ts
+++ b/lib/articles/parseArticlesPageParam.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { parseArticlesPageParam } from '@/lib/articles/parseArticlesPageParam'
+
+describe('parseArticlesPageParam', () => {
+  it('returns positive integer pages unchanged', () => {
+    expect(parseArticlesPageParam('1')).toBe(1)
+    expect(parseArticlesPageParam('12')).toBe(12)
+  })
+
+  it('falls back to page 1 for malformed values', () => {
+    expect(parseArticlesPageParam(null)).toBe(1)
+    expect(parseArticlesPageParam('abc')).toBe(1)
+    expect(parseArticlesPageParam('0')).toBe(1)
+    expect(parseArticlesPageParam('-2')).toBe(1)
+    expect(parseArticlesPageParam('1.5')).toBe(1)
+    expect(parseArticlesPageParam('Infinity')).toBe(1)
+  })
+})

--- a/lib/articles/parseArticlesPageParam.ts
+++ b/lib/articles/parseArticlesPageParam.ts
@@ -1,0 +1,7 @@
+export function parseArticlesPageParam(
+  value: string | null | undefined
+): number {
+  const parsed = Number(value ?? '1')
+  if (!Number.isInteger(parsed) || parsed < 1) return 1
+  return parsed
+}

--- a/lib/auth/postAuthNavigation.test.ts
+++ b/lib/auth/postAuthNavigation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { shouldUseFullPageAuthNavigation } from '@/lib/auth/postAuthNavigation'
+
+describe('shouldUseFullPageAuthNavigation', () => {
+  it('uses client routing for normal return paths', () => {
+    expect(shouldUseFullPageAuthNavigation('/articles', null)).toBe(false)
+  })
+
+  it('uses full navigation for article tip resume params', () => {
+    expect(
+      shouldUseFullPageAuthNavigation('/writer/post?resumeArticleTip=1', null)
+    ).toBe(true)
+  })
+
+  it('uses full navigation for pending highlight tip intent', () => {
+    expect(
+      shouldUseFullPageAuthNavigation('/writer/post', {
+        kind: 'highlight',
+        articleId: 'articles:123',
+        articleSlug: 'post',
+        highlightText: 'Highlighted text',
+        startOffset: 0,
+        endOffset: 16,
+      })
+    ).toBe(true)
+  })
+})

--- a/lib/auth/postAuthNavigation.ts
+++ b/lib/auth/postAuthNavigation.ts
@@ -1,0 +1,11 @@
+import type { PendingTipIntent } from '@/lib/tip/pendingTipIntent'
+
+export function shouldUseFullPageAuthNavigation(
+  returnPath: string,
+  pendingTipIntent: PendingTipIntent | null
+): boolean {
+  return (
+    returnPath.includes('resumeArticleTip=1') ||
+    pendingTipIntent?.kind === 'highlight'
+  )
+}


### PR DESCRIPTION
## Summary

- Hardened publish readiness by requiring a saved receiving wallet before articles can go live.
- Made first publish use the saved draft id and made submitted Stellar tips safe to retry when app sync fails.
- Reduced signed-in home fragility and bounded creator workspace data loading.
- Fixed the wallet dashboard receiving-address field so owners can type or paste a replacement address and save it directly.

## Changes

- Added backend wallet guards for `createArticle({ published: true })` and `publishArticle`.
- Updated editor publishing to publish the just-saved draft id, block final publish until wallet setup exists, and stop if latest changes fail to save.
- Reworked wallet setup entry points, wallet disconnect state, earnings wallet setup behavior, and saved receiving-wallet editing.
- Added submitted-receipt retry paths for article and highlight tips so retry records the same Stellar transaction without resubmitting.
- Matched registration tip-resume navigation to login behavior.
- Added creator workspace summary query/index, section-level fallbacks, and malformed `/articles?page=` sanitization.

## Testing

- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run test:once`
- `bun run build` (passed after allowing network for `next/font` Google Fonts fetches)
- `./node_modules/.bin/prettier --check components/stellar/WalletSettings.tsx components/stellar/WalletSettings.test.tsx`
- `bun run test:once components/dashboard/DashboardWalletContent.test.tsx components/stellar/ContextualWalletSetup.test.tsx components/stellar/WalletSettings.test.tsx`
- GitHub PR checks: Build, Required, Lint/Typecheck/Test, Dependency Audit, PR hygiene, commit subjects, PR title, Vercel, and Vercel Preview Comments all passed after the wallet edit fix.

## Manual QA

- Project-owner manual QA completed against the PR checklist.
- Wallet setup note found during QA: the receiving wallet stale-state fix worked, but the saved wallet address field was not directly editable.
- Follow-up fix added an editable receiving wallet field with Save/Reset actions and client-side Stellar public-key validation.

## Notes

- The first sandboxed build failed because network-restricted `next/font` could not fetch Google Fonts; rerunning with network access passed.
- Merge target remains `development`.
